### PR TITLE
fix: correctly set write mode when insert overwrite table

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -13,6 +13,7 @@
  */
 package org.lance.spark.write;
 
+import org.lance.WriteParams;
 import org.lance.spark.LanceSparkWriteOptions;
 
 import org.apache.spark.sql.connector.write.BatchWrite;
@@ -112,9 +113,25 @@ public class SparkWrite implements Write {
 
     @Override
     public Write build() {
+      LanceSparkWriteOptions options =
+          LanceSparkWriteOptions.builder()
+              .storageOptions(writeOptions.getStorageOptions())
+              .namespace(writeOptions.getNamespace())
+              .tableId(writeOptions.getTableId())
+              .batchSize(writeOptions.getBatchSize())
+              .datasetUri(writeOptions.getDatasetUri())
+              .dataStorageVersion(writeOptions.getDataStorageVersion())
+              .maxBytesPerFile(writeOptions.getMaxBytesPerFile())
+              .maxRowsPerFile(writeOptions.getMaxRowsPerFile())
+              .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
+              .queueDepth(writeOptions.getQueueDepth())
+              .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
+              .writeMode(overwrite ? WriteParams.WriteMode.OVERWRITE : writeOptions.getWriteMode())
+              .build();
+
       return new SparkWrite(
           schema,
-          writeOptions,
+          options,
           overwrite,
           initialStorageOptions,
           namespaceImpl,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -114,20 +114,22 @@ public class SparkWrite implements Write {
     @Override
     public Write build() {
       LanceSparkWriteOptions options =
-          LanceSparkWriteOptions.builder()
-              .storageOptions(writeOptions.getStorageOptions())
-              .namespace(writeOptions.getNamespace())
-              .tableId(writeOptions.getTableId())
-              .batchSize(writeOptions.getBatchSize())
-              .datasetUri(writeOptions.getDatasetUri())
-              .dataStorageVersion(writeOptions.getDataStorageVersion())
-              .maxBytesPerFile(writeOptions.getMaxBytesPerFile())
-              .maxRowsPerFile(writeOptions.getMaxRowsPerFile())
-              .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
-              .queueDepth(writeOptions.getQueueDepth())
-              .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
-              .writeMode(overwrite ? WriteParams.WriteMode.OVERWRITE : writeOptions.getWriteMode())
-              .build();
+          !overwrite
+              ? writeOptions
+              : LanceSparkWriteOptions.builder()
+                  .storageOptions(writeOptions.getStorageOptions())
+                  .namespace(writeOptions.getNamespace())
+                  .tableId(writeOptions.getTableId())
+                  .batchSize(writeOptions.getBatchSize())
+                  .datasetUri(writeOptions.getDatasetUri())
+                  .dataStorageVersion(writeOptions.getDataStorageVersion())
+                  .maxBytesPerFile(writeOptions.getMaxBytesPerFile())
+                  .maxRowsPerFile(writeOptions.getMaxRowsPerFile())
+                  .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
+                  .queueDepth(writeOptions.getQueueDepth())
+                  .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
+                  .writeMode(WriteParams.WriteMode.OVERWRITE)
+                  .build();
 
       return new SparkWrite(
           schema,


### PR DESCRIPTION
If insert overwrite table using spark sql

```sql
insert overwrite table ...
```

the SparkWriteBuilder.overwrite will be set to true.

So the Fragment's write mode should be set to `OVERWRITE` in order to ensure consistency with new data's schema. If the write mode is not `OVERWRITE`, consider the following operations:

1. create one table with some data.
2. drop a column from the table.
3. insert overwrite this table with new data.

If write mode is default value `APPEND`, then the new created fragment's data files are built with old lance schema. This will cause a mismatch between the field IDs in the data file and the field IDs in the final Dataset Schema.