### PR TITLE
refactor: remove param largeVarTypes from LanceArrowUtils.toArrowSchema

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -574,7 +574,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             .allocator(LanceRuntime.allocator())
             .namespace(namespace)
             .tableId(tableIdList)
-            .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false))
+            .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
             .mode(WriteParams.WriteMode.CREATE)
             .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
             .storageOptions(catalogConfig.getStorageOptions())
@@ -619,7 +619,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Dataset.write()
           .allocator(LanceRuntime.allocator())
           .uri(datasetUri)
-          .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false))
+          .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
           .mode(WriteParams.WriteMode.CREATE)
           .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
           .storageOptions(readOptions.getStorageOptions())
@@ -738,7 +738,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.of(tableIdList),
             name);
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     Map<String, String> merged =
         LanceRuntime.mergeStorageOptions(catalogConfig.getStorageOptions(), initialStorageOptions);
     StagedCommit stagedCommit =
@@ -762,7 +762,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
         createReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     StagedCommit stagedCommit =
         StagedCommit.forNewTable(
             arrowSchema, datasetUri, catalogConfig.getStorageOptions(), null, null);
@@ -809,7 +809,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.of(tableIdList),
             name);
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     Dataset ds = openDataset(readOptions);
     StagedCommit stagedCommit =
         StagedCommit.forExistingTable(ds, arrowSchema, namespace, tableIdList);
@@ -840,7 +840,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       throw new NoSuchTableException(ident);
     }
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, null, null);
     return createStagedDataset(readOptions, processedSchema, null, null, null, stagedCommit);
   }
@@ -892,7 +892,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.of(tableIdList),
             name);
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     StagedCommit stagedCommit;
     if (exists) {
       Dataset ds = openDataset(readOptions);
@@ -924,7 +924,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
     boolean exists = tableExistsAtPath(ident);
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     StagedCommit stagedCommit;
 
     if (exists) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -110,7 +110,7 @@ public class LanceCountStarPartitionReader implements PartitionReader<ColumnarBa
   private ColumnarBatch createCountResultBatch(long count, StructType resultSchema) {
     VectorSchemaRoot root =
         VectorSchemaRoot.create(
-            LanceArrowUtils.toArrowSchema(resultSchema, "UTC", false, false), allocator);
+            LanceArrowUtils.toArrowSchema(resultSchema, "UTC", false), allocator);
 
     root.allocateNew();
     BigIntVector countVector = (BigIntVector) root.getVector("count");

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
@@ -147,7 +147,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
     }
 
     // Commit merge operation using transaction builder
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false);
     try (Dataset dataset = openDataset(writeOptions)) {
       Merge merge = Merge.builder().fragments(fragments).schema(arrowSchema).build();
       dataset.newTransactionBuilder().operation(merge).build().commit();
@@ -277,7 +277,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
       BufferAllocator allocator = LanceRuntime.allocator();
       data =
           VectorSchemaRoot.create(
-              LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false, false), allocator);
+              LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false), allocator);
 
       writer = org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(data, writerSchema);
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -139,7 +139,7 @@ public class LanceBatchWrite implements BatchWrite {
             .flatMap(List::stream)
             .collect(Collectors.toList());
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", true, false);
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", true);
     boolean isOverwrite = overwrite || writeOptions.isOverwrite();
 
     if (stagedCommit != null) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -93,7 +93,7 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, int queueDepth) {
     this(
         LanceRuntime.allocator(),
-        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, false),
+        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
         sparkSchema,
         batchSize,
         queueDepth);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -66,7 +66,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   public SemaphoreArrowBatchWriteBuffer(StructType sparkSchema, int batchSize) {
     this(
         LanceRuntime.allocator(),
-        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, false),
+        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
         sparkSchema,
         batchSize);
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
@@ -286,7 +286,7 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
       BufferAllocator allocator = LanceRuntime.allocator();
       data =
           VectorSchemaRoot.create(
-              LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false, false), allocator);
+              LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false), allocator);
 
       writer = org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(data, writerSchema);
     }

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -42,13 +42,11 @@ object LanceArrowWriter {
   def create(
       schema: StructType,
       timeZoneId: String,
-      errorOnDuplicatedFieldNames: Boolean = true,
-      largeVarTypes: Boolean = false): LanceArrowWriter = {
+      errorOnDuplicatedFieldNames: Boolean = true): LanceArrowWriter = {
     val arrowSchema = LanceArrowUtils.toArrowSchema(
       schema,
       timeZoneId,
-      errorOnDuplicatedFieldNames,
-      largeVarTypes)
+      errorOnDuplicatedFieldNames)
     val root = VectorSchemaRoot.create(arrowSchema, new RootAllocator(Long.MaxValue))
     create(root, schema)
   }

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -153,7 +153,7 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
       .add("regular_string", StringType, nullable = true)
       .add("large_string", StringType, nullable = true, largeVarCharMetadata)
 
-    val arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", false, false)
+    val arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", false)
 
     // Regular string should use Utf8
     val regularField = arrowSchema.findField("regular_string")
@@ -163,21 +163,4 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     val largeField = arrowSchema.findField("large_string")
     assert(largeField.getType === ArrowType.LargeUtf8.INSTANCE)
   }
-
-  test("largeVarTypes parameter produces LargeUtf8 for all strings") {
-    val schema = new StructType()
-      .add("string1", StringType, nullable = true)
-      .add("string2", StringType, nullable = true)
-
-    // Without largeVarTypes, should use Utf8
-    val arrowSchemaSmall = LanceArrowUtils.toArrowSchema(schema, "UTC", false, false)
-    assert(arrowSchemaSmall.findField("string1").getType === ArrowType.Utf8.INSTANCE)
-    assert(arrowSchemaSmall.findField("string2").getType === ArrowType.Utf8.INSTANCE)
-
-    // With largeVarTypes=true, should use LargeUtf8
-    val arrowSchemaLarge = LanceArrowUtils.toArrowSchema(schema, "UTC", false, true)
-    assert(arrowSchemaLarge.findField("string1").getType === ArrowType.LargeUtf8.INSTANCE)
-    assert(arrowSchemaLarge.findField("string2").getType === ArrowType.LargeUtf8.INSTANCE)
-  }
-
 }


### PR DESCRIPTION
Close https://github.com/lance-format/lance-spark/issues/268

The PR https://github.com/lance-format/lance-spark/pull/146 supports large varchar column. So the parameter largeVarTypes seems unnecessary and can be removed to make code more concise.