### PR TITLE
feat: enable auto-publish for Maven Central deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,11 +550,12 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>ossrh</publishingServerId>
                             <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary
- Updated central-publishing-maven-plugin from v0.4.0 to v0.8.0
- Added `<autoPublish>true</autoPublish>` configuration to enable automatic publishing of artifacts to Maven Central

## Benefits
This change eliminates the need for manual intervention when publishing artifacts to Maven Central, streamlining the release process.

🤖 Generated with [Claude Code](https://claude.ai/code)