### PR TITLE
refactor: set overwrite write mode on replace operation fragment writes

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -310,6 +310,10 @@ public class LanceDataset
 
     if (stagedCommit != null) {
       builder.setStagedCommit(stagedCommit);
+      // Set write mode to OVERWRITE so that Fragment.create() infers schema from the
+      // arrow stream rather than validating against the existing dataset schema. This
+      // allows replacing a table with a different schema.
+      builder.truncate();
     }
     return builder;
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -110,18 +110,8 @@ public class LanceBatchWrite implements BatchWrite {
 
   @Override
   public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
-    // For staged operations (REPLACE TABLE, CREATE OR REPLACE), pass a flag so that
-    // Fragment.create() uses the stream's schema instead of validating against the existing
-    // dataset schema.
-    boolean isStagedOperation = (stagedCommit != null);
     return new LanceDataWriter.WriterFactory(
-        schema,
-        writeOptions,
-        initialStorageOptions,
-        namespaceImpl,
-        namespaceProperties,
-        tableId,
-        isStagedOperation);
+        schema, writeOptions, initialStorageOptions, namespaceImpl, namespaceProperties, tableId);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -107,21 +107,13 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
 
-    /**
-     * When true, indicates this is a staged operation (REPLACE TABLE, CREATE OR REPLACE). For
-     * staged operations, we don't pass WriteMode to Fragment.create() so that Lance uses the
-     * stream's schema directly instead of validating against the existing dataset schema.
-     */
-    private final boolean isStagedOperation;
-
     protected WriterFactory(
         StructType schema,
         LanceSparkWriteOptions writeOptions,
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId,
-        boolean isStagedOperation) {
+        List<String> tableId) {
       // Everything passed to writer factory should be serializable
       this.schema = schema;
       this.writeOptions = writeOptions;
@@ -129,7 +121,6 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       this.namespaceImpl = namespaceImpl;
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
-      this.isStagedOperation = isStagedOperation;
     }
 
     @Override
@@ -174,12 +165,7 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
           LanceRuntime.mergeStorageOptions(writeOptions.getStorageOptions(), initialStorageOptions);
 
       WriteParams.Builder builder = new WriteParams.Builder();
-      // For staged operations (REPLACE TABLE, CREATE OR REPLACE), don't set the write mode.
-      // This allows Lance to use the stream's schema directly instead of loading and
-      // validating against the existing dataset schema.
-      if (!isStagedOperation) {
-        builder.withMode(writeOptions.getWriteMode());
-      }
+      builder.withMode(writeOptions.getWriteMode());
       if (writeOptions.getMaxRowsPerFile() != null) {
         builder.withMaxRowsPerFile(writeOptions.getMaxRowsPerFile());
       }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
@@ -58,8 +58,7 @@ public class LanceDataWriterTest {
               null, // initialStorageOptions
               null, // namespaceImpl
               null, // namespaceProperties
-              null, // tableId
-              false); // isStagedOperation
+              null); // tableId
       LanceDataWriter dataWriter = (LanceDataWriter) writerFactory.createWriter(0, 0);
 
       int rows = 132;


### PR DESCRIPTION
Using `builder.truncate` to enforce the write mode to be `OVERWRITE` (arguable could be `CREATE` for non-existent table sin `CREATE_OR_REPLACE`). This is required so that the default `APPEND` is not passed to the writer.

This replaces the current approach of passing a `isStaged` flag through to the writer so that it can choose to not set write mode. The end result is the same - the schema of write is inferred from the arrow schema on the stream, but IMO this is a bit cleaned since we don't introduce a specifically variable and pass through multiple layers to get there.