### PR TITLE
feat: drop java 8 support

### DIFF
--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -92,10 +92,10 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
     
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
     
     - name: Set up Python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,7 +60,7 @@ jobs:
           inputs.mode == 'dry_run'
         run: |
           mvn --batch-mode -DskipTests package
-      - name: Publish with Java 8
+      - name: Publish to Maven Central
         if: |
           github.event_name == 'release' ||
           inputs.mode == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
     
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
     
     - name: Set up Python

--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -65,8 +65,8 @@ See [Configuration](config.md) for more details.
 
 | Java Version | Support Status | Notes                                                        |
 |--------------|----------------|--------------------------------------------------------------|
-| Java 8       | ✅ Supported    | Minimum required version                                     |
-| Java 11      | ✅ Supported    | Recommended for production                                   |
+| Java 8       | ❌ Not Supported | No longer supported                                         |
+| Java 11      | ✅ Supported    | Minimum required version                                     |
 | Java 17      | ✅ Supported    | Latest LTS version (Spark 4.0 dropped Java 8 and 11 support) |
 | Java 21+     | ⚠️ Untested    | May work but not officially tested                           |
 

--- a/pom.xml
+++ b/pom.xml
@@ -438,23 +438,13 @@
 
     <profiles>
         <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>[1.8,1.8.999]</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.source>1.8</maven.compiler.source>
-                <maven.compiler.target>1.8</maven.compiler.target>
-            </properties>
-        </profile>
-        <profile>
             <id>jdk11+</id>
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
             <properties>
-                
-                <maven.compiler.release>8</maven.compiler.release>
+
+                <maven.compiler.release>11</maven.compiler.release>
             </properties>
             <build>
                 <plugins>


### PR DESCRIPTION
Dropping java 8 support in lance-spark, resolve [ticket](https://github.com/lancedb/lance-spark/issues/56)