### PR TITLE
feat: add TPC-H benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,21 @@ benchmark-run:
 .PHONY: benchmark
 benchmark: benchmark-generate benchmark-run
 
+.PHONY: benchmark-tpch-generate
+benchmark-tpch-generate:
+	cd benchmark && \
+		SPARK_VERSION=$(SPARK_VERSION) SCALA_VERSION=$(SCALA_VERSION) \
+		./scripts/generate-tpch-data.sh $(SF) $(FORMATS) $(SPARK_MASTER)
+
+.PHONY: benchmark-tpch-run
+benchmark-tpch-run:
+	cd benchmark && \
+		SPARK_VERSION=$(SPARK_VERSION) SCALA_VERSION=$(SCALA_VERSION) \
+		./scripts/run-tpch-benchmark.sh $(FORMATS) $(SPARK_MASTER) $(ITERATIONS)
+
+.PHONY: benchmark-tpch
+benchmark-tpch: benchmark-tpch-generate benchmark-tpch-run
+
 SF ?= 1
 FORMATS ?= lance,parquet
 SPARK_MASTER ?= local[*]
@@ -282,10 +297,13 @@ help:
 	@echo "  docker-test            - Run integration tests in lance-spark-test container"
 	@echo ""
 	@echo "Benchmark:"
-	@echo "  benchmark-build        - Build benchmark jar"
-	@echo "  benchmark-generate     - Generate TPC-DS data via Spark (SF=1 FORMATS=lance,parquet)"
-	@echo "  benchmark-run          - Run TPC-DS queries (FORMATS=lance,parquet ITERATIONS=3)"
-	@echo "  benchmark              - Generate data + run queries (end-to-end)"
+	@echo "  benchmark-build         - Build benchmark jar (shared by TPC-DS and TPC-H)"
+	@echo "  benchmark-generate      - Generate TPC-DS data via Spark (SF=1 FORMATS=lance,parquet)"
+	@echo "  benchmark-run           - Run TPC-DS queries (FORMATS=lance,parquet ITERATIONS=3)"
+	@echo "  benchmark               - Generate TPC-DS data + run queries (end-to-end)"
+	@echo "  benchmark-tpch-generate - Generate TPC-H data via Spark (SF=1 FORMATS=lance,parquet)"
+	@echo "  benchmark-tpch-run      - Run TPC-H queries (FORMATS=lance,parquet ITERATIONS=3)"
+	@echo "  benchmark-tpch          - Generate TPC-H data + run queries (end-to-end)"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  serve-docs     - Serve documentation locally"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -217,7 +217,7 @@ spark-submit \
   --master local[*] \
   --driver-memory 8g \
   --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
   --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \
   benchmark/target/lance-spark-benchmark-*.jar \
@@ -273,7 +273,7 @@ spark-submit \
   --executor-cores 4 \
   --num-executors 8 \
   --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.sql.adaptive.enabled=true \
   --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
   --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,22 +1,40 @@
-# TPC-DS Benchmark for Lance Spark
+# Lance Spark Benchmarks
 
-Runs the [TPC-DS](http://www.tpc.org/tpcds/) query suite against Lance and Parquet formats using Apache Spark, comparing query performance, correctness, and resource usage.
+Runs the [TPC-DS](http://www.tpc.org/tpcds/) and [TPC-H](http://www.tpc.org/tpch/) query suites against Lance and Parquet formats using Apache Spark, comparing query performance, correctness, and resource usage.
 
 `parquet` here refers to Spark's built-in Parquet reader, used as a performance baseline.
 
 ## Architecture
 
-Data generation uses the [Apache Kyuubi TPC-DS connector](https://kyuubi.readthedocs.io/en/master/connector/spark/tpcds.html), a pure-Spark data source that generates TPC-DS data in parallel across executors. No external `dsdgen` binary, CSV files, or intermediate formats are needed — data is written directly into the target format (Lance, Parquet, etc.) and can target any Spark-supported storage (local, S3, GCS, HDFS).
+Data generation uses Apache Kyuubi's [TPC-DS](https://kyuubi.readthedocs.io/en/master/connector/spark/tpcds.html) and [TPC-H](https://kyuubi.readthedocs.io/en/master/connector/spark/tpch.html) connectors — pure-Spark data sources that generate test data in parallel across executors. No external `dsdgen`/`dbgen` binaries, CSV files, or intermediate formats are needed — data is written directly into the target format (Lance, Parquet, etc.) and can target any Spark-supported storage (local, S3, GCS, HDFS).
 
-The pipeline is split into two independent Spark jobs:
+Each benchmark is split into two independent Spark jobs:
 
-1. **`TpcdsDataGenerator`** — Reads from the Kyuubi TPC-DS catalog and writes all 24 tables directly into each target format.
-2. **`TpcdsBenchmarkRunner`** — Registers the generated tables and runs the 99 TPC-DS queries, comparing formats.
+1. **Data generator** — Reads from the Kyuubi catalog and writes all tables directly into each target format (24 tables for TPC-DS, 8 tables for TPC-H).
+2. **Benchmark runner** — Registers the generated tables and runs the full query suite, comparing formats (99 queries for TPC-DS, 22 for TPC-H).
+
+Both benchmarks share the same reporting infrastructure (`BenchmarkResult`, `BenchmarkReporter`, `QueryMetrics`, `QueryMetricsListener`) and produce output in the same CSV/summary format, so results are directly comparable across workloads.
 
 ### TODO
 - **Delta / Iceberg support** — not yet included because they require additional catalog/metastore tooling outside lance-spark's scope.
 
-## Quick Start
+## Data Layout
+
+The default data directories are isolated between the two benchmarks:
+
+```
+benchmark/data/          # TPC-DS tables (default DATA_DIR for TPC-DS scripts)
+benchmark/data/tpch/     # TPC-H tables (default DATA_DIR for TPC-H scripts)
+benchmark/results/       # tpcds_*.csv AND tpch_*.csv (shared)
+```
+
+**Why the isolation matters**: TPC-DS and TPC-H both define a `customer` table with *different* schemas. If both benchmarks shared one data directory, `createOrReplaceTempView("customer", ...)` would silently overwrite one with the other between runs, causing cryptic query failures. If you override `DATA_DIR`, use distinct paths for the two benchmarks to preserve this isolation.
+
+The shared `benchmark/results/` directory is fine — CSV files are prefixed `tpcds_*.csv` or `tpch_*.csv` so they never collide.
+
+## Running TPC-DS
+
+### Quick Start
 
 ```bash
 # Build the jars first
@@ -55,9 +73,53 @@ SPARK_VERSION=3.5 SCALA_VERSION=2.12 ./benchmark/scripts/generate-data.sh 10
 
 Set `SPARK_HOME` if `spark-submit` is not on your `PATH`.
 
+## Running TPC-H
+
+### Quick Start
+
+```bash
+# Build the jars first (shared with TPC-DS)
+make bundle SPARK_VERSION=3.5 SCALA_VERSION=2.12
+make benchmark-build
+
+# End-to-end: generate data + run queries
+make benchmark-tpch SF=10 FORMATS=parquet,lance ITERATIONS=3
+```
+
+Or run the two phases separately:
+
+```bash
+# Step 1: Generate TPC-H data (parallel Spark job)
+./benchmark/scripts/generate-tpch-data.sh [SCALE_FACTOR] [FORMATS] [SPARK_MASTER]
+
+# Step 2: Run benchmark queries against generated data
+./benchmark/scripts/run-tpch-benchmark.sh [FORMATS] [SPARK_MASTER] [ITERATIONS]
+```
+
+### Examples
+
+```bash
+# Generate SF=10 data in both formats
+./benchmark/scripts/generate-tpch-data.sh 10 parquet,lance local[*]
+
+# Run queries with profiling
+EXPLAIN=true METRICS=true ./benchmark/scripts/run-tpch-benchmark.sh parquet,lance local[*] 3
+
+# Run a subset of queries
+QUERIES=q1,q6,q14 ./benchmark/scripts/run-tpch-benchmark.sh lance local[*] 1
+
+# Override default data dir (e.g. to avoid the default benchmark/data/tpch location)
+DATA_DIR=/tmp/tpch-sf10 ./benchmark/scripts/generate-tpch-data.sh 10
+
+# Override Spark/Scala versions
+SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./benchmark/scripts/generate-tpch-data.sh 10
+```
+
+TPC-H query files (`benchmark/src/main/resources/tpch-queries/q1.sql` through `q22.sql`) are derived from Apache Kyuubi's `kyuubi-spark-connector-tpch` test resources (Apache 2.0 licensed).
+
 ### Using the Docker environment
 
-If you don't have Spark installed locally, use the existing `spark-lance` Docker container. The benchmark jar, data, and results directories are volume-mounted automatically.
+If you don't have Spark installed locally, use the existing `spark-lance` Docker container. The benchmark jar, data, and results directories are volume-mounted automatically — the same container and mounts work for both TPC-DS and TPC-H.
 
 ```bash
 # Build jars on the host
@@ -67,19 +129,34 @@ make benchmark-build
 # Start the Spark container
 make docker-up
 
-# Generate data (inside the container)
+# Generate TPC-DS data (inside the container)
 docker exec spark-lance spark-submit \
   --class org.lance.spark.benchmark.TpcdsDataGenerator \
   --master local[*] \
   /home/lance/benchmark/lance-spark-benchmark-0.3.0-beta.1.jar \
   --data-dir /home/lance/data --scale-factor 1 --formats parquet,lance
 
-# Run benchmark queries (inside the container)
+# Run TPC-DS benchmark queries (inside the container)
 docker exec spark-lance spark-submit \
   --class org.lance.spark.benchmark.TpcdsBenchmarkRunner \
   --master local[*] \
   /home/lance/benchmark/lance-spark-benchmark-0.3.0-beta.1.jar \
   --data-dir /home/lance/data --results-dir /home/lance/results \
+  --formats parquet,lance --iterations 3
+
+# Generate TPC-H data (inside the container, note the /tpch subdir)
+docker exec spark-lance spark-submit \
+  --class org.lance.spark.benchmark.TpchDataGenerator \
+  --master local[*] \
+  /home/lance/benchmark/lance-spark-benchmark-0.3.0-beta.1.jar \
+  --data-dir /home/lance/data/tpch --scale-factor 1 --formats parquet,lance
+
+# Run TPC-H benchmark queries (inside the container)
+docker exec spark-lance spark-submit \
+  --class org.lance.spark.benchmark.TpchBenchmarkRunner \
+  --master local[*] \
+  /home/lance/benchmark/lance-spark-benchmark-0.3.0-beta.1.jar \
+  --data-dir /home/lance/data/tpch --results-dir /home/lance/results \
   --formats parquet,lance --iterations 3
 
 # Results appear on the host at benchmark/results/
@@ -102,9 +179,11 @@ make docker-shell
        Metrics: tasks=12 cpu=680ms gc=15ms read=45MB shuffle_r=2MB shuffle_w=2MB
 ```
 
+Both flags work for TPC-DS and TPC-H runners.
+
 ## Running on an External Cluster
 
-To benchmark against a standalone or YARN cluster with data in an object store (S3, GCS, HDFS):
+To benchmark against a standalone or YARN cluster with data in an object store (S3, GCS, HDFS), the same `spark-submit` patterns apply — only the runner class differs between TPC-DS and TPC-H.
 
 ### 1. Build the jars
 
@@ -113,11 +192,12 @@ make bundle SPARK_VERSION=3.5 SCALA_VERSION=2.12
 make benchmark-build
 ```
 
-### 2. Generate TPC-DS data directly to object store
+### 2. Generate data directly to object store
 
-Data generation is a Spark job — it writes directly to any Spark-supported storage:
+Data generation is a Spark job — it writes directly to any Spark-supported storage. Use `TpcdsDataGenerator` or `TpchDataGenerator` depending on the workload:
 
 ```bash
+# TPC-DS (SF=10)
 spark-submit \
   --class org.lance.spark.benchmark.TpcdsDataGenerator \
   --master local[*] \
@@ -130,18 +210,38 @@ spark-submit \
   --data-dir s3a://my-bucket/tpcds/sf10 \
   --scale-factor 10 \
   --formats parquet,lance
+
+# TPC-H (SF=10) — note distinct bucket path to avoid `customer` collision
+spark-submit \
+  --class org.lance.spark.benchmark.TpchDataGenerator \
+  --master local[*] \
+  --driver-memory 8g \
+  --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
+  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
+  --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \
+  benchmark/target/lance-spark-benchmark-*.jar \
+  --data-dir s3a://my-bucket/tpch/sf10 \
+  --scale-factor 10 \
+  --formats parquet,lance
 ```
 
-Or use the script with env vars:
+Or use the wrapper scripts with env vars:
 
 ```bash
+# TPC-DS
 DATA_DIR=s3a://my-bucket/tpcds/sf10 \
 ./benchmark/scripts/generate-data.sh 10 parquet,lance local[*]
+
+# TPC-H
+DATA_DIR=s3a://my-bucket/tpch/sf10 \
+./benchmark/scripts/generate-tpch-data.sh 10 parquet,lance local[*]
 ```
 
 ### 3. Run benchmark queries on the cluster
 
 ```bash
+# TPC-DS
 spark-submit \
   --class org.lance.spark.benchmark.TpcdsBenchmarkRunner \
   --master spark://cluster-master:7077 \
@@ -162,6 +262,28 @@ spark-submit \
   --iterations 3 \
   --explain \
   --metrics
+
+# TPC-H — identical submit flags, just a different class and paths
+spark-submit \
+  --class org.lance.spark.benchmark.TpchBenchmarkRunner \
+  --master spark://cluster-master:7077 \
+  --deploy-mode client \
+  --driver-memory 8g \
+  --executor-memory 16g \
+  --executor-cores 4 \
+  --num-executors 8 \
+  --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
+  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.adaptive.enabled=true \
+  --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
+  --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \
+  benchmark/target/lance-spark-benchmark-*.jar \
+  --data-dir s3a://my-bucket/tpch/sf10 \
+  --results-dir s3a://my-bucket/tpch/sf10/results \
+  --formats parquet,lance \
+  --iterations 3 \
+  --explain \
+  --metrics
 ```
 
 For YARN:
@@ -176,17 +298,19 @@ For GCS, use `--conf spark.hadoop.google.cloud.auth.service.account.json.keyfile
 
 ## Output
 
-Results are written to a timestamped CSV file (e.g. `tpcds_20260318_062221.csv`) and a summary table is printed to stdout:
+Results are written to a timestamped CSV file (e.g. `tpcds_20260318_062221.csv` or `tpch_20260318_073015.csv`) and a summary table is printed to stdout:
 
 ```
+=== TPC-H Benchmark Summary ===
+
 Query     parquet(ms)    lance(ms)      Ratio   Status
 -------------------------------------------------------
-q1               2505         1529       1.64x     PASS
-q3                796          756       1.05x     PASS
-q4               6426        14229       0.45x     PASS
+q1               2105         1890       1.11x     PASS
+q3                756          712       1.06x     PASS
+q6                890          542       1.64x     PASS
 ...
-Geometric mean ratio (parquet/lance): 0.87x
-Queries passed: 75, partial/failed: 30
+Geometric mean ratio (parquet/lance): 0.91x
+Queries passed: 22, partial/failed: 0
 Row count validation: all matching
 ```
 
@@ -197,20 +321,34 @@ When `--metrics` is enabled, extra columns appear (CPU time, bytes read, shuffle
 ```
 benchmark/
 ├── scripts/
-│   ├── generate-data.sh          # Data generation via Spark + Kyuubi connector
-│   └── run-benchmark.sh          # Query runner
+│   ├── generate-data.sh             # TPC-DS data generation wrapper
+│   ├── run-benchmark.sh             # TPC-DS query runner wrapper
+│   ├── submit-datagen.sh            # TPC-DS cluster-ready data generation
+│   ├── submit-benchmark.sh          # TPC-DS cluster-ready query runner
+│   ├── generate-tpch-data.sh        # TPC-H data generation wrapper
+│   ├── run-tpch-benchmark.sh        # TPC-H query runner wrapper
+│   ├── submit-tpch-datagen.sh       # TPC-H cluster-ready data generation
+│   └── submit-tpch-benchmark.sh     # TPC-H cluster-ready query runner
 ├── src/main/java/org/lance/spark/benchmark/
-│   ├── TpcdsDataGenerator.java   # Spark job: Kyuubi TPC-DS → Lance/Parquet
-│   ├── TpcdsBenchmarkRunner.java # Main entry point for query benchmarking
-│   ├── TpcdsDataLoader.java      # Register pre-generated tables as temp views
-│   ├── TpcdsQueryRunner.java     # Query execution loop
-│   ├── BenchmarkResult.java      # Per-query result record
-│   ├── BenchmarkReporter.java    # CSV + summary output
-│   ├── QueryMetrics.java         # Per-query task-level metrics
-│   └── QueryMetricsListener.java # SparkListener for metrics collection
-├── src/main/resources/tpcds-queries/
-│   └── q1.sql ... q99.sql        # 103 TPC-DS query files
-├── data/                         # Generated data (gitignored)
-├── results/                      # Output CSVs (gitignored)
+│   ├── TpcdsDataGenerator.java      # Spark job: Kyuubi TPC-DS → Lance/Parquet
+│   ├── TpcdsBenchmarkRunner.java    # TPC-DS query benchmarking entry point
+│   ├── TpcdsDataLoader.java         # Register pre-generated TPC-DS tables
+│   ├── TpcdsQueryRunner.java        # TPC-DS query execution loop
+│   ├── TpchDataGenerator.java       # Spark job: Kyuubi TPC-H → Lance/Parquet
+│   ├── TpchBenchmarkRunner.java     # TPC-H query benchmarking entry point
+│   ├── TpchDataLoader.java          # Register pre-generated TPC-H tables
+│   ├── TpchQueryRunner.java         # TPC-H query execution loop
+│   ├── BenchmarkResult.java         # Per-query result record (shared)
+│   ├── BenchmarkReporter.java       # CSV + summary output (shared)
+│   ├── QueryMetrics.java            # Per-query task-level metrics (shared)
+│   └── QueryMetricsListener.java    # SparkListener for metrics (shared)
+├── src/main/resources/
+│   ├── tpcds-queries/
+│   │   └── q1.sql ... q99.sql       # 103 TPC-DS query files
+│   └── tpch-queries/
+│       └── q1.sql ... q22.sql       # 22 TPC-H query files
+├── data/                            # Generated data (gitignored)
+│   └── tpch/                        # TPC-H default subdirectory (isolated)
+├── results/                         # Output CSVs (gitignored)
 └── pom.xml
 ```

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -7,8 +7,8 @@
     <version>0.3.0-beta.1</version>
     <packaging>jar</packaging>
 
-    <name>Lance Spark TPC-DS Benchmark</name>
-    <description>TPC-DS benchmark for Lance Spark connector</description>
+    <name>Lance Spark Benchmark (TPC-DS + TPC-H)</name>
+    <description>TPC-DS and TPC-H benchmarks for Lance Spark connector</description>
 
     <properties>
         <spark.compat.version>3.5</spark.compat.version>
@@ -33,6 +33,13 @@
             <artifactId>kyuubi-spark-connector-tpcds_${scala.compat.version}</artifactId>
             <version>${kyuubi.version}</version>
         </dependency>
+        <!-- Kyuubi TPC-H connector: pure-Spark data source for parallel TPC-H
+             data generation. No external dbgen binary needed. -->
+        <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-spark-connector-tpch_${scala.compat.version}</artifactId>
+            <version>${kyuubi.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -48,13 +55,6 @@
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.lance.spark.benchmark.TpcdsBenchmarkRunner</mainClass>
-                        </manifest>
-                    </archive>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -67,9 +67,6 @@
                         </goals>
                         <configuration>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.lance.spark.benchmark.TpcdsBenchmarkRunner</mainClass>
-                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <filters>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -55,6 +55,13 @@
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.lance.spark.benchmark.TpcdsBenchmarkRunner</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -67,6 +74,9 @@
                         </goals>
                         <configuration>
                             <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.lance.spark.benchmark.TpcdsBenchmarkRunner</mainClass>
+                                </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <filters>

--- a/benchmark/scripts/generate-tpch-data.sh
+++ b/benchmark/scripts/generate-tpch-data.sh
@@ -46,6 +46,15 @@ echo "Spark master:    ${SPARK_MASTER}"
 echo "Spark version:   ${SPARK_VERSION}"
 echo "Scala version:   ${SCALA_VERSION}"
 echo "Data dir:        ${DATA_DIR}"
+if [ -n "${FILE_FORMAT_VERSION:-}" ]; then
+  echo "File format version: ${FILE_FORMAT_VERSION}"
+fi
+if [ -n "${MAX_BYTES_PER_FILE:-}" ]; then
+  echo "Max bytes/file:  ${MAX_BYTES_PER_FILE}"
+fi
+if [ -n "${MAX_ROWS_PER_FILE:-}" ]; then
+  echo "Max rows/file:   ${MAX_ROWS_PER_FILE}"
+fi
 echo ""
 
 # Step 1: Build benchmark jar if needed
@@ -81,12 +90,14 @@ ${SPARK_SUBMIT} \
   --driver-memory "${DRIVER_MEMORY:-4g}" \
   --executor-memory "${EXECUTOR_MEMORY:-4g}" \
   --jars "${BUNDLE_JAR}" \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
+  ${MAX_BYTES_PER_FILE:+ --conf spark.sql.catalog.lance_default.max_bytes_per_file="${MAX_BYTES_PER_FILE}"} \
+  ${MAX_ROWS_PER_FILE:+ --conf spark.sql.catalog.lance_default.max_row_per_file="${MAX_ROWS_PER_FILE}"} \
   "${BENCHMARK_JAR}" \
   --data-dir "${DATA_DIR}" \
   --scale-factor "${SCALE_FACTOR}" \
-  --formats "${FORMATS}"
+  --formats "${FORMATS}"${FILE_FORMAT_VERSION:+ --file-format-version "${FILE_FORMAT_VERSION}"}
 
 echo ""
 echo "=== Data generation complete ==="

--- a/benchmark/scripts/generate-tpch-data.sh
+++ b/benchmark/scripts/generate-tpch-data.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TPC-H data generation via Spark (using Kyuubi TPC-H connector).
+#
+# Generates TPC-H tables in parallel across Spark executors and writes
+# them directly into the target format(s) — no intermediate files.
+#
+# Note: defaults DATA_DIR to ${BENCHMARK_DIR}/data/tpch to avoid schema
+# collision with TPC-DS (both suites define a `customer` table with
+# different schemas).
+#
+# Usage:
+#   ./generate-tpch-data.sh [SCALE_FACTOR] [FORMATS] [SPARK_MASTER]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="${SCRIPT_DIR}/.."
+
+# Configurable Spark/Scala versions (override via environment)
+SPARK_VERSION="${SPARK_VERSION:-3.5}"
+SCALA_VERSION="${SCALA_VERSION:-2.12}"
+
+SCALE_FACTOR="${1:-1}"
+FORMATS="${2:-parquet,lance}"
+SPARK_MASTER="${3:-local[*]}"
+
+# Object store / external paths — default to local when unset
+DATA_DIR="${DATA_DIR:-${BENCHMARK_DIR}/data/tpch}"
+
+echo "=== TPC-H Data Generation ==="
+echo "Scale factor:    ${SCALE_FACTOR}"
+echo "Formats:         ${FORMATS}"
+echo "Spark master:    ${SPARK_MASTER}"
+echo "Spark version:   ${SPARK_VERSION}"
+echo "Scala version:   ${SCALA_VERSION}"
+echo "Data dir:        ${DATA_DIR}"
+echo ""
+
+# Step 1: Build benchmark jar if needed
+BENCHMARK_JAR="${BENCHMARK_DIR}/target/lance-spark-benchmark.jar"
+if [ ! -f "${BENCHMARK_JAR}" ]; then
+  echo "--- Building benchmark jar (Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION}) ---"
+  cd "${BENCHMARK_DIR}"
+  ../mvnw  package -DskipTests -q \
+    -Dspark.compat.version="${SPARK_VERSION}" \
+    -Dscala.compat.version="${SCALA_VERSION}"
+  cd "${SCRIPT_DIR}"
+fi
+
+# Step 2: Find the bundle jar
+BUNDLE_JAR=$(find "${BENCHMARK_DIR}/.." -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" -not -name "*sources*" -not -name "*javadoc*" | head -1)
+if [ -z "${BUNDLE_JAR}" ]; then
+  echo "WARNING: lance-spark bundle jar not found. Building it..."
+  cd "${BENCHMARK_DIR}/.."
+  make bundle SPARK_VERSION="${SPARK_VERSION}" SCALA_VERSION="${SCALA_VERSION}"
+  BUNDLE_JAR=$(find "${BENCHMARK_DIR}/.." -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" -not -name "*sources*" -not -name "*javadoc*" | head -1)
+  cd "${SCRIPT_DIR}"
+fi
+
+# Step 3: Generate data via spark-submit
+SPARK_SUBMIT="spark-submit"
+if [ -n "${SPARK_HOME:-}" ]; then
+  SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
+fi
+
+${SPARK_SUBMIT} \
+  --class org.lance.spark.benchmark.TpchDataGenerator \
+  --master "${SPARK_MASTER}" \
+  --driver-memory "${DRIVER_MEMORY:-4g}" \
+  --executor-memory "${EXECUTOR_MEMORY:-4g}" \
+  --jars "${BUNDLE_JAR}" \
+  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
+  "${BENCHMARK_JAR}" \
+  --data-dir "${DATA_DIR}" \
+  --scale-factor "${SCALE_FACTOR}" \
+  --formats "${FORMATS}"
+
+echo ""
+echo "=== Data generation complete ==="

--- a/benchmark/scripts/run-tpch-benchmark.sh
+++ b/benchmark/scripts/run-tpch-benchmark.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TPC-H benchmark query runner.
+#
+# Tables must already exist under DATA_DIR/<format>/. Use generate-tpch-data.sh
+# (or TpchDataGenerator) to create them first.
+#
+# Note: defaults DATA_DIR to ${BENCHMARK_DIR}/data/tpch to avoid schema
+# collision with TPC-DS (both suites define a `customer` table with
+# different schemas).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="${SCRIPT_DIR}/.."
+
+# Configurable Spark/Scala versions (override via environment)
+SPARK_VERSION="${SPARK_VERSION:-3.5}"
+SCALA_VERSION="${SCALA_VERSION:-2.12}"
+
+FORMATS="${1:-lance,parquet}"
+SPARK_MASTER="${2:-local[*]}"
+ITERATIONS="${3:-3}"
+
+# Object store / external paths — default to local when unset
+DATA_DIR="${DATA_DIR:-${BENCHMARK_DIR}/data/tpch}"
+RESULTS_DIR="${RESULTS_DIR:-${BENCHMARK_DIR}/results}"
+
+echo "=== TPC-H Benchmark ==="
+echo "Formats:         ${FORMATS}"
+echo "Spark master:    ${SPARK_MASTER}"
+echo "Iterations:      ${ITERATIONS}"
+echo "Spark version:   ${SPARK_VERSION}"
+echo "Scala version:   ${SCALA_VERSION}"
+echo "Data dir:        ${DATA_DIR}"
+echo "Results dir:     ${RESULTS_DIR}"
+echo ""
+
+# Step 1: Build benchmark jar if needed
+echo "--- Step 1: Build benchmark jar ---"
+BENCHMARK_JAR="${BENCHMARK_DIR}/target/lance-spark-benchmark.jar"
+if [ ! -f "${BENCHMARK_JAR}" ]; then
+  cd "${BENCHMARK_DIR}"
+  ../mvnw package -DskipTests -q \
+    -Dspark.compat.version="${SPARK_VERSION}" \
+    -Dscala.compat.version="${SCALA_VERSION}"
+  cd "${SCRIPT_DIR}"
+fi
+
+# Step 2: Find the bundle jar
+BUNDLE_JAR=$(find "${BENCHMARK_DIR}/.." -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" -not -name "*sources*" -not -name "*javadoc*" | head -1)
+if [ -z "${BUNDLE_JAR}" ]; then
+  echo "WARNING: lance-spark bundle jar not found. Building it..."
+  cd "${BENCHMARK_DIR}/.."
+  make bundle SPARK_VERSION="${SPARK_VERSION}" SCALA_VERSION="${SCALA_VERSION}"
+  BUNDLE_JAR=$(find "${BENCHMARK_DIR}/.." -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" -not -name "*sources*" -not -name "*javadoc*" | head -1)
+  cd "${SCRIPT_DIR}"
+fi
+
+# Step 3: Run benchmark via spark-submit
+echo ""
+echo "--- Step 3: Run benchmark ---"
+mkdir -p "${RESULTS_DIR}"
+
+SPARK_SUBMIT="spark-submit"
+if [ -n "${SPARK_HOME:-}" ]; then
+  SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
+fi
+
+# Build extra benchmark args from environment
+BENCHMARK_EXTRA_ARGS=""
+if [ "${EXPLAIN:-false}" = true ]; then
+  BENCHMARK_EXTRA_ARGS="${BENCHMARK_EXTRA_ARGS} --explain"
+fi
+if [ "${METRICS:-false}" = true ]; then
+  BENCHMARK_EXTRA_ARGS="${BENCHMARK_EXTRA_ARGS} --metrics"
+fi
+if [ -n "${QUERIES:-}" ]; then
+  BENCHMARK_EXTRA_ARGS="${BENCHMARK_EXTRA_ARGS} --queries ${QUERIES}"
+fi
+
+${SPARK_SUBMIT} \
+  --class org.lance.spark.benchmark.TpchBenchmarkRunner \
+  --master "${SPARK_MASTER}" \
+  --driver-memory "${DRIVER_MEMORY:-4g}" \
+  --executor-memory "${EXECUTOR_MEMORY:-4g}" \
+  --jars "${BUNDLE_JAR}" \
+  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
+  "${BENCHMARK_JAR}" \
+  --data-dir "${DATA_DIR}" \
+  --results-dir "${RESULTS_DIR}" \
+  --formats "${FORMATS}" \
+  --iterations "${ITERATIONS}"${BENCHMARK_EXTRA_ARGS}
+
+echo ""
+echo "=== Benchmark complete ==="
+echo "Results saved to ${RESULTS_DIR}/"

--- a/benchmark/scripts/run-tpch-benchmark.sh
+++ b/benchmark/scripts/run-tpch-benchmark.sh
@@ -96,7 +96,7 @@ ${SPARK_SUBMIT} \
   --driver-memory "${DRIVER_MEMORY:-4g}" \
   --executor-memory "${EXECUTOR_MEMORY:-4g}" \
   --jars "${BUNDLE_JAR}" \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
   "${BENCHMARK_JAR}" \
   --data-dir "${DATA_DIR}" \

--- a/benchmark/scripts/submit-benchmark.sh
+++ b/benchmark/scripts/submit-benchmark.sh
@@ -274,7 +274,7 @@ if [[ -n "${EXECUTOR_CORES}" ]]; then
 fi
 
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 if [[ -n "${BUNDLE_JAR}" ]] && [[ "${BUNDLE_JAR}" != "${SPARK_HOME}"/jars/* ]]; then
     SUBMIT_ARGS+=("--jars" "${BUNDLE_JAR}")

--- a/benchmark/scripts/submit-datagen.sh
+++ b/benchmark/scripts/submit-datagen.sh
@@ -279,7 +279,7 @@ fi
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
 
 # Lance extension
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 # Kyuubi TPC-DS catalog
 SUBMIT_ARGS+=("--conf" "spark.sql.catalog.tpcds=org.apache.kyuubi.spark.connector.tpcds.TPCDSCatalog")

--- a/benchmark/scripts/submit-tpch-benchmark.sh
+++ b/benchmark/scripts/submit-tpch-benchmark.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Submit TPC-H benchmark queries as a Spark job.
+#
+# Submits via spark-submit using whatever Spark configuration is already
+# present (spark-defaults.conf, SPARK_HOME, etc.). Works with local mode,
+# standalone clusters, YARN, and Kubernetes.
+#
+# Tables must already exist under <data-dir>/<format>/. Use submit-tpch-datagen.sh
+# (or TpchDataGenerator) to create them first.
+#
+# The benchmark jar (shaded, includes Kyuubi TPC-H connector) is built
+# on-the-fly if not already present.
+#
+# Usage:
+#   ./submit-tpch-benchmark.sh --data-dir <path> --results-dir <path> [OPTIONS]
+#
+# Examples:
+#   # Run all 22 queries, 3 iterations, against both formats
+#   ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/tpch/results
+#
+#   # Lance only, with explain plans and metrics
+#   ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/tpch/results -f lance --explain --metrics
+#
+#   # Run specific queries
+#   ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/tpch/results --queries q3,q5,q10
+#
+#   # Build for Spark 4.0 / Scala 2.13
+#   SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/results
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+FORMATS="lance,parquet"
+DATA_DIR=""
+RESULTS_DIR=""
+ITERATIONS=3
+MAX_EXECUTORS=10
+DRIVER_MEMORY=""
+EXECUTOR_MEMORY=""
+EXECUTOR_CORES=""
+BENCHMARK_JAR=""
+APP_NAME=""
+EXPLAIN=""
+METRICS=""
+QUERIES=""
+EXTRA_CONF=()
+
+# Configurable Spark/Scala versions (override via environment)
+SPARK_VERSION="${SPARK_VERSION:-3.5}"
+SCALA_VERSION="${SCALA_VERSION:-2.12}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="${SCRIPT_DIR}/.."
+PROJECT_ROOT="${BENCHMARK_DIR}/.."
+
+# Detect Spark home — check common locations
+if [[ -z "${SPARK_HOME:-}" ]]; then
+    for candidate in /opt/spark /usr/local/spark; do
+        if [[ -x "${candidate}/bin/spark-submit" ]]; then
+            SPARK_HOME="${candidate}"
+            break
+        fi
+    done
+    # Also search for versioned Spark dirs (e.g. /spark-4.0.1-bin-without-hadoop)
+    if [[ -z "${SPARK_HOME:-}" ]]; then
+        for candidate in /spark-*/bin/spark-submit; do
+            if [[ -x "$candidate" ]]; then
+                SPARK_HOME="$(dirname "$(dirname "$candidate")")"
+                break
+            fi
+        done
+    fi
+fi
+SPARK_HOME="${SPARK_HOME:-/opt/spark}"
+SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+show_help() {
+    cat <<'EOF'
+Usage: submit-tpch-benchmark.sh --data-dir <path> --results-dir <path> [OPTIONS]
+
+Run TPC-H benchmark queries against pre-generated Lance and Parquet tables.
+
+Options:
+    --data-dir, -d DIR          Data directory with generated tables (REQUIRED)
+    --results-dir, -r DIR       Output directory for CSV results (REQUIRED)
+    --formats, -f FORMATS       Comma-separated formats (default: lance,parquet)
+    --iterations, -i NUM        Iterations per query (default: 3)
+    --max-executors NUM         Dynamic allocation max executors (default: 10)
+    --driver-memory MEM         Driver memory, e.g. 8g (default: from Spark config)
+    --executor-memory MEM       Executor memory, e.g. 16g (default: from Spark config)
+    --executor-cores NUM        Executor cores (default: from Spark config)
+    --benchmark-jar JAR         Path to pre-built benchmark jar (auto-built if absent)
+    --app-name NAME             Spark application name
+    --explain                   Print EXPLAIN plan for each query (first iteration)
+    --metrics                   Collect per-query task-level metrics
+    --queries QUERIES           Comma-separated query subset (e.g. q3,q5,q10)
+    --conf KEY=VALUE            Extra Spark conf (repeatable)
+    -h, --help                  Show this help message
+
+Environment variables:
+    SPARK_VERSION               Spark major version for build (default: 3.5)
+    SCALA_VERSION               Scala version for build (default: 2.12)
+    SPARK_HOME                  Path to Spark installation
+
+Examples:
+    # Run all queries, 3 iterations, both formats
+    ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/tpch/results
+
+    # Lance only, with profiling
+    ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/results -f lance --explain --metrics
+
+    # Specific queries, 1 iteration
+    ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/results --queries q3,q10 -i 1
+
+    # Build for Spark 4.0 / Scala 2.13
+    SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./submit-tpch-benchmark.sh -d /tmp/tpch/sf1 -r /tmp/results
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --data-dir|-d)
+            DATA_DIR="$2"; shift 2 ;;
+        --results-dir|-r)
+            RESULTS_DIR="$2"; shift 2 ;;
+        --formats|-f)
+            FORMATS="$2"; shift 2 ;;
+        --iterations|-i)
+            ITERATIONS="$2"; shift 2 ;;
+        --max-executors)
+            MAX_EXECUTORS="$2"; shift 2 ;;
+        --driver-memory)
+            DRIVER_MEMORY="$2"; shift 2 ;;
+        --executor-memory)
+            EXECUTOR_MEMORY="$2"; shift 2 ;;
+        --executor-cores)
+            EXECUTOR_CORES="$2"; shift 2 ;;
+        --benchmark-jar)
+            BENCHMARK_JAR="$2"; shift 2 ;;
+        --app-name)
+            APP_NAME="$2"; shift 2 ;;
+        --explain)
+            EXPLAIN="true"; shift ;;
+        --metrics)
+            METRICS="true"; shift ;;
+        --queries)
+            QUERIES="$2"; shift 2 ;;
+        --conf)
+            EXTRA_CONF+=("--conf" "$2"); shift 2 ;;
+        -h|--help)
+            show_help; exit 0 ;;
+        *)
+            echo "Error: unknown option $1" >&2
+            show_help >&2
+            exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate required arguments
+# ---------------------------------------------------------------------------
+if [[ -z "${DATA_DIR}" || -z "${RESULTS_DIR}" ]]; then
+    echo "Error: --data-dir and --results-dir are both required." >&2
+    echo "" >&2
+    show_help >&2
+    exit 1
+fi
+
+if [[ -z "${APP_NAME}" ]]; then
+    APP_NAME="${USER:-tpch}-benchmark"
+fi
+
+# ---------------------------------------------------------------------------
+# Validate Spark
+# ---------------------------------------------------------------------------
+if [[ ! -x "${SPARK_SUBMIT}" ]]; then
+    echo "Error: spark-submit not found at ${SPARK_SUBMIT}" >&2
+    echo "Set SPARK_HOME or ensure Spark is installed." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve Spark version for Maven build
+# ---------------------------------------------------------------------------
+case "${SPARK_VERSION}" in
+    3.4) MVN_SPARK_VERSION="3.4.4" ;;
+    3.5) MVN_SPARK_VERSION="3.5.5" ;;
+    4.0) MVN_SPARK_VERSION="4.0.0" ;;
+    4.1) MVN_SPARK_VERSION="4.0.0" ;;
+    *)   MVN_SPARK_VERSION="${SPARK_VERSION}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Build benchmark jar if needed
+# ---------------------------------------------------------------------------
+if [[ -z "${BENCHMARK_JAR}" ]]; then
+    BENCHMARK_JAR="${BENCHMARK_DIR}/target/lance-spark-benchmark-0.3.0-beta.1.jar"
+fi
+
+if [[ ! -f "${BENCHMARK_JAR}" ]]; then
+    echo "--- Building benchmark jar (Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION}) ---"
+    MVNW="${PROJECT_ROOT}/mvnw"
+    if [[ ! -x "${MVNW}" ]]; then
+        echo "Error: Maven wrapper not found at ${MVNW}" >&2
+        echo "Run from the lance-spark project root, or pass --benchmark-jar." >&2
+        exit 1
+    fi
+    (cd "${BENCHMARK_DIR}" && "${MVNW}" package -DskipTests -q \
+        -Dspark.version="${MVN_SPARK_VERSION}" \
+        -Dspark.compat.version="${SPARK_VERSION}" \
+        -Dscala.compat.version="${SCALA_VERSION}")
+    echo "Benchmark jar built: ${BENCHMARK_JAR}"
+fi
+
+if [[ ! -f "${BENCHMARK_JAR}" ]]; then
+    echo "Error: benchmark jar not found at ${BENCHMARK_JAR}" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Find the lance-spark bundle jar
+# ---------------------------------------------------------------------------
+BUNDLE_JAR=""
+
+for f in "${SPARK_HOME}"/jars/lance-spark-bundle-*.jar; do
+    if [[ -f "$f" ]]; then
+        BUNDLE_JAR="$f"
+        break
+    fi
+done
+
+if [[ -z "${BUNDLE_JAR}" ]]; then
+    BUNDLE_JAR=$(find "${PROJECT_ROOT}" \
+        -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" \
+        -not -name "*sources*" -not -name "*javadoc*" 2>/dev/null | head -1)
+fi
+
+# ---------------------------------------------------------------------------
+# Build spark-submit command
+# ---------------------------------------------------------------------------
+SUBMIT_ARGS=()
+
+SUBMIT_ARGS+=("--class" "org.lance.spark.benchmark.TpchBenchmarkRunner")
+SUBMIT_ARGS+=("--name" "${APP_NAME}")
+
+if [[ -n "${DRIVER_MEMORY}" ]]; then
+    SUBMIT_ARGS+=("--driver-memory" "${DRIVER_MEMORY}")
+fi
+if [[ -n "${EXECUTOR_MEMORY}" ]]; then
+    SUBMIT_ARGS+=("--executor-memory" "${EXECUTOR_MEMORY}")
+fi
+if [[ -n "${EXECUTOR_CORES}" ]]; then
+    SUBMIT_ARGS+=("--executor-cores" "${EXECUTOR_CORES}")
+fi
+
+SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+
+if [[ -n "${BUNDLE_JAR}" ]] && [[ "${BUNDLE_JAR}" != "${SPARK_HOME}"/jars/* ]]; then
+    SUBMIT_ARGS+=("--jars" "${BUNDLE_JAR}")
+fi
+
+if [[ ${#EXTRA_CONF[@]} -gt 0 ]]; then
+    SUBMIT_ARGS+=("${EXTRA_CONF[@]}")
+fi
+
+# The benchmark jar (application jar)
+SUBMIT_ARGS+=("${BENCHMARK_JAR}")
+
+# Application arguments (passed to TpchBenchmarkRunner.main)
+SUBMIT_ARGS+=("--data-dir" "${DATA_DIR}")
+SUBMIT_ARGS+=("--results-dir" "${RESULTS_DIR}")
+SUBMIT_ARGS+=("--formats" "${FORMATS}")
+SUBMIT_ARGS+=("--iterations" "${ITERATIONS}")
+
+if [[ -n "${EXPLAIN}" ]]; then
+    SUBMIT_ARGS+=("--explain")
+fi
+if [[ -n "${METRICS}" ]]; then
+    SUBMIT_ARGS+=("--metrics")
+fi
+if [[ -n "${QUERIES}" ]]; then
+    SUBMIT_ARGS+=("--queries" "${QUERIES}")
+fi
+
+# ---------------------------------------------------------------------------
+# Print summary and submit
+# ---------------------------------------------------------------------------
+echo "============================================="
+echo "  TPC-H Benchmark — Spark Submit"
+echo "============================================="
+echo "Formats:         ${FORMATS}"
+echo "Iterations:      ${ITERATIONS}"
+echo "Data dir:        ${DATA_DIR}"
+echo "Results dir:     ${RESULTS_DIR}"
+echo "Max executors:   ${MAX_EXECUTORS}"
+echo "Spark version:   ${SPARK_VERSION}"
+echo "Scala version:   ${SCALA_VERSION}"
+echo "Spark home:      ${SPARK_HOME}"
+echo "Benchmark jar:   ${BENCHMARK_JAR}"
+if [[ -n "${BUNDLE_JAR}" ]]; then
+    echo "Bundle jar:      ${BUNDLE_JAR}"
+fi
+if [[ -n "${QUERIES}" ]]; then
+    echo "Queries:         ${QUERIES}"
+fi
+echo "Explain:         ${EXPLAIN:-false}"
+echo "Metrics:         ${METRICS:-false}"
+echo "App name:        ${APP_NAME}"
+echo "============================================="
+echo ""
+
+exec "${SPARK_SUBMIT}" "${SUBMIT_ARGS[@]}"

--- a/benchmark/scripts/submit-tpch-benchmark.sh
+++ b/benchmark/scripts/submit-tpch-benchmark.sh
@@ -274,7 +274,7 @@ if [[ -n "${EXECUTOR_CORES}" ]]; then
 fi
 
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 if [[ -n "${BUNDLE_JAR}" ]] && [[ "${BUNDLE_JAR}" != "${SPARK_HOME}"/jars/* ]]; then
     SUBMIT_ARGS+=("--jars" "${BUNDLE_JAR}")

--- a/benchmark/scripts/submit-tpch-datagen.sh
+++ b/benchmark/scripts/submit-tpch-datagen.sh
@@ -54,6 +54,7 @@ EXECUTOR_CORES=""
 BENCHMARK_JAR=""
 APP_NAME=""
 USE_DOUBLE_FOR_DECIMAL=""
+FILE_FORMAT_VERSION=""
 EXTRA_CONF=()
 
 # Configurable Spark/Scala versions (override via environment)
@@ -106,6 +107,7 @@ Options:
     --benchmark-jar JAR         Path to pre-built benchmark jar (auto-built if absent)
     --app-name NAME             Spark application name
     --use-double-for-decimal    Convert TPC-H decimal columns to double
+    --file-format-version VER   Lance file format version for writes (e.g. LEGACY, STABLE, 2.2)
     --conf KEY=VALUE            Extra Spark conf (repeatable)
     -h, --help                  Show this help message
 
@@ -126,6 +128,9 @@ Examples:
 
     # Build for Spark 4.0 / Scala 2.13
     SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./submit-tpch-datagen.sh -d /tmp/tpch/sf1
+
+    # Generate Lance tables with a specific file format version
+    ./submit-tpch-datagen.sh -d /tmp/tpch/sf1 --file-format-version LEGACY
 EOF
 }
 
@@ -154,6 +159,8 @@ while [[ $# -gt 0 ]]; do
             APP_NAME="$2"; shift 2 ;;
         --use-double-for-decimal)
             USE_DOUBLE_FOR_DECIMAL="true"; shift ;;
+        --file-format-version)
+            FILE_FORMAT_VERSION="$2"; shift 2 ;;
         --conf)
             EXTRA_CONF+=("--conf" "$2"); shift 2 ;;
         -h|--help)
@@ -272,7 +279,7 @@ fi
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
 
 # Lance extension
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 # Kyuubi TPC-H catalog
 SUBMIT_ARGS+=("--conf" "spark.sql.catalog.tpch=org.apache.kyuubi.spark.connector.tpch.TPCHCatalog")
@@ -299,6 +306,10 @@ if [[ -n "${USE_DOUBLE_FOR_DECIMAL}" ]]; then
     SUBMIT_ARGS+=("--use-double-for-decimal")
 fi
 
+if [[ -n "${FILE_FORMAT_VERSION}" ]]; then
+    SUBMIT_ARGS+=("--file-format-version" "${FILE_FORMAT_VERSION}")
+fi
+
 # ---------------------------------------------------------------------------
 # Print summary and submit
 # ---------------------------------------------------------------------------
@@ -315,6 +326,9 @@ echo "Spark home:      ${SPARK_HOME}"
 echo "Benchmark jar:   ${BENCHMARK_JAR}"
 if [[ -n "${BUNDLE_JAR}" ]]; then
     echo "Bundle jar:      ${BUNDLE_JAR}"
+fi
+if [[ -n "${FILE_FORMAT_VERSION}" ]]; then
+    echo "File format ver: ${FILE_FORMAT_VERSION}"
 fi
 echo "App name:        ${APP_NAME}"
 echo "============================================="

--- a/benchmark/scripts/submit-tpch-datagen.sh
+++ b/benchmark/scripts/submit-tpch-datagen.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Submit TPC-H data generation as a Spark job.
+#
+# Submits via spark-submit using whatever Spark configuration is already
+# present (spark-defaults.conf, SPARK_HOME, etc.). Works with local mode,
+# standalone clusters, YARN, and Kubernetes.
+#
+# The benchmark jar (shaded, includes Kyuubi TPC-H connector) is built
+# on-the-fly if not already present.
+#
+# Usage:
+#   ./submit-tpch-datagen.sh --data-dir <path> [OPTIONS]
+#
+# Examples:
+#   # Generate SF=1 in both formats to a local directory
+#   ./submit-tpch-datagen.sh -d /tmp/tpch/sf1
+#
+#   # Generate SF=10 Lance-only to an object store, 20 executors
+#   ./submit-tpch-datagen.sh -d s3a://my-bucket/tpch/sf10 -s 10 -f lance --max-executors 20
+#
+#   # Generate SF=100 with custom resources
+#   ./submit-tpch-datagen.sh -d /data/tpch/sf100 -s 100 --max-executors 50 --driver-memory 16g
+#
+#   # Build for Spark 4.0 / Scala 2.13
+#   SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./submit-tpch-datagen.sh -d /tmp/tpch/sf1
+#
+#   # Use pre-built benchmark jar
+#   ./submit-tpch-datagen.sh -d /data/tpch/sf1 --benchmark-jar /path/to/benchmark.jar
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+SCALE_FACTOR=1
+FORMATS="parquet,lance"
+DATA_DIR=""
+MAX_EXECUTORS=10
+DRIVER_MEMORY=""
+EXECUTOR_MEMORY=""
+EXECUTOR_CORES=""
+BENCHMARK_JAR=""
+APP_NAME=""
+USE_DOUBLE_FOR_DECIMAL=""
+EXTRA_CONF=()
+
+# Configurable Spark/Scala versions (override via environment)
+SPARK_VERSION="${SPARK_VERSION:-3.5}"
+SCALA_VERSION="${SCALA_VERSION:-2.12}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="${SCRIPT_DIR}/.."
+PROJECT_ROOT="${BENCHMARK_DIR}/.."
+
+# Detect Spark home — check common locations
+if [[ -z "${SPARK_HOME:-}" ]]; then
+    for candidate in /opt/spark /usr/local/spark; do
+        if [[ -x "${candidate}/bin/spark-submit" ]]; then
+            SPARK_HOME="${candidate}"
+            break
+        fi
+    done
+    # Also search for versioned Spark dirs (e.g. /spark-4.0.1-bin-without-hadoop)
+    if [[ -z "${SPARK_HOME:-}" ]]; then
+        for candidate in /spark-*/bin/spark-submit; do
+            if [[ -x "$candidate" ]]; then
+                SPARK_HOME="$(dirname "$(dirname "$candidate")")"
+                break
+            fi
+        done
+    fi
+fi
+SPARK_HOME="${SPARK_HOME:-/opt/spark}"
+SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+show_help() {
+    cat <<'EOF'
+Usage: submit-tpch-datagen.sh --data-dir <path> [OPTIONS]
+
+Generate TPC-H data via a Spark job using the Kyuubi TPC-H connector.
+
+Options:
+    --data-dir, -d DIR          Output directory (REQUIRED)
+                                Supports local paths, s3a://, gs://, abfss://, etc.
+    --scale-factor, -s SF       TPC-H scale factor (default: 1)
+    --formats, -f FORMATS       Comma-separated formats (default: parquet,lance)
+    --max-executors NUM         Dynamic allocation max executors (default: 10)
+    --driver-memory MEM         Driver memory, e.g. 8g (default: from Spark config)
+    --executor-memory MEM       Executor memory, e.g. 16g (default: from Spark config)
+    --executor-cores NUM        Executor cores (default: from Spark config)
+    --benchmark-jar JAR         Path to pre-built benchmark jar (auto-built if absent)
+    --app-name NAME             Spark application name
+    --use-double-for-decimal    Convert TPC-H decimal columns to double
+    --conf KEY=VALUE            Extra Spark conf (repeatable)
+    -h, --help                  Show this help message
+
+Environment variables:
+    SPARK_VERSION               Spark major version for build (default: 3.5)
+    SCALA_VERSION               Scala version for build (default: 2.12)
+    SPARK_HOME                  Path to Spark installation
+
+Examples:
+    # Local SF=1, both formats
+    ./submit-tpch-datagen.sh -d /tmp/tpch/sf1
+
+    # SF=10 to S3, Lance only, 20 executors
+    ./submit-tpch-datagen.sh -d s3a://my-bucket/tpch/sf10 -s 10 -f lance --max-executors 20
+
+    # SF=100 with custom resources
+    ./submit-tpch-datagen.sh -d /data/tpch/sf100 -s 100 --max-executors 50 --driver-memory 16g
+
+    # Build for Spark 4.0 / Scala 2.13
+    SPARK_VERSION=4.0 SCALA_VERSION=2.13 ./submit-tpch-datagen.sh -d /tmp/tpch/sf1
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --data-dir|-d)
+            DATA_DIR="$2"; shift 2 ;;
+        --scale-factor|-s)
+            SCALE_FACTOR="$2"; shift 2 ;;
+        --formats|-f)
+            FORMATS="$2"; shift 2 ;;
+        --max-executors)
+            MAX_EXECUTORS="$2"; shift 2 ;;
+        --driver-memory)
+            DRIVER_MEMORY="$2"; shift 2 ;;
+        --executor-memory)
+            EXECUTOR_MEMORY="$2"; shift 2 ;;
+        --executor-cores)
+            EXECUTOR_CORES="$2"; shift 2 ;;
+        --benchmark-jar)
+            BENCHMARK_JAR="$2"; shift 2 ;;
+        --app-name)
+            APP_NAME="$2"; shift 2 ;;
+        --use-double-for-decimal)
+            USE_DOUBLE_FOR_DECIMAL="true"; shift ;;
+        --conf)
+            EXTRA_CONF+=("--conf" "$2"); shift 2 ;;
+        -h|--help)
+            show_help; exit 0 ;;
+        *)
+            echo "Error: unknown option $1" >&2
+            show_help >&2
+            exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate required arguments
+# ---------------------------------------------------------------------------
+if [[ -z "${DATA_DIR}" ]]; then
+    echo "Error: --data-dir is required." >&2
+    echo "" >&2
+    show_help >&2
+    exit 1
+fi
+
+if [[ -z "${APP_NAME}" ]]; then
+    APP_NAME="${USER:-tpch}-datagen-sf${SCALE_FACTOR}"
+fi
+
+# ---------------------------------------------------------------------------
+# Validate Spark
+# ---------------------------------------------------------------------------
+if [[ ! -x "${SPARK_SUBMIT}" ]]; then
+    echo "Error: spark-submit not found at ${SPARK_SUBMIT}" >&2
+    echo "Set SPARK_HOME or ensure Spark is installed." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve Spark version for Maven build
+# ---------------------------------------------------------------------------
+# Map SPARK_VERSION (major) to the full version used by the parent POM
+case "${SPARK_VERSION}" in
+    3.4) MVN_SPARK_VERSION="3.4.4" ;;
+    3.5) MVN_SPARK_VERSION="3.5.5" ;;
+    4.0) MVN_SPARK_VERSION="4.0.0" ;;
+    4.1) MVN_SPARK_VERSION="4.0.0" ;;  # TODO: update when 4.1 releases
+    *)   MVN_SPARK_VERSION="${SPARK_VERSION}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Build benchmark jar if needed
+# ---------------------------------------------------------------------------
+if [[ -z "${BENCHMARK_JAR}" ]]; then
+    BENCHMARK_JAR="${BENCHMARK_DIR}/target/lance-spark-benchmark-0.3.0-beta.1.jar"
+fi
+
+if [[ ! -f "${BENCHMARK_JAR}" ]]; then
+    echo "--- Building benchmark jar (Spark ${SPARK_VERSION}, Scala ${SCALA_VERSION}) ---"
+    MVNW="${PROJECT_ROOT}/mvnw"
+    if [[ ! -x "${MVNW}" ]]; then
+        echo "Error: Maven wrapper not found at ${MVNW}" >&2
+        echo "Run from the lance-spark project root, or pass --benchmark-jar." >&2
+        exit 1
+    fi
+    (cd "${BENCHMARK_DIR}" && "${MVNW}" package -DskipTests -q \
+        -Dspark.version="${MVN_SPARK_VERSION}" \
+        -Dspark.compat.version="${SPARK_VERSION}" \
+        -Dscala.compat.version="${SCALA_VERSION}")
+    echo "Benchmark jar built: ${BENCHMARK_JAR}"
+fi
+
+if [[ ! -f "${BENCHMARK_JAR}" ]]; then
+    echo "Error: benchmark jar not found at ${BENCHMARK_JAR}" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Find the lance-spark bundle jar
+# ---------------------------------------------------------------------------
+# Prefer a jar already in Spark's jars/ directory.
+# Fall back to the locally-built bundle from the project tree.
+BUNDLE_JAR=""
+
+# Check Spark jars dir first
+for f in "${SPARK_HOME}"/jars/lance-spark-bundle-*.jar; do
+    if [[ -f "$f" ]]; then
+        BUNDLE_JAR="$f"
+        break
+    fi
+done
+
+# Fall back to project-built bundle (match current Spark/Scala version)
+if [[ -z "${BUNDLE_JAR}" ]]; then
+    BUNDLE_JAR=$(find "${PROJECT_ROOT}" \
+        -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" \
+        -not -name "*sources*" -not -name "*javadoc*" 2>/dev/null | head -1)
+fi
+
+# ---------------------------------------------------------------------------
+# Build spark-submit command
+# ---------------------------------------------------------------------------
+SUBMIT_ARGS=()
+
+SUBMIT_ARGS+=("--class" "org.lance.spark.benchmark.TpchDataGenerator")
+SUBMIT_ARGS+=("--name" "${APP_NAME}")
+
+# Resource overrides (only set if user specified; otherwise inherit spark-defaults.conf)
+if [[ -n "${DRIVER_MEMORY}" ]]; then
+    SUBMIT_ARGS+=("--driver-memory" "${DRIVER_MEMORY}")
+fi
+if [[ -n "${EXECUTOR_MEMORY}" ]]; then
+    SUBMIT_ARGS+=("--executor-memory" "${EXECUTOR_MEMORY}")
+fi
+if [[ -n "${EXECUTOR_CORES}" ]]; then
+    SUBMIT_ARGS+=("--executor-cores" "${EXECUTOR_CORES}")
+fi
+
+# Dynamic allocation — inherit defaults but allow overriding max executors
+SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
+
+# Lance extension
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+
+# Kyuubi TPC-H catalog
+SUBMIT_ARGS+=("--conf" "spark.sql.catalog.tpch=org.apache.kyuubi.spark.connector.tpch.TPCHCatalog")
+
+# Add bundle jar if not already in Spark jars dir
+if [[ -n "${BUNDLE_JAR}" ]] && [[ "${BUNDLE_JAR}" != "${SPARK_HOME}"/jars/* ]]; then
+    SUBMIT_ARGS+=("--jars" "${BUNDLE_JAR}")
+fi
+
+# Extra user confs
+if [[ ${#EXTRA_CONF[@]} -gt 0 ]]; then
+    SUBMIT_ARGS+=("${EXTRA_CONF[@]}")
+fi
+
+# The benchmark jar (application jar)
+SUBMIT_ARGS+=("${BENCHMARK_JAR}")
+
+# Application arguments (passed to TpchDataGenerator.main)
+SUBMIT_ARGS+=("--data-dir" "${DATA_DIR}")
+SUBMIT_ARGS+=("--scale-factor" "${SCALE_FACTOR}")
+SUBMIT_ARGS+=("--formats" "${FORMATS}")
+
+if [[ -n "${USE_DOUBLE_FOR_DECIMAL}" ]]; then
+    SUBMIT_ARGS+=("--use-double-for-decimal")
+fi
+
+# ---------------------------------------------------------------------------
+# Print summary and submit
+# ---------------------------------------------------------------------------
+echo "============================================="
+echo "  TPC-H Data Generation — Spark Submit"
+echo "============================================="
+echo "Scale factor:    ${SCALE_FACTOR}"
+echo "Formats:         ${FORMATS}"
+echo "Data dir:        ${DATA_DIR}"
+echo "Max executors:   ${MAX_EXECUTORS}"
+echo "Spark version:   ${SPARK_VERSION}"
+echo "Scala version:   ${SCALA_VERSION}"
+echo "Spark home:      ${SPARK_HOME}"
+echo "Benchmark jar:   ${BENCHMARK_JAR}"
+if [[ -n "${BUNDLE_JAR}" ]]; then
+    echo "Bundle jar:      ${BUNDLE_JAR}"
+fi
+echo "App name:        ${APP_NAME}"
+echo "============================================="
+echo ""
+
+exec "${SPARK_SUBMIT}" "${SUBMIT_ARGS[@]}"

--- a/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkReporter.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkReporter.java
@@ -24,9 +24,16 @@ import java.util.Map;
 public class BenchmarkReporter {
 
   private final List<BenchmarkResult> results;
+  private final String benchmarkName;
 
+  /** Backward-compatible constructor — defaults the benchmark name to "TPC-DS". */
   public BenchmarkReporter(List<BenchmarkResult> results) {
+    this(results, "TPC-DS");
+  }
+
+  public BenchmarkReporter(List<BenchmarkResult> results, String benchmarkName) {
     this.results = results;
+    this.benchmarkName = benchmarkName;
   }
 
   public void writeCsv(String outputPath) throws IOException {
@@ -85,7 +92,7 @@ public class BenchmarkReporter {
     boolean hasMetrics = results.stream().anyMatch(r -> r.getMetrics() != null);
 
     System.out.println();
-    System.out.println("=== TPC-DS Benchmark Summary ===");
+    System.out.println("=== " + benchmarkName + " Benchmark Summary ===");
     System.out.println();
 
     StringBuilder header = new StringBuilder(String.format("%-8s", "Query"));

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchBenchmarkRunner.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchBenchmarkRunner.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Runs TPC-H queries against pre-generated tables and reports results.
+ *
+ * <p>Tables must already exist under {@code <data-dir>/<format>/} — use
+ * {@link TpchDataGenerator} to create them first.
+ */
+public class TpchBenchmarkRunner {
+
+  public static void main(String[] args) throws Exception {
+    String dataDir = null;
+    String resultsDir = null;
+    String formatsStr = "lance,parquet";
+    int iterations = 3;
+    boolean explain = false;
+    boolean metrics = false;
+    String queries = null;
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--data-dir":
+          dataDir = args[++i];
+          break;
+        case "--results-dir":
+          resultsDir = args[++i];
+          break;
+        case "--formats":
+          formatsStr = args[++i];
+          break;
+        case "--iterations":
+          iterations = Integer.parseInt(args[++i]);
+          break;
+        case "--explain":
+          explain = true;
+          break;
+        case "--metrics":
+          metrics = true;
+          break;
+        case "--queries":
+          queries = args[++i];
+          break;
+        default:
+          System.err.println("Unknown argument: " + args[i]);
+          printUsage();
+          System.exit(1);
+      }
+    }
+
+    if (dataDir == null || resultsDir == null) {
+      System.err.println("Missing required arguments.");
+      printUsage();
+      System.exit(1);
+    }
+
+    String[] formats = formatsStr.split(",");
+
+    SparkSession spark =
+        SparkSession.builder().appName("TPC-H Benchmark").getOrCreate();
+
+    try {
+      // Register metrics listener if requested
+      QueryMetricsListener metricsListener = null;
+      if (metrics) {
+        metricsListener = new QueryMetricsListener();
+        spark.sparkContext().addSparkListener(metricsListener);
+      }
+
+      TpchDataLoader loader = new TpchDataLoader(spark, dataDir);
+      TpchQueryRunner runner =
+          new TpchQueryRunner(spark, iterations, explain, metricsListener, queries);
+      List<BenchmarkResult> allResults = new ArrayList<>();
+
+      for (String format : formats) {
+        format = format.trim();
+        System.out.println();
+        System.out.println("=== Format: " + format + " ===");
+        System.out.flush();
+
+        // Register pre-generated tables as temp views
+        loader.registerTables(format);
+
+        // Run queries
+        List<BenchmarkResult> formatResults = runner.runAllQueries(format);
+        allResults.addAll(formatResults);
+
+        // Unregister tables for next format
+        loader.unregisterTables();
+      }
+
+      // Report
+      BenchmarkReporter reporter = new BenchmarkReporter(allResults, "TPC-H");
+
+      String timestamp =
+          LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+      String csvPath = resultsDir + "/tpch_" + timestamp + ".csv";
+      reporter.writeCsv(csvPath);
+      reporter.printSummary();
+
+    } finally {
+      spark.stop();
+    }
+  }
+
+  private static void printUsage() {
+    System.err.println(
+        "Usage: TpchBenchmarkRunner"
+            + " --data-dir <path>"
+            + " --results-dir <path>"
+            + " [--formats lance,parquet]"
+            + " [--iterations 3]"
+            + " [--explain]"
+            + " [--metrics]"
+            + " [--queries q1,q3,q5]");
+  }
+}

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataGenerator.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataGenerator.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Spark job that generates TPC-H data using the Kyuubi TPC-H connector
+ * and writes each table directly into the target format(s) (Lance, Parquet, etc.).
+ *
+ * <p>The Kyuubi connector generates data in parallel across Spark executors —
+ * no external {@code dbgen} binary or intermediate CSV/dat files are needed.
+ *
+ * <p>Usage:
+ * <pre>
+ *   spark-submit --class org.lance.spark.benchmark.TpchDataGenerator \
+ *     benchmark.jar \
+ *     --data-dir s3a://bucket/tpch/sf10 \
+ *     --scale-factor 10 \
+ *     --formats parquet,lance
+ * </pre>
+ */
+public class TpchDataGenerator {
+
+  /** The 8 TPC-H tables as named in the Kyuubi catalog. */
+  static final List<String> TPCH_TABLES =
+      Arrays.asList(
+          "customer",
+          "lineitem",
+          "nation",
+          "orders",
+          "part",
+          "partsupp",
+          "region",
+          "supplier");
+
+  public static void main(String[] args) throws Exception {
+    String dataDir = null;
+    int scaleFactor = 1;
+    String formatsStr = "parquet,lance";
+    boolean useDoubleForDecimal = false;
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--data-dir":
+          dataDir = args[++i];
+          break;
+        case "--scale-factor":
+          scaleFactor = Integer.parseInt(args[++i]);
+          break;
+        case "--formats":
+          formatsStr = args[++i];
+          break;
+        case "--use-double-for-decimal":
+          useDoubleForDecimal = true;
+          break;
+        default:
+          System.err.println("Unknown argument: " + args[i]);
+          printUsage();
+          System.exit(1);
+      }
+    }
+
+    if (dataDir == null) {
+      System.err.println("Missing required argument: --data-dir");
+      printUsage();
+      System.exit(1);
+    }
+
+    String[] formats = formatsStr.split(",");
+
+    // Configure Kyuubi TPC-H catalog
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .appName("TPC-H Data Generator (SF=" + scaleFactor + ")")
+            .config(
+                "spark.sql.catalog.tpch",
+                "org.apache.kyuubi.spark.connector.tpch.TPCHCatalog");
+
+    if (useDoubleForDecimal) {
+      builder.config("spark.sql.catalog.tpch.useDoubleForDecimal", "true");
+    }
+
+    SparkSession spark = builder.getOrCreate();
+
+    try {
+      System.out.println("=== TPC-H Data Generation ===");
+      System.out.println("Scale factor:  " + scaleFactor);
+      System.out.println("Formats:       " + formatsStr);
+      System.out.println("Data dir:      " + dataDir);
+      System.out.println();
+      System.out.flush();
+
+      String catalogDb = "tpch.sf" + scaleFactor;
+
+      for (String format : formats) {
+        format = format.trim();
+        System.out.println("--- Generating " + format + " tables ---");
+        System.out.flush();
+
+        for (String table : TPCH_TABLES) {
+          generateTable(spark, catalogDb, table, format, dataDir);
+        }
+
+        System.out.println();
+      }
+
+      System.out.println("=== Data generation complete ===");
+      System.out.flush();
+
+    } finally {
+      spark.stop();
+    }
+  }
+
+  private static void generateTable(
+      SparkSession spark, String catalogDb, String table, String format, String dataDir) {
+
+    boolean isLance = "lance".equalsIgnoreCase(format);
+    String tablePath = dataDir + "/" + format + "/" + table;
+    if (isLance) {
+      tablePath = TpcdsDataGenerator.toLancePath(tablePath) + ".lance";
+    }
+
+    // Check if table already exists using Hadoop filesystem API (avoids noisy Spark warnings)
+    try {
+      Path hadoopPath = new Path(dataDir + "/" + format + "/" + table + (isLance ? ".lance" : ""));
+      FileSystem fs = hadoopPath.getFileSystem(
+          spark.sparkContext().hadoopConfiguration());
+      if (fs.exists(hadoopPath)) {
+        System.out.println("  SKIP " + table + " (already exists at " + hadoopPath + ")");
+        System.out.flush();
+        return;
+      }
+    } catch (Exception e) {
+      // Could not check — proceed with generation
+    }
+
+    System.out.print("  GENERATE " + table + "...");
+    System.out.flush();
+    long start = System.currentTimeMillis();
+
+    // Read from Kyuubi TPC-H catalog — data is generated in parallel
+    Dataset<Row> df = spark.read().table(catalogDb + "." + table);
+
+    String writeFormat = isLance ? "lance" : format;
+    SaveMode mode = isLance ? SaveMode.ErrorIfExists : SaveMode.Overwrite;
+
+    df.write().mode(mode).format(writeFormat).save(tablePath);
+
+    long elapsed = System.currentTimeMillis() - start;
+    long count = spark.read().format(writeFormat).load(tablePath).count();
+    System.out.println(" " + count + " rows (" + elapsed + "ms)");
+    System.out.flush();
+  }
+
+  private static void printUsage() {
+    System.err.println(
+        "Usage: TpchDataGenerator"
+            + " --data-dir <path>"
+            + " [--scale-factor 1]"
+            + " [--formats parquet,lance]"
+            + " [--use-double-for-decimal]");
+  }
+}

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataGenerator.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataGenerator.java
@@ -58,6 +58,7 @@ public class TpchDataGenerator {
     int scaleFactor = 1;
     String formatsStr = "parquet,lance";
     boolean useDoubleForDecimal = false;
+    String fileFormatVersion = null;
 
     for (int i = 0; i < args.length; i++) {
       switch (args[i]) {
@@ -72,6 +73,9 @@ public class TpchDataGenerator {
           break;
         case "--use-double-for-decimal":
           useDoubleForDecimal = true;
+          break;
+        case "--file-format-version":
+          fileFormatVersion = args[++i];
           break;
         default:
           System.err.println("Unknown argument: " + args[i]);
@@ -107,6 +111,9 @@ public class TpchDataGenerator {
       System.out.println("Scale factor:  " + scaleFactor);
       System.out.println("Formats:       " + formatsStr);
       System.out.println("Data dir:      " + dataDir);
+      if (fileFormatVersion != null) {
+        System.out.println("File format version: " + fileFormatVersion);
+      }
       System.out.println();
       System.out.flush();
 
@@ -118,7 +125,7 @@ public class TpchDataGenerator {
         System.out.flush();
 
         for (String table : TPCH_TABLES) {
-          generateTable(spark, catalogDb, table, format, dataDir);
+          generateTable(spark, catalogDb, table, format, dataDir, fileFormatVersion);
         }
 
         System.out.println();
@@ -133,7 +140,8 @@ public class TpchDataGenerator {
   }
 
   private static void generateTable(
-      SparkSession spark, String catalogDb, String table, String format, String dataDir) {
+      SparkSession spark, String catalogDb, String table, String format, String dataDir,
+      String fileFormatVersion) {
 
     boolean isLance = "lance".equalsIgnoreCase(format);
     String tablePath = dataDir + "/" + format + "/" + table;
@@ -165,7 +173,11 @@ public class TpchDataGenerator {
     String writeFormat = isLance ? "lance" : format;
     SaveMode mode = isLance ? SaveMode.ErrorIfExists : SaveMode.Overwrite;
 
-    df.write().mode(mode).format(writeFormat).save(tablePath);
+    org.apache.spark.sql.DataFrameWriter<Row> writer = df.write().mode(mode).format(writeFormat);
+    if (isLance && fileFormatVersion != null) {
+      writer = writer.option("file_format_version", fileFormatVersion);
+    }
+    writer.save(tablePath);
 
     long elapsed = System.currentTimeMillis() - start;
     long count = spark.read().format(writeFormat).load(tablePath).count();
@@ -179,6 +191,7 @@ public class TpchDataGenerator {
             + " --data-dir <path>"
             + " [--scale-factor 1]"
             + " [--formats parquet,lance]"
-            + " [--use-double-for-decimal]");
+            + " [--use-double-for-decimal]"
+            + " [--file-format-version <version>]");
   }
 }

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataLoader.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchDataLoader.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Registers pre-generated TPC-H tables as Spark temp views for querying.
+ *
+ * <p>Tables must be generated beforehand using {@link TpchDataGenerator}.
+ */
+public class TpchDataLoader {
+
+  private final SparkSession spark;
+  private final String dataDir;
+
+  public TpchDataLoader(SparkSession spark, String dataDir) {
+    this.spark = spark;
+    this.dataDir = dataDir;
+  }
+
+  /**
+   * Registers all TPC-H tables for the given format as temp views.
+   *
+   * @param format the storage format (e.g. "lance", "parquet")
+   */
+  public void registerTables(String format) {
+    String formatDir = dataDir + "/" + format;
+    boolean isLance = "lance".equalsIgnoreCase(format);
+    String readFormat = isLance ? "lance" : format;
+
+    int registered = 0;
+    for (String tableName : TpchDataGenerator.TPCH_TABLES) {
+      String tablePath = formatDir + "/" + tableName;
+      if (isLance) {
+        tablePath = TpcdsDataGenerator.toLancePath(tablePath) + ".lance";
+      }
+
+      try {
+        spark.read().format(readFormat).load(tablePath).createOrReplaceTempView(tableName);
+        registered++;
+      } catch (Exception e) {
+        System.out.println("  SKIP " + tableName + " (not found at " + tablePath + ")");
+        System.out.flush();
+      }
+    }
+
+    System.out.println(
+        "Registered " + registered + "/" + TpchDataGenerator.TPCH_TABLES.size()
+            + " tables for format: " + format);
+    System.out.flush();
+  }
+
+  /**
+   * Drops all TPC-H temp views (used between format runs).
+   */
+  public void unregisterTables() {
+    for (String tableName : TpchDataGenerator.TPCH_TABLES) {
+      spark.catalog().dropTempView(tableName);
+    }
+  }
+}

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchQueryRunner.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchQueryRunner.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+
+public class TpchQueryRunner {
+
+  private final SparkSession spark;
+  private final int iterations;
+  private final boolean explain;
+  private final QueryMetricsListener metricsListener;
+  private final Set<String> queryFilter;
+
+  public TpchQueryRunner(
+      SparkSession spark,
+      int iterations,
+      boolean explain,
+      QueryMetricsListener metricsListener,
+      String queriesFilter) {
+    this.spark = spark;
+    this.iterations = iterations;
+    this.explain = explain;
+    this.metricsListener = metricsListener;
+    if (queriesFilter != null && !queriesFilter.isEmpty()) {
+      this.queryFilter = new HashSet<>(Arrays.asList(queriesFilter.split(",")));
+    } else {
+      this.queryFilter = null;
+    }
+  }
+
+  public List<BenchmarkResult> runAllQueries(String format) {
+    List<BenchmarkResult> results = new ArrayList<>();
+    List<String> queryNames = getAvailableQueries();
+    if (queryFilter != null) {
+      queryNames = queryNames.stream().filter(queryFilter::contains).collect(Collectors.toList());
+    }
+
+    System.out.println(
+        "Running " + queryNames.size() + " queries x " + iterations + " iterations for " + format);
+    System.out.flush();
+
+    for (String queryName : queryNames) {
+      String sql = loadQuery(queryName);
+      if (sql == null) {
+        continue;
+      }
+
+      for (int i = 1; i <= iterations; i++) {
+        BenchmarkResult result = runQuery(queryName, format, sql, i);
+        results.add(result);
+
+        String status = result.isSuccess() ? "OK" : "FAIL";
+        System.out.printf(
+            "  [%s] %s iter=%d time=%dms rows=%d%n",
+            status, queryName, i, result.getElapsedMs(), result.getRowCount());
+        if (result.getMetrics() != null) {
+          System.out.println("       Metrics: " + result.getMetrics().toSummaryString());
+        }
+        if (!result.isSuccess()) {
+          System.out.println("       Error: " + result.getErrorMessage());
+        }
+        System.out.flush();
+      }
+    }
+
+    return results;
+  }
+
+  private BenchmarkResult runQuery(String queryName, String format, String sql, int iteration) {
+    // Split on semicolons to handle multi-statement queries
+    String[] statements = sql.split(";");
+
+    // Find the first non-empty statement for EXPLAIN
+    String firstStatement = null;
+    for (String stmt : statements) {
+      String trimmed = stmt.trim();
+      if (!trimmed.isEmpty()) {
+        firstStatement = trimmed;
+        break;
+      }
+    }
+
+    // Print EXPLAIN on first iteration if enabled
+    if (explain && iteration == 1 && firstStatement != null) {
+      try {
+        System.out.println("  --- EXPLAIN " + queryName + " ---");
+        spark.sql("EXPLAIN EXTENDED " + firstStatement).show(false);
+        System.out.flush();
+      } catch (Exception e) {
+        System.out.println("  (EXPLAIN failed: " + e.getMessage() + ")");
+      }
+    }
+
+    // Set job group and reset metrics listener
+    String jobGroup = format + "." + queryName + ".iter" + iteration;
+    spark.sparkContext().setJobGroup(jobGroup, queryName, false);
+    if (metricsListener != null) {
+      metricsListener.reset(jobGroup);
+    }
+
+    long start = System.currentTimeMillis();
+    try {
+      long rowCount = 0;
+      for (String stmt : statements) {
+        String trimmed = stmt.trim();
+        if (trimmed.isEmpty()) {
+          continue;
+        }
+        Dataset<Row> result = spark.sql(trimmed);
+        rowCount = result.count();
+      }
+      long elapsed = System.currentTimeMillis() - start;
+
+      QueryMetrics metrics = metricsListener != null ? metricsListener.getMetrics() : null;
+      return BenchmarkResult.success(queryName, format, iteration, elapsed, rowCount, metrics);
+    } catch (Exception e) {
+      long elapsed = System.currentTimeMillis() - start;
+      String msg = e.getMessage();
+      if (msg != null && msg.length() > 200) {
+        msg = msg.substring(0, 200) + "...";
+      }
+      return BenchmarkResult.failure(queryName, format, iteration, elapsed, msg);
+    } finally {
+      spark.sparkContext().clearJobGroup();
+    }
+  }
+
+  List<String> getAvailableQueries() {
+    List<String> queries = new ArrayList<>();
+    // TPC-H has exactly 22 queries (q1..q22), no a/b variants.
+    for (int i = 1; i <= 22; i++) {
+      String name = "q" + i;
+      String resourcePath = "/tpch-queries/" + name + ".sql";
+      if (getClass().getResourceAsStream(resourcePath) != null) {
+        queries.add(name);
+      }
+    }
+    return queries;
+  }
+
+  private String loadQuery(String queryName) {
+    String resourcePath = "/tpch-queries/" + queryName + ".sql";
+    try (InputStream is = getClass().getResourceAsStream(resourcePath)) {
+      if (is == null) {
+        return null;
+      }
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+        return reader.lines().collect(Collectors.joining("\n"));
+      }
+    } catch (Exception e) {
+      System.err.println("Failed to load query " + queryName + ": " + e.getMessage());
+      return null;
+    }
+  }
+}

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpchQueryRunner.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpchQueryRunner.java
@@ -36,6 +36,10 @@ public class TpchQueryRunner {
   private final QueryMetricsListener metricsListener;
   private final Set<String> queryFilter;
 
+  public TpchQueryRunner(SparkSession spark, int iterations) {
+    this(spark, iterations, false, null, null);
+  }
+
   public TpchQueryRunner(
       SparkSession spark,
       int iterations,
@@ -76,8 +80,8 @@ public class TpchQueryRunner {
 
         String status = result.isSuccess() ? "OK" : "FAIL";
         System.out.printf(
-            "  [%s] %s iter=%d time=%dms rows=%d%n",
-            status, queryName, i, result.getElapsedMs(), result.getRowCount());
+            "  [%s] %s iter=%d time=%dms%n",
+            status, queryName, i, result.getElapsedMs());
         if (result.getMetrics() != null) {
           System.out.println("       Metrics: " + result.getMetrics().toSummaryString());
         }
@@ -125,19 +129,18 @@ public class TpchQueryRunner {
 
     long start = System.currentTimeMillis();
     try {
-      long rowCount = 0;
       for (String stmt : statements) {
         String trimmed = stmt.trim();
         if (trimmed.isEmpty()) {
           continue;
         }
         Dataset<Row> result = spark.sql(trimmed);
-        rowCount = result.count();
+        result.write().format("noop").mode("overwrite").save();
       }
       long elapsed = System.currentTimeMillis() - start;
 
       QueryMetrics metrics = metricsListener != null ? metricsListener.getMetrics() : null;
-      return BenchmarkResult.success(queryName, format, iteration, elapsed, rowCount, metrics);
+      return BenchmarkResult.success(queryName, format, iteration, elapsed, metrics);
     } catch (Exception e) {
       long elapsed = System.currentTimeMillis() - start;
       String msg = e.getMessage();

--- a/benchmark/src/main/resources/tpch-queries/q1.sql
+++ b/benchmark/src/main/resources/tpch-queries/q1.sql
@@ -1,0 +1,23 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    l_returnflag,
+    l_linestatus,
+    round(sum(l_quantity), 2) as sum_qty,
+    round(sum(l_extendedprice), 2) as sum_base_price,
+    round(sum(l_extendedprice * (1 - l_discount)), 2) as sum_disc_price,
+    round(sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)), 2) as sum_charge,
+    round(avg(l_quantity), 2) as avg_qty,
+    round(avg(l_extendedprice), 2) as avg_price,
+    round(avg(l_discount), 2) as avg_disc,
+    count(*) as count_order
+from
+    lineitem
+where
+    l_shipdate <= date '1998-12-01' - interval '90' day
+group by
+    l_returnflag,
+    l_linestatus
+order by
+    l_returnflag,
+    l_linestatus

--- a/benchmark/src/main/resources/tpch-queries/q10.sql
+++ b/benchmark/src/main/resources/tpch-queries/q10.sql
@@ -1,0 +1,34 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    c_custkey,
+    c_name,
+    round(sum(l_extendedprice * (1 - l_discount)), 1) as revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+from
+    customer,
+    orders,
+    lineitem,
+    nation
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate >= date '1993-10-01'
+    and o_orderdate < date '1993-10-01' + interval '3' month
+    and l_returnflag = 'R'
+    and c_nationkey = n_nationkey
+group by
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+order by
+    revenue desc
+limit 20

--- a/benchmark/src/main/resources/tpch-queries/q11.sql
+++ b/benchmark/src/main/resources/tpch-queries/q11.sql
@@ -1,0 +1,29 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) as value
+from
+    partsupp,
+    supplier,
+    nation
+where
+    ps_suppkey = s_suppkey
+    and s_nationkey = n_nationkey
+    and n_name = 'GERMANY'
+group by
+    ps_partkey having
+        sum(ps_supplycost * ps_availqty) > (
+            select
+                sum(ps_supplycost * ps_availqty) * 0.0001000000
+            from
+                partsupp,
+                supplier,
+                nation
+            where
+                ps_suppkey = s_suppkey
+                and s_nationkey = n_nationkey
+                and n_name = 'GERMANY'
+        )
+order by
+    value desc

--- a/benchmark/src/main/resources/tpch-queries/q12.sql
+++ b/benchmark/src/main/resources/tpch-queries/q12.sql
@@ -1,0 +1,30 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    l_shipmode,
+    sum(case
+        when o_orderpriority = '1-URGENT'
+            or o_orderpriority = '2-HIGH'
+            then 1
+        else 0
+    end) as high_line_count,
+    sum(case
+        when o_orderpriority <> '1-URGENT'
+            and o_orderpriority <> '2-HIGH'
+            then 1
+        else 0
+    end) as low_line_count
+from
+    orders,
+    lineitem
+where
+    o_orderkey = l_orderkey
+    and l_shipmode in ('MAIL', 'SHIP')
+    and l_commitdate < l_receiptdate
+    and l_shipdate < l_commitdate
+    and l_receiptdate >= date '1994-01-01'
+    and l_receiptdate < date '1994-01-01' + interval '1' year
+group by
+    l_shipmode
+order by
+    l_shipmode

--- a/benchmark/src/main/resources/tpch-queries/q13.sql
+++ b/benchmark/src/main/resources/tpch-queries/q13.sql
@@ -1,0 +1,22 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    c_count,
+    count(*) as custdist
+from
+    (
+        select
+            c_custkey,
+            count(o_orderkey) as c_count
+        from
+            customer left outer join orders on
+                c_custkey = o_custkey
+                and o_comment not like '%special%requests%'
+        group by
+            c_custkey
+    ) as c_orders
+group by
+    c_count
+order by
+    custdist desc,
+    c_count desc

--- a/benchmark/src/main/resources/tpch-queries/q14.sql
+++ b/benchmark/src/main/resources/tpch-queries/q14.sql
@@ -1,0 +1,15 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    round(100.00 * sum(case
+        when p_type like 'PROMO%'
+            then l_extendedprice * (1 - l_discount)
+        else 0
+    end) / sum(l_extendedprice * (1 - l_discount)), 2) as promo_revenue
+from
+    lineitem,
+    part
+where
+    l_partkey = p_partkey
+    and l_shipdate >= date '1995-09-01'
+    and l_shipdate < date '1995-09-01' + interval '1' month

--- a/benchmark/src/main/resources/tpch-queries/q15.sql
+++ b/benchmark/src/main/resources/tpch-queries/q15.sql
@@ -1,0 +1,34 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+with revenue0 as
+    (select
+        l_suppkey as supplier_no,
+        sum(l_extendedprice * (1 - l_discount)) as total_revenue
+    from
+        lineitem
+    where
+        l_shipdate >= date '1996-01-01'
+        and l_shipdate < date '1996-01-01' + interval '3' month
+    group by
+        l_suppkey)
+
+
+select
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    round(total_revenue, 2) as total_revenue
+from
+    supplier,
+    revenue0
+where
+    s_suppkey = supplier_no
+    and total_revenue = (
+        select
+            max(total_revenue)
+        from
+            revenue0
+    )
+order by
+    s_suppkey

--- a/benchmark/src/main/resources/tpch-queries/q16.sql
+++ b/benchmark/src/main/resources/tpch-queries/q16.sql
@@ -1,0 +1,32 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    p_brand,
+    p_type,
+    p_size,
+    count(distinct ps_suppkey) as supplier_cnt
+from
+    partsupp,
+    part
+where
+    p_partkey = ps_partkey
+    and p_brand <> 'Brand#45'
+    and p_type not like 'MEDIUM POLISHED%'
+    and p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+    and ps_suppkey not in (
+        select
+            s_suppkey
+        from
+            supplier
+        where
+            s_comment like '%Customer%Complaints%'
+    )
+group by
+    p_brand,
+    p_type,
+    p_size
+order by
+    supplier_cnt desc,
+    p_brand,
+    p_type,
+    p_size

--- a/benchmark/src/main/resources/tpch-queries/q17.sql
+++ b/benchmark/src/main/resources/tpch-queries/q17.sql
@@ -1,0 +1,19 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    sum(l_extendedprice) / 7.0 as avg_yearly
+from
+    lineitem,
+    part
+where
+    p_partkey = l_partkey
+    and p_brand = 'Brand#23'
+    and p_container = 'MED BOX'
+    and l_quantity < (
+        select
+            0.2 * avg(l_quantity)
+        from
+            lineitem
+        where
+            l_partkey = p_partkey
+    )

--- a/benchmark/src/main/resources/tpch-queries/q18.sql
+++ b/benchmark/src/main/resources/tpch-queries/q18.sql
@@ -1,0 +1,35 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+from
+    customer,
+    orders,
+    lineitem
+where
+    o_orderkey in (
+        select
+            l_orderkey
+        from
+            lineitem
+        group by
+            l_orderkey having
+                sum(l_quantity) > 300
+    )
+    and c_custkey = o_custkey
+    and o_orderkey = l_orderkey
+group by
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+order by
+    o_totalprice desc,
+    o_orderdate
+limit 100

--- a/benchmark/src/main/resources/tpch-queries/q19.sql
+++ b/benchmark/src/main/resources/tpch-queries/q19.sql
@@ -1,0 +1,37 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    sum(l_extendedprice* (1 - l_discount)) as revenue
+from
+    lineitem,
+    part
+where
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#12'
+        and p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        and l_quantity >= 1 and l_quantity <= 1 + 10
+        and p_size between 1 and 5
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#23'
+        and p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        and l_quantity >= 10 and l_quantity <= 10 + 10
+        and p_size between 1 and 10
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        and p_brand = 'Brand#34'
+        and p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        and l_quantity >= 20 and l_quantity <= 20 + 10
+        and p_size between 1 and 15
+        and l_shipmode in ('AIR', 'AIR REG')
+        and l_shipinstruct = 'DELIVER IN PERSON'
+    )

--- a/benchmark/src/main/resources/tpch-queries/q2.sql
+++ b/benchmark/src/main/resources/tpch-queries/q2.sql
@@ -1,0 +1,46 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+from
+    part,
+    supplier,
+    partsupp,
+    nation,
+    region
+where
+    p_partkey = ps_partkey
+    and s_suppkey = ps_suppkey
+    and p_size = 15
+    and p_type like '%BRASS'
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = 'EUROPE'
+    and ps_supplycost = (
+        select
+            min(ps_supplycost)
+        from
+            partsupp,
+            supplier,
+            nation,
+            region
+        where
+            p_partkey = ps_partkey
+            and s_suppkey = ps_suppkey
+            and s_nationkey = n_nationkey
+            and n_regionkey = r_regionkey
+            and r_name = 'EUROPE'
+    )
+order by
+    s_acctbal desc,
+    n_name,
+    s_name,
+    p_partkey
+limit 100

--- a/benchmark/src/main/resources/tpch-queries/q20.sql
+++ b/benchmark/src/main/resources/tpch-queries/q20.sql
@@ -1,0 +1,39 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    s_name,
+    s_address
+from
+    supplier,
+    nation
+where
+    s_suppkey in (
+        select
+            ps_suppkey
+        from
+            partsupp
+        where
+            ps_partkey in (
+                select
+                    p_partkey
+                from
+                    part
+                where
+                    p_name like 'forest%'
+            )
+            and ps_availqty > (
+                select
+                    0.5 * sum(l_quantity)
+                from
+                    lineitem
+                where
+                    l_partkey = ps_partkey
+                    and l_suppkey = ps_suppkey
+                    and l_shipdate >= date '1994-01-01'
+                    and l_shipdate < date '1994-01-01' + interval '1' year
+            )
+    )
+    and s_nationkey = n_nationkey
+    and n_name = 'CANADA'
+order by
+    s_name

--- a/benchmark/src/main/resources/tpch-queries/q21.sql
+++ b/benchmark/src/main/resources/tpch-queries/q21.sql
@@ -1,0 +1,42 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    s_name,
+    count(*) as numwait
+from
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+where
+    s_suppkey = l1.l_suppkey
+    and o_orderkey = l1.l_orderkey
+    and o_orderstatus = 'F'
+    and l1.l_receiptdate > l1.l_commitdate
+    and exists (
+        select
+            *
+        from
+            lineitem l2
+        where
+            l2.l_orderkey = l1.l_orderkey
+            and l2.l_suppkey <> l1.l_suppkey
+    )
+    and not exists (
+        select
+            *
+        from
+            lineitem l3
+        where
+            l3.l_orderkey = l1.l_orderkey
+            and l3.l_suppkey <> l1.l_suppkey
+            and l3.l_receiptdate > l3.l_commitdate
+    )
+    and s_nationkey = n_nationkey
+    and n_name = 'SAUDI ARABIA'
+group by
+    s_name
+order by
+    numwait desc,
+    s_name
+limit 100

--- a/benchmark/src/main/resources/tpch-queries/q22.sql
+++ b/benchmark/src/main/resources/tpch-queries/q22.sql
@@ -1,0 +1,39 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    cntrycode,
+    count(*) as numcust,
+    round(sum(c_acctbal), 2) as totacctbal
+from
+    (
+        select
+            substring(c_phone, 1, 2) as cntrycode,
+            c_acctbal
+        from
+            customer
+        where
+            substring(c_phone, 1, 2) in
+                ('13', '31', '23', '29', '30', '18', '17')
+            and c_acctbal > (
+                select
+                    avg(c_acctbal)
+                from
+                    customer
+                where
+                    c_acctbal > 0.00
+                    and substring(c_phone, 1, 2) in
+                        ('13', '31', '23', '29', '30', '18', '17')
+            )
+            and not exists (
+                select
+                    *
+                from
+                    orders
+                where
+                    o_custkey = c_custkey
+            )
+    ) as custsale
+group by
+    cntrycode
+order by
+    cntrycode

--- a/benchmark/src/main/resources/tpch-queries/q3.sql
+++ b/benchmark/src/main/resources/tpch-queries/q3.sql
@@ -1,0 +1,25 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) as revenue,
+    o_orderdate,
+    o_shippriority
+from
+    customer,
+    orders,
+    lineitem
+where
+    c_mktsegment = 'BUILDING'
+    and c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and o_orderdate < date '1995-03-15'
+    and l_shipdate > date '1995-03-15'
+group by
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+order by
+    revenue desc,
+    o_orderdate
+limit 10

--- a/benchmark/src/main/resources/tpch-queries/q4.sql
+++ b/benchmark/src/main/resources/tpch-queries/q4.sql
@@ -1,0 +1,23 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    o_orderpriority,
+    count(*) as order_count
+from
+    orders
+where
+    o_orderdate >= date '1993-07-01'
+    and o_orderdate < date '1993-07-01' + interval '3' month
+    and exists (
+        select
+            *
+        from
+            lineitem
+        where
+            l_orderkey = o_orderkey
+            and l_commitdate < l_receiptdate
+    )
+group by
+    o_orderpriority
+order by
+    o_orderpriority

--- a/benchmark/src/main/resources/tpch-queries/q5.sql
+++ b/benchmark/src/main/resources/tpch-queries/q5.sql
@@ -1,0 +1,26 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    n_name,
+    round(sum(l_extendedprice * (1 - l_discount)), 2) as revenue
+from
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+where
+    c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and l_suppkey = s_suppkey
+    and c_nationkey = s_nationkey
+    and s_nationkey = n_nationkey
+    and n_regionkey = r_regionkey
+    and r_name = 'ASIA'
+    and o_orderdate >= date '1994-01-01'
+    and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+    n_name
+order by
+    revenue desc

--- a/benchmark/src/main/resources/tpch-queries/q6.sql
+++ b/benchmark/src/main/resources/tpch-queries/q6.sql
@@ -1,0 +1,11 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    round(sum(l_extendedprice * l_discount), 2) as revenue
+from
+    lineitem
+where
+    l_shipdate >= date '1994-01-01'
+    and l_shipdate < date '1994-01-01' + interval '1' year
+    and l_discount between .06 - 0.01 and .06 + 0.01
+    and l_quantity < 24

--- a/benchmark/src/main/resources/tpch-queries/q7.sql
+++ b/benchmark/src/main/resources/tpch-queries/q7.sql
@@ -1,0 +1,41 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    supp_nation,
+    cust_nation,
+    l_year,
+    round(sum(volume), 2) as revenue
+from
+    (
+        select
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            year(l_shipdate) as l_year,
+            l_extendedprice * (1 - l_discount) as volume
+        from
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        where
+            s_suppkey = l_suppkey
+            and o_orderkey = l_orderkey
+            and c_custkey = o_custkey
+            and s_nationkey = n1.n_nationkey
+            and c_nationkey = n2.n_nationkey
+            and (
+                (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
+                or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
+            )
+            and l_shipdate between date '1995-01-01' and date '1996-12-31'
+    ) as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year

--- a/benchmark/src/main/resources/tpch-queries/q8.sql
+++ b/benchmark/src/main/resources/tpch-queries/q8.sql
@@ -1,0 +1,39 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    o_year,
+    sum(case
+        when nation = 'BRAZIL' then volume
+        else 0
+    end) / sum(volume) as mkt_share
+from
+    (
+        select
+            year(o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) as volume,
+            n2.n_name as nation
+        from
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        where
+            p_partkey = l_partkey
+            and s_suppkey = l_suppkey
+            and l_orderkey = o_orderkey
+            and o_custkey = c_custkey
+            and c_nationkey = n1.n_nationkey
+            and n1.n_regionkey = r_regionkey
+            and r_name = 'AMERICA'
+            and s_nationkey = n2.n_nationkey
+            and o_orderdate between date '1995-01-01' and date '1996-12-31'
+            and p_type = 'ECONOMY ANODIZED STEEL'
+    ) as all_nations
+group by
+    o_year
+order by
+    o_year

--- a/benchmark/src/main/resources/tpch-queries/q9.sql
+++ b/benchmark/src/main/resources/tpch-queries/q9.sql
@@ -1,0 +1,34 @@
+-- Source: Apache Kyuubi kyuubi-spark-connector-tpch test resources (Apache 2.0 licensed)
+
+select
+    nation,
+    o_year,
+    round(sum(amount), 2) as sum_profit
+from
+    (
+        select
+            n_name as nation,
+            year(o_orderdate) as o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount
+        from
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        where
+            s_suppkey = l_suppkey
+            and ps_suppkey = l_suppkey
+            and ps_partkey = l_partkey
+            and p_partkey = l_partkey
+            and o_orderkey = l_orderkey
+            and s_nationkey = n_nationkey
+            and p_name like '%green%'
+    ) as profit
+group by
+    nation,
+    o_year
+order by
+    nation,
+    o_year desc


### PR DESCRIPTION
Closes https://github.com/lance-format/lance-spark/issues/242

Implemented on the basis of TPC-DS benchmark infrastructure and similarly to it.

## Summary

### Files changed (4 in-place edits)
1. **`Makefile`** — Added `benchmark-tpch-generate`, `benchmark-tpch-run`, `benchmark-tpch` targets. Updated `make help` block to list all benchmark targets with TPC-DS vs TPC-H distinction.
2. **`benchmark/README.md`** — Restructured to cover both benchmarks with shared Architecture, Data Layout (explaining the `customer` schema collision), Docker, and External Cluster sections. Every Quick Start leads with `make`.
3. **`benchmark/pom.xml`** — Added `kyuubi-spark-connector-tpch_${scala.compat.version}` dependency (v1.11.0), renamed to "Lance Spark Benchmark (TPC-DS + TPC-H)", removed stale `<mainClass>TpcdsBenchmarkRunner</mainClass>` from both `maven-jar-plugin` and `maven-shade-plugin` (since there's no longer a single default runner).
4. **`BenchmarkReporter.java`** — Added 2-arg constructor `BenchmarkReporter(List<BenchmarkResult>, String benchmarkName)`. Existing 1-arg constructor delegates with `"TPC-DS"` (backward compatible — TpcdsBenchmarkRunner needs no changes). Line 94 header string now uses the parameter.

### Files added (31 new files)

**Java classes (4)** — all in `org.lance.spark.benchmark` package:
- `TpchDataGenerator.java` — 8 TPC-H tables via Kyuubi `tpch.sfN` catalog, reuses `TpcdsDataGenerator.toLancePath()` for cross-cloud path conversion
- `TpchDataLoader.java` — registers/unregisters TPC-H temp views
- `TpchQueryRunner.java` — loads from `/tpch-queries/` classpath, iterates q1..q22 only (no a/b variant loop), drops the dead 2-arg convenience constructor from the TPC-DS equivalent
- `TpchBenchmarkRunner.java` — app name "TPC-H Benchmark", uses new 2-arg `BenchmarkReporter` with "TPC-H", writes CSV with `tpch_` prefix

**SQL query files (22)** — `benchmark/src/main/resources/tpch-queries/q1.sql` through `q22.sql`, sourced from Apache Kyuubi's TPC-H test resources (Apache 2.0 licensed), each with a provenance comment header. **q15 uses the CTE form** (verified by `grep CREATE VIEW` returning no matches) to avoid the multi-statement row-count edge case in the `;`-splitting query runner.

**Shell scripts (4)** — all chmod +x, all with `set -euo pipefail`, all parametrized via `SPARK_VERSION`/`SCALA_VERSION`/`DATA_DIR`/`RESULTS_DIR` env vars (zero hardcoded versions):
- `generate-tpch-data.sh` — simple wrapper, defaults `DATA_DIR` to `${BENCHMARK_DIR}/data/tpch`
- `run-tpch-benchmark.sh` — simple wrapper, same `EXPLAIN`/`METRICS`/`QUERIES` env passthrough as TPC-DS
- `submit-tpch-datagen.sh` — advanced wrapper with full arg parsing, Kyuubi TPC-H catalog config, `APP_NAME` defaults to `${USER}-tpch-datagen-sfN`
- `submit-tpch-benchmark.sh` — advanced wrapper with cluster-ready configuration