### PR TITLE
fix: missing metadata issues when converting between ArrowField and SparkField

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -405,9 +405,20 @@ public class SchemaConverter {
       dataType.setType("timestamp");
     } else if (sparkType instanceof DecimalType) {
       DecimalType decimalType = (DecimalType) sparkType;
-      dataType.setType("decimal128");
-      // This is the convention set in lance-namespace/src/schema.rs
-      dataType.setLength((long) decimalType.precision() * 1000 + decimalType.scale());
+      int precision = decimalType.precision();
+      if (precision <= 9) {
+        dataType.setType("decimal32");
+      } else if (precision <= 18) {
+        dataType.setType("decimal64");
+      } else if (precision <= 38) {
+        dataType.setType("decimal128");
+      } else {
+        dataType.setType("decimal256");
+      }
+      // Encodes precision and scale into a single length field using the convention
+      // set in lance-namespace/src/schema.rs:
+      // https://github.com/lance-format/lance/blob/5f4bf81a3624865de411cf0e154b55bedbaee564/rust/lance-namespace/src/schema.rs#L76-L80
+      dataType.setLength((long) precision * 1000 + decimalType.scale());
     } else if (sparkType instanceof NullType) {
       dataType.setType("null");
     } else if (sparkType instanceof YearMonthIntervalType) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -42,10 +42,12 @@ import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.sql.types.UserDefinedType;
 import org.apache.spark.sql.types.YearMonthIntervalType;
+import scala.collection.JavaConverters;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_KEY;
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_VALUE;
@@ -339,6 +341,16 @@ public class SchemaConverter {
     field.setNullable(sparkField.nullable());
     field.setType(
         toJsonArrowDataType(sparkField.dataType(), sparkField.name(), sparkField.metadata()));
+    if (sparkField.metadata() != null) {
+      Map<String, String> stringMap =
+          JavaConverters.mapAsJavaMapConverter(sparkField.metadata().map())
+              .asJava()
+              .entrySet()
+              .stream()
+              .filter(entry -> entry.getValue() != null)
+              .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()));
+      field.setMetadata(stringMap);
+    }
     return field;
   }
 
@@ -386,15 +398,16 @@ public class SchemaConverter {
     } else if (sparkType instanceof BinaryType) {
       dataType.setType("binary");
     } else if (sparkType instanceof DateType) {
-      dataType.setType("date");
+      dataType.setType("date32");
     } else if (sparkType instanceof TimestampType) {
       dataType.setType("timestamp");
     } else if (sparkType instanceof TimestampNTZType) {
       dataType.setType("timestamp");
     } else if (sparkType instanceof DecimalType) {
       DecimalType decimalType = (DecimalType) sparkType;
-      dataType.setType("decimal");
-      // Note: precision and scale would need additional fields if supported
+      dataType.setType("decimal128");
+      // This is the convention set in lance-namespace/src/schema.rs
+      dataType.setLength((long) decimalType.precision() * 1000 + decimalType.scale());
     } else if (sparkType instanceof NullType) {
       dataType.setType("null");
     } else if (sparkType instanceof YearMonthIntervalType) {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -242,7 +242,7 @@ object LanceArrowUtils {
           name,
           fieldType,
           fields.map { field =>
-            toArrowField(field.name, field.dataType, field.nullable, timeZoneId)
+            toArrowField(field.name, field.dataType, field.nullable, timeZoneId, field.metadata)
           }.toSeq.asJava)
       case MapType(keyType, valueType, valueContainsNull) =>
         val mapType = new FieldType(nullable, new ArrowType.Map(false), null, meta.asJava)


### PR DESCRIPTION
fix bugs:
1. toArrowField: fix the issue of missing meta(comment) inside the struct data type.
2. toJsonArrowField: fix the issue of missing metadata in field.
3. toJsonArrowDataType: fix  type compatibility.