### PR TITLE
fix: type-aware literal casting in filter pushdown for Decimal, Date, and Timestamp columns

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -31,6 +31,12 @@ import org.apache.spark.sql.sources.Or;
 import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.sources.StringEndsWith;
 import org.apache.spark.sql.sources.StringStartsWith;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DateType;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampType;
 
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -45,15 +51,17 @@ public class FilterPushDown {
    * Create SQL 'where clause' from Spark filters.
    *
    * @param filters Supported spark filters
+   * @param schema the full table schema, used for type-aware literal compilation
    * @return where clause, or Optional.empty() if filters do not exist
    */
-  public static Optional<String> compileFiltersToSqlWhereClause(Filter[] filters) {
+  public static Optional<String> compileFiltersToSqlWhereClause(
+      Filter[] filters, StructType schema) {
     if (filters.length == 0) {
       return Optional.empty();
     }
     List<String> compiledFilters = new ArrayList<>();
     for (Filter filter : filters) {
-      compileFilter(filter).ifPresent(compiledFilters::add);
+      compileFilter(filter, schema).ifPresent(compiledFilters::add);
     }
     String whereClause =
         compiledFilters.stream()
@@ -123,33 +131,38 @@ public class FilterPushDown {
     }
   }
 
-  private static Optional<String> compileFilter(Filter filter) {
+  private static Optional<String> compileFilter(Filter filter, StructType schema) {
     if (filter instanceof GreaterThan) {
       GreaterThan f = (GreaterThan) filter;
-      return Optional.of(f.attribute() + " > " + compileValue(f.value()));
+      return Optional.of(
+          f.attribute() + " > " + compileValue(f.value(), columnType(schema, f.attribute())));
     } else if (filter instanceof LessThan) {
       LessThan f = (LessThan) filter;
-      return Optional.of(f.attribute() + " < " + compileValue(f.value()));
+      return Optional.of(
+          f.attribute() + " < " + compileValue(f.value(), columnType(schema, f.attribute())));
     } else if (filter instanceof LessThanOrEqual) {
       LessThanOrEqual f = (LessThanOrEqual) filter;
-      return Optional.of(f.attribute() + " <= " + compileValue(f.value()));
+      return Optional.of(
+          f.attribute() + " <= " + compileValue(f.value(), columnType(schema, f.attribute())));
     } else if (filter instanceof GreaterThanOrEqual) {
       GreaterThanOrEqual f = (GreaterThanOrEqual) filter;
-      return Optional.of(f.attribute() + " >= " + compileValue(f.value()));
+      return Optional.of(
+          f.attribute() + " >= " + compileValue(f.value(), columnType(schema, f.attribute())));
     } else if (filter instanceof EqualTo) {
       EqualTo f = (EqualTo) filter;
-      return Optional.of(f.attribute() + " == " + compileValue(f.value()));
+      return Optional.of(
+          f.attribute() + " == " + compileValue(f.value(), columnType(schema, f.attribute())));
     } else if (filter instanceof Or) {
       Or f = (Or) filter;
-      Optional<String> left = compileFilter(f.left());
-      Optional<String> right = compileFilter(f.right());
+      Optional<String> left = compileFilter(f.left(), schema);
+      Optional<String> right = compileFilter(f.right(), schema);
       if (left.isEmpty()) return right;
       if (right.isEmpty()) return left;
       return Optional.of(String.format("(%s) OR (%s)", left.get(), right.get()));
     } else if (filter instanceof And) {
       And f = (And) filter;
-      Optional<String> left = compileFilter(f.left());
-      Optional<String> right = compileFilter(f.right());
+      Optional<String> left = compileFilter(f.left(), schema);
+      Optional<String> right = compileFilter(f.right(), schema);
       if (left.isEmpty()) return right;
       if (right.isEmpty()) return left;
       return Optional.of(String.format("(%s) AND (%s)", left.get(), right.get()));
@@ -161,14 +174,15 @@ public class FilterPushDown {
       return Optional.of(String.format("%s IS NOT NULL", f.attribute()));
     } else if (filter instanceof Not) {
       Not f = (Not) filter;
-      Optional<String> child = compileFilter(f.child());
+      Optional<String> child = compileFilter(f.child(), schema);
       if (child.isEmpty()) return child;
       return Optional.of(String.format("NOT (%s)", child.get()));
     } else if (filter instanceof In) {
       In in = (In) filter;
+      DataType colType = columnType(schema, in.attribute());
       String values =
           Arrays.stream(in.values())
-              .map(FilterPushDown::compileValue)
+              .map(v -> compileValue(v, colType))
               .collect(Collectors.joining(","));
       return Optional.of(String.format("%s IN (%s)", in.attribute(), values));
     }
@@ -176,20 +190,56 @@ public class FilterPushDown {
     return Optional.empty();
   }
 
-  private static String compileValue(Object value) {
+  /**
+   * Looks up the data type of a column in the schema.
+   *
+   * @return the column's DataType, or null if the column is not found
+   */
+  private static DataType columnType(StructType schema, String attribute) {
+    if (schema == null) {
+      return null;
+    }
+    try {
+      StructField field = schema.apply(attribute);
+      return field.dataType();
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private static String compileValue(Object value, DataType columnType) {
     if (value instanceof Date) {
       return "date '" + value + "'";
     } else if (value instanceof Timestamp) {
       return "timestamp '" + value + "'";
     } else if (value instanceof String) {
-      return "'" + value + "'";
+      String s = (String) value;
+      if (columnType instanceof DateType) {
+        return "date '" + s + "'";
+      } else if (columnType instanceof TimestampType) {
+        return "timestamp '" + s + "'";
+      }
+      return "'" + s + "'";
     } else if (value instanceof BigDecimal) {
       BigDecimal bd = (BigDecimal) value;
+      if (columnType instanceof DecimalType) {
+        DecimalType dt = (DecimalType) columnType;
+        return "CAST("
+            + bd.toPlainString()
+            + " AS DECIMAL("
+            + dt.precision()
+            + ", "
+            + dt.scale()
+            + "))";
+      }
       int scale = bd.scale();
       // Java returns precision=1 for zero regardless of scale (e.g. 0.00 → precision=1, scale=2).
       // Arrow requires precision >= scale, so clamp precision up if needed.
       int precision = Math.max(bd.precision(), scale);
       return "CAST(" + bd.toPlainString() + " AS DECIMAL(" + precision + ", " + scale + "))";
+    } else if (value instanceof Number && columnType instanceof DecimalType) {
+      DecimalType dt = (DecimalType) columnType;
+      return "CAST(" + value + " AS DECIMAL(" + dt.precision() + ", " + dt.scale() + "))";
     } else if (value instanceof Object[]) {
       Object[] array = (Object[]) value;
       StringBuilder sb = new StringBuilder();
@@ -197,7 +247,7 @@ public class FilterPushDown {
         if (sb.length() > 0) {
           sb.append(", ");
         }
-        sb.append(compileValue(obj));
+        sb.append(compileValue(obj, columnType));
       }
       return sb.toString();
     } else {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -55,6 +55,7 @@ public class LanceScanBuilder
         SupportsPushDownTopN,
         SupportsPushDownAggregates {
   private final LanceSparkReadOptions readOptions;
+  private final StructType fullSchema;
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
@@ -84,6 +85,7 @@ public class LanceScanBuilder
       java.util.Map<String, String> initialStorageOptions,
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties) {
+    this.fullSchema = schema;
     this.schema = schema;
     this.readOptions = readOptions;
     this.initialStorageOptions = initialStorageOptions;
@@ -140,7 +142,8 @@ public class LanceScanBuilder
     // Close the lazily opened dataset - it's no longer needed after build
     closeLazyDataset();
 
-    Optional<String> whereCondition = FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters);
+    Optional<String> whereCondition =
+        FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters, fullSchema);
     return new LanceScan(
         schema,
         readOptions,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
@@ -16,6 +16,8 @@ package org.lance.spark.read;
 import org.lance.spark.utils.Optional;
 
 import org.apache.spark.sql.sources.*;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -32,7 +34,7 @@ public class FilterPushDownTest {
         new Filter[] {
           new GreaterThan("age", 30), new LessThanOrEqual("salary", 100000), new IsNotNull("name")
         };
-    Optional<String> whereClause1 = FilterPushDown.compileFiltersToSqlWhereClause(filters1);
+    Optional<String> whereClause1 = FilterPushDown.compileFiltersToSqlWhereClause(filters1, null);
     assertTrue(whereClause1.isPresent());
     assertEquals("(age > 30) AND (salary <= 100000) AND (name IS NOT NULL)", whereClause1.get());
 
@@ -43,13 +45,13 @@ public class FilterPushDownTest {
           new StringContains("name", "John"),
           new LessThan("salary", 50000)
         };
-    Optional<String> whereClause2 = FilterPushDown.compileFiltersToSqlWhereClause(filters2);
+    Optional<String> whereClause2 = FilterPushDown.compileFiltersToSqlWhereClause(filters2, null);
     assertTrue(whereClause2.isPresent());
     assertEquals("(age > 30) AND (salary < 50000)", whereClause2.get());
 
     // Test case 3: Empty filters array
     Filter[] filters3 = new Filter[] {};
-    Optional<String> whereClause3 = FilterPushDown.compileFiltersToSqlWhereClause(filters3);
+    Optional<String> whereClause3 = FilterPushDown.compileFiltersToSqlWhereClause(filters3, null);
     assertFalse(whereClause3.isPresent());
 
     // Test case 4: Mixed supported and unsupported filters
@@ -60,7 +62,7 @@ public class FilterPushDownTest {
           new IsNull("address"),
           new EqualTo("country", "USA")
         };
-    Optional<String> whereClause4 = FilterPushDown.compileFiltersToSqlWhereClause(filters4);
+    Optional<String> whereClause4 = FilterPushDown.compileFiltersToSqlWhereClause(filters4, null);
     assertTrue(whereClause4.isPresent());
     assertEquals("(age > 30) AND (address IS NULL) AND (country == 'USA')", whereClause4.get());
 
@@ -71,7 +73,7 @@ public class FilterPushDownTest {
           new Or(new IsNotNull("name"), new IsNull("address")),
           new And(new LessThan("salary", 100000), new GreaterThanOrEqual("salary", 50000))
         };
-    Optional<String> whereClause5 = FilterPushDown.compileFiltersToSqlWhereClause(filters5);
+    Optional<String> whereClause5 = FilterPushDown.compileFiltersToSqlWhereClause(filters5, null);
     assertTrue(whereClause5.isPresent());
     assertEquals(
         "(NOT (age > 30)) AND ((name IS NOT NULL) OR (address IS NULL)) AND ((salary < 100000) AND (salary >= 50000))",
@@ -82,7 +84,7 @@ public class FilterPushDownTest {
   public void testCompileFiltersToSqlWhereClauseWithEmptyFilters() {
     Filter[] filters = new Filter[] {};
 
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertFalse(whereClause.isPresent());
   }
 
@@ -92,7 +94,7 @@ public class FilterPushDownTest {
     values[0] = 500;
     values[1] = 600;
     Filter[] filters = new Filter[] {new GreaterThan("age", 30), new In("salary", values)};
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals("(age > 30) AND (salary IN (500,600))", whereClause.get());
   }
@@ -103,7 +105,7 @@ public class FilterPushDownTest {
     values[0] = "500";
     values[1] = "600";
     Filter[] filters = new Filter[] {new GreaterThan("age", 30), new In("salary", values)};
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals("(age > 30) AND (salary IN ('500','600'))", whereClause.get());
   }
@@ -117,7 +119,7 @@ public class FilterPushDownTest {
           new GreaterThanOrEqual("net_profit", new BigDecimal("100.00")),
           new LessThanOrEqual("net_profit", new BigDecimal("200.00"))
         };
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals(
         "(net_profit >= CAST(100.00 AS DECIMAL(5, 2))) AND (net_profit <= CAST(200.00 AS DECIMAL(5, 2)))",
@@ -129,7 +131,7 @@ public class FilterPushDownTest {
     Object[] values =
         new Object[] {new BigDecimal("100.00"), new BigDecimal("150.00"), new BigDecimal("200.00")};
     Filter[] filters = new Filter[] {new In("price", values)};
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals(
         "(price IN (CAST(100.00 AS DECIMAL(5, 2)),CAST(150.00 AS DECIMAL(5, 2)),CAST(200.00 AS DECIMAL(5, 2))))",
@@ -144,7 +146,7 @@ public class FilterPushDownTest {
           new GreaterThan("amount", new BigDecimal("1234567.89")),
           new LessThan("amount", new BigDecimal("0.5"))
         };
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals(
         "(amount > CAST(1234567.89 AS DECIMAL(9, 2))) AND (amount < CAST(0.5 AS DECIMAL(1, 1)))",
@@ -161,7 +163,7 @@ public class FilterPushDownTest {
           new GreaterThan("net_paid", new BigDecimal("0.00")),
           new GreaterThan("net_profit", new BigDecimal("1.00"))
         };
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals(
         "(net_paid > CAST(0.00 AS DECIMAL(2, 2))) AND (net_profit > CAST(1.00 AS DECIMAL(3, 2)))",
@@ -177,7 +179,7 @@ public class FilterPushDownTest {
           new GreaterThanOrEqual("d_date", Date.valueOf("2000-08-23")),
           new LessThanOrEqual("d_date", Date.valueOf("2000-09-06"))
         };
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals(
         "(d_date >= date '2000-08-23') AND (d_date <= date '2000-09-06')", whereClause.get());
@@ -189,8 +191,96 @@ public class FilterPushDownTest {
     // Timestamp, not Utf8.
     Filter[] filters =
         new Filter[] {new EqualTo("created_at", Timestamp.valueOf("2024-01-15 10:30:00.0"))};
-    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, null);
     assertTrue(whereClause.isPresent());
     assertEquals("(created_at == timestamp '2024-01-15 10:30:00.0')", whereClause.get());
+  }
+
+  @Test
+  public void testBigDecimalUsesColumnType() {
+    // When schema is available, BigDecimal should use the column's precision/scale
+    // rather than the value's own precision/scale, for consistency.
+    StructType schema = new StructType().add("net_profit", DataTypes.createDecimalType(7, 2));
+    Filter[] filters =
+        new Filter[] {new GreaterThanOrEqual("net_profit", new BigDecimal("100.00"))};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(net_profit >= CAST(100.00 AS DECIMAL(7, 2)))", whereClause.get());
+  }
+
+  @Test
+  public void testDoubleToDecimalCast() {
+    // Spark sometimes pushes Double literals for Decimal columns (e.g. TPC-DS q32).
+    // Without schema-aware casting, the bare "0.99" is parsed as Float64 by DataFusion,
+    // which rejects Float64-to-Decimal128 conversion.
+    StructType schema = new StructType().add("i_current_price", DataTypes.createDecimalType(7, 2));
+    Filter[] filters = new Filter[] {new GreaterThanOrEqual("i_current_price", 0.99)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(i_current_price >= CAST(0.99 AS DECIMAL(7, 2)))", whereClause.get());
+  }
+
+  @Test
+  public void testIntegerToDecimalCast() {
+    // Spark may push Integer literals for Decimal columns.
+    StructType schema = new StructType().add("price", DataTypes.createDecimalType(10, 2));
+    Filter[] filters = new Filter[] {new EqualTo("price", 100)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(price == CAST(100 AS DECIMAL(10, 2)))", whereClause.get());
+  }
+
+  @Test
+  public void testLongToDecimalCast() {
+    StructType schema = new StructType().add("amount", DataTypes.createDecimalType(18, 0));
+    Filter[] filters = new Filter[] {new LessThan("amount", 999999999L)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(amount < CAST(999999999 AS DECIMAL(18, 0)))", whereClause.get());
+  }
+
+  @Test
+  public void testStringToDateCast() {
+    // Spark sometimes pushes String literals for Date columns (e.g. TPC-DS q58).
+    // Without schema-aware casting, the string '2000-01-27' is parsed as Utf8 by DataFusion,
+    // which rejects Utf8-to-Date32 conversion.
+    StructType schema = new StructType().add("d_date", DataTypes.DateType);
+    Filter[] filters = new Filter[] {new GreaterThanOrEqual("d_date", "2000-01-27")};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(d_date >= date '2000-01-27')", whereClause.get());
+  }
+
+  @Test
+  public void testStringToTimestampCast() {
+    StructType schema = new StructType().add("event_time", DataTypes.TimestampType);
+    Filter[] filters = new Filter[] {new LessThan("event_time", "2024-01-15 10:30:00")};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(event_time < timestamp '2024-01-15 10:30:00')", whereClause.get());
+  }
+
+  @Test
+  public void testDoubleInDecimalColumn() {
+    // IN clause with Double values for a Decimal column.
+    StructType schema = new StructType().add("price", DataTypes.createDecimalType(7, 2));
+    Object[] values = new Object[] {1.5, 2.5, 3.5};
+    Filter[] filters = new Filter[] {new In("price", values)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals(
+        "(price IN (CAST(1.5 AS DECIMAL(7, 2)),CAST(2.5 AS DECIMAL(7, 2)),CAST(3.5 AS DECIMAL(7, 2))))",
+        whereClause.get());
+  }
+
+  @Test
+  public void testStringInDateColumn() {
+    // IN clause with String values for a Date column.
+    StructType schema = new StructType().add("d_date", DataTypes.DateType);
+    Object[] values = new Object[] {"2000-01-27", "2000-02-15"};
+    Filter[] filters = new Filter[] {new In("d_date", values)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters, schema);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(d_date IN (date '2000-01-27',date '2000-02-15'))", whereClause.get());
   }
 }


### PR DESCRIPTION
### Summary

- Thread column type information into `FilterPushDown.compileValue()` to emit correctly typed SQL literals for pushed-down filters

### Motivation

Closes #350.

When Spark pushes filter predicates to lance-core, it sometimes passes literals whose Java types don't match the column's Arrow type. Lance-core's DataFusion parser rejects the mismatch:

- `Double`/`Integer`/`Long` literal for a `Decimal128` column → DataFusion receives `Float64`/`Int32`/`Int64`, cannot convert to `Decimal128`
- `String` literal for a `Date32` column → DataFusion receives `Utf8`, cannot convert to `Date32`

This affects 27 TPC-DS queries (q5, q12, q13, q16, q20, q21, q28, q32, q33, q37, q40, q43, q49, q56, q58, q60, q61, q64, q77, q80, q82, q83, q91, q92, q94, q95, q98).

### Changes

| File | Change |
|------|--------|
| `FilterPushDown.java` | Add `StructType schema` parameter to `compileFiltersToSqlWhereClause()` and `compileFilter()`. `compileValue()` now accepts `DataType columnType` and emits `CAST(... AS DECIMAL(p,s))` for numeric-to-decimal, `date '...'` for string-to-date, and `timestamp '...'` for string-to-timestamp. `BigDecimal` also uses column type when available. |
| `LanceScanBuilder.java` | Store `fullSchema` (the pre-pruning table schema) and pass it to filter compilation in `build()`. Needed because `pruneColumns()` may remove filtered columns from `schema`. |
| `FilterPushDownTest.java` | Add 8 new tests: Double/Integer/Long→Decimal, BigDecimal-with-schema, String→Date, String→Timestamp, IN-with-Double-in-Decimal, IN-with-String-in-Date. |

### Test plan

- [x] `make test` — 339 tests pass, 0 failures
- [x] `make lint` — 0 violations