### PR TITLE
feat: enable create / drop tags and using tags as version on select queries

### DIFF
--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,7 +15,7 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, DropTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
 
 import scala.jdk.CollectionConverters._
 
@@ -88,6 +88,12 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val tagName = ctx.tagName.getText
     val version = Option(ctx.version).map(_.accept(this))
     CreateTag(table, tagName, version)
+  }
+
+  override def visitDropTag(ctx: LanceSqlExtensionsParser.DropTagContext): DropTag = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val tagName = ctx.tagName.getText
+    DropTag(table, tagName)
   }
 
   override def visitNumericVersion(ctx: LanceSqlExtensionsParser.NumericVersionContext)

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,7 +15,7 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, DropTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
 
 import scala.jdk.CollectionConverters._
 
@@ -88,6 +88,12 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val tagName = ctx.tagName.getText
     val version = Option(ctx.version).map(_.accept(this))
     CreateTag(table, tagName, version)
+  }
+
+  override def visitDropTag(ctx: LanceSqlExtensionsParser.DropTagContext): DropTag = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val tagName = ctx.tagName.getText
+    DropTag(table, tagName)
   }
 
   override def visitNumericVersion(ctx: LanceSqlExtensionsParser.NumericVersionContext)

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,7 +15,7 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, DropTag, LogicalPlan, NamedArgument, Optimize, Vacuum}
 
 import scala.jdk.CollectionConverters._
 
@@ -88,6 +88,12 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val tagName = ctx.tagName.getText
     val version = Option(ctx.version).map(_.accept(this))
     CreateTag(table, tagName, version)
+  }
+
+  override def visitDropTag(ctx: LanceSqlExtensionsParser.DropTagContext): DropTag = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val tagName = ctx.tagName.getText
+    DropTag(table, tagName)
   }
 
   override def visitNumericVersion(ctx: LanceSqlExtensionsParser.NumericVersionContext)

--- a/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
+++ b/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
@@ -22,6 +22,7 @@ statement
     : ALTER TABLE multipartIdentifier ADD COLUMNS columnList FROM identifier                    #addColumnsBackfill
     | ALTER TABLE multipartIdentifier CREATE INDEX indexName=identifier USING method=identifier '(' columnList ')' (WITH '(' (namedArgument (',' namedArgument)*)? ')')? #createIndex
     | ALTER TABLE multipartIdentifier CREATE TAG tagName=identifier (VERSION AS OF version=versionValue)? #createTag
+    | ALTER TABLE multipartIdentifier DROP TAG tagName=identifier                               #dropTag
     | OPTIMIZE multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?        #optimize
     | VACUUM multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?          #vacuum
     ;
@@ -73,6 +74,7 @@ ALTER: 'ALTER';
 AS: 'AS';
 COLUMNS: 'COLUMNS';
 CREATE: 'CREATE';
+DROP: 'DROP';
 FROM: 'FROM';
 INDEX: 'INDEX';
 OF: 'OF';

--- a/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
+++ b/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
@@ -21,8 +21,14 @@ singleStatement
 statement
     : ALTER TABLE multipartIdentifier ADD COLUMNS columnList FROM identifier                    #addColumnsBackfill
     | ALTER TABLE multipartIdentifier CREATE INDEX indexName=identifier USING method=identifier '(' columnList ')' (WITH '(' (namedArgument (',' namedArgument)*)? ')')? #createIndex
+    | ALTER TABLE multipartIdentifier CREATE TAG tagName=identifier (VERSION AS OF version=versionValue)? #createTag
     | OPTIMIZE multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?        #optimize
     | VACUUM multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?          #vacuum
+    ;
+
+versionValue
+    : number                          #numericVersion
+    | STRING                          #stringVersion
     ;
 
 multipartIdentifier
@@ -64,14 +70,18 @@ number
 
 ADD: 'ADD';
 ALTER: 'ALTER';
+AS: 'AS';
 COLUMNS: 'COLUMNS';
 CREATE: 'CREATE';
 FROM: 'FROM';
 INDEX: 'INDEX';
+OF: 'OF';
 OPTIMIZE: 'OPTIMIZE';
 TABLE: 'TABLE';
+TAG: 'TAG';
 USING: 'USING';
 VACUUM: 'VACUUM';
+VERSION: 'VERSION';
 WITH: 'WITH';
 
 TRUE: 'TRUE';

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -70,6 +70,7 @@ public class LanceSparkReadOptions implements Serializable {
   private final boolean pushDownFilters;
   private final Integer blockSize;
   private final Integer version;
+  private final String tag;
   private final Integer indexCacheSize;
   private final Integer metadataCacheSize;
   private final int batchSize;
@@ -91,6 +92,7 @@ public class LanceSparkReadOptions implements Serializable {
     this.pushDownFilters = builder.pushDownFilters;
     this.blockSize = builder.blockSize;
     this.version = builder.version;
+    this.tag = builder.tag;
     this.indexCacheSize = builder.indexCacheSize;
     this.metadataCacheSize = builder.metadataCacheSize;
     this.batchSize = builder.batchSize;
@@ -193,6 +195,10 @@ public class LanceSparkReadOptions implements Serializable {
     return version;
   }
 
+  public String getTag() {
+    return tag;
+  }
+
   public Integer getIndexCacheSize() {
     return indexCacheSize;
   }
@@ -267,6 +273,9 @@ public class LanceSparkReadOptions implements Serializable {
     if (version != null) {
       builder.setVersion(version);
     }
+    if (tag != null) {
+      builder.setTag(tag);
+    }
     if (indexCacheSize != null) {
       builder.setIndexCacheSize(indexCacheSize);
     }
@@ -293,6 +302,7 @@ public class LanceSparkReadOptions implements Serializable {
         && Objects.equals(datasetUri, that.datasetUri)
         && Objects.equals(blockSize, that.blockSize)
         && Objects.equals(version, that.version)
+        && Objects.equals(tag, that.tag)
         && Objects.equals(indexCacheSize, that.indexCacheSize)
         && Objects.equals(metadataCacheSize, that.metadataCacheSize)
         && Objects.equals(storageOptions, that.storageOptions)
@@ -306,6 +316,7 @@ public class LanceSparkReadOptions implements Serializable {
         pushDownFilters,
         blockSize,
         version,
+        tag,
         indexCacheSize,
         metadataCacheSize,
         batchSize,
@@ -321,6 +332,7 @@ public class LanceSparkReadOptions implements Serializable {
     private Integer blockSize;
     private Query nearest;
     private Integer version;
+    private String tag;
     private Integer indexCacheSize;
     private Integer metadataCacheSize;
     private int batchSize = DEFAULT_BATCH_SIZE;
@@ -362,6 +374,11 @@ public class LanceSparkReadOptions implements Serializable {
 
     public Builder version(Integer version) {
       this.version = version;
+      return this;
+    }
+
+    public Builder tag(String tag) {
+      this.tag = tag;
       return this;
     }
 
@@ -415,7 +432,12 @@ public class LanceSparkReadOptions implements Serializable {
         this.blockSize = Integer.parseInt(options.get(CONFIG_BLOCK_SIZE));
       }
       if (options.containsKey(CONFIG_VERSION)) {
-        this.version = Integer.parseInt(options.get(CONFIG_VERSION));
+        String versionValue = options.get(CONFIG_VERSION);
+        try {
+          this.version = Integer.parseInt(versionValue);
+        } catch (NumberFormatException e) {
+          this.tag = versionValue;
+        }
       }
       if (options.containsKey(CONFIG_INDEX_CACHE_SIZE)) {
         this.indexCacheSize = Integer.parseInt(options.get(CONFIG_INDEX_CACHE_SIZE));

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTag.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTag.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
+/**
+ * CreateTag logical plan representing tag creation on a Lance dataset.
+ *
+ * This command creates a named tag for a specific version (or latest if not specified).
+ * The version can be specified as either:
+ * - A Long representing the numeric version number
+ * - A String representing a tag name that will be resolved to a version
+ */
+case class CreateTag(
+    table: LogicalPlan,
+    tagName: String,
+    version: Option[Any]) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = CreateTagOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    version match {
+      case Some(v) => s"CreateTag($tagName for version $v)"
+      case None => s"CreateTag($tagName for latest)"
+    }
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan])
+      : CreateTag = {
+    copy(table = newChildren(0))
+  }
+}
+
+object CreateTagOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("tag_name", DataTypes.StringType, nullable = false),
+      StructField("version", DataTypes.LongType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DropTag.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DropTag.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
+/**
+ * DropTag logical plan representing tag deletion on a Lance dataset.
+ *
+ * This command deletes a named tag from the dataset.
+ */
+case class DropTag(
+    table: LogicalPlan,
+    tagName: String) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = DropTagOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    s"DropTag($tagName)"
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): DropTag = {
+    copy(table = newChildren(0))
+  }
+}
+
+object DropTagOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("tag_name", DataTypes.StringType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTagExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTagExec.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.CreateTagOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.{Dataset, Ref}
+import org.lance.spark.{LanceDataset, LanceRuntime, LanceSparkReadOptions}
+
+case class CreateTagExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    tagName: String,
+    version: Option[Any]) extends LeafV2CommandExec {
+
+  override def output: Seq[Attribute] = CreateTagOutputType.SCHEMA
+
+  override protected def run(): Seq[InternalRow] = {
+    val lanceDataset = catalog.loadTable(ident) match {
+      case lanceDataset: LanceDataset => lanceDataset
+      case _ =>
+        throw new UnsupportedOperationException("CREATE TAG only supports LanceDataset")
+    }
+
+    val readOptions = lanceDataset.readOptions()
+
+    val taggedVersion = {
+      val dataset = openDataset(readOptions)
+      try {
+        version match {
+          case Some(v: java.lang.Long) =>
+            dataset.tags().create(tagName, Ref.ofMain(v.longValue()))
+            v.longValue()
+          case Some(v: String) =>
+            dataset.tags().create(tagName, Ref.ofTag(v))
+            dataset.version()
+          case None =>
+            val latestVersion = dataset.latestVersion()
+            dataset.tags().create(tagName, Ref.ofMain(latestVersion))
+            latestVersion
+          case Some(other) =>
+            throw new IllegalArgumentException(
+              s"Unsupported version type: ${other.getClass.getName}")
+        }
+      } finally {
+        dataset.close()
+      }
+    }
+
+    Seq(new GenericInternalRow(Array[Any](UTF8String.fromString(tagName), taggedVersion)))
+  }
+
+  private def openDataset(readOptions: LanceSparkReadOptions): Dataset = {
+    if (readOptions.hasNamespace) {
+      Dataset.open()
+        .allocator(LanceRuntime.allocator())
+        .namespace(readOptions.getNamespace)
+        .tableId(readOptions.getTableId)
+        .build()
+    } else {
+      Dataset.open()
+        .allocator(LanceRuntime.allocator())
+        .uri(readOptions.getDatasetUri)
+        .readOptions(readOptions.toReadOptions())
+        .build()
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropTagExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropTagExec.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.DropTagOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.Dataset
+import org.lance.spark.{LanceDataset, LanceRuntime, LanceSparkReadOptions}
+
+case class DropTagExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    tagName: String) extends LeafV2CommandExec {
+
+  override def output: Seq[Attribute] = DropTagOutputType.SCHEMA
+
+  override protected def run(): Seq[InternalRow] = {
+    val lanceDataset = catalog.loadTable(ident) match {
+      case lanceDataset: LanceDataset => lanceDataset
+      case _ =>
+        throw new UnsupportedOperationException("DROP TAG only supports LanceDataset")
+    }
+
+    val readOptions = lanceDataset.readOptions()
+
+    val dataset = openDataset(readOptions)
+    try {
+      dataset.tags().delete(tagName)
+    } finally {
+      dataset.close()
+    }
+
+    Seq(new GenericInternalRow(Array[Any](UTF8String.fromString(tagName))))
+  }
+
+  private def openDataset(readOptions: LanceSparkReadOptions): Dataset = {
+    if (readOptions.hasNamespace) {
+      Dataset.open()
+        .allocator(LanceRuntime.allocator())
+        .namespace(readOptions.getNamespace)
+        .tableId(readOptions.getTableId)
+        .build()
+    } else {
+      Dataset.open()
+        .allocator(LanceRuntime.allocator())
+        .uri(readOptions.getDatasetUri)
+        .readOptions(readOptions.toReadOptions())
+        .build()
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, LogicalPlan, Optimize, Vacuum}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, DropTag, LogicalPlan, Optimize, Vacuum}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 
@@ -44,6 +44,9 @@ case class LanceDataSourceV2Strategy(session: SparkSession) extends SparkStrateg
 
     case CreateTag(ResolvedIdentifier(catalog, ident), tagName, version) =>
       CreateTagExec(asTableCatalog(catalog), ident, tagName, version) :: Nil
+
+    case DropTag(ResolvedIdentifier(catalog, ident), tagName) =>
+      DropTagExec(asTableCatalog(catalog), ident, tagName) :: Nil
 
     case _ => Nil
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.ResolvedIdentifier
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
-import org.apache.spark.sql.catalyst.plans.logical._
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, CreateTag, LogicalPlan, Optimize, Vacuum}
 import org.apache.spark.sql.connector.catalog._
 import org.apache.spark.sql.execution.{SparkPlan, SparkStrategy}
 
@@ -41,6 +41,9 @@ case class LanceDataSourceV2Strategy(session: SparkSession) extends SparkStrateg
         method,
         columns,
         args) :: Nil
+
+    case CreateTag(ResolvedIdentifier(catalog, ident), tagName, version) =>
+      CreateTagExec(asTableCatalog(catalog), ident, tagName, version) :: Nil
 
     case _ => Nil
   }


### PR DESCRIPTION
Adding support for tags in various APIs:

## Spark SQL
To create a new tag using the specified "<version>" or latest if not provided.
`ALTER TABLE <table> CREATE TAG <tag> [VERSION AS OF <version>]`

To delete an existing tag
`ALTER TABLE <table> DROP TAG <tag>`

To query a table using tag as version
`SELECT * FROM <table> VERSION AS OF <tag>`

## Spark API
```
spark.read()
    .option("version", "<tag>")
    ...
```