### PR TITLE
fix: handle Decimal, Date, and Timestamp literals in filter pushdown

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -185,13 +185,11 @@ public class FilterPushDown {
       return "'" + value + "'";
     } else if (value instanceof BigDecimal) {
       BigDecimal bd = (BigDecimal) value;
-      return "CAST("
-          + bd.toPlainString()
-          + " AS DECIMAL("
-          + bd.precision()
-          + ", "
-          + bd.scale()
-          + "))";
+      int scale = bd.scale();
+      // Java returns precision=1 for zero regardless of scale (e.g. 0.00 → precision=1, scale=2).
+      // Arrow requires precision >= scale, so clamp precision up if needed.
+      int precision = Math.max(bd.precision(), scale);
+      return "CAST(" + bd.toPlainString() + " AS DECIMAL(" + precision + ", " + scale + "))";
     } else if (value instanceof Object[]) {
       Object[] array = (Object[]) value;
       StringBuilder sb = new StringBuilder();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
@@ -152,6 +152,23 @@ public class FilterPushDownTest {
   }
 
   @Test
+  public void testDecimalZeroValuePrecisionClamped() {
+    // Java's BigDecimal returns precision=1 for zero regardless of scale, e.g.
+    // new BigDecimal("0.00") has precision=1 and scale=2. Arrow rejects DECIMAL(1,2) because
+    // scale > precision is invalid. The fix clamps: precision = max(precision, scale).
+    Filter[] filters =
+        new Filter[] {
+          new GreaterThan("net_paid", new BigDecimal("0.00")),
+          new GreaterThan("net_profit", new BigDecimal("1.00"))
+        };
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    assertTrue(whereClause.isPresent());
+    assertEquals(
+        "(net_paid > CAST(0.00 AS DECIMAL(2, 2))) AND (net_profit > CAST(1.00 AS DECIMAL(3, 2)))",
+        whereClause.get());
+  }
+
+  @Test
   public void testDateFilterPushDown() {
     // Date literals must use the 'date' keyword so Lance's DataFusion parser produces Date32,
     // not Utf8, which would fail type resolution against Date columns.


### PR DESCRIPTION
Lance's DataFusion SQL parser rejects bare numeric literals (e.g. 100.00) as Float64 when the target column is Decimal128, and rejects quoted date/ timestamp strings as Utf8 when the target column is Date32/Timestamp.

- BigDecimal values are now emitted as CAST(x AS DECIMAL(p, s))
- java.sql.Date values are now emitted as  date 'yyyy-MM-dd'
- java.sql.Timestamp values are now emitted as  timestamp '...'

Fixes failures on TPC-DS queries that filter on Decimal columns (e.g. q13) and Date columns (e.g. q5).