### PR TITLE
ci: install base module before test for submodule

### DIFF
--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -103,6 +103,8 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "maven"
+      - name: Install base
+        run: make install-base SCALA_VERSION=${{ matrix.scala-version }}
       - name: Run tests
         run: make test SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }}
 


### PR DESCRIPTION
If a new version is bumped and the base module package does not exist in maven repository, there is a error when run test for submodule:

```java
2026-02-27T08:35:38.5973032Z [INFO] ------------------------------------------------------------------------
2026-02-27T08:35:38.5974035Z [INFO] BUILD FAILURE
2026-02-27T08:35:38.5974448Z [INFO] ------------------------------------------------------------------------
2026-02-27T08:35:38.5974806Z [INFO] Total time:  16.021 s
2026-02-27T08:35:38.5976932Z [INFO] Finished at: 2026-02-27T08:35:38Z
2026-02-27T08:35:38.5977501Z [INFO] ------------------------------------------------------------------------
2026-02-27T08:35:38.5988220Z [ERROR] Failed to execute goal on project lance-spark-3.4_2.12: Could not resolve dependencies for project org.lance:lance-spark-3.4_2.12:jar:0.2.0-beta.1
2026-02-27T08:35:38.5988726Z [ERROR] dependency: org.lance:lance-spark-base_2.12:jar:0.2.0-beta.1 (compile)
2026-02-27T08:35:38.6001286Z [ERROR] 	Could not find artifact org.lance:lance-spark-base_2.12:jar:0.2.0-beta.1 in central (https://repo.maven.apache.org/maven2)
2026-02-27T08:35:38.6003717Z [ERROR] dependency: org.lance:lance-spark-base_2.12:jar:tests:0.2.0-beta.1 (test)
2026-02-27T08:35:38.6005005Z [ERROR] 	Could not find artifact org.lance:lance-spark-base_2.12:jar:tests:0.2.0-beta.1 in central (https://repo.maven.apache.org/maven2)
2026-02-27T08:35:38.6005461Z [ERROR] 
2026-02-27T08:35:38.6006541Z [ERROR] -> [Help 1]
2026-02-27T08:35:38.6007096Z [ERROR] 
2026-02-27T08:35:38.6007523Z [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
2026-02-27T08:35:38.6007850Z [ERROR] Re-run Maven using the -X switch to enable full debug logging.
2026-02-27T08:35:38.6007981Z [ERROR] 
2026-02-27T08:35:38.6008534Z [ERROR] For more information about the errors and possible solutions, please read the following articles:
2026-02-27T08:35:38.6009207Z [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
2026-02-27T08:35:38.6339124Z make: *** [Makefile:64: test] Error 1
```

This modification ensure that the base module is firstly installed to local maven repository.