### PR TITLE
feat: correctly handle asynchronous thread's error when writing data

### DIFF
--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -59,6 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrdering {
   private final StructType sparkSchema;
@@ -218,6 +219,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     @Override
     public DeltaWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
+
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
 
@@ -228,7 +231,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
-        writeBuffer = new QueuedArrowBatchWriteBuffer(sparkSchema, batchSize, queueDepth);
+        writeBuffer = new QueuedArrowBatchWriteBuffer(sparkSchema, batchSize, queueDepth, fragmentCreationError);
       } else {
         writeBuffer = new SemaphoreArrowBatchWriteBuffer(sparkSchema, batchSize);
       }

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -231,7 +231,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
-        writeBuffer = new QueuedArrowBatchWriteBuffer(sparkSchema, batchSize, queueDepth, fragmentCreationError);
+        writeBuffer =
+            new QueuedArrowBatchWriteBuffer(
+                sparkSchema, batchSize, queueDepth, fragmentCreationError);
       } else {
         writeBuffer = new SemaphoreArrowBatchWriteBuffer(sparkSchema, batchSize);
       }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrdering {
   private final StructType sparkSchema;
@@ -218,6 +219,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     @Override
     public DeltaWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
+
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
 
@@ -228,9 +231,12 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
-        writeBuffer = new QueuedArrowBatchWriteBuffer(sparkSchema, batchSize, queueDepth);
+        writeBuffer =
+            new QueuedArrowBatchWriteBuffer(
+                sparkSchema, batchSize, queueDepth, fragmentCreationError);
       } else {
-        writeBuffer = new SemaphoreArrowBatchWriteBuffer(sparkSchema, batchSize);
+        writeBuffer =
+            new SemaphoreArrowBatchWriteBuffer(sparkSchema, batchSize, fragmentCreationError);
       }
 
       // Get storage options provider for credential refresh
@@ -244,6 +250,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
               Data.exportArrayStream(LanceRuntime.allocator(), writeBuffer, arrowStream);
               return Fragment.create(
                   writeOptions.getDatasetUri(), arrowStream, params, storageOptionsProvider);
+            } catch (Throwable e) {
+              fragmentCreationError.set(e);
+              throw e;
             }
           };
       FutureTask<List<FragmentMetadata>> fragmentCreationTask = new FutureTask<>(fragmentCreator);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class LanceDataWriter implements DataWriter<InternalRow> {
   private ArrowBatchWriteBuffer writeBuffer;
@@ -125,6 +126,8 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
+
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
 
@@ -135,9 +138,10 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
-        writeBuffer = new QueuedArrowBatchWriteBuffer(schema, batchSize, queueDepth);
+        writeBuffer =
+            new QueuedArrowBatchWriteBuffer(schema, batchSize, queueDepth, fragmentCreationError);
       } else {
-        writeBuffer = new SemaphoreArrowBatchWriteBuffer(schema, batchSize);
+        writeBuffer = new SemaphoreArrowBatchWriteBuffer(schema, batchSize, fragmentCreationError);
       }
 
       // Get storage options provider for credential refresh
@@ -151,6 +155,9 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
               Data.exportArrayStream(LanceRuntime.allocator(), writeBuffer, arrowStream);
               return Fragment.create(
                   writeOptions.getDatasetUri(), arrowStream, params, storageOptionsProvider);
+            } catch (Throwable e) {
+              fragmentCreationError.set(e);
+              throw e;
             }
           };
       FutureTask<List<FragmentMetadata>> fragmentCreationTask = new FutureTask<>(fragmentCreator);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Queue-based buffer for Arrow batches that enables pipelined batch processing.
@@ -58,6 +59,9 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   /** Queue holding completed batches ready for consumption. */
   private final BlockingQueue<VectorSchemaRoot> batchQueue;
 
+  /** Reference to hold any error during fragment creation for error propagation. */
+  private final AtomicReference<Throwable> fragmentCreationError;
+
   /** Child allocator for producer batches (shares root with consumer for buffer transfer). */
   private final BufferAllocator producerAllocator;
 
