### PR TITLE
fix: set classloader for Kryo

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceSerializeUtil.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceSerializeUtil.scala
@@ -26,6 +26,7 @@ object LanceSerializeUtil {
     override def initialValue(): Kryo = {
       val kryo = new Kryo()
       kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()))
+      kryo.setClassLoader(getClass.getClassLoader)
       kryo
     }
   }


### PR DESCRIPTION
Kryo's default classloader is the one that loaded the Kryo class. However, when loading Lance libraries using `--jars` or `--packages`, the Lance classes will be on a child classloader, while Kryo is on the app classloader. The end result is that Kryo will throw a `ClassNotFoundException` when attempting to instantiate a Lance object during deserialization.

This PR sets the Kryo classloader to be the one that loaded the Lance utility class.
