### PR TITLE
chore: add --no-transfer-progress to reduce Maven log noise in CI

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--no-transfer-progress


### PR DESCRIPTION
Add `.mvn/maven.config` with `--no-transfer-progress` to suppress Maven dependency download logs, reducing CI log noise and making build output easier to read.