### PR TITLE
chore: exclude slf4j-api to prevent jar conflict in spark classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,11 +146,23 @@
             <groupId>com.lancedb</groupId>
             <artifactId>lance-core</artifactId>
             <version>${lance.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.lancedb</groupId>
             <artifactId>lance-namespace-core</artifactId>
             <version>${lance-namespace.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Recently, we met a ClassNotFound Expcetion when using lance-spark. The reason we found is that slf4j-api's classes were builded to fat jar and our original spark classpath(jars directory) already has slf4j-api jar.

We should exclude it.