### PR TITLE
chore: update lance dependency to v5.0.0-rc.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.1</lance-spark.version>
-        <lance.version>5.0.0-beta.6</lance.version>
+        <lance.version>5.0.0-rc.1</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Updated `lance.version` in `pom.xml` from `5.0.0-beta.6` to `5.0.0-rc.1`.
- Verified Docker-pinned versions in `docker/Dockerfile` are aligned:
  - `LANCE_SPARK_VERSION=0.4.0-beta.1` (matches `lance-spark.version` in `pom.xml`)
  - `LANCE_NS_VERSION=0.6.1` (matches `lance-core` `v5.0.0-rc.1` dependency in Lance source)

## Verification
- `make lint` passed.
- `make install` passed for Spark 3.5 / Scala 2.12 after installing `org.lance:lance-core:5.0.0-rc.1` to local Maven cache from the Lance `v5.0.0-rc.1` source tag.

## Trigger
- Triggering tag: `refs/tags/v5.0.0-rc.1`
