### PR TITLE
fix: stabilize flaky MergeInto fragment distribution test

### DIFF
--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseMergeIntoTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseMergeIntoTest.java
@@ -101,7 +101,7 @@ public abstract class BaseMergeIntoTest {
             new org.apache.spark.sql.types.StructType().add("id", "int").add("value", "int"))
         .union(
             spark
-                .range(0, 200)
+                .range(0, 2000)
                 .repartition(SHUFFLE_PARTITIONS)
                 .selectExpr("cast(id + 1000 as int) as id", "cast(id as int) as value"))
         .createOrReplaceTempView("merge_source");
@@ -128,7 +128,7 @@ public abstract class BaseMergeIntoTest {
             .first()
             .getLong(0);
     Assertions.assertEquals(
-        200L, insertedRowCount, "Expected merge to insert 200 rows into new fragments");
+        2000L, insertedRowCount, "Expected merge to insert 2000 rows into new fragments");
     long updatedCount =
         spark
             .sql(
@@ -154,18 +154,26 @@ public abstract class BaseMergeIntoTest {
     Assertions.assertEquals(0L, deletedCount, "Expected rows 5 and 6 to be deleted");
 
     // Inserted rows should span multiple fragments to avoid skew.
-    long insertFragmentCount =
+    List<org.apache.spark.sql.Row> fragStats =
         spark
             .sql(
-                "SELECT COUNT(DISTINCT _fragid) FROM "
+                "SELECT _fragid, COUNT(*) as cnt FROM "
                     + catalogName
                     + ".default."
                     + tableName
-                    + " WHERE tag = 'inserted'")
-            .first()
-            .getLong(0);
+                    + " WHERE tag = 'inserted' GROUP BY _fragid ORDER BY _fragid")
+            .collectAsList();
+    long insertFragmentCount = fragStats.size();
     Assertions.assertTrue(
-        insertFragmentCount >= 2, "Expected inserted rows to span multiple fragments");
+        insertFragmentCount >= 2,
+        "Expected inserted rows to span multiple fragments, but got "
+            + insertFragmentCount
+            + " fragment(s). Distribution: "
+            + fragStats
+            + ". master="
+            + spark.sparkContext().master()
+            + ", shuffle.partitions="
+            + spark.conf().get("spark.sql.shuffle.partitions"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

`testMergeIntoInsertDistributionOnNullSegmentId` intermittently fails in CI:

```
2026-03-25T08:41:13.1870808Z [ERROR] MergeIntoTest>BaseMergeIntoTest.testMergeIntoInsertDistributionOnNullSegmentId:167 Expected inserted rows to span multiple fragments ==> expected: <true> but was: <false>
```

This PR makes the test more robust and adds diagnostics for future failures.

## Changes

1. **Increase insert rows from 200 to 2000** — with only 200 rows and 4 shuffle partitions in a resource-constrained CI environment, edge-case partitioning can route all insert rows into a single write task, producing just 1 fragment. 2000 rows makes this statistically negligible.

2. **Enrich the fragment count assertion with diagnostics** — the original query (`SELECT COUNT(DISTINCT _fragid) ... WHERE tag = 'inserted'`) was replaced with a `GROUP BY _fragid` query so the assertion failure message can include the per-fragment row distribution, along with the session's `master` and `shuffle.partitions` settings. This enables root-cause analysis from a single CI failure log without needing to re-run with extra logging.

Before:
```
Expected inserted rows to span multiple fragments ==> expected: <true> but was: <false>
```

After:
```
Expected inserted rows to span multiple fragments, but got 1 fragment(s).
Distribution: [[0,2000]]. master=local[4], shuffle.partitions=4
```

## Test plan
- [x] 100 consecutive full-suite runs (`make test`) with 0 failures locally