### PR TITLE
chore: update lance dependency to v2.0.0-rc.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.1.3-beta.7</lance-spark.version>
-        <lance.version>2.0.0-beta.10</lance.version>
+        <lance.version>2.0.0-rc.3</lance.version>
 
         <antlr4.version>4.9.3</antlr4.version>
 


### PR DESCRIPTION
## Summary
- Bump Lance dependency to `2.0.0-rc.3`.
- Dockerfile versions unchanged: `LANCE_SPARK_VERSION` already matches `0.1.3-beta.7`, and `LANCE_NS_VERSION` remains `0.4.5` (per lance-core `2.0.0-rc.3` POM).

## Build Verification
- `make lint`
- `make install` (after installing `org.lance:lance-core:2.0.0-rc.3` locally from tag `refs/tags/v2.0.0-rc.3` with `-Dskip.build.jni=true`)

## Reference
- https://github.com/lance-format/lance/releases/tag/v2.0.0-rc.3 (refs/tags/v2.0.0-rc.3)
