### PR TITLE
fix: ensure custom namespace is recreated after serde

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -83,6 +83,8 @@ public abstract class BaseLanceNamespaceSparkCatalog implements TableCatalog, Su
   private static final String CONFIG_PARENT_DELIMITER_DEFAULT = ".";
 
   private LanceNamespace namespace;
+  private String namespaceImpl;
+  private Map<String, String> namespaceConfig;
   private String name;
   private Optional<String> extraLevel;
   private Optional<List<String>> parentPrefix;
@@ -100,7 +102,7 @@ public abstract class BaseLanceNamespaceSparkCatalog implements TableCatalog, Su
     if (!options.containsKey(CONFIG_IMPL)) {
       throw new IllegalArgumentException("Missing required configuration: " + CONFIG_IMPL);
     }
-    String impl = options.get(CONFIG_IMPL);
+    this.namespaceImpl = options.get(CONFIG_IMPL);
 
     // Handle parent prefix configuration
     if (options.containsKey(CONFIG_PARENT)) {
@@ -113,18 +115,19 @@ public abstract class BaseLanceNamespaceSparkCatalog implements TableCatalog, Su
       this.parentPrefix = Optional.empty();
     }
 
-    // Initialize the namespace with proper configuration
-    Map<String, String> namespaceOptions = new HashMap<>(options);
+    // Store namespace config for serialization to executors
+    this.namespaceConfig = new HashMap<>(options);
 
     // Use the global buffer allocator
