### PR TITLE
fix: fix filter pushdown of date and time columns

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -176,7 +176,11 @@ public class FilterPushDown {
   }
 
   private static String compileValue(Object value) {
-    if (value instanceof String || value instanceof Timestamp || value instanceof Date) {
+    if (value instanceof Date) {
+      return "date '" + value + "'";
+    } else if (value instanceof Timestamp) {
+      return "timestamp '" + value + "'";
+    } else if (value instanceof String) {
       return "'" + value + "'";
     } else if (value instanceof Object[]) {
       Object[] array = (Object[]) value;


### PR DESCRIPTION
java.sql.Date is wrapped as a quoted string '2000-08-23', which Lance's DataFusion parser receives as Utf8 — not Date32.

The fix: use the SQL date literal syntax date '2000-08-23' so DataFusion parses it as a proper Date32 value


The error before:

Driver stacktrace:
  Caused by: java.lang.IllegalArgumentException: Invalid user input: Error resolving filter expression (d_date IS NOT NULL) AND (d_date >= '2000-08-23') AND (d_date <= '2000-09-06') AND (d_date_sk IS NOT NULL): Invalid user input: Received literal Utf8("2000-08-23") and could not convert to literal of type 'Date32', /workspace/rust/lance-datafusion/src/logical_expr.rs:27:17, /workspace/rust/lance-datafusion/src/planner.rs:852:17