### PR TITLE
chore: update lance dependency to v2.0.0-rc.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.1.3-beta.7</lance-spark.version>
-        <lance.version>2.0.0-beta.10</lance.version>
+        <lance.version>2.0.0-rc.1</lance.version>
 
         <antlr4.version>4.9.3</antlr4.version>
 


### PR DESCRIPTION
## Summary
- Bump lance-core dependency to 2.0.0-rc.1.
- Dockerfile versions already aligned (LANCE_SPARK_VERSION 0.1.3-beta.7, LANCE_NS_VERSION 0.4.5), so no Docker changes required.

## Testing
- make lint
- make install (after locally installing lance-core 2.0.0-rc.1 with -Dskip.build.jni=true)

## Reference
- refs/tags/v2.0.0-rc.1