-    this.namespace = LanceNamespace.connect(impl, namespaceOptions, LanceRuntime.allocator());
+    this.namespace =
+        LanceNamespace.connect(namespaceImpl, namespaceConfig, LanceRuntime.allocator());
 
     // Handle extra level name configuration
     if (options.containsKey(CONFIG_EXTRA_LEVEL)) {
       this.extraLevel = Optional.of(options.get(CONFIG_EXTRA_LEVEL));
-    } else if ("dir".equals(impl)) {
+    } else if ("dir".equals(namespaceImpl)) {
       this.extraLevel = Optional.of("default");
-    } else if ("rest".equals(impl)) {
+    } else if ("rest".equals(namespaceImpl)) {
       this.extraLevel = determineExtraLevelForRest();
     } else {
       this.extraLevel = Optional.empty();
@@ -388,6 +391,8 @@ public abstract class BaseLanceNamespaceSparkCatalog implements TableCatalog, Su
         .withCatalogDefaults(catalogConfig)
         .namespace(namespace)
         .tableId(tableId)
+        .namespaceImpl(namespaceImpl)
+        .namespaceConfig(namespaceConfig)
         .build();
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -78,6 +78,12 @@ public class LanceSparkReadOptions implements Serializable {
   /** The table identifier within the namespace, used for credential refresh. */
   private final List<String> tableId;
 
+  /** The namespace implementation type (e.g., "rest", "dir") for reconstruction after deser. */
+  private final String namespaceImpl;
+
+  /** The namespace configuration options for reconstruction after deserialization. */
+  private final Map<String, String> namespaceConfig;
+
   private LanceSparkReadOptions(Builder builder) {
     this.datasetUri = builder.datasetUri;
     String[] paths = extractDbPathAndDatasetName(datasetUri);
@@ -93,6 +99,9 @@ public class LanceSparkReadOptions implements Serializable {
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
+    this.namespaceImpl = builder.namespaceImpl;
+    this.namespaceConfig =
+        builder.namespaceConfig != null ? new HashMap<>(builder.namespaceConfig) : null;
   }
 
   /** Creates a new builder for LanceSparkReadOptions. */
@@ -207,7 +216,15 @@ public class LanceSparkReadOptions implements Serializable {
     return storageOptions;
   }
 
+  /**
+   * Returns the namespace, reconstructing it from config if needed after deserialization.
+   *
+   * @return the namespace, or null if not configured
+   */
   public LanceNamespace getNamespace() {
+    if (namespace == null && hasNamespaceConfig()) {
+      namespace = LanceNamespace.connect(namespaceImpl, namespaceConfig, LanceRuntime.allocator());
+    }
     return namespace;
   }
 
@@ -215,8 +232,33 @@ public class LanceSparkReadOptions implements Serializable {
     return tableId;
   }
 
+  public String getNamespaceImpl() {
+    return namespaceImpl;
+  }
+
+  public Map<String, String> getNamespaceConfig() {
+    return namespaceConfig;
+  }
+
+  /**
+   * Returns true if namespace mode is configured. This checks if the namespace is available or can
+   * be reconstructed from serialized config.
+   */
   public boolean hasNamespace() {
-    return namespace != null && tableId != null;
+    if (namespace != null && tableId != null) {
+      return true;
+    }
+    // Namespace can be reconstructed if we have the config
+    return tableId != null && namespaceImpl != null && namespaceConfig != null;
+  }
+
+  /**
+   * Returns true if the namespace config is available for reconstruction.
+   *
+   * @return true if namespace can be reconstructed from config
+   */
+  public boolean hasNamespaceConfig() {
+    return namespaceImpl != null && namespaceConfig != null;
   }
 
   /**
@@ -311,6 +353,8 @@ public class LanceSparkReadOptions implements Serializable {
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
+    private String namespaceImpl;
+    private Map<String, String> namespaceConfig;
 
     private Builder() {}
 
@@ -366,6 +410,28 @@ public class LanceSparkReadOptions implements Serializable {
 
     public Builder tableId(List<String> tableId) {
       this.tableId = tableId;
+      return this;
+    }
+
+    /**
+     * Sets the namespace implementation type for reconstruction after deserialization.
+     *
+     * @param namespaceImpl the namespace implementation type (e.g., "rest", "dir")
+     * @return this builder
+     */
+    public Builder namespaceImpl(String namespaceImpl) {
+      this.namespaceImpl = namespaceImpl;
+      return this;
+    }
+
+    /**
+     * Sets the namespace configuration for reconstruction after deserialization.
+     *
+     * @param namespaceConfig the namespace configuration options
+     * @return this builder
+     */
+    public Builder namespaceConfig(Map<String, String> namespaceConfig) {
+      this.namespaceConfig = namespaceConfig != null ? new HashMap<>(namespaceConfig) : null;
       return this;
     }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -86,6 +86,7 @@ public class LanceFragmentScanner implements AutoCloseable {
   public static LanceFragmentScanner create(int fragmentId, LanceInputPartition inputPartition) {
     try {
       LanceSparkReadOptions readOptions = inputPartition.getReadOptions();
+
       CacheKey key = new CacheKey(readOptions, inputPartition.getScanId());
       Map<Integer, Fragment> cachedFragments = LOADING_CACHE.get(key);
       Fragment fragment = cachedFragments.get(fragmentId);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LanceSparkReadOptionsTest {
+
+  @Test
+  public void testBuilderWithNamespaceConfig() {
+    Map<String, String> namespaceConfig = new HashMap<>();
+    namespaceConfig.put("impl", "rest");
+    namespaceConfig.put("uri", "http://localhost:8080");
+
+    List<String> tableId = Arrays.asList("namespace1", "table1");
+
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path/to/dataset")
+            .tableId(tableId)
+            .namespaceImpl("rest")
+            .namespaceConfig(namespaceConfig)
+            .build();
+
+    assertEquals("rest", options.getNamespaceImpl());
+    assertNotNull(options.getNamespaceConfig());
+    assertEquals("rest", options.getNamespaceConfig().get("impl"));
+    assertEquals("http://localhost:8080", options.getNamespaceConfig().get("uri"));
+    assertEquals(tableId, options.getTableId());
+  }
+
+  @Test
+  public void testHasNamespaceWithConfig() {
+    Map<String, String> namespaceConfig = new HashMap<>();
+    namespaceConfig.put("impl", "rest");
+
+    List<String> tableId = Arrays.asList("namespace1", "table1");
+
+    // With namespace config but no namespace object
+    LanceSparkReadOptions optionsWithConfig =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path/to/dataset")
+            .tableId(tableId)
+            .namespaceImpl("rest")
+            .namespaceConfig(namespaceConfig)
+            .build();
+
+    // hasNamespace() should return true because config is available for reconstruction
+    assertTrue(optionsWithConfig.hasNamespace());
+    assertTrue(optionsWithConfig.hasNamespaceConfig());
+    // But the actual namespace object is null (not set directly)
+    assertNull(optionsWithConfig.getNamespace());
+  }
+
+  @Test
+  public void testHasNamespaceWithoutConfig() {
+    // Without namespace config
+    LanceSparkReadOptions optionsWithoutConfig =
+        LanceSparkReadOptions.builder().datasetUri("s3://bucket/path/to/dataset").build();
+
+    assertFalse(optionsWithoutConfig.hasNamespace());
+    assertFalse(optionsWithoutConfig.hasNamespaceConfig());
+    assertNull(optionsWithoutConfig.getNamespaceImpl());
+    assertNull(optionsWithoutConfig.getNamespaceConfig());
+  }
+
+  @Test
+  public void testHasNamespaceRequiresTableId() {
+    Map<String, String> namespaceConfig = new HashMap<>();
+    namespaceConfig.put("impl", "rest");
+
+    // With namespace config but no tableId
+    LanceSparkReadOptions optionsNoTableId =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path/to/dataset")
+            .namespaceImpl("rest")
+            .namespaceConfig(namespaceConfig)
+            .build();
+
+    // hasNamespace() should return false because tableId is required
+    assertFalse(optionsNoTableId.hasNamespace());
+    // But hasNamespaceConfig() should still be true
+    assertTrue(optionsNoTableId.hasNamespaceConfig());
+  }
+
+  @Test
+  public void testSerializationPreservesNamespaceConfig()
+      throws IOException, ClassNotFoundException {
+    Map<String, String> namespaceConfig = new HashMap<>();
+    namespaceConfig.put("impl", "rest");
+    namespaceConfig.put("uri", "http://localhost:8080");
+    namespaceConfig.put("token", "secret-token");
+
+    List<String> tableId = Arrays.asList("namespace1", "table1");
+
+    LanceSparkReadOptions original =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path/to/dataset")
+            .tableId(tableId)
+            .namespaceImpl("rest")
+            .namespaceConfig(namespaceConfig)
+            .batchSize(1024)
+            .pushDownFilters(false)
+            .build();
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(original);
+    }
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    LanceSparkReadOptions deserialized;
+    try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+      deserialized = (LanceSparkReadOptions) ois.readObject();
+    }
+
+    // Verify namespace config is preserved
+    assertEquals(original.getNamespaceImpl(), deserialized.getNamespaceImpl());
+    assertEquals(original.getNamespaceConfig(), deserialized.getNamespaceConfig());
+    assertEquals(original.getTableId(), deserialized.getTableId());
+
+    // Verify other fields are preserved
+    assertEquals(original.getDatasetUri(), deserialized.getDatasetUri());
+    assertEquals(original.getBatchSize(), deserialized.getBatchSize());
+    assertEquals(original.isPushDownFilters(), deserialized.isPushDownFilters());
+
+    // The transient namespace field should be null after deserialization
+    // (actual reconstruction happens in LanceFragmentScanner)
+    assertNull(deserialized.getNamespace());
+
+    // But hasNamespaceConfig should still be true
+    assertTrue(deserialized.hasNamespaceConfig());
+  }
+
+  @Test
+  public void testSerializationWithoutNamespaceConfig() throws IOException, ClassNotFoundException {
+    LanceSparkReadOptions original =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path/to/dataset")
+            .batchSize(512)
+            .build();
+
+    // Serialize
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(original);
+    }
+
+    // Deserialize
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    LanceSparkReadOptions deserialized;
+    try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+      deserialized = (LanceSparkReadOptions) ois.readObject();
+    }
+
+    // Verify fields are preserved
+    assertEquals(original.getDatasetUri(), deserialized.getDatasetUri());
+    assertEquals(original.getBatchSize(), deserialized.getBatchSize());
+
+    // No namespace config
+    assertNull(deserialized.getNamespaceImpl());
+    assertNull(deserialized.getNamespaceConfig());
+    assertFalse(deserialized.hasNamespaceConfig());
+  }
+}


### PR DESCRIPTION
# Issue
https://github.com/lance-format/lance-spark/commit/913c6b8f91483d4231e62279bae7c616b0a1e75c modified the codebase to not deserialize namespace, and provided a setter for the reader class on executors to re-add the namespace for use. Looks like the setter was created but was not used. This causes any namespace operations to error out with 403s from object store due to no namespace object being created on the executors.

# Changes
This will instantiate a connection object per partition (which isn't great) on each executor. Ideally we should make a mechanism to allow executors to refresh their creds from the driver so we don't get a thundering-herd of refresh requests for long-running jobs.