### PR TITLE
fix: set version of `maven-shade-plugin` used in `lance-spark-bundle-*` modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
     </properties>
 
     <modules>
@@ -438,6 +439,11 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>${maven-shade-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Currently, there is no explicit version management of `maven-shade-plugin`, which is used in `lance-spark-budle-*` modules. And there is no `org.apache.maven.plugins:maven-shade-plugin:pom`, for instance, in [this Maven repository](https://repo1.maven.org/maven2/org/apache/maven/plugins/maven-shade-plugin/), which could lead to compilation fail by Maven.

This PR sets `maven-shade-plugin` version explicitly using in plugin management of the parent `pom`.

