### PR TITLE
fix: prevent LanceDataWriter.abort() from hanging

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -73,6 +73,12 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
 
   @Override
   public void abort() throws IOException {
+    // Signal the write buffer that no more data will be produced.
+    // This unblocks the fragment creation thread's consumer side
+    // (which reads from the buffer via ArrowReader interface),
+    // preventing a deadlock where the consumer waits for more data
+    // while we wait for the consumer to finish.
+    writeBuffer.setFinished();
     fragmentCreationThread.interrupt();
     try {
       // Have a timeout to avoid hanging in native method indefinitely

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceDataWriterTest.java
@@ -35,8 +35,10 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class LanceDataWriterTest {
   @TempDir static Path tempDir;
@@ -72,6 +74,62 @@ public class LanceDataWriterTest {
       List<FragmentMetadata> fragments = commitMessage.getFragments();
       assertEquals(1, fragments.size());
       assertEquals(rows, fragments.get(0).getPhysicalRows());
+    }
+  }
+
+  /**
+   * Tests that abort() does not hang when called after partial writes. This reproduces the deadlock
+   * reported in issue #114: when a Spark task fails mid-write, the driver calls abort() which must
+   * complete promptly. Before the fix, abort() would hang because the fragment creation thread's
+   * consumer side was blocked waiting for more data that would never come.
+   */
+  @Test
+  public void testAbortDoesNotHang(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Collections.singletonList(field));
+      LanceSparkWriteOptions writeOptions =
+          LanceSparkWriteOptions.from(
+              tempDir.resolve(datasetName + LanceSparkReadOptions.LANCE_FILE_SUFFIX).toString());
+      StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+      LanceDataWriter.WriterFactory writerFactory =
+          new LanceDataWriter.WriterFactory(
+              sparkSchema,
+              writeOptions,
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null); // tableId
+      LanceDataWriter dataWriter = (LanceDataWriter) writerFactory.createWriter(0, 0);
+
+      // Write partial data (fewer rows than batch size) to create the deadlock scenario:
+      // the consumer thread is waiting for a full batch while the producer stops writing.
+      int partialRows = 5;
+      for (int i = 0; i < partialRows; i++) {
+        InternalRow row = new GenericInternalRow(new Object[] {i});
+        dataWriter.write(row);
+      }
+
+      // abort() must complete within a reasonable time.
+      // Before the fix, this would hang indefinitely because the fragment creation
+      // thread was blocked in loadNextBatch() waiting for more data.
+      Thread abortThread =
+          new Thread(
+              () -> {
+                try {
+                  dataWriter.abort();
+                } catch (IOException e) {
+                  // ExecutionException is expected since fragment creation may fail on abort
+                }
+              });
+      abortThread.start();
+      abortThread.join(TimeUnit.SECONDS.toMillis(30));
+
+      assertFalse(
+          abortThread.isAlive(),
+          "abort() should complete within 30 seconds, but it is still hanging. "
+              + "This indicates the deadlock from issue #114 is present.");
     }
   }
 }


### PR DESCRIPTION
To fix https://github.com/lance-format/lance-spark/issues/114.

When a Spark task throws an exception, the driver kills the executor and calls `LanceDataWriter.abort()`. However, `abort()` can hang indefinitely because it waits for the fragment creation thread to finish (`FutureTask.get()`), while that thread is blocked in `ArrowBatchWriteBuffer.loadNextBatch()` waiting for more data from the producer — which has already stopped writing.                                                                        

The root cause is that `abort()` never signals the write buffer that no more data will be produced. In contrast, `commit()` correctly calls `writeBuffer.setFinished()` before waiting. The fix adds the same `writeBuffer.setFinished()` call at the beginning of `abort()` to unblock the consumer side and break the deadlock.

This also adds a test that reproduces the deadlock scenario: writing partial data (fewer rows than batch size) then calling `abort()`, asserting it completes within a bounded time. Newly added tests will report the following errors before the current pull request (PR) is fixed:

```
[INFO] Running org.lance.spark.write.LanceDataWriterTest
19:11:46.593 INFO [main] BaseAllocator.<clinit>: Debug mode disabled. Enable with the VM option -Darrow.memory.debug.allocator=true.
19:11:46.596 INFO [main] DefaultAllocationManagerOption.getDefaultAllocationManagerFactory: allocation manager type not specified, using netty as the default type
19:11:46.599 INFO [main] CheckAllocator.reportResult: Using DefaultAllocationManager at memory-netty/15.0.2/arrow-memory-netty-15.0.2.jar!/org/apache/arrow/memory/DefaultAllocationManagerFactory.class
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 32.80 s <<< FAILURE! -- in org.lance.spark.write.LanceDataWriterTest
[ERROR] org.lance.spark.write.LanceDataWriterTest.testAbortDoesNotHang(TestInfo) -- Time elapsed: 32.54 s <<< FAILURE!
org.opentest4j.AssertionFailedError: abort() should complete within 30 seconds, but it is still hanging. This indicates the deadlock from issue #114 is present. ==> expected: <false> but was: <true>
  at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
  at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
  at org.junit.jupiter.api.AssertFalse.failNotFalse(AssertFalse.java:63)
  at org.junit.jupiter.api.AssertFalse.assertFalse(AssertFalse.java:36)
  at org.junit.jupiter.api.Assertions.assertFalse(Assertions.java:239)
  at org.lance.spark.write.LanceDataWriterTest.testAbortDoesNotHang(LanceDataWriterTest.java:129)
  at java.base/java.lang.reflect.Method.invoke(Method.java:569)
  at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
  at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   LanceDataWriterTest.testAbortDoesNotHang:129 abort() should complete within 30 seconds, but it is still hanging. This indicates the deadlock from issue #114 is present. ==> expected: <false> but was: <true>
[INFO] 
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
```
