### PR TITLE
chore: update lance dependency to v4.0.0-rc.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.3.0-beta.1</lance-spark.version>
-        <lance.version>4.0.0-beta.13</lance.version>
+        <lance.version>4.0.0-rc.1</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Update Maven property `lance.version` in `pom.xml` from `4.0.0-beta.13` to `4.0.0-rc.1`.
- Verified Docker version pins:
  - `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.3.0-beta.1`).
  - `LANCE_NS_VERSION` remains `0.5.2`, matching the `lance-namespace-core` version transitively included by `lance-core:4.0.0-rc.1`.

## Verification
- `make lint` passed.
- `make install` passed (default Spark 3.5 / Scala 2.12 build path).

## Trigger
- Triggering tag: `refs/tags/v4.0.0-rc.1`
