### PR TITLE
fix: pin arrow version to 15.0

### DIFF
--- a/lance-spark-3.4_2.12/pom.xml
+++ b/lance-spark-3.4_2.12/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala212.version}</scala.version>
         <scala.compat.version>${scala212.compat.version}</scala.compat.version>
+        <arrow.version>${arrow14.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-3.4_2.13/pom.xml
+++ b/lance-spark-3.4_2.13/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala213.version}</scala.version>
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow14.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-3.5_2.12/pom.xml
+++ b/lance-spark-3.5_2.12/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala212.version}</scala.version>
         <scala.compat.version>${scala212.compat.version}</scala.compat.version>
+        <arrow.version>${arrow15.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-3.5_2.13/pom.xml
+++ b/lance-spark-3.5_2.13/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala213.version}</scala.version>
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow15.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-4.0_2.13/pom.xml
+++ b/lance-spark-4.0_2.13/pom.xml
@@ -19,6 +19,7 @@
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
         <antlr4.version>4.13.1</antlr4.version>
         <java.release>17</java.release>
+        <arrow.version>${arrow17.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-bundle-3.4_2.12/pom.xml
+++ b/lance-spark-bundle-3.4_2.12/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala212.version}</scala.version>
         <scala.compat.version>${scala212.compat.version}</scala.compat.version>
+        <arrow.version>${arrow14.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-bundle-3.4_2.13/pom.xml
+++ b/lance-spark-bundle-3.4_2.13/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala213.version}</scala.version>
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow14.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-bundle-3.5_2.12/pom.xml
+++ b/lance-spark-bundle-3.5_2.12/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala212.version}</scala.version>
         <scala.compat.version>${scala212.compat.version}</scala.compat.version>
+        <arrow.version>${arrow15.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-bundle-3.5_2.13/pom.xml
+++ b/lance-spark-bundle-3.5_2.13/pom.xml
@@ -15,9 +15,9 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arrow.version>${arrow15.version}</arrow.version>
         <scala.version>${scala213.version}</scala.version>
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow15.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/lance-spark-bundle-4.0_2.13/pom.xml
+++ b/lance-spark-bundle-4.0_2.13/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <scala.version>${scala213.version}</scala.version>
         <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow17.version}</arrow.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -53,11 +53,13 @@
         <lance-spark.version>0.1.3-beta.8</lance-spark.version>
         <lance.version>2.0.0-beta.10</lance.version>
 
-        <antlr4.version>4.9.3</antlr4.version>
+        <arrow14.version>14.0.2</arrow14.version>
+        <arrow15.version>15.0.2</arrow15.version>
+        <arrow17.version>17.0.0</arrow17.version>
+        <!-- Default Arrow version (Spark 3.5); modules override as needed -->
+        <arrow.version>${arrow15.version}</arrow.version>
 
-        <arrow15.version>15.0.0</arrow15.version>
-        <arrow18.version>18.3.0</arrow18.version>
-        <arrow.version>${arrow18.version}</arrow.version>
+        <antlr4.version>4.9.3</antlr4.version>
 
         <spark34.version>3.4.4</spark34.version>
         <spark35.version>3.5.5</spark35.version>
@@ -136,34 +138,46 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.arrow</groupId>
-                <artifactId>arrow-c-data</artifactId>
-                <version>${arrow.version}</version>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-sql_${scala.compat.version}</artifactId>
+                <version>${spark.version}</version>
                 <scope>provided</scope>
+            </dependency>
+            <!-- Arrow version pinning - modules override arrow.version as needed -->
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-vector</artifactId>
+                <version>${arrow.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.arrow</groupId>
-                <artifactId>arrow-dataset</artifactId>
+                <artifactId>arrow-format</artifactId>
                 <version>${arrow.version}</version>
-                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-memory-core</artifactId>
+                <version>${arrow.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.arrow</groupId>
                 <artifactId>arrow-memory-netty</artifactId>
                 <version>${arrow.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.arrow</groupId>
-                <artifactId>arrow-vector</artifactId>
+                <artifactId>arrow-memory-netty-buffer-patch</artifactId>
                 <version>${arrow.version}</version>
-                <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.spark</groupId>
-                <artifactId>spark-sql_${scala.compat.version}</artifactId>
-                <version>${spark.version}</version>
-                <scope>provided</scope>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-c-data</artifactId>
+                <version>${arrow.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.arrow</groupId>
+                <artifactId>arrow-dataset</artifactId>
+                <version>${arrow.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -469,7 +483,6 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <arrow.version>${arrow15.version}</arrow.version>
                 <spark.version>${spark34.version}</spark.version>
                 <spark.compat.version>${spark34.compat.version}</spark.compat.version>
             </properties>
@@ -480,7 +493,6 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <arrow.version>${arrow15.version}</arrow.version>
                 <spark.version>${spark35.version}</spark.version>
                 <spark.compat.version>${spark35.compat.version}</spark.compat.version>
             </properties>
@@ -491,7 +503,6 @@
                 <activeByDefault>false</activeByDefault>
             </activation>
             <properties>
-                <arrow.version>${arrow18.version}</arrow.version>
                 <spark.version>${spark40.version}</spark.version>
                 <spark.compat.version>${spark40.compat.version}</spark.compat.version>
             </properties>


### PR DESCRIPTION
The [recent upgrade of arrow version](https://github.com/lance-format/lance/commit/341a599dfaa376078f5c77bda7e000d1aaa249a3) (15.0 -> 18.3) in lance-core does not play well with Spark 3.5. This results in failures within the Lance Spark connector for simple operations (ex. `CREATE TABLE`). In this PR we pin the arrow version to 15.0 ([used for ~2 years](https://github.com/lance-format/lance/commit/035662907086f1bb284260043622e1c303c10696)) for all 3.5 and 3.4 profiles. The other alternative approaches are to (1) downgrade lance-core arrow dependency or (2) maintain separate lance-core branches. This seems like the most reasonable approach.

Closes: https://github.com/lance-format/lance-spark/issues/196