### PR TITLE
chore: update lance dependency to v2.0.0-rc.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.1.3-beta.7</lance-spark.version>
-        <lance.version>2.0.0-beta.10</lance.version>
+        <lance.version>2.0.0-rc.2</lance.version>
 
         <antlr4.version>4.9.3</antlr4.version>
 


### PR DESCRIPTION
## Summary
- Bumped `lance.version` to `2.0.0-rc.2`.
- Verified Dockerfile env versions already match `lance-spark.version` (0.1.3-beta.7) and `lance-namespace-core` (0.4.5).

## Verification
- `make lint`
- `make install`

## References
- Triggering tag: refs/tags/v2.0.0-rc.2
