### PR TITLE
fix: add --fail flag to curl downloads in docker/Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -47,16 +47,16 @@ ENV LANCE_NS_VERSION=0.6.1
 
 # Download spark
 RUN mkdir -p ${SPARK_HOME} \
- && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3${SPARK_SCALA_SUFFIX}.tgz -o spark.tgz \
+ && curl -fL https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3${SPARK_SCALA_SUFFIX}.tgz -o spark.tgz \
  && tar xvzf spark.tgz --directory /opt/spark --strip-components 1 \
  && rm -rf spark.tgz
 
 # Download lance-spark bundle JAR from Maven
-RUN curl -L https://repo1.maven.org/maven2/com/lancedb/lance-spark-bundle-3.5_2.12/${LANCE_SPARK_VERSION}/lance-spark-bundle-3.5_2.12-${LANCE_SPARK_VERSION}.jar \
+RUN curl -fL https://repo1.maven.org/maven2/com/lancedb/lance-spark-bundle-3.5_2.12/${LANCE_SPARK_VERSION}/lance-spark-bundle-3.5_2.12-${LANCE_SPARK_VERSION}.jar \
  -o /opt/spark/jars/lance-spark-bundle_2.12-${LANCE_SPARK_VERSION}.jar
 
 # Download additional Lance namespace implementation jars from Maven
-RUN curl -L https://repo1.maven.org/maven2/com/lancedb/lance-namespace-glue/${LANCE_NS_VERSION}/lance-namespace-glue-${LANCE_NS_VERSION}.jar \
+RUN curl -fL https://repo1.maven.org/maven2/com/lancedb/lance-namespace-glue/${LANCE_NS_VERSION}/lance-namespace-glue-${LANCE_NS_VERSION}.jar \
  -o /opt/spark/jars/lance-namespace-glue-${LANCE_NS_VERSION}.jar
 
 # For local testing, uncomment the lines below and comment out the Maven downloads above:
@@ -66,18 +66,18 @@ RUN curl -L https://repo1.maven.org/maven2/com/lancedb/lance-namespace-glue/${LA
 # Download OpenDAL native libraries for Linux architectures
 ENV OPENDAL_VERSION=0.48.0
 RUN mkdir -p /tmp/opendal && cd /tmp/opendal \
- && curl -L https://repo1.maven.org/maven2/org/apache/opendal/opendal/${OPENDAL_VERSION}/opendal-${OPENDAL_VERSION}-linux-x86_64.jar -o opendal-linux-x86_64.jar \
- && curl -L https://repo1.maven.org/maven2/org/apache/opendal/opendal/${OPENDAL_VERSION}/opendal-${OPENDAL_VERSION}-linux-aarch_64.jar -o opendal-linux-aarch_64.jar \
+ && curl -fL https://repo1.maven.org/maven2/org/apache/opendal/opendal/${OPENDAL_VERSION}/opendal-${OPENDAL_VERSION}-linux-x86_64.jar -o opendal-linux-x86_64.jar \
+ && curl -fL https://repo1.maven.org/maven2/org/apache/opendal/opendal/${OPENDAL_VERSION}/opendal-${OPENDAL_VERSION}-linux-aarch_64.jar -o opendal-linux-aarch_64.jar \
  && mv *.jar /opt/spark/jars/ \
  && cd / && rm -rf /tmp/opendal
 
 # Download AWS SDK Bundle v2
 ENV AWS_SDK_VERSION=2.20.43
-RUN curl -L https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/${AWS_SDK_VERSION}/bundle-${AWS_SDK_VERSION}.jar \
+RUN curl -fL https://repo1.maven.org/maven2/software/amazon/awssdk/bundle/${AWS_SDK_VERSION}/bundle-${AWS_SDK_VERSION}.jar \
  -o /opt/spark/jars/aws-sdk-bundle-${AWS_SDK_VERSION}.jar
 
 # Install AWS CLI (optional, for S3 support)
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl -fL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
  && unzip awscliv2.zip \
  && sudo ./aws/install \
  && rm awscliv2.zip \

--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -16,7 +16,7 @@ RUN apt-get update && \
 
 RUN npm install -g azurite
 
-RUN curl -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linux-amd64/minio && \
+RUN curl -fL -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linux-amd64/minio && \
     chmod +x /usr/local/bin/minio
 
 RUN python3 -m venv /opt/venv && \
@@ -38,7 +38,7 @@ ARG SPARK_SCALA_SUFFIX=
 ENV PYTHONPATH="${SPARK_HOME}/python/lib/py4j-${PY4J_VERSION}-src.zip:${PYTHONPATH}"
 
 RUN mkdir -p ${SPARK_HOME} \
-    && curl https://archive.apache.org/dist/spark/spark-${SPARK_DOWNLOAD_VERSION}/spark-${SPARK_DOWNLOAD_VERSION}-bin-hadoop3${SPARK_SCALA_SUFFIX}.tgz \
+    && curl -fL https://archive.apache.org/dist/spark/spark-${SPARK_DOWNLOAD_VERSION}/spark-${SPARK_DOWNLOAD_VERSION}-bin-hadoop3${SPARK_SCALA_SUFFIX}.tgz \
        -o spark.tgz \
     && tar xzf spark.tgz --directory ${SPARK_HOME} --strip-components 1 \
     && rm spark.tgz


### PR DESCRIPTION
## Summary

Adds `-fL` to every `curl` invocation in `docker/Dockerfile` and `docker/Dockerfile.test-base` so that the build fails loudly when an HTTP download returns a 4xx/5xx response, instead of silently saving the error page as the output file.

Without `-f`, curl exits with status 0 on HTTP 4xx/5xx and writes the response body (usually an HTML error page) into the output file. This caused `lance-spark-bundle_2.12-0.4.0-beta.1.jar` and `lance-namespace-glue-0.6.1.jar` to be silently created as 554-byte HTML 404 pages inside the spark-lance image, which then crashed Spark at runtime with `Failed to find the data source: lance`.

`-L` is added uniformly so that Maven Central and AWS redirects are followed (some curl calls already had `-L`, others didn't — this also standardizes on `curl -fL` everywhere).

Fixes #404

## What this PR does NOT do

This PR is intentionally minimal. It does not:
- Update `LANCE_SPARK_VERSION` (currently `0.4.0-beta.1`, not on Maven Central)
- Update `LANCE_NS_VERSION` (currently `0.6.1`, also not on Maven Central)
- Update opendal / AWS SDK versions
- Add hadolint or any other Dockerfile linter to CI

These are separate maintainer decisions; the goal here is just to make the existing pipeline fail explicitly when something is wrong, regardless of which version the maintainers eventually settle on.

## Test plan

- [ ] `docker build -f docker/Dockerfile .` still builds successfully when all upstream URLs are valid (or fails immediately with `curl: (22)` when they aren't)
- [ ] Manual negative test: temporarily set `LANCE_SPARK_VERSION=does-not-exist` and verify `make docker-build` now fails at the curl step with `curl: (22) The requested URL returned error: 404`, instead of silently producing a broken image
- [ ] No runtime behaviour change for valid downloads — `-f` only affects HTTP error responses, and `-L` is harmless on non-redirect URLs

## Precedent

Same class of bug as #183 (which addressed the Spark tarball download), now applied uniformly to all downloads in both Dockerfiles so the trap doesn't catch the next person who bumps a version to something temporarily missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
