### PR TITLE
feat: add use_large_var_types option to avoid 2GB Arrow vector overflow

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -56,12 +56,14 @@ public class LanceSparkWriteOptions implements Serializable {
   public static final String CONFIG_QUEUE_DEPTH = "queue_depth";
   public static final String CONFIG_BATCH_SIZE = "batch_size";
   public static final String CONFIG_ENABLE_STABLE_ROW_IDS = "enable_stable_row_ids";
+  public static final String CONFIG_USE_LARGE_VAR_TYPES = "use_large_var_types";
 
   private static final WriteMode DEFAULT_WRITE_MODE = WriteMode.APPEND;
   private static final boolean DEFAULT_USE_QUEUED_WRITE_BUFFER = false;
   private static final int DEFAULT_QUEUE_DEPTH = 8;
   // Changed from 512 to 8192 for better write performance consistency with read path
   private static final int DEFAULT_BATCH_SIZE = 8192;
+  private static final boolean DEFAULT_USE_LARGE_VAR_TYPES = false;
 
   private final String datasetUri;
   private final WriteMode writeMode;
@@ -75,6 +77,7 @@ public class LanceSparkWriteOptions implements Serializable {
   // Boxed so we can represent "unset" (null): when null, callers omit the flag and lance-core
   // inherits from the manifest (e.g. append without re-specifying). Staged commit uses primitives.
   private final Boolean enableStableRowIds;
+  private final boolean useLargeVarTypes;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -94,6 +97,7 @@ public class LanceSparkWriteOptions implements Serializable {
     this.queueDepth = builder.queueDepth;
     this.batchSize = builder.batchSize;
     this.enableStableRowIds = builder.enableStableRowIds;
+    this.useLargeVarTypes = builder.useLargeVarTypes;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -166,6 +170,10 @@ public class LanceSparkWriteOptions implements Serializable {
   /** Nullable when the write option was not specified (see field comment above). */
   public Boolean getEnableStableRowIds() {
     return enableStableRowIds;
+  }
+
+  public boolean isUseLargeVarTypes() {
+    return useLargeVarTypes;
   }
 
   public Map<String, String> getStorageOptions() {
@@ -265,6 +273,7 @@ public class LanceSparkWriteOptions implements Serializable {
     return useQueuedWriteBuffer == that.useQueuedWriteBuffer
         && queueDepth == that.queueDepth
         && batchSize == that.batchSize
+        && useLargeVarTypes == that.useLargeVarTypes
         && Objects.equals(datasetUri, that.datasetUri)
         && writeMode == that.writeMode
         && Objects.equals(maxRowsPerFile, that.maxRowsPerFile)
@@ -289,6 +298,7 @@ public class LanceSparkWriteOptions implements Serializable {
         queueDepth,
         batchSize,
         enableStableRowIds,
+        useLargeVarTypes,
         storageOptions,
         tableId);
   }
@@ -305,6 +315,7 @@ public class LanceSparkWriteOptions implements Serializable {
     private int queueDepth = DEFAULT_QUEUE_DEPTH;
     private int batchSize = DEFAULT_BATCH_SIZE;
     private Boolean enableStableRowIds;
+    private boolean useLargeVarTypes = DEFAULT_USE_LARGE_VAR_TYPES;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -361,6 +372,11 @@ public class LanceSparkWriteOptions implements Serializable {
       return this;
     }
 
+    public Builder useLargeVarTypes(boolean useLargeVarTypes) {
+      this.useLargeVarTypes = useLargeVarTypes;
+      return this;
+    }
+
     public Builder storageOptions(Map<String, String> storageOptions) {
       this.storageOptions = new HashMap<>(storageOptions);
       return this;
@@ -413,6 +429,9 @@ public class LanceSparkWriteOptions implements Serializable {
       }
       if (options.containsKey(CONFIG_ENABLE_STABLE_ROW_IDS)) {
         this.enableStableRowIds = Boolean.parseBoolean(options.get(CONFIG_ENABLE_STABLE_ROW_IDS));
+      }
+      if (options.containsKey(CONFIG_USE_LARGE_VAR_TYPES)) {
+        this.useLargeVarTypes = Boolean.parseBoolean(options.get(CONFIG_USE_LARGE_VAR_TYPES));
       }
       return this;
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -132,6 +132,7 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
+      boolean useLargeVarTypes = writeOptions.isUseLargeVarTypes();
 
       // Merge initial storage options with write options
       WriteParams params = buildWriteParams();
@@ -140,9 +141,10 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
-        writeBuffer = new QueuedArrowBatchWriteBuffer(schema, batchSize, queueDepth);
+        writeBuffer =
+            new QueuedArrowBatchWriteBuffer(schema, batchSize, queueDepth, useLargeVarTypes);
       } else {
-        writeBuffer = new SemaphoreArrowBatchWriteBuffer(schema, batchSize);
+        writeBuffer = new SemaphoreArrowBatchWriteBuffer(schema, batchSize, useLargeVarTypes);
       }
 
       // Create fragment in background thread

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -91,9 +91,15 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, int queueDepth) {
+    this(sparkSchema, batchSize, queueDepth, false);
+  }
+
+  /** Simplified constructor with large var types support. */
+  public QueuedArrowBatchWriteBuffer(
+      StructType sparkSchema, int batchSize, int queueDepth, boolean useLargeVarTypes) {
     this(
         LanceRuntime.allocator(),
-        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
+        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, useLargeVarTypes),
         sparkSchema,
         batchSize,
         queueDepth);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -69,9 +69,15 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public SemaphoreArrowBatchWriteBuffer(StructType sparkSchema, int batchSize) {
+    this(sparkSchema, batchSize, false);
+  }
+
+  /** Simplified constructor with large var types support. */
+  public SemaphoreArrowBatchWriteBuffer(
+      StructType sparkSchema, int batchSize, boolean useLargeVarTypes) {
     this(
         LanceRuntime.allocator(),
-        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false),
+        LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, useLargeVarTypes),
         sparkSchema,
         batchSize);
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -165,13 +165,22 @@ object LanceArrowUtils {
       schema: StructType,
       timeZoneId: String,
       errorOnDuplicatedFieldNames: Boolean): Schema = {
+    toArrowSchema(schema, timeZoneId, errorOnDuplicatedFieldNames, largeVarTypes = false)
+  }
+
+  def toArrowSchema(
+      schema: StructType,
+      timeZoneId: String,
+      errorOnDuplicatedFieldNames: Boolean,
+      largeVarTypes: Boolean): Schema = {
     new Schema(schema.map { field =>
       toArrowField(
         field.name,
         deduplicateFieldNames(field.dataType, errorOnDuplicatedFieldNames),
         field.nullable,
         timeZoneId,
-        field.metadata)
+        field.metadata,
+        largeVarTypes)
     }.asJava)
   }
 
@@ -180,8 +189,9 @@ object LanceArrowUtils {
       dt: DataType,
       nullable: Boolean,
       timeZoneId: String,
-      metadata: org.apache.spark.sql.types.Metadata = null): Field = {
-    var large: Boolean = false
+      metadata: org.apache.spark.sql.types.Metadata = null,
+      largeVarTypes: Boolean = false): Field = {
+    var large: Boolean = largeVarTypes
     var meta: Map[String, String] = Map.empty
 
     if (metadata != null) {
@@ -222,7 +232,12 @@ object LanceArrowUtils {
                 null),
               Seq.empty[Field].asJava)
           } else {
-            toArrowField("element", elementType, containsNull, timeZoneId)
+            toArrowField(
+              "element",
+              elementType,
+              containsNull,
+              timeZoneId,
+              largeVarTypes = largeVarTypes)
           }
           new Field(
             name,
@@ -234,7 +249,12 @@ object LanceArrowUtils {
             name,
             fieldType,
             Seq(
-              toArrowField("element", elementType, containsNull, timeZoneId)).asJava)
+              toArrowField(
+                "element",
+                elementType,
+                containsNull,
+                timeZoneId,
+                largeVarTypes = largeVarTypes)).asJava)
         }
       case StructType(fields) =>
         val fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null, meta.asJava)
@@ -242,7 +262,12 @@ object LanceArrowUtils {
           name,
           fieldType,
           fields.map { field =>
-            toArrowField(field.name, field.dataType, field.nullable, timeZoneId)
+            toArrowField(
+              field.name,
+              field.dataType,
+              field.nullable,
+              timeZoneId,
+              largeVarTypes = largeVarTypes)
           }.toSeq.asJava)
       case MapType(keyType, valueType, valueContainsNull) =>
         val mapType = new FieldType(nullable, new ArrowType.Map(false), null, meta.asJava)
@@ -256,7 +281,8 @@ object LanceArrowUtils {
               .add(MapVector.KEY_NAME, keyType, nullable = false)
               .add(MapVector.VALUE_NAME, valueType, nullable = valueContainsNull),
             nullable = false,
-            timeZoneId)).asJava)
+            timeZoneId,
+            largeVarTypes = largeVarTypes)).asJava)
       case udt: UserDefinedType[_] =>
         toArrowField(name, udt.sqlType, nullable, timeZoneId)
       case dataType =>

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -267,7 +267,8 @@ object LanceArrowUtils {
               field.dataType,
               field.nullable,
               timeZoneId,
-              largeVarTypes = largeVarTypes)
+              field.metadata,
+              largeVarTypes)
           }.toSeq.asJava)
       case MapType(keyType, valueType, valueContainsNull) =>
         val mapType = new FieldType(nullable, new ArrowType.Map(false), null, meta.asJava)
@@ -284,7 +285,7 @@ object LanceArrowUtils {
             timeZoneId,
             largeVarTypes = largeVarTypes)).asJava)
       case udt: UserDefinedType[_] =>
-        toArrowField(name, udt.sqlType, nullable, timeZoneId)
+        toArrowField(name, udt.sqlType, nullable, timeZoneId, largeVarTypes = largeVarTypes)
       case dataType =>
         val fieldType =
           new FieldType(nullable, toArrowType(dataType, timeZoneId, large, name), null, meta.asJava)


### PR DESCRIPTION
## Summary
- Adds a `use_large_var_types` write option (default `false`) that switches string/binary columns from `VarCharVector`/`VarBinaryVector` (32-bit offsets, 2GB limit) to `LargeVarCharVector`/`LargeVarBinaryVector` (64-bit offsets, no practical limit)
- Fixes `OversizedAllocationException` when a single batch accumulates >2GB of variable-width data (e.g., large blobs or long strings)
- The flag propagates through nested types (arrays, structs, maps)

## Usage
```scala
df.write.format("lance")
  .option("use_large_var_types", "true")
  .save("/path/to/dataset")
```

## Test plan
- [x] All 52 existing unit tests pass with no regressions
- [ ] Integration test with large string/binary data exceeding 2GB per batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)