### PR TITLE
fix: move Spark vectorized classes under org.lance

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
@@ -15,6 +15,8 @@ package org.lance.spark.internal;
 
 import org.lance.spark.LanceConstant;
 import org.lance.spark.read.LanceInputPartition;
+import org.lance.spark.vectorized.BlobStructAccessor;
+import org.lance.spark.vectorized.LanceArrowColumnVector;
 
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -24,12 +26,10 @@ import org.apache.spark.sql.execution.vectorized.ConstantColumnVector;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.vectorized.BlobStructAccessor;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.vectorized.ColumnarMap;
-import org.apache.spark.sql.vectorized.LanceArrowColumnVector;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -18,6 +18,7 @@ import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.vectorized.LanceArrowColumnVector;
 
 import com.google.common.collect.Lists;
 import org.apache.arrow.memory.BufferAllocator;
@@ -28,7 +29,6 @@ import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
-import org.apache.spark.sql.vectorized.LanceArrowColumnVector;
 
 import java.io.IOException;
 import java.util.List;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobPositionColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobPositionColumnVector.java
@@ -11,17 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
-/** A column vector that provides the size values from a blob struct. */
-public class BlobSizeColumnVector extends ColumnVector {
+/** A column vector that provides the position values from a blob struct. */
+public class BlobPositionColumnVector extends ColumnVector {
   private final BlobStructAccessor blobAccessor;
 
-  public BlobSizeColumnVector(BlobStructAccessor blobAccessor) {
+  public BlobPositionColumnVector(BlobStructAccessor blobAccessor) {
     super(DataTypes.LongType);
     this.blobAccessor = blobAccessor;
   }
@@ -48,68 +51,68 @@ public class BlobSizeColumnVector extends ColumnVector {
 
   @Override
   public boolean getBoolean(int rowId) {
-    throw new UnsupportedOperationException("Cannot get boolean from blob size");
+    throw new UnsupportedOperationException("Cannot get boolean from blob position");
   }
 
   @Override
   public byte getByte(int rowId) {
-    throw new UnsupportedOperationException("Cannot get byte from blob size");
+    throw new UnsupportedOperationException("Cannot get byte from blob position");
   }
 
   @Override
   public short getShort(int rowId) {
-    throw new UnsupportedOperationException("Cannot get short from blob size");
+    throw new UnsupportedOperationException("Cannot get short from blob position");
   }
 
   @Override
   public int getInt(int rowId) {
-    Long size = blobAccessor.getSize(rowId);
-    return size != null ? size.intValue() : 0;
+    Long position = blobAccessor.getPosition(rowId);
+    return position != null ? position.intValue() : 0;
   }
 
   @Override
   public long getLong(int rowId) {
-    Long size = blobAccessor.getSize(rowId);
-    return size != null ? size : 0L;
+    Long position = blobAccessor.getPosition(rowId);
+    return position != null ? position : 0L;
   }
 
   @Override
   public float getFloat(int rowId) {
-    throw new UnsupportedOperationException("Cannot get float from blob size");
+    throw new UnsupportedOperationException("Cannot get float from blob position");
   }
 
   @Override
   public double getDouble(int rowId) {
-    throw new UnsupportedOperationException("Cannot get double from blob size");
+    throw new UnsupportedOperationException("Cannot get double from blob position");
   }
 
   @Override
   public ColumnarArray getArray(int rowId) {
-    throw new UnsupportedOperationException("Cannot get array from blob size");
+    throw new UnsupportedOperationException("Cannot get array from blob position");
   }
 
   @Override
   public ColumnarMap getMap(int ordinal) {
-    throw new UnsupportedOperationException("Cannot get map from blob size");
+    throw new UnsupportedOperationException("Cannot get map from blob position");
   }
 
   @Override
   public Decimal getDecimal(int rowId, int precision, int scale) {
-    throw new UnsupportedOperationException("Cannot get decimal from blob size");
+    throw new UnsupportedOperationException("Cannot get decimal from blob position");
   }
 
   @Override
   public UTF8String getUTF8String(int rowId) {
-    throw new UnsupportedOperationException("Cannot get string from blob size");
+    throw new UnsupportedOperationException("Cannot get string from blob position");
   }
 
   @Override
   public byte[] getBinary(int rowId) {
-    throw new UnsupportedOperationException("Cannot get binary from blob size");
+    throw new UnsupportedOperationException("Cannot get binary from blob position");
   }
 
   @Override
   public ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException("Blob size has no children");
+    throw new UnsupportedOperationException("Blob position has no children");
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobSizeColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobSizeColumnVector.java
@@ -11,17 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
-/** A column vector that provides the position values from a blob struct. */
-public class BlobPositionColumnVector extends ColumnVector {
+/** A column vector that provides the size values from a blob struct. */
+public class BlobSizeColumnVector extends ColumnVector {
   private final BlobStructAccessor blobAccessor;
 
-  public BlobPositionColumnVector(BlobStructAccessor blobAccessor) {
+  public BlobSizeColumnVector(BlobStructAccessor blobAccessor) {
     super(DataTypes.LongType);
     this.blobAccessor = blobAccessor;
   }
@@ -48,68 +51,68 @@ public class BlobPositionColumnVector extends ColumnVector {
 
   @Override
   public boolean getBoolean(int rowId) {
-    throw new UnsupportedOperationException("Cannot get boolean from blob position");
+    throw new UnsupportedOperationException("Cannot get boolean from blob size");
   }
 
   @Override
   public byte getByte(int rowId) {
-    throw new UnsupportedOperationException("Cannot get byte from blob position");
+    throw new UnsupportedOperationException("Cannot get byte from blob size");
   }
 
   @Override
   public short getShort(int rowId) {
-    throw new UnsupportedOperationException("Cannot get short from blob position");
+    throw new UnsupportedOperationException("Cannot get short from blob size");
   }
 
   @Override
   public int getInt(int rowId) {
-    Long position = blobAccessor.getPosition(rowId);
-    return position != null ? position.intValue() : 0;
+    Long size = blobAccessor.getSize(rowId);
+    return size != null ? size.intValue() : 0;
   }
 
   @Override
   public long getLong(int rowId) {
-    Long position = blobAccessor.getPosition(rowId);
-    return position != null ? position : 0L;
+    Long size = blobAccessor.getSize(rowId);
+    return size != null ? size : 0L;
   }
 
   @Override
   public float getFloat(int rowId) {
-    throw new UnsupportedOperationException("Cannot get float from blob position");
+    throw new UnsupportedOperationException("Cannot get float from blob size");
   }
 
   @Override
   public double getDouble(int rowId) {
-    throw new UnsupportedOperationException("Cannot get double from blob position");
+    throw new UnsupportedOperationException("Cannot get double from blob size");
   }
 
   @Override
   public ColumnarArray getArray(int rowId) {
-    throw new UnsupportedOperationException("Cannot get array from blob position");
+    throw new UnsupportedOperationException("Cannot get array from blob size");
   }
 
   @Override
   public ColumnarMap getMap(int ordinal) {
-    throw new UnsupportedOperationException("Cannot get map from blob position");
+    throw new UnsupportedOperationException("Cannot get map from blob size");
   }
 
   @Override
   public Decimal getDecimal(int rowId, int precision, int scale) {
-    throw new UnsupportedOperationException("Cannot get decimal from blob position");
+    throw new UnsupportedOperationException("Cannot get decimal from blob size");
   }
 
   @Override
   public UTF8String getUTF8String(int rowId) {
-    throw new UnsupportedOperationException("Cannot get string from blob position");
+    throw new UnsupportedOperationException("Cannot get string from blob size");
   }
 
   @Override
   public byte[] getBinary(int rowId) {
-    throw new UnsupportedOperationException("Cannot get binary from blob position");
+    throw new UnsupportedOperationException("Cannot get binary from blob size");
   }
 
   @Override
   public ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException("Blob position has no children");
+    throw new UnsupportedOperationException("Blob size has no children");
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobStructAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/BlobStructAccessor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.complex.StructVector;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/FixedSizeListAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/FixedSizeListAccessor.java
@@ -11,10 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
 
 /**
  * Accessor for FixedSizeListVector that provides array access for Spark. This wraps a

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrayAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrayAccessor.java
@@ -11,25 +11,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
 
-public class LanceArrayAccessor extends ArrowColumnVector.ArrowVectorAccessor {
+public class LanceArrayAccessor {
 
   private final ListVector accessor;
   private final LanceArrowColumnVector arrayData;
 
   public LanceArrayAccessor(ListVector vector) {
-    super(vector);
     this.accessor = vector;
     this.arrayData = new LanceArrowColumnVector(vector.getDataVector());
   }
 
-  @Override
-  final ColumnarArray getArray(int rowId) {
+  public boolean isNullAt(int rowId) {
+    return this.accessor.isNull(rowId);
+  }
+
+  public int getNullCount() {
+    return this.accessor.getNullCount();
+  }
+
+  public ColumnarArray getArray(int rowId) {
     int start = accessor.getElementStartIndex(rowId);
     int end = accessor.getElementEndIndex(rowId);
     return new ColumnarArray(arrayData, start, end - start);
+  }
+
+  public void close() {
+    this.accessor.close();
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.lance.spark.utils.BlobUtils;
 
@@ -27,6 +27,10 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.util.LanceArrowUtils;
+import org.apache.spark.sql.vectorized.ArrowColumnVector;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
 public class LanceArrowColumnVector extends ColumnVector {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceLargeArrayAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceLargeArrayAccessor.java
@@ -11,30 +11,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
 
 /**
  * Accessor for LargeListVector (64-bit offset lists) that wraps element vectors in
  * LanceArrowColumnVector. This ensures that elements are properly handled by Lance-specific
  * accessors.
  */
-public class LanceLargeArrayAccessor extends ArrowColumnVector.ArrowVectorAccessor {
+public class LanceLargeArrayAccessor {
 
   private final LargeListVector accessor;
   private final LanceArrowColumnVector arrayData;
 
   public LanceLargeArrayAccessor(LargeListVector vector) {
-    super(vector);
     this.accessor = vector;
     this.arrayData = new LanceArrowColumnVector(vector.getDataVector());
   }
 
-  @Override
-  final ColumnarArray getArray(int rowId) {
+  public boolean isNullAt(int rowId) {
+    return this.accessor.isNull(rowId);
+  }
+
+  public int getNullCount() {
+    return this.accessor.getNullCount();
+  }
+
+  public ColumnarArray getArray(int rowId) {
     long start = accessor.getElementStartIndex(rowId);
     long end = accessor.getElementEndIndex(rowId);
     return new ColumnarArray(arrayData, (int) start, (int) (end - start));
+  }
+
+  public void close() {
+    this.accessor.close();
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceStructAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceStructAccessor.java
@@ -11,22 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.spark.sql.vectorized.ColumnVector;
 
 /**
  * Accessor for Arrow StructVector that wraps child vectors in LanceArrowColumnVector. This ensures
  * that nested fields within structs (including arrays) are properly handled by Lance-specific
  * accessors.
  */
-public class LanceStructAccessor extends ArrowColumnVector.ArrowVectorAccessor {
+public class LanceStructAccessor {
 
   private final StructVector accessor;
   private final LanceArrowColumnVector[] childColumns;
 
   public LanceStructAccessor(StructVector vector) {
-    super(vector);
     this.accessor = vector;
 
     // Create LanceArrowColumnVector wrappers for all child vectors
@@ -37,6 +37,14 @@ public class LanceStructAccessor extends ArrowColumnVector.ArrowVectorAccessor {
     }
   }
 
+  public boolean isNullAt(int rowId) {
+    return this.accessor.isNull(rowId);
+  }
+
+  public int getNullCount() {
+    return this.accessor.getNullCount();
+  }
+
   /**
    * Returns the child column vector at the given ordinal.
    *
@@ -45,5 +53,9 @@ public class LanceStructAccessor extends ArrowColumnVector.ArrowVectorAccessor {
    */
   public ColumnVector getChild(int ordinal) {
     return childColumns[ordinal];
+  }
+
+  public void close() {
+    this.accessor.close();
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LargeVarCharAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LargeVarCharAccessor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.spark.unsafe.types.UTF8String;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt1Accessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt1Accessor.java
@@ -11,23 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
-import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.UInt1Vector;
 
 /**
- * Accessor for unsigned 64-bit integers (UInt8). Maps to Spark LongType (may overflow for values
- * &gt; Long.MAX_VALUE, but no better option).
+ * Accessor for unsigned 8-bit integers (UInt1). Maps to Spark ShortType (signed 16-bit can hold all
+ * UInt8 values 0-255).
  */
-public class UInt8Accessor {
-  private final UInt8Vector accessor;
+public class UInt1Accessor {
+  private final UInt1Vector accessor;
 
-  UInt8Accessor(UInt8Vector vector) {
+  UInt1Accessor(UInt1Vector vector) {
     this.accessor = vector;
   }
 
-  final long getLong(int rowId) {
-    return accessor.getObjectNoOverflow(rowId).longValueExact();
+  final short getShort(int rowId) {
+    return (short) Byte.toUnsignedInt(accessor.get(rowId));
   }
 
   final boolean isNullAt(int rowId) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt2Accessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt2Accessor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
 import org.apache.arrow.vector.UInt2Vector;
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt4Accessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt4Accessor.java
@@ -11,23 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
-import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt4Vector;
 
 /**
- * Accessor for unsigned 8-bit integers (UInt1). Maps to Spark ShortType (signed 16-bit can hold all
- * UInt8 values 0-255).
+ * Accessor for unsigned 32-bit integers (UInt4). Maps to Spark LongType (signed 64-bit can hold all
+ * UInt32 values 0-4294967295).
  */
-public class UInt1Accessor {
-  private final UInt1Vector accessor;
+public class UInt4Accessor {
+  private final UInt4Vector accessor;
 
-  UInt1Accessor(UInt1Vector vector) {
+  UInt4Accessor(UInt4Vector vector) {
     this.accessor = vector;
   }
 
-  final short getShort(int rowId) {
-    return (short) Byte.toUnsignedInt(accessor.get(rowId));
+  final long getLong(int rowId) {
+    return Integer.toUnsignedLong(accessor.get(rowId));
   }
 
   final boolean isNullAt(int rowId) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt8Accessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/UInt8Accessor.java
@@ -11,23 +11,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.spark.sql.vectorized;
+package org.lance.spark.vectorized;
 
-import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
 
 /**
- * Accessor for unsigned 32-bit integers (UInt4). Maps to Spark LongType (signed 64-bit can hold all
- * UInt32 values 0-4294967295).
+ * Accessor for unsigned 64-bit integers (UInt8). Maps to Spark LongType (may overflow for values
+ * &gt; Long.MAX_VALUE, but no better option).
  */
-public class UInt4Accessor {
-  private final UInt4Vector accessor;
+public class UInt8Accessor {
+  private final UInt8Vector accessor;
 
-  UInt4Accessor(UInt4Vector vector) {
+  UInt8Accessor(UInt8Vector vector) {
     this.accessor = vector;
   }
 
   final long getLong(int rowId) {
-    return Integer.toUnsignedLong(accessor.get(rowId));
+    return accessor.getObjectNoOverflow(rowId).longValueExact();
   }
 
   final boolean isNullAt(int rowId) {

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/vectorized/LanceArrowColumnVectorSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/vectorized/LanceArrowColumnVectorSuite.scala
@@ -29,6 +29,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.{ArrowUtils, LanceArrowUtils}
 import org.apache.spark.unsafe.types.UTF8String
 import org.lance.spark.LanceConstant
+import org.lance.spark.vectorized.LanceArrowColumnVector
 import org.scalatest.funsuite.AnyFunSuite
 
 class LanceArrowColumnVectorSuite extends AnyFunSuite {


### PR DESCRIPTION
In a standard Spark setup, Spark loads its own jars (e.g. those in the `jars` directory) using the app classloader, and additional jars (e.g. using `--jars` or `--packages`) via a child classloader. Java modules are loaded by a single classloader, and packages shouldn't span multiple modules.

Currently, the Lance vectorized reader classes in the Lance Spark bundle are in the `org.apache.spark.sql.vectorized` package, and Spark classes also use this package. This causes issues when loading the Lance Spark bundle in Spark's child classloader. For example, the `LanceArrayAccessor` extends `ArrowColumnVector$ArrowVectorAccessor`, these classes are in the same package but will be in different modules. The end result is an error such as:

```java.lang.IllegalAccessError: class org.apache.spark.sql.vectorized.LanceArrayAccessor cannot access its abstract superclass org.apache.spark.sql.vectorized.ArrowColumnVector$ArrowVectorAccessor (org.apache.spark.sql.vectorized.LanceArrayAccessor is in unnamed module of loader org.apache.spark.util.MutableURLClassLoader @20de05e5; org.apache.spark.sql.vectorized.ArrowColumnVector$ArrowVectorAccessor is in unnamed module of loader 'app')```

To reproduce, you can launch Spark like `spark-shell --jars lance-bundle.jar` and then query a table with an array column.

This PR moves the vectorized reader classes from the Spark package `org.apache.spark.sql.vectorized` to the Lance package `org.lance.spark.vectorized` and removes the inheritance of `ArrowVectorAccessor`.