### PR TITLE
chore: update lance dependency to v2.0.0-rc.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.1.3-beta.7</lance-spark.version>
-        <lance.version>2.0.0-beta.10</lance.version>
+        <lance.version>2.0.0-rc.4</lance.version>
 
         <antlr4.version>4.9.3</antlr4.version>
 


### PR DESCRIPTION
## Summary
- Bump lance-core dependency to 2.0.0-rc.4 via the root pom.
- Dockerfile versions already aligned (LANCE_SPARK_VERSION=0.1.3-beta.7, LANCE_NS_VERSION=0.4.5).

## Build Verification
- `make lint`
- `make install` (fails: org.lance:lance-core:2.0.0-rc.4 not found in Maven Central)

## Triggering Tag
- refs/tags/v2.0.0-rc.4
