### PR TITLE
fix: replace scala.jdk.CollectionConverters with scala.collection.JavaConverters in Scala 2.12

### DIFF
--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LogicalPlan, NamedArgument, Optimize, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.ParserUtils
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LogicalPlan, NamedArgument, Optimize, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.ParserUtils
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -30,7 +30,7 @@ import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRunti
 
 import java.util.{Collections, Optional, UUID}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Physical execution of distributed CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeExec.scala
@@ -22,7 +22,7 @@ import org.lance.{Dataset, ReadOptions}
 import org.lance.compaction.{Compaction, CompactionOptions, CompactionTask, RewriteResult}
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 case class OptimizeExec(
     catalog: TableCatalog,

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
@@ -22,7 +22,7 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.lance.Dataset
 import org.lance.spark.{LanceDataset, LanceRuntime, LanceSparkReadOptions}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Physical execution of SHOW INDEXES for Lance datasets.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VacuumExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VacuumExec.scala
@@ -21,7 +21,7 @@ import org.lance.Dataset
 import org.lance.cleanup.CleanupPolicy
 import org.lance.spark.{LanceDataset, LanceRuntime, LanceSparkReadOptions}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 case class VacuumExec(
     catalog: TableCatalog,

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.LanceArrowUtils
 import org.lance.spark.utils.VectorUtils
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 /**
  * Custom ArrowWriter implementation that supports converting Spark DataFrame


### PR DESCRIPTION

## Problem

Running the `lance-spark-bundle-3.5_2.12` artifact in local Spark sessions or outside a full Spark distribution encounter the following error at runtime:

```
java.lang.ClassNotFoundException: scala.jdk.CollectionConverters$
    at org.lance.spark.arrow.LanceArrowWriter$.create(LanceArrowWriter.scala)
    ...
Caused by: java.lang.NoClassDefFoundError: scala/jdk/CollectionConverters$
```

## Root Cause

`scala.jdk.CollectionConverters` was introduced in **Scala 2.13**. It does not exist in the **Scala 2.12** standard library.

## Why It Compiled Successfully

`scala.jdk.CollectionConverters` was backported to Scala 2.12 via `scala-collection-compat` ≥ 2.1.3. During the lance-spark build, `scala-collection-compat_2.12:2.7.0` is present on the compile classpath, but only because it is pulled in **transitively** from `spark-core_2.12` with **`provided`** scope:

```
org.apache.spark:spark-core_2.12:3.5.x (provided)
  └─ org.scala-lang.modules:scala-collection-compat_2.12:2.7.0 (provided)
```

Since it's `provided`, it's available at compile time, so the code compiles and CI passes. The class references are embedded in the compiled bytecode (verifiable via `javap`), but the jar is not bundled into the artifact and not declared as a runtime dependency.

## Why It Works in Some Environments

In a real Spark cluster, `scala-collection-compat` ships as part of the Spark distribution and is available on the executor classpath. This masks the problem in standard deployments. It only surfaces in local test environments or when using the fat bundle jar outside a full Spark installation, for example `SparkSession.builder().master("local[*]")` where the full Spark distribution jars are not on the classpath.