@@ -81,22 +85,27 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   public QueuedArrowBatchWriteBuffer(
       BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
-    this(allocator, schema, sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH);
+    this(allocator, schema, sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH, new AtomicReference<>());
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize) {
-    this(sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH);
+    this(sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH, new AtomicReference<>());
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
-  public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, int queueDepth) {
+  public QueuedArrowBatchWriteBuffer(
+      StructType sparkSchema,
+      int batchSize,
+      int queueDepth,
+      AtomicReference<Throwable> fragmentCreationError) {
     this(
         LanceRuntime.allocator(),
         LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
         sparkSchema,
         batchSize,
-        queueDepth);
+        queueDepth,
+        fragmentCreationError);
   }
 
   public QueuedArrowBatchWriteBuffer(
@@ -104,7 +113,8 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       Schema schema,
       StructType sparkSchema,
       int batchSize,
-      int queueDepth) {
+      int queueDepth,
+      AtomicReference<Throwable> fragmentCreationError) {
     super(allocator);
     Preconditions.checkNotNull(schema);
     Preconditions.checkArgument(batchSize > 0, "Batch size must be positive");
@@ -115,6 +125,7 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     this.batchSize = batchSize;
     this.queueDepth = queueDepth;
     this.batchQueue = new ArrayBlockingQueue<>(queueDepth);
+    this.fragmentCreationError = fragmentCreationError;
 
     // Create a child allocator for producer that shares the same root as the consumer
     // allocator. This is required for Arrow buffer transfer between producer and consumer.
@@ -147,6 +158,10 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   public void write(InternalRow row) {
     Preconditions.checkNotNull(row);
     Preconditions.checkState(!producerFinished, "Cannot write after setFinished() is called");
+
+    if (fragmentCreationError.get() != null) {
+      throw new RuntimeException("Failed to write data to lance", fragmentCreationError.get());
+    }
 
     try {
       currentArrowWriter.write(row);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -26,7 +26,9 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Buffers Spark rows into Arrow batches for consumption by Lance fragment creation.
@@ -49,9 +51,14 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private final AtomicInteger count = new AtomicInteger(0);
   private final Semaphore writeToken;
   private final Semaphore loadToken;
+  private final AtomicReference<Throwable> fragmentCreationError;
 
   public SemaphoreArrowBatchWriteBuffer(
-      BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
+      BufferAllocator allocator,
+      Schema schema,
+      StructType sparkSchema,
+      int batchSize,
+      AtomicReference<Throwable> fragmentCreationError) {
     super(allocator);
     Preconditions.checkNotNull(schema);
     Preconditions.checkArgument(batchSize > 0);
@@ -60,6 +67,12 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     this.batchSize = batchSize;
     this.writeToken = new Semaphore(0);
     this.loadToken = new Semaphore(0);
+    this.fragmentCreationError = fragmentCreationError;
+  }
+
+  public SemaphoreArrowBatchWriteBuffer(
+      BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
+    this(allocator, schema, sparkSchema, batchSize, new AtomicReference<>());
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
@@ -68,26 +81,48 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
         LanceRuntime.allocator(),
         LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
         sparkSchema,
-        batchSize);
+        batchSize,
+        new AtomicReference<>());
+  }
+
+  public SemaphoreArrowBatchWriteBuffer(
+      StructType sparkSchema, int batchSize, AtomicReference<Throwable> fragmentCreationError) {
+    this(
+        LanceRuntime.allocator(),
+        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
+        sparkSchema,
+        batchSize,
+        fragmentCreationError);
   }
 
   @Override
   public void write(InternalRow row) {
     Preconditions.checkNotNull(row);
-    try {
-      // wait util prepareLoadNextBatch to release write token
-      writeToken.acquire();
 
-      // Write to Arrow buffer
-      arrowWriter.write(row);
-
-      if (count.incrementAndGet() == batchSize) {
-        // notify loadNextBatch to take the batch
-        loadToken.release();
+    // wait until prepareLoadNextBatch releases write token
+    int retry = 0;
+    while (retry++ < 100) {
+      if (fragmentCreationError != null && fragmentCreationError.get() != null) {
+        throw new RuntimeException("Failed to write data to lance", fragmentCreationError.get());
       }
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+
+      try {
+        if (writeToken.tryAcquire(6, TimeUnit.SECONDS)) {
+          // Write to Arrow buffer
+          arrowWriter.write(row);
+
+          if (count.incrementAndGet() == batchSize) {
+            // notify loadNextBatch to take the batch
+            loadToken.release();
+          }
+          return;
+        }
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
+
+    throw new RuntimeException("Timeout to write row to lance.");
   }
 
   @Override
@@ -114,7 +149,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
         return false;
       }
 
-      // wait util batch is full or finished
+      // wait until batch is full or finished
       loadToken.acquire();
 
       // Finish the batch (flush Arrow vectors)

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/QueuedArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/QueuedArrowBatchWriteBufferTest.java
@@ -26,10 +26,14 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,7 +66,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 34;
       final int queueDepth = 4;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -130,7 +135,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 34; // Will have 1 full batch (34) + 1 partial batch (16)
       final int queueDepth = 2;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -181,7 +187,8 @@ public class QueuedArrowBatchWriteBufferTest {
       StructType sparkSchema = createIntSparkSchema();
 
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, 100, 2);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, 100, 2, new AtomicReference<>());
 
       AtomicInteger batchCount = new AtomicInteger(0);
 
@@ -225,7 +232,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 512;
       final int queueDepth = 8;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -281,7 +289,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 10;
       final int queueDepth = 1;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -348,7 +357,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 50;
       final int queueDepth = 4;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -461,7 +471,8 @@ public class QueuedArrowBatchWriteBufferTest {
       final int batchSize = 10;
       final int queueDepth = 4;
       final QueuedArrowBatchWriteBuffer writeBuffer =
-          new QueuedArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize, queueDepth);
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, new AtomicReference<>());
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -503,6 +514,81 @@ public class QueuedArrowBatchWriteBufferTest {
 
       assertEquals(totalRows, rowsWritten.get());
       assertEquals(totalRows, rowsRead.get());
+      // Queue should have been used (max size > 0 at some point)
+      assertTrue(maxQueueSize.get() >= 0);
+      writeBuffer.close();
+    }
+  }
+
+  @Test
+  public void testWriteErrorPropagation() throws Exception {
+    // Test that the queue buffers batches when consumer is slow
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createIntSchema();
+      StructType sparkSchema = createIntSparkSchema();
+
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
+
+      final int totalRows = 100;
+      final int batchSize = 10;
+      final int queueDepth = 4;
+      final QueuedArrowBatchWriteBuffer writeBuffer =
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, fragmentCreationError);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger maxQueueSize = new AtomicInteger(0);
+
+      Callable<Integer> read =
+          () -> {
+            try {
+              if (writeBuffer.loadNextBatch()) {
+                VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+                rowsRead.addAndGet(root.getRowCount());
+
+                // Throw a mock exception after reading a batch
+                throw new RuntimeException("Mock exception");
+              }
+              return rowsRead.get();
+            } catch (Throwable e) {
+              fragmentCreationError.set(e);
+              throw e;
+            }
+          };
+
+      // Start background thread to read from the queue
+      FutureTask<Integer> readTask = new FutureTask<>(read);
+      Thread readerThread = new Thread(readTask);
+      readerThread.start();
+
+      // Write data to queue until it throws an exception
+      Assertions.assertThrows(
+          RuntimeException.class,
+          () -> {
+            try {
+              for (int i = 0; i < totalRows; i++) {
+                InternalRow row = new GenericInternalRow(new Object[] {i + 1});
+                writeBuffer.write(row);
+                // Track max queue size
+                int currentSize = writeBuffer.getCurrentQueueSize();
+                maxQueueSize.updateAndGet(prev -> Math.max(prev, currentSize));
+                rowsWritten.incrementAndGet();
+
+                if (rowsWritten.get() >= batchSize) {
+                  // Wait some time to allow the reader to read a batch and throw an exception
+                  Thread.sleep(2000);
+                }
+              }
+            } finally {
+              writeBuffer.setFinished();
+            }
+          });
+
+      Assertions.assertThrows(ExecutionException.class, readTask::get);
+
+      assertEquals(batchSize, rowsWritten.get());
+      assertEquals(batchSize, rowsRead.get());
       // Queue should have been used (max size > 0 at some point)
       assertTrue(maxQueueSize.get() >= 0);
       writeBuffer.close();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
@@ -26,11 +26,16 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -53,8 +58,10 @@ public class SemaphoreArrowBatchWriteBufferTest {
 
       final int totalRows = 125;
       final int batchSize = 34;
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
       final SemaphoreArrowBatchWriteBuffer writeBuffer =
-          new SemaphoreArrowBatchWriteBuffer(allocator, schema, sparkSchema, batchSize);
+          new SemaphoreArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, fragmentCreationError);
 
       AtomicInteger rowsWritten = new AtomicInteger(0);
       AtomicInteger rowsRead = new AtomicInteger(0);
@@ -104,6 +111,83 @@ public class SemaphoreArrowBatchWriteBufferTest {
       readerThread.join();
       assertEquals(totalRows, rowsWritten.get());
       assertEquals(totalRows, rowsRead.get());
+      writeBuffer.close();
+    }
+  }
+
+  @Test
+  public void testWriteErrorPropagation() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field field =
+          new Field(
+              "column1",
+              FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.INT.getType()),
+              null);
+      Schema schema = new Schema(Collections.singletonList(field));
+
+      StructType sparkSchema =
+          new StructType(
+              new StructField[] {
+                DataTypes.createStructField("column1", DataTypes.IntegerType, true)
+              });
+
+      final int totalRows = 125;
+      final int batchSize = 34;
+      final AtomicReference<Throwable> fragmentCreationError = new AtomicReference<>();
+      final SemaphoreArrowBatchWriteBuffer writeBuffer =
+          new SemaphoreArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, fragmentCreationError);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicLong expectedBytesRead = new AtomicLong(0);
+
+      Callable<Integer> read =
+          () -> {
+            try {
+              if (writeBuffer.loadNextBatch()) {
+                VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+                int rowCount = root.getRowCount();
+                rowsRead.addAndGet(rowCount);
+                try (ArrowRecordBatch recordBatch = new VectorUnloader(root).getRecordBatch()) {
+                  expectedBytesRead.addAndGet(recordBatch.computeBodyLength());
+                }
+                for (int i = 0; i < rowCount; i++) {
+                  int value = (int) root.getVector("column1").getObject(i);
+                  assertEquals(value, rowsRead.get() - rowCount + i + 1);
+                }
+
+                // Throw a mock exception after reading a batch
+                throw new RuntimeException("Mock exception");
+              }
+              return rowsRead.get();
+            } catch (Throwable e) {
+              fragmentCreationError.set(e);
+              throw e;
+            }
+          };
+
+      // Start background thread to read data
+      FutureTask<Integer> readTask = new FutureTask<>(read);
+      Thread readerThread = new Thread(readTask);
+      readerThread.start();
+
+      // Write data
+      Assertions.assertThrows(
+          RuntimeException.class,
+          () -> {
+            for (int i = 0; i < totalRows; i++) {
+              InternalRow row = new GenericInternalRow(new Object[] {i + 1});
+              writeBuffer.write(row);
+              rowsWritten.incrementAndGet();
+            }
+            writeBuffer.setFinished();
+          });
+
+      Assertions.assertThrows(ExecutionException.class, readTask::get);
+
+      assertEquals(batchSize, rowsWritten.get());
+      assertEquals(batchSize, rowsRead.get());
       writeBuffer.close();
     }
   }


### PR DESCRIPTION
Currently data is written in a asynchronous thread see [LanceDataWriter](https://github.com/lance-format/lance-spark/blob/main/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java#L147).

If an exception occurs in an asynchronous thread, the Spark task cannot detect it promptly, and in extreme cases, this may cause the Spark task's worker thread to hang indefinitely.

This PR uses a `AtomicReference<Throwable>` to handle the exception between the two threads. When exception occurs, it will be set to the AtomicReference and the Spark task can detect it immediately.