### PR TITLE
fix: add timeout for LanceDataWriter.abort

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -72,7 +72,10 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     try {
       // Have a timeout to avoid hanging in native method indefinitely
       fragmentCreationTask.get(5, TimeUnit.MINUTES);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while waiting for reader thread to finish", e);
+    } catch (ExecutionException | TimeoutException e) {
       throw new IOException("Failed to abort the reader thread", e);
     }
     close();


### PR DESCRIPTION
We found the Spark task can hang in `LanceDataWriter.abort()`, as the native method is not responding to interrupt, so the Spark job hangs forever. So this PR adds a timeout in `abort()` allow Spark task to exit and retry.

Example of stack trace in https://gist.github.com/c21/80f25098b0bd4ffa21b4e4a5b957a501 .