### PR TITLE
fix: use manifest summary for stats reporting

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceDatasetAdapter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceDatasetAdapter.java
@@ -112,17 +112,6 @@ public class LanceDatasetAdapter {
     }
   }
 
-  public static Optional<Long> getDatasetDataSize(LanceConfig config) {
-    String uri = config.getDatasetUri();
-    ReadOptions options = SparkOptions.genReadOptionFromConfig(config);
-    try (Dataset dataset = Dataset.open(allocator, uri, options)) {
-      return Optional.of(dataset.calculateDataSize());
-    } catch (IllegalArgumentException e) {
-      // dataset not found
-      return Optional.empty();
-    }
-  }
-
   public static List<Integer> getFragmentIds(LanceConfig config) {
     String uri = config.getDatasetUri();
     ReadOptions options = SparkOptions.genReadOptionFromConfig(config);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -50,6 +50,7 @@ public class LanceScan
   private final Optional<Integer> offset;
   private final Optional<List<ColumnOrdering>> topNSortOrders;
   private final Optional<Aggregation> pushedAggregation;
+  private final LanceStatistics statistics;
   private final String scanId = UUID.randomUUID().toString();
 
   public LanceScan(
@@ -59,7 +60,8 @@ public class LanceScan
       Optional<Integer> limit,
       Optional<Integer> offset,
       Optional<List<ColumnOrdering>> topNSortOrders,
-      Optional<Aggregation> pushedAggregation) {
+      Optional<Aggregation> pushedAggregation,
+      LanceStatistics statistics) {
     this.schema = schema;
     this.config = config;
     this.whereConditions = whereConditions;
@@ -67,6 +69,7 @@ public class LanceScan
     this.offset = offset;
     this.topNSortOrders = topNSortOrders;
     this.pushedAggregation = pushedAggregation;
+    this.statistics = statistics;
   }
 
   @Override
@@ -122,7 +125,7 @@ public class LanceScan
 
   @Override
   public Statistics estimateStatistics() {
-    return new LanceStatistics(config);
+    return statistics;
   }
 
   private static class LanceReaderFactory implements PartitionReaderFactory {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -13,38 +13,40 @@
  */
 package org.lance.spark.read;
 
-import org.lance.spark.LanceConfig;
-import org.lance.spark.internal.LanceDatasetAdapter;
-import org.lance.spark.utils.Optional;
+import org.lance.ManifestSummary;
 
 import org.apache.spark.sql.connector.read.Statistics;
 
+import java.io.Serializable;
 import java.util.OptionalLong;
 
-public class LanceStatistics implements Statistics {
-  private final Optional<Long> rowNumber;
-  private final Optional<Long> dataBytesSize;
+/**
+ * Lance dataset statistics based on ManifestSummary. This provides O(1) access to pre-computed
+ * statistics from the manifest metadata.
+ */
+public class LanceStatistics implements Statistics, Serializable {
+  private static final long serialVersionUID = 1L;
 
-  public LanceStatistics(LanceConfig config) {
-    this.rowNumber = LanceDatasetAdapter.getDatasetRowCount(config);
-    this.dataBytesSize = LanceDatasetAdapter.getDatasetDataSize(config);
+  private final long numRows;
+  private final long sizeInBytes;
+
+  /**
+   * Create statistics from a ManifestSummary.
+   *
+   * @param summary the manifest summary containing pre-computed statistics
+   */
+  public LanceStatistics(ManifestSummary summary) {
+    this.numRows = summary.getTotalRows();
+    this.sizeInBytes = summary.getTotalFilesSize();
   }
 
   @Override
   public OptionalLong sizeInBytes() {
-    if (dataBytesSize.isPresent()) {
-      return OptionalLong.of(dataBytesSize.get());
-    } else {
-      return OptionalLong.empty();
-    }
+    return OptionalLong.of(sizeInBytes);
   }
 
   @Override
   public OptionalLong numRows() {
-    if (rowNumber.isPresent()) {
-      return OptionalLong.of(rowNumber.get());
-    } else {
-      return OptionalLong.empty();
-    }
+    return OptionalLong.of(numRows);
   }
 }


### PR DESCRIPTION
This uses manifest summary to report stats instead of computing stats directly against data files.

Note that this still only reports full table stats, it does not report stats after filter and projection pushdown, and it also does not report column stats. This will be added later as a part of column stats project.