### PR TITLE
feat: add server-side write support via namespace API

### DIFF
--- a/docs/src/operations/dml/insert-into.md
+++ b/docs/src/operations/dml/insert-into.md
@@ -265,6 +265,7 @@ These options control how data is written to Lance datasets. They can be set usi
 | `batch_size`             | Integer | `512`    | Number of rows per batch during writing.                                             |
 | `use_queued_write_buffer`| Boolean | `false`  | Use pipelined write buffer for improved throughput.                                  |
 | `queue_depth`            | Integer | `8`      | Queue depth for pipelined writes (only used when `use_queued_write_buffer=true`).    |
+| `server_side_write`      | Boolean | `false`  | Send data to namespace via `insertIntoTable` API instead of writing directly to storage. Requires a namespace that supports write operations. |
 
 ### Example: Controlling File Size
 
@@ -333,4 +334,72 @@ These options control how data is written to Lance datasets. They can be set usi
         .option("use_queued_write_buffer", "true")
         .option("queue_depth", "4")
         .save("/path/to/output.lance")
+    ```
+
+### Example: Server-Side Writes
+
+When using a namespace that supports write operations (e.g., LanceDB Enterprise, Apache Gravitino),
+you can enable server-side writes to send data to the namespace via the `insertIntoTable` API instead
+of writing directly to object storage. This is useful when:
+
+- Spark workers don't have direct access to the underlying storage
+- You want centralized write control through the server
+- You want to avoid distributing storage credentials to workers
+- Your server can handle higher throughput than direct object store writes
+- Your server offers additional features (e.g., real-time indexing)
+
+**Requirements:**
+
+- Must use a namespace implementation that supports `insertIntoTable` operation
+- Not compatible with staged operations like `CREATE OR REPLACE TABLE`
+
+=== "Python"
+    ```python
+    # Configure namespace (example with REST namespace)
+    spark = SparkSession.builder \
+        .appName("lance-server-write-example") \
+        .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
+        .config("spark.sql.catalog.lance.impl", "rest") \
+        .config("spark.sql.catalog.lance.uri", "https://your-server.example.com") \
+        .config("spark.sql.catalog.lance.headers.x-api-key", "your-api-key") \
+        .getOrCreate()
+
+    # Enable server-side write
+    df.writeTo("lance.mydb.mytable") \
+        .option("server_side_write", "true") \
+        .append()
+    ```
+
+=== "Scala"
+    ```scala
+    // Configure namespace (example with REST namespace)
+    val spark = SparkSession.builder()
+        .appName("lance-server-write-example")
+        .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog")
+        .config("spark.sql.catalog.lance.impl", "rest")
+        .config("spark.sql.catalog.lance.uri", "https://your-server.example.com")
+        .config("spark.sql.catalog.lance.headers.x-api-key", "your-api-key")
+        .getOrCreate()
+
+    // Enable server-side write
+    df.writeTo("lance.mydb.mytable")
+        .option("server_side_write", "true")
+        .append()
+    ```
+
+=== "Java"
+    ```java
+    // Configure namespace (example with REST namespace)
+    SparkSession spark = SparkSession.builder()
+        .appName("lance-server-write-example")
+        .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog")
+        .config("spark.sql.catalog.lance.impl", "rest")
+        .config("spark.sql.catalog.lance.uri", "https://your-server.example.com")
+        .config("spark.sql.catalog.lance.headers.x-api-key", "your-api-key")
+        .getOrCreate();
+
+    // Enable server-side write
+    df.writeTo("lance.mydb.mytable")
+        .option("server_side_write", "true")
+        .append();
     ```

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -55,6 +55,7 @@ public class LanceSparkWriteOptions implements Serializable {
   public static final String CONFIG_USE_QUEUED_WRITE_BUFFER = "use_queued_write_buffer";
   public static final String CONFIG_QUEUE_DEPTH = "queue_depth";
   public static final String CONFIG_BATCH_SIZE = "batch_size";
+  public static final String CONFIG_SERVER_SIDE_WRITE = "server_side_write";
 
   private static final WriteMode DEFAULT_WRITE_MODE = WriteMode.APPEND;
   private static final boolean DEFAULT_USE_QUEUED_WRITE_BUFFER = false;
@@ -71,6 +72,7 @@ public class LanceSparkWriteOptions implements Serializable {
   private final boolean useQueuedWriteBuffer;
   private final int queueDepth;
   private final int batchSize;
+  private final boolean serverSideWrite;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -89,6 +91,7 @@ public class LanceSparkWriteOptions implements Serializable {
     this.useQueuedWriteBuffer = builder.useQueuedWriteBuffer;
     this.queueDepth = builder.queueDepth;
     this.batchSize = builder.batchSize;
+    this.serverSideWrite = builder.serverSideWrite;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -156,6 +159,10 @@ public class LanceSparkWriteOptions implements Serializable {
 
   public int getBatchSize() {
     return batchSize;
+  }
+
+  public boolean isServerSideWrite() {
+    return serverSideWrite;
   }
 
   public Map<String, String> getStorageOptions() {
@@ -243,6 +250,7 @@ public class LanceSparkWriteOptions implements Serializable {
         && Objects.equals(maxRowsPerGroup, that.maxRowsPerGroup)
         && Objects.equals(maxBytesPerFile, that.maxBytesPerFile)
         && dataStorageVersion == that.dataStorageVersion
+        && serverSideWrite == that.serverSideWrite
         && Objects.equals(storageOptions, that.storageOptions)
         && Objects.equals(tableId, that.tableId);
   }
@@ -259,6 +267,7 @@ public class LanceSparkWriteOptions implements Serializable {
         useQueuedWriteBuffer,
         queueDepth,
         batchSize,
+        serverSideWrite,
         storageOptions,
         tableId);
   }
@@ -274,6 +283,7 @@ public class LanceSparkWriteOptions implements Serializable {
     private boolean useQueuedWriteBuffer = DEFAULT_USE_QUEUED_WRITE_BUFFER;
     private int queueDepth = DEFAULT_QUEUE_DEPTH;
     private int batchSize = DEFAULT_BATCH_SIZE;
+    private boolean serverSideWrite = false;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -322,6 +332,11 @@ public class LanceSparkWriteOptions implements Serializable {
 
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
+      return this;
+    }
+
+    public Builder serverSideWrite(boolean serverSideWrite) {
+      this.serverSideWrite = serverSideWrite;
       return this;
     }
 
@@ -375,6 +390,9 @@ public class LanceSparkWriteOptions implements Serializable {
         int parsedBatchSize = Integer.parseInt(options.get(CONFIG_BATCH_SIZE));
         Preconditions.checkArgument(parsedBatchSize > 0, "batch_size must be positive");
         this.batchSize = parsedBatchSize;
+      }
+      if (options.containsKey(CONFIG_SERVER_SIDE_WRITE)) {
+        this.serverSideWrite = Boolean.parseBoolean(options.get(CONFIG_SERVER_SIDE_WRITE));
       }
       return this;
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/ServerSideBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/ServerSideBatchWrite.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.InsertIntoTableRequest;
+import org.lance.namespace.model.InsertIntoTableResponse;
+import org.lance.spark.LanceRuntime;
+import org.lance.spark.LanceSparkWriteOptions;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.DataWriter;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * BatchWrite implementation for server-side writes.
+ *
+ * <p>Instead of writing data directly to object storage, this sends Arrow IPC data to the Lance
+ * Namespace API via {@link LanceNamespace#insertIntoTable}, which handles the actual writing on the
+ * server side.
+ */
+public class ServerSideBatchWrite implements BatchWrite {
+  private static final Logger logger = LoggerFactory.getLogger(ServerSideBatchWrite.class);
+
+  private final StructType schema;
+  private final LanceSparkWriteOptions writeOptions;
+  private final boolean overwrite;
+  private final String namespaceImpl;
+  private final Map<String, String> namespaceProperties;
+  private final List<String> tableId;
+
+  public ServerSideBatchWrite(
+      StructType schema,
+      LanceSparkWriteOptions writeOptions,
+      boolean overwrite,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      List<String> tableId) {
+    this.schema = schema;
+    this.writeOptions = writeOptions;
+    this.overwrite = overwrite;
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = namespaceProperties;
+    this.tableId = tableId;
+  }
+
+  @Override
+  public DataWriterFactory createBatchWriterFactory(PhysicalWriteInfo info) {
+    return new ServerSideWriterFactory(
+        schema, writeOptions, overwrite, namespaceImpl, namespaceProperties, tableId);
+  }
+
+  @Override
+  public boolean useCommitCoordinator() {
+    return false;
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    long totalRowsWritten =
+        Arrays.stream(messages)
+            .map(m -> (ServerSideTaskCommit) m)
+            .mapToLong(ServerSideTaskCommit::getRowsWritten)
+            .sum();
+    logger.info("Server-side write completed. Total rows written: {}", totalRowsWritten);
+  }
+
+  @Override
+  public void abort(WriterCommitMessage[] messages) {
+    logger.warn("Server-side write aborted.");
+  }
+
+  @Override
+  public String toString() {
+    return String.format("ServerSideBatchWrite(tableId=%s)", String.join(".", tableId));
+  }
+
+  /** Factory for creating server-side data writers. */
+  public static class ServerSideWriterFactory implements DataWriterFactory, Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final StructType schema;
+    private final LanceSparkWriteOptions writeOptions;
+    private final boolean overwrite;
+    private final String namespaceImpl;
+    private final Map<String, String> namespaceProperties;
+    private final List<String> tableId;
+
+    public ServerSideWriterFactory(
+        StructType schema,
+        LanceSparkWriteOptions writeOptions,
+        boolean overwrite,
+        String namespaceImpl,
+        Map<String, String> namespaceProperties,
+        List<String> tableId) {
+      this.schema = schema;
+      this.writeOptions = writeOptions;
+      this.overwrite = overwrite;
+      this.namespaceImpl = namespaceImpl;
+      this.namespaceProperties = namespaceProperties;
+      this.tableId = tableId;
+    }
+
+    @Override
+    public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      return new ServerSideDataWriter(
+          schema, writeOptions, overwrite, namespaceImpl, namespaceProperties, tableId);
+    }
+  }
+
+  /** Data writer that buffers rows and sends them to the namespace on commit. */
+  public static class ServerSideDataWriter implements DataWriter<InternalRow> {
+    private static final Logger logger = LoggerFactory.getLogger(ServerSideDataWriter.class);
+
+    private final StructType sparkSchema;
+    private final LanceSparkWriteOptions writeOptions;
+    private final boolean overwrite;
+    private final String namespaceImpl;
+    private final Map<String, String> namespaceProperties;
+    private final List<String> tableId;
+    private final int batchSize;
+
+    private VectorSchemaRoot root;
+    private org.lance.spark.arrow.LanceArrowWriter arrowWriter;
+    private ByteArrayOutputStream outputStream;
+    private ArrowStreamWriter ipcWriter;
+    private int rowCount = 0;
+    private long totalRowsWritten = 0;
+    private boolean closed = false;
+
+    public ServerSideDataWriter(
+        StructType sparkSchema,
+        LanceSparkWriteOptions writeOptions,
+        boolean overwrite,
+        String namespaceImpl,
+        Map<String, String> namespaceProperties,
+        List<String> tableId) {
+      this.sparkSchema = sparkSchema;
+      this.writeOptions = writeOptions;
+      this.overwrite = overwrite;
+      this.namespaceImpl = namespaceImpl;
+      this.namespaceProperties = namespaceProperties;
+      this.tableId = tableId;
+      this.batchSize = writeOptions.getBatchSize();
+
+      initializeBuffer();
+    }
+
+    private void initializeBuffer() {
+      BufferAllocator allocator = LanceRuntime.allocator();
+      Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, false);
+      root = VectorSchemaRoot.create(arrowSchema, allocator);
+      arrowWriter = org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(root, sparkSchema);
+      outputStream = new ByteArrayOutputStream();
+
+      try {
+        ipcWriter = new ArrowStreamWriter(root, null, outputStream);
+        ipcWriter.start();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to initialize Arrow IPC writer", e);
+      }
+    }
+
+    @Override
+    public void write(InternalRow record) throws IOException {
+      arrowWriter.write(record);
+      rowCount++;
+
+      if (rowCount >= batchSize) {
+        flushBatch();
+      }
+    }
+
+    private void flushBatch() throws IOException {
+      if (rowCount > 0) {
+        arrowWriter.finish();
+        ipcWriter.writeBatch();
+        totalRowsWritten += rowCount;
+        rowCount = 0;
+        root.clear();
+        arrowWriter = org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(root, sparkSchema);
+      }
+    }
+
+    @Override
+    public WriterCommitMessage commit() throws IOException {
+      flushBatch();
+      ipcWriter.end();
+
+      byte[] arrowIpcData = outputStream.toByteArray();
+
+      if (arrowIpcData.length > 0 && totalRowsWritten > 0) {
+        sendToNamespace(arrowIpcData);
+      }
+
+      close();
+      return new ServerSideTaskCommit(totalRowsWritten);
+    }
+
+    private void sendToNamespace(byte[] arrowIpcData) throws IOException {
+      LanceNamespace namespace =
+          LanceNamespace.connect(namespaceImpl, namespaceProperties, LanceRuntime.allocator());
+
+      String mode = overwrite ? "overwrite" : "append";
+      InsertIntoTableRequest request = new InsertIntoTableRequest().id(tableId).mode(mode);
+
+      try {
+        InsertIntoTableResponse response = namespace.insertIntoTable(request, arrowIpcData);
+        logger.debug(
+            "Server-side insert completed for table {}, transaction_id: {}",
+            tableId,
+            response.getTransactionId());
+      } catch (UnsupportedOperationException e) {
+        throw new IOException(
+            String.format(
+                "Namespace implementation '%s' does not support insertIntoTable. "
+                    + "Server-side write requires a namespace that implements write operations.",
+                namespaceImpl),
+            e);
+      } catch (Exception e) {
+        throw new IOException(
+            String.format("Failed to insert data for table %s: %s", tableId, e.getMessage()), e);
+      }
+    }
+
+    @Override
+    public void abort() throws IOException {
+      close();
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (!closed) {
+        closed = true;
+        if (ipcWriter != null) {
+          try {
+            ipcWriter.close();
+          } catch (Exception e) {
+            // Ignore close errors
+          }
+        }
+        if (root != null) {
+          root.close();
+        }
+        if (outputStream != null) {
+          outputStream.close();
+        }
+      }
+    }
+  }
+
+  /** Commit message for server-side writes. */
+  public static class ServerSideTaskCommit implements WriterCommitMessage, Serializable {
+    private static final long serialVersionUID = 1L;
+    private final long rowsWritten;
+
+    public ServerSideTaskCommit(long rowsWritten) {
+      this.rowsWritten = rowsWritten;
+    }
+
+    public long getRowsWritten() {
+      return rowsWritten;
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -66,6 +66,21 @@ public class SparkWrite implements Write {
 
   @Override
   public BatchWrite toBatch() {
+    if (writeOptions.isServerSideWrite()) {
+      if (namespaceImpl == null) {
+        throw new IllegalArgumentException(
+            "Server-side write requires a namespace implementation. "
+                + "Configure with: spark.sql.catalog.<name>.impl=<namespace-impl>");
+      }
+      if (stagedCommit != null) {
+        throw new UnsupportedOperationException(
+            "Server-side write does not support staged commits (CREATE OR REPLACE TABLE). "
+                + "Use INSERT INTO or INSERT OVERWRITE instead.");
+      }
+      return new ServerSideBatchWrite(
+          schema, writeOptions, overwrite, namespaceImpl, namespaceProperties, tableId);
+    }
+
     return new LanceBatchWrite(
         schema,
         writeOptions,
@@ -137,6 +152,7 @@ public class SparkWrite implements Write {
                   .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
                   .queueDepth(writeOptions.getQueueDepth())
                   .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
+                  .serverSideWrite(writeOptions.isServerSideWrite())
                   .writeMode(WriteParams.WriteMode.OVERWRITE)
                   .build();
 


### PR DESCRIPTION
## Summary

- Add `server_side_write` option that sends Arrow IPC data to the Lance Namespace API via `insertIntoTable` instead of writing directly to object storage
- This enables server-side write for any namespace implementation that supports write operations (e.g., LanceDB Enterprise, Apache Gravitino)

## Use Cases

Server-side writes are useful when:

- Spark workers don't have direct access to the underlying storage
- You want centralized write control through the server
- You want to avoid distributing storage credentials to workers
- Your server can handle higher throughput than direct object store writes
- Your server offers additional features (e.g., real-time indexing)

## Changes

- Add `server_side_write` option to `LanceSparkWriteOptions`
- Add `ServerSideBatchWrite` class that uses `LanceNamespace.insertIntoTable()` API
- Route to server-side write path in `SparkWrite.toBatch()` when enabled
- Update documentation with usage examples

## Usage

```python
# Configure namespace (example with REST namespace)
spark = SparkSession.builder \
    .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
    .config("spark.sql.catalog.lance.impl", "rest") \
    .config("spark.sql.catalog.lance.uri", "https://your-server.example.com") \
    .config("spark.sql.catalog.lance.headers.x-api-key", "your-api-key") \
    .getOrCreate()

# Enable server-side write
df.writeTo("lance.mydb.mytable") \
    .option("server_side_write", "true") \
    .append()
```

## Test plan

- [x] Build succeeds (`make install-base`)
- [x] Lint passes (`make lint`)
- [x] Format passes (`make format`)
- [ ] Integration test with namespace server

🤖 Generated with [Claude Code](https://claude.com/claude-code)