### PR TITLE
feat: support refreshing vended credentials in worker

### DIFF
--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceNamespaceSparkCatalog.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceNamespaceSparkCatalog.java
@@ -15,9 +15,18 @@ package org.lance.spark;
 
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Map;
+
 public class LanceNamespaceSparkCatalog extends BaseLanceNamespaceSparkCatalog {
 
-  public LanceDataset createDataset(LanceSparkReadOptions readOptions, StructType sparkSchema) {
-    return new LanceDataset(readOptions, sparkSchema);
+  @Override
+  public LanceDataset createDataset(
+      LanceSparkReadOptions readOptions,
+      StructType sparkSchema,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties) {
+    return new LanceDataset(
+        readOptions, sparkSchema, initialStorageOptions, namespaceImpl, namespaceProperties);
   }
 }

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceSparkDataSource.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceSparkDataSource.java
@@ -18,6 +18,6 @@ import org.apache.spark.sql.types.StructType;
 public class LanceSparkDataSource extends LanceDataSource {
   @Override
   public LanceDataset createDataset(LanceSparkReadOptions readOptions, StructType sparkSchema) {
-    return new LanceDataset(readOptions, sparkSchema);
+    return new LanceDataset(readOptions, sparkSchema, null, null, null);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceNamespaceSparkCatalog.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceNamespaceSparkCatalog.java
@@ -15,9 +15,18 @@ package org.lance.spark;
 
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Map;
+
 public class LanceNamespaceSparkCatalog extends BaseLanceNamespaceSparkCatalog {
 
-  public LanceDataset createDataset(LanceSparkReadOptions readOptions, StructType sparkSchema) {
-    return new LancePositionDeltaDataset(readOptions, sparkSchema);
+  @Override
+  public LanceDataset createDataset(
+      LanceSparkReadOptions readOptions,
+      StructType sparkSchema,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties) {
+    return new LancePositionDeltaDataset(
+        readOptions, sparkSchema, initialStorageOptions, namespaceImpl, namespaceProperties);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
@@ -18,15 +18,27 @@ import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Map;
+
 public class LancePositionDeltaDataset extends LanceDataset implements SupportsRowLevelOperations {
-  public LancePositionDeltaDataset(LanceSparkReadOptions readOptions, StructType sparkSchema) {
-    super(readOptions, sparkSchema);
+  public LancePositionDeltaDataset(
+      LanceSparkReadOptions readOptions,
+      StructType sparkSchema,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties) {
+    super(readOptions, sparkSchema, initialStorageOptions, namespaceImpl, namespaceProperties);
   }
 
   @Override
   public RowLevelOperationBuilder newRowLevelOperationBuilder(
       RowLevelOperationInfo rowLevelOperationInfo) {
     return new LanceRowLevelOperationBuilder(
-        rowLevelOperationInfo.command(), sparkSchema, readOptions());
+        rowLevelOperationInfo.command(),
+        sparkSchema,
+        readOptions(),
+        getInitialStorageOptions(),
+        getNamespaceImpl(),
+        getNamespaceProperties());
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceSparkDataSource.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceSparkDataSource.java
@@ -18,6 +18,6 @@ import org.apache.spark.sql.types.StructType;
 public class LanceSparkDataSource extends LanceDataSource {
   @Override
   public LanceDataset createDataset(LanceSparkReadOptions readOptions, StructType sparkSchema) {
-    return new LancePositionDeltaDataset(readOptions, sparkSchema);
+    return new LancePositionDeltaDataset(readOptions, sparkSchema, null, null, null);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
@@ -19,17 +19,47 @@ import org.apache.spark.sql.connector.write.DeltaWrite;
 import org.apache.spark.sql.connector.write.DeltaWriteBuilder;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.List;
+import java.util.Map;
+
 public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
   private final StructType sparkSchema;
   private final LanceSparkWriteOptions writeOptions;
 
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final Map<String, String> namespaceProperties;
+  private final List<String> tableId;
+
   public SparkPositionDeltaWriteBuilder(
-      StructType sparkSchema, LanceSparkWriteOptions writeOptions) {
+      StructType sparkSchema,
+      LanceSparkWriteOptions writeOptions,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      List<String> tableId) {
     this.sparkSchema = sparkSchema;
     this.writeOptions = writeOptions;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
+    this.tableId = tableId;
   }
 
   public DeltaWrite build() {
-    return new SparkPositionDeltaWrite(sparkSchema, writeOptions);
+    return new SparkPositionDeltaWrite(
+        sparkSchema,
+        writeOptions,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        tableId);
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceCatalog.java
@@ -65,7 +65,7 @@ public class LanceCatalog implements TableCatalog {
     } catch (IllegalArgumentException e) {
       throw new NoSuchTableException(ident);
     }
-    return new LanceDataset(readOptions, schema);
+    return new LanceDataset(readOptions, schema, null, null, null);
   }
 
   @Override
@@ -86,7 +86,7 @@ public class LanceCatalog implements TableCatalog {
     } catch (IllegalArgumentException e) {
       throw new TableAlreadyExistsException(ident);
     }
-    return new LanceDataset(readOptions, schema);
+    return new LanceDataset(readOptions, schema, null, null, null);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
@@ -22,6 +22,7 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.List;
+import java.util.Map;
 
 public class LanceInputPartition implements InputPartition {
   private static final long serialVersionUID = 4723894723984723984L;
@@ -37,25 +38,16 @@ public class LanceInputPartition implements InputPartition {
   private final Optional<Aggregation> pushedAggregation;
   private final String scanId;
 
-  public LanceInputPartition(
-      StructType schema,
-      int partitionId,
-      LanceSplit lanceSplit,
-      LanceSparkReadOptions readOptions,
-      Optional<String> whereCondition,
-      String scanId) {
-    this(
-        schema,
-        partitionId,
-        lanceSplit,
-        readOptions,
-        whereCondition,
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty(),
-        Optional.empty(),
-        scanId);
-  }
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final Map<String, String> namespaceProperties;
 
   public LanceInputPartition(
       StructType schema,
@@ -67,7 +59,10 @@ public class LanceInputPartition implements InputPartition {
       Optional<Integer> offset,
       Optional<List<ColumnOrdering>> topNSortOrders,
       Optional<Aggregation> pushedAggregation,
-      String scanId) {
+      String scanId,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties) {
     this.schema = schema;
     this.partitionId = partitionId;
     this.lanceSplit = lanceSplit;
@@ -78,6 +73,9 @@ public class LanceInputPartition implements InputPartition {
     this.topNSortOrders = topNSortOrders;
     this.pushedAggregation = pushedAggregation;
     this.scanId = scanId;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
   }
 
   public StructType getSchema() {
@@ -118,5 +116,17 @@ public class LanceInputPartition implements InputPartition {
 
   public String getScanId() {
     return scanId;
+  }
+
+  public Map<String, String> getInitialStorageOptions() {
+    return initialStorageOptions;
+  }
+
+  public String getNamespaceImpl() {
+    return namespaceImpl;
+  }
+
+  public Map<String, String> getNamespaceProperties() {
+    return namespaceProperties;
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -53,6 +53,17 @@ public class LanceScan
   private final LanceStatistics statistics;
   private final String scanId = UUID.randomUUID().toString();
 
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final java.util.Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final java.util.Map<String, String> namespaceProperties;
+
   public LanceScan(
       StructType schema,
       LanceSparkReadOptions readOptions,
@@ -61,7 +72,10 @@ public class LanceScan
       Optional<Integer> offset,
       Optional<List<ColumnOrdering>> topNSortOrders,
       Optional<Aggregation> pushedAggregation,
-      LanceStatistics statistics) {
+      LanceStatistics statistics,
+      java.util.Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      java.util.Map<String, String> namespaceProperties) {
     this.schema = schema;
     this.readOptions = readOptions;
     this.whereConditions = whereConditions;
@@ -70,6 +84,9 @@ public class LanceScan
     this.topNSortOrders = topNSortOrders;
     this.pushedAggregation = pushedAggregation;
     this.statistics = statistics;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
   }
 
   @Override
@@ -93,7 +110,10 @@ public class LanceScan
                     offset,
                     topNSortOrders,
                     pushedAggregation,
-                    scanId))
+                    scanId,
+                    initialStorageOptions,
+                    namespaceImpl,
+                    namespaceProperties))
         .toArray(InputPartition[]::new);
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -67,9 +67,28 @@ public class LanceScanBuilder
   // Lazily opened dataset for reuse during scan building
   private Dataset lazyDataset = null;
 
-  public LanceScanBuilder(StructType schema, LanceSparkReadOptions readOptions) {
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final java.util.Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final java.util.Map<String, String> namespaceProperties;
+
+  public LanceScanBuilder(
+      StructType schema,
+      LanceSparkReadOptions readOptions,
+      java.util.Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      java.util.Map<String, String> namespaceProperties) {
     this.schema = schema;
     this.readOptions = readOptions;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
   }
 
   /**
@@ -129,7 +148,10 @@ public class LanceScanBuilder
         offset,
         topNSortOrders,
         pushedAggregation,
-        statistics);
+        statistics,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 import org.apache.spark.sql.types.StructType;
 
 import java.util.List;
+import java.util.Map;
 
 /** Spark write builder. */
 public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOrdering {
@@ -39,16 +40,45 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
   private final StructType schema;
   private final List<String> newColumns;
 
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final Map<String, String> namespaceProperties;
+  private final List<String> tableId;
+
   AddColumnsBackfillWrite(
-      StructType schema, LanceSparkWriteOptions writeOptions, List<String> newColumns) {
+      StructType schema,
+      LanceSparkWriteOptions writeOptions,
+      List<String> newColumns,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      List<String> tableId) {
     this.schema = schema;
     this.writeOptions = writeOptions;
     this.newColumns = newColumns;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
+    this.tableId = tableId;
   }
 
   @Override
   public BatchWrite toBatch() {
-    return new AddColumnsBackfillBatchWrite(schema, writeOptions, newColumns);
+    return new AddColumnsBackfillBatchWrite(
+        schema,
+        writeOptions,
+        newColumns,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        tableId);
   }
 
   @Override
@@ -76,16 +106,45 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
     private final StructType schema;
     private final List<String> newColumns;
 
+    /**
+     * Initial storage options fetched from namespace.describeTable() on the driver. These are
+     * passed to workers so they can reuse the credentials without calling describeTable again.
+     */
+    private final Map<String, String> initialStorageOptions;
+
+    /** Namespace configuration for credential refresh on workers. */
+    private final String namespaceImpl;
+
+    private final Map<String, String> namespaceProperties;
+    private final List<String> tableId;
+
     public AddColumnsWriteBuilder(
-        StructType schema, LanceSparkWriteOptions writeOptions, List<String> newColumns) {
+        StructType schema,
+        LanceSparkWriteOptions writeOptions,
+        List<String> newColumns,
+        Map<String, String> initialStorageOptions,
+        String namespaceImpl,
+        Map<String, String> namespaceProperties,
+        List<String> tableId) {
       this.schema = schema;
       this.writeOptions = writeOptions;
       this.newColumns = newColumns;
+      this.initialStorageOptions = initialStorageOptions;
+      this.namespaceImpl = namespaceImpl;
+      this.namespaceProperties = namespaceProperties;
+      this.tableId = tableId;
     }
 
     @Override
     public Write build() {
-      return new AddColumnsBackfillWrite(schema, writeOptions, newColumns);
+      return new AddColumnsBackfillWrite(
+          schema,
+          writeOptions,
+          newColumns,
+          initialStorageOptions,
+          namespaceImpl,
+          namespaceProperties,
+          tableId);
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -22,21 +22,54 @@ import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.List;
+import java.util.Map;
+
 /** Spark write builder. */
 public class SparkWrite implements Write {
   private final LanceSparkWriteOptions writeOptions;
   private final StructType schema;
   private final boolean overwrite;
 
-  SparkWrite(StructType schema, LanceSparkWriteOptions writeOptions, boolean overwrite) {
+  /**
+   * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
+   * to workers so they can reuse the credentials without calling describeTable again.
+   */
+  private final Map<String, String> initialStorageOptions;
+
+  /** Namespace configuration for credential refresh on workers. */
+  private final String namespaceImpl;
+
+  private final Map<String, String> namespaceProperties;
+  private final List<String> tableId;
+
+  SparkWrite(
+      StructType schema,
+      LanceSparkWriteOptions writeOptions,
+      boolean overwrite,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      List<String> tableId) {
     this.schema = schema;
     this.writeOptions = writeOptions;
     this.overwrite = overwrite;
+    this.initialStorageOptions = initialStorageOptions;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
+    this.tableId = tableId;
   }
 
   @Override
   public BatchWrite toBatch() {
-    return new LanceBatchWrite(schema, writeOptions, overwrite);
+    return new LanceBatchWrite(
+        schema,
+        writeOptions,
+        overwrite,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        tableId);
   }
 
   @Override
@@ -50,14 +83,43 @@ public class SparkWrite implements Write {
     private final StructType schema;
     private boolean overwrite = false;
 
-    public SparkWriteBuilder(StructType schema, LanceSparkWriteOptions writeOptions) {
+    /**
+     * Initial storage options fetched from namespace.describeTable() on the driver. These are
+     * passed to workers so they can reuse the credentials without calling describeTable again.
+     */
+    private final Map<String, String> initialStorageOptions;
+
+    /** Namespace configuration for credential refresh on workers. */
+    private final String namespaceImpl;
+
+    private final Map<String, String> namespaceProperties;
+    private final List<String> tableId;
+
+    public SparkWriteBuilder(
+        StructType schema,
+        LanceSparkWriteOptions writeOptions,
+        Map<String, String> initialStorageOptions,
+        String namespaceImpl,
+        Map<String, String> namespaceProperties,
+        List<String> tableId) {
       this.schema = schema;
       this.writeOptions = writeOptions;
+      this.initialStorageOptions = initialStorageOptions;
+      this.namespaceImpl = namespaceImpl;
+      this.namespaceProperties = namespaceProperties;
+      this.tableId = tableId;
     }
 
     @Override
     public Write build() {
-      return new SparkWrite(schema, writeOptions, overwrite);
+      return new SparkWrite(
+          schema,
+          writeOptions,
+          overwrite,
+          initialStorageOptions,
+          namespaceImpl,
+          namespaceProperties,
+          tableId);
     }
 
     @Override

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -56,7 +56,7 @@ case class AddColumnsBackfillExec(
     }
 
     val relation = DataSourceV2Relation.create(
-      new LanceDataset(originalTable.readOptions(), actualQuery.schema),
+      new LanceDataset(originalTable.readOptions(), actualQuery.schema, null, null, null),
       Some(catalog),
       Some(ident))
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -22,10 +22,11 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.json4s.JsonAST.{JBool, JDouble, JField, JInt, JNull, JObject, JString}
 import org.json4s.jackson.JsonMethods.{compact, render}
 import org.lance.Dataset
+import org.lance.ReadOptions
 import org.lance.index.{Index, IndexOptions, IndexParams, IndexType}
 import org.lance.index.scalar.ScalarIndexParams
 import org.lance.operation.{CreateIndex => AddIndexOperation}
-import org.lance.spark.{LanceDataset, LanceRuntime, LanceSparkReadOptions}
+import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 
 import java.util.{Collections, Optional, UUID}
 
@@ -99,6 +100,21 @@ case class AddIndexExec(
     val uuid = UUID.randomUUID()
     val indexType = IndexTypeUtils.buildIndexType(method)
 
+    // Get namespace info from catalog if available (for credential vending on workers)
+    val (nsImpl, nsProps, tableId, initialStorageOpts): (
+        Option[String],
+        Option[Map[String, String]],
+        Option[List[String]],
+        Option[Map[String, String]]) = catalog match {
+      case nsCatalog: BaseLanceNamespaceSparkCatalog =>
+        (
+          Option(nsCatalog.getNamespaceImpl),
+          Option(nsCatalog.getNamespaceProperties).map(_.asScala.toMap),
+          Option(readOptions.getTableId).map(_.asScala.toList),
+          Option(lanceDataset.getInitialStorageOptions).map(_.asScala.toMap))
+      case _ => (None, None, None, None)
+    }
+
     // Build per-fragment tasks
     val tasks = fragmentIds.map { fid =>
       IndexTaskExecutor.create(
@@ -108,7 +124,11 @@ case class AddIndexExec(
         toJson(args),
         indexName,
         uuid.toString,
-        fid)
+        fid,
+        nsImpl,
+        nsProps,
+        tableId,
+        initialStorageOpts)
     }.toSeq
 
     val rdd = session.sparkContext.parallelize(tasks, tasks.size)
@@ -174,7 +194,12 @@ case class IndexTaskExecutor(
     json: String,
     indexName: String,
     uuid: String,
-    fragmentId: Int) extends Serializable {
+    fragmentId: Int,
+    namespaceImpl: Option[String],
+    namespaceProperties: Option[Map[String, String]],
+    tableId: Option[List[String]],
+    initialStorageOptions: Option[Map[String, String]]) extends Serializable {
+
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](lanceConf)
     val columns = decode[Array[String]](columnsEnc).toSeq
@@ -191,19 +216,26 @@ case class IndexTaskExecutor(
       .withFragmentIds(Collections.singletonList(fragmentId))
       .build()
 
-    val dataset = if (readOptions.hasNamespace) {
-      Dataset.open()
-        .allocator(LanceRuntime.allocator())
-        .namespace(readOptions.getNamespace)
-        .tableId(readOptions.getTableId)
-        .build()
-    } else {
-      Dataset.open()
-        .allocator(LanceRuntime.allocator())
-        .uri(readOptions.getDatasetUri)
-        .readOptions(readOptions.toReadOptions)
-        .build()
+    // Build ReadOptions with merged storage options and credential refresh provider
+    val merged = LanceRuntime.mergeStorageOptions(
+      readOptions.getStorageOptions,
+      initialStorageOptions.map(_.asJava).orNull)
+    val provider = LanceRuntime.getOrCreateStorageOptionsProvider(
+      namespaceImpl.orNull,
+      namespaceProperties.map(_.asJava).orNull,
+      tableId.map(_.asJava).orNull)
+
+    val builder = new ReadOptions.Builder().setStorageOptions(merged)
+    if (provider != null) {
+      builder.setStorageOptionsProvider(provider)
     }
+
+    val dataset = Dataset.open()
+      .allocator(LanceRuntime.allocator())
+      .uri(readOptions.getDatasetUri)
+      .readOptions(builder.build())
+      .build()
+
     try {
       dataset.createIndex(indexOptions)
     } finally {
@@ -222,7 +254,11 @@ object IndexTaskExecutor {
       json: String,
       indexName: String,
       uuid: String,
-      fragmentId: Int): IndexTaskExecutor = {
+      fragmentId: Int,
+      namespaceImpl: Option[String],
+      namespaceProperties: Option[Map[String, String]],
+      tableId: Option[List[String]],
+      initialStorageOptions: Option[Map[String, String]]): IndexTaskExecutor = {
     IndexTaskExecutor(
       encode(readOptions),
       encode(cols.toArray),
@@ -230,7 +266,11 @@ object IndexTaskExecutor {
       json,
       indexName,
       uuid,
-      fragmentId)
+      fragmentId,
+      namespaceImpl,
+      namespaceProperties,
+      tableId,
+      initialStorageOptions)
   }
 }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
@@ -73,11 +73,18 @@ public class TestUtils {
       inputPartition =
           new LanceInputPartition(
               schema,
-              0,
+              0 /* partitionId */,
               new LanceSplit(Arrays.asList(0, 1)),
               readOptions,
-              Optional.empty(),
-              "test");
+              Optional.empty() /* whereCondition */,
+              Optional.empty() /* limit */,
+              Optional.empty() /* offset */,
+              Optional.empty() /* topNSortOrders */,
+              Optional.empty() /* pushedAggregation */,
+              "test" /* scanId */,
+              null /* initialStorageOptions */,
+              null /* namespaceImpl */,
+              null /* namespaceProperties */);
     }
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
@@ -34,11 +34,18 @@ public class LanceColumnarPartitionReaderTest {
     LanceInputPartition partition =
         new LanceInputPartition(
             TestUtils.TestTable1Config.schema,
-            0,
+            0 /* partitionId */,
             split,
             TestUtils.TestTable1Config.readOptions,
-            Optional.empty(),
-            "test");
+            Optional.empty() /* whereCondition */,
+            Optional.empty() /* limit */,
+            Optional.empty() /* offset */,
+            Optional.empty() /* topNSortOrders */,
+            Optional.empty() /* pushedAggregation */,
+            "test" /* scanId */,
+            null /* initialStorageOptions */,
+            null /* namespaceImpl */,
+            null /* namespaceProperties */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;
       int rowIndex = 0;
@@ -69,15 +76,18 @@ public class LanceColumnarPartitionReaderTest {
     LanceInputPartition partition =
         new LanceInputPartition(
             TestUtils.TestTable1Config.schema,
-            0,
+            0 /* partitionId */,
             split,
             TestUtils.TestTable1Config.readOptions,
-            Optional.empty(),
-            Optional.of(1),
-            Optional.of(1),
-            Optional.empty(),
-            Optional.empty(), // pushedAggregation
-            "testOffsetAndLimit");
+            Optional.empty() /* whereCondition */,
+            Optional.of(1) /* limit */,
+            Optional.of(1) /* offset */,
+            Optional.empty() /* topNSortOrders */,
+            Optional.empty() /* pushedAggregation */,
+            "testOffsetAndLimit" /* scanId */,
+            null /* initialStorageOptions */,
+            null /* namespaceImpl */,
+            null /* namespaceProperties */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;
       int rowIndex = 1;
@@ -110,15 +120,18 @@ public class LanceColumnarPartitionReaderTest {
     LanceInputPartition partition =
         new LanceInputPartition(
             TestUtils.TestTable1Config.schema,
-            0,
+            0 /* partitionId */,
             split,
             TestUtils.TestTable1Config.readOptions,
-            Optional.empty(),
-            Optional.of(1),
-            Optional.empty(),
-            Optional.of(Collections.singletonList(builder.build())),
-            Optional.empty(), // pushedAggregation
-            "testTopN");
+            Optional.empty() /* whereCondition */,
+            Optional.of(1) /* limit */,
+            Optional.empty() /* offset */,
+            Optional.of(Collections.singletonList(builder.build())) /* topNSortOrders */,
+            Optional.empty() /* pushedAggregation */,
+            "testTopN" /* scanId */,
+            null /* initialStorageOptions */,
+            null /* namespaceImpl */,
+            null /* namespaceProperties */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceDatasetReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceDatasetReadTest.java
@@ -116,11 +116,18 @@ public class LanceDatasetReadTest {
             fragment,
             new LanceInputPartition(
                 schema,
-                0,
+                0 /* partitionId */,
                 new LanceSplit(Arrays.asList(fragment)),
                 TestUtils.TestTable1Config.readOptions,
-                Optional.empty(),
-                "validateFragment"))) {
+                Optional.empty() /* whereCondition */,
+                Optional.empty() /* limit */,
+                Optional.empty() /* offset */,
+                Optional.empty() /* topNSortOrders */,
+                Optional.empty() /* pushedAggregation */,
+                "validateFragment" /* scanId */,
+                null /* initialStorageOptions */,
+                null /* namespaceImpl */,
+                null /* namespaceProperties */))) {
       try (ArrowReader reader = scanner.getArrowReader()) {
         VectorSchemaRoot root = reader.getVectorSchemaRoot();
         assertNotNull(root);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -59,7 +59,15 @@ public class LanceBatchWriteTest {
       // Append data to lance dataset
       LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
       StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
-      LanceBatchWrite lanceBatchWrite = new LanceBatchWrite(sparkSchema, writeOptions, false);
+      LanceBatchWrite lanceBatchWrite =
+          new LanceBatchWrite(
+              sparkSchema,
+              writeOptions,
+              false,
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null); // tableId
       DataWriterFactory factor = lanceBatchWrite.createBatchWriterFactory(() -> 1);
 
       int rows = 132;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
@@ -52,7 +52,13 @@ public class LanceDataWriterTest {
               tempDir.resolve(datasetName + LanceSparkReadOptions.LANCE_FILE_SUFFIX).toString());
       StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
       LanceDataWriter.WriterFactory writerFactory =
-          new LanceDataWriter.WriterFactory(sparkSchema, writeOptions);
+          new LanceDataWriter.WriterFactory(
+              sparkSchema,
+              writeOptions,
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null); // tableId
       LanceDataWriter dataWriter = (LanceDataWriter) writerFactory.createWriter(0, 0);
 
       int rows = 132;


### PR DESCRIPTION
Based on https://github.com/lance-format/lance-spark/pull/174

Make the changes across the codebase so that we record namespace impl and properties in initial Spark catalog initialization time, and then pass it to worker to perform read and write to properly refresh vended credentials.

Also some refactoring to centralize global caches to `LanceRuntime`

cc @bryanck @jtuglu1