### PR TITLE
fix: persist() hanging bug

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
@@ -21,9 +21,10 @@ import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.types.StructType;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class LanceInputPartition implements InputPartition {
+public class LanceInputPartition implements InputPartition, Serializable {
   private static final long serialVersionUID = 4723894723984723984L;
 
   private final StructType schema;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -128,7 +128,8 @@ public class LanceScan
     return statistics;
   }
 
-  private static class LanceReaderFactory implements PartitionReaderFactory {
+  private static class LanceReaderFactory implements PartitionReaderFactory, Serializable {
+    private static final long serialVersionUID = 1L;
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
       Preconditions.checkArgument(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
@@ -363,4 +363,35 @@ public abstract class BaseSparkConnectorReadTest {
     scala.collection.Seq<?> arr = (scala.collection.Seq<?>) selectRows.get(0).get(0);
     assertEquals(3, arr.size());
   }
+
+  @Test
+  public void testPersistWithReplicatedStorageLevel() {
+    // This test verifies that LanceInputPartition and LanceReaderFactory
+    // are properly serializable, which is required for persist() with
+    // replicated storage levels like MEMORY_AND_DISK_2.
+    //
+    // Before the fix, this would hang indefinitely because Spark couldn't
+    // serialize the reader factory for replication.
+    Dataset<Row> df =
+        spark
+            .read()
+            .format(LanceDataSource.name)
+            .option(
+                LanceSparkReadOptions.CONFIG_DATASET_URI,
+                TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+            .load();
+
+    // Use MEMORY_AND_DISK_2 which requires serialization for replication
+    df.persist(org.apache.spark.storage.StorageLevel.MEMORY_AND_DISK_2());
+
+    // Force materialization - this would hang before the serialization fix
+    List<Row> rows = df.collectAsList();
+    assertEquals(TestUtils.TestTable1Config.expectedValues.size(), rows.size());
+
+    // Verify we can read from the persisted DataFrame
+    long count = df.count();
+    assertEquals(TestUtils.TestTable1Config.expectedValues.size(), count);
+
+    df.unpersist();
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/SerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/SerializationTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.TestUtils;
+import org.lance.spark.utils.Optional;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for serialization of Lance Spark connector classes.
+ *
+ * <p>These tests verify that the reader classes can be properly serialized, which is required for
+ * Spark operations like persist() with replication (e.g., MEMORY_AND_DISK_2).
+ *
+ * <p>Note: Full integration testing with persist(MEMORY_AND_DISK_2) is covered in
+ * BaseSparkConnectorReadTest.testPersistWithReplicatedStorageLevel()
+ */
+public class SerializationTest {
+
+  @Test
+  public void testLanceInputPartitionSerializable() throws Exception {
+    LanceInputPartition partition = TestUtils.TestTable1Config.inputPartition;
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(partition);
+    oos.close();
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    LanceInputPartition deserialized = (LanceInputPartition) ois.readObject();
+    ois.close();
+
+    // Verify
+    assertNotNull(deserialized);
+    assertEquals(partition.getPartitionId(), deserialized.getPartitionId());
+    assertEquals(partition.getScanId(), deserialized.getScanId());
+    assertEquals(partition.getSchema(), deserialized.getSchema());
+    assertEquals(
+        partition.getLanceSplit().getFragments(), deserialized.getLanceSplit().getFragments());
+  }
+
+  @Test
+  public void testLanceInputPartitionWithAllFieldsSerializable() throws Exception {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col1", DataTypes.StringType, true),
+              DataTypes.createStructField("col2", DataTypes.IntegerType, false),
+            });
+
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.from(TestUtils.TestTable1Config.datasetUri);
+    LanceSplit split = new LanceSplit(Arrays.asList(0, 1, 2));
+
+    LanceInputPartition partition =
+        new LanceInputPartition(
+            schema,
+            5,
+            split,
+            readOptions,
+            Optional.of("col1 = 'test'"),
+            Optional.of(100),
+            Optional.of(10),
+            Optional.empty(),
+            Optional.empty(),
+            "scan-123");
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(partition);
+    oos.close();
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    LanceInputPartition deserialized = (LanceInputPartition) ois.readObject();
+    ois.close();
+
+    // Verify all fields
+    assertNotNull(deserialized);
+    assertEquals(schema, deserialized.getSchema());
+    assertEquals(5, deserialized.getPartitionId());
+    assertEquals(Arrays.asList(0, 1, 2), deserialized.getLanceSplit().getFragments());
+    assertEquals("col1 = 'test'", deserialized.getWhereCondition().get());
+    assertEquals(Integer.valueOf(100), deserialized.getLimit().get());
+    assertEquals(Integer.valueOf(10), deserialized.getOffset().get());
+    assertEquals("scan-123", deserialized.getScanId());
+  }
+
+  @Test
+  public void testLanceSplitSerializable() throws Exception {
+    LanceSplit split = new LanceSplit(Arrays.asList(0, 1, 2, 3, 4));
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(split);
+    oos.close();
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    LanceSplit deserialized = (LanceSplit) ois.readObject();
+    ois.close();
+
+    assertNotNull(deserialized);
+    assertEquals(Arrays.asList(0, 1, 2, 3, 4), deserialized.getFragments());
+  }
+
+  @Test
+  public void testLanceSparkReadOptionsSerializable() throws Exception {
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.from(TestUtils.TestTable1Config.datasetUri);
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(readOptions);
+    oos.close();
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    LanceSparkReadOptions deserialized = (LanceSparkReadOptions) ois.readObject();
+    ois.close();
+
+    assertNotNull(deserialized);
+    assertEquals(readOptions.getDatasetUri(), deserialized.getDatasetUri());
+  }
+}


### PR DESCRIPTION
Fixes #169.

Prior to the fix, persist() would hang. After the fix, we are able to see the expected `1` return value.
```python
from pyspark.sql import SparkSession
from pyspark import StorageLevel

spark = SparkSession.builder \
    .appName("test") \
    .config("spark.jars.packages", "<your bundle version>") \
    .config("spark.sql.catalog.lance", "com.lance.spark.LanceNamespaceSparkCatalog") \
    .config("spark.sql.catalog.lance.impl", "<your catalog impl>") \
    .getOrCreate()

foo = spark.sql("select title_id from <dataset> 1")
foo.explain()
foo.persist(storageLevel=StorageLevel.MEMORY_AND_DISK_2) # hangs here
foo.count()
```