### PR TITLE
fix: count start aggregate pushdown read options

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -14,8 +14,10 @@
 package org.lance.spark.read;
 
 import org.lance.Dataset;
+import org.lance.ReadOptions;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
+import org.lance.namespace.LanceNamespaceStorageOptionsProvider;
 import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.vectorized.LanceArrowColumnVector;
@@ -32,6 +34,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Partition reader for pushed down aggregates. This reader computes the aggregate result directly
@@ -91,20 +94,32 @@ public class LanceCountStarPartitionReader implements PartitionReader<ColumnarBa
   }
 
   private Dataset openDataset(LanceSparkReadOptions readOptions) {
-    if (readOptions.hasNamespace()) {
-      return Dataset.open()
-          .allocator(allocator)
-          .namespace(readOptions.getNamespace())
-          .tableId(readOptions.getTableId())
-          .readOptions(readOptions.toReadOptions())
-          .build();
-    } else {
-      return Dataset.open()
-          .allocator(allocator)
-          .uri(readOptions.getDatasetUri())
-          .readOptions(readOptions.toReadOptions())
-          .build();
+    Map<String, String> merged =
+        LanceRuntime.mergeStorageOptions(
+            readOptions.getStorageOptions(), inputPartition.getInitialStorageOptions());
+    LanceNamespaceStorageOptionsProvider provider =
+        LanceRuntime.getOrCreateStorageOptionsProvider(
+            inputPartition.getNamespaceImpl(),
+            inputPartition.getNamespaceProperties(),
+            readOptions.getTableId());
+
+    ReadOptions.Builder builder =
+        new ReadOptions.Builder()
+            .setStorageOptions(merged)
+            .setSession(LanceRuntime.session(readOptions.getCatalogName()));
+
+    if (provider != null) {
+      builder.setStorageOptionsProvider(provider);
     }
+    if (readOptions.getVersion() != null) {
+      builder.setVersion(readOptions.getVersion());
+    }
+
+    return Dataset.open()
+        .allocator(LanceRuntime.allocator())
+        .uri(readOptions.getDatasetUri())
+        .readOptions(builder.build())
+        .build();
   }
 
   private ColumnarBatch createCountResultBatch(long count, StructType resultSchema) {


### PR DESCRIPTION
This PR fixes the read options when opening a dataset with the count star agg pushdown reader. It uses the same logic as the regular fragment reader to open the dataset. Without this fix, and when using a namespace that provides vended credentials, a count star query with a filter will fail, i.e. `select count(*) from mydb.mytable where id=1`.

This is the error that shows up in Spark:
```
java.lang.IllegalArgumentException: Dataset at path lance/datasets/xxx was not found: LanceError(IO): Generic S3 error: Error performing list request: Error performing GET https://s3.us-east-1.amazonaws.com/bucket?list-type=2&prefix=lance%2Fdatasets%2Fxxx%2F_versions%2F in 242.09975ms - Server returned non-2xx status code: 400 Bad Request: <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidToken</Code><Message>The provided token is malformed or otherwise invalid...
```