### PR TITLE
fix(benchmark): accurately materialize tpcds query

### DIFF
--- a/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkReporter.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkReporter.java
@@ -51,17 +51,11 @@ public class BenchmarkReporter {
 
     // Compute median time per query per format
     Map<String, Map<String, Long>> medianTimes = new LinkedHashMap<>();
-    Map<String, Map<String, Long>> rowCounts = new LinkedHashMap<>();
 
     for (BenchmarkResult r : results) {
       medianTimes
           .computeIfAbsent(r.getQueryName(), k -> new LinkedHashMap<>())
           .merge(r.getFormat(), r.getElapsedMs(), Long::min);
-      if (r.isSuccess()) {
-        rowCounts
-            .computeIfAbsent(r.getQueryName(), k -> new LinkedHashMap<>())
-            .put(r.getFormat(), r.getRowCount());
-      }
     }
 
     // Compute per-query median across iterations
@@ -189,30 +183,6 @@ public class BenchmarkReporter {
     }
 
     System.out.printf("Queries passed: %d, partial/failed: %d%n", passCount, failCount);
-
-    // Row count validation
-    if (formats.size() >= 2) {
-      int mismatchCount = 0;
-      for (Map.Entry<String, Map<String, Long>> entry : rowCounts.entrySet()) {
-        Map<String, Long> counts = entry.getValue();
-        if (counts.size() >= 2) {
-          Long first = null;
-          for (Long c : counts.values()) {
-            if (first == null) {
-              first = c;
-            } else if (!first.equals(c)) {
-              mismatchCount++;
-              System.out.println(
-                  "  ROW COUNT MISMATCH: " + entry.getKey() + " -> " + counts);
-              break;
-            }
-          }
-        }
-      }
-      if (mismatchCount == 0) {
-        System.out.println("Row count validation: all matching");
-      }
-    }
   }
 
   private QueryMetrics findMetricsForQuery(String queryName) {

--- a/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkResult.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/BenchmarkResult.java
@@ -19,7 +19,6 @@ public class BenchmarkResult {
   private final String format;
   private final int iteration;
   private final long elapsedMs;
-  private final long rowCount;
   private final boolean success;
   private final String errorMessage;
   private final QueryMetrics metrics;
@@ -29,7 +28,6 @@ public class BenchmarkResult {
       String format,
       int iteration,
       long elapsedMs,
-      long rowCount,
       boolean success,
       String errorMessage,
       QueryMetrics metrics) {
@@ -37,32 +35,24 @@ public class BenchmarkResult {
     this.format = format;
     this.iteration = iteration;
     this.elapsedMs = elapsedMs;
-    this.rowCount = rowCount;
     this.success = success;
     this.errorMessage = errorMessage;
     this.metrics = metrics;
   }
 
   public static BenchmarkResult success(
-      String queryName, String format, int iteration, long elapsedMs, long rowCount) {
-    return new BenchmarkResult(queryName, format, iteration, elapsedMs, rowCount, true, null, null);
+      String queryName, String format, int iteration, long elapsedMs) {
+    return new BenchmarkResult(queryName, format, iteration, elapsedMs, true, null, null);
   }
 
   public static BenchmarkResult success(
-      String queryName,
-      String format,
-      int iteration,
-      long elapsedMs,
-      long rowCount,
-      QueryMetrics metrics) {
-    return new BenchmarkResult(
-        queryName, format, iteration, elapsedMs, rowCount, true, null, metrics);
+      String queryName, String format, int iteration, long elapsedMs, QueryMetrics metrics) {
+    return new BenchmarkResult(queryName, format, iteration, elapsedMs, true, null, metrics);
   }
 
   public static BenchmarkResult failure(
       String queryName, String format, int iteration, long elapsedMs, String errorMessage) {
-    return new BenchmarkResult(
-        queryName, format, iteration, elapsedMs, -1, false, errorMessage, null);
+    return new BenchmarkResult(queryName, format, iteration, elapsedMs, false, errorMessage, null);
   }
 
   public String getQueryName() {
@@ -79,10 +69,6 @@ public class BenchmarkResult {
 
   public long getElapsedMs() {
     return elapsedMs;
-  }
-
-  public long getRowCount() {
-    return rowCount;
   }
 
   public boolean isSuccess() {
@@ -105,7 +91,6 @@ public class BenchmarkResult {
             format,
             String.valueOf(iteration),
             String.valueOf(elapsedMs),
-            String.valueOf(rowCount),
             String.valueOf(success),
             errorMessage == null ? "" : "\"" + errorMessage.replace("\"", "\"\"") + "\"");
     if (metrics != null) {
@@ -115,7 +100,7 @@ public class BenchmarkResult {
   }
 
   public static String csvHeader() {
-    return "query,format,iteration,elapsed_ms,row_count,success,error";
+    return "query,format,iteration,elapsed_ms,success,error";
   }
 
   public static String csvHeaderWithMetrics() {

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpcdsQueryRunner.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpcdsQueryRunner.java
@@ -80,8 +80,8 @@ public class TpcdsQueryRunner {
 
         String status = result.isSuccess() ? "OK" : "FAIL";
         System.out.printf(
-            "  [%s] %s iter=%d time=%dms rows=%d%n",
-            status, queryName, i, result.getElapsedMs(), result.getRowCount());
+            "  [%s] %s iter=%d time=%dms%n",
+            status, queryName, i, result.getElapsedMs());
         if (result.getMetrics() != null) {
           System.out.println("       Metrics: " + result.getMetrics().toSummaryString());
         }
@@ -129,19 +129,18 @@ public class TpcdsQueryRunner {
 
     long start = System.currentTimeMillis();
     try {
-      long rowCount = 0;
       for (String stmt : statements) {
         String trimmed = stmt.trim();
         if (trimmed.isEmpty()) {
           continue;
         }
         Dataset<Row> result = spark.sql(trimmed);
-        rowCount = result.count();
+        result.write().format("noop").mode("overwrite").save();
       }
       long elapsed = System.currentTimeMillis() - start;
 
       QueryMetrics metrics = metricsListener != null ? metricsListener.getMetrics() : null;
-      return BenchmarkResult.success(queryName, format, iteration, elapsed, rowCount, metrics);
+      return BenchmarkResult.success(queryName, format, iteration, elapsed, metrics);
     } catch (Exception e) {
       long elapsed = System.currentTimeMillis() - start;
       String msg = e.getMessage();


### PR DESCRIPTION
Fix https://github.com/lance-format/lance-spark/issues/414

## Problem
The TPC-DS benchmark runner used `Dataset.count()` as the action to trigger query execution. However, `count()` activates Lance's count optimization, which scans with an empty schema (no columns). For queries containing scalar subqueries (e.g., TPC-DS q9), this optimization causes the subqueries to never be materialized

This means the benchmark was not accurately measuring real query execution behavior

## Approach
- The fix replaces `result.count()` with `result.write().format("noop").mode("overwrite").save()`, which forces Spark to fully materialize the query plan -- including all subqueries -- without triggering the count optimization shortcut. 
- The "noop" format is a built-in Spark sink that discards all output rows after computing them, making it an ideal replacement that still exercises the full query execution path.
- Since row counts are no longer available (the noop sink does not return a count), all row-count-related functionality is removed

## Test Coverage
No new tests. The benchmark module is a standalone harness rather than a tested library. To validate this change, one could:
Run TPC-DS q9 (trigger by df.show) against a Lance dataset and verify that the whole subqueries are materialized