### PR TITLE
test: add unit tests for utility classes

### DIFF
--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -31,25 +31,25 @@ import static org.junit.jupiter.api.Assertions.*;
 public class BlobUtilsTest {
 
   @Test
-  public void testIsBlobSparkField_nullField() {
+  public void testIsBlobSparkFieldNullField() {
     assertFalse(BlobUtils.isBlobSparkField(null));
   }
 
   @Test
-  public void testIsBlobSparkField_emptyMetadata() {
+  public void testIsBlobSparkFieldEmptyMetadata() {
     StructField field = DataTypes.createStructField("col", DataTypes.BinaryType, true);
     assertFalse(BlobUtils.isBlobSparkField(field));
   }
 
   @Test
-  public void testIsBlobSparkField_noKey() {
+  public void testIsBlobSparkFieldNoKey() {
     Metadata metadata = new MetadataBuilder().putString("other-key", "value").build();
     StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
     assertFalse(BlobUtils.isBlobSparkField(field));
   }
 
   @Test
-  public void testIsBlobSparkField_wrongValue() {
+  public void testIsBlobSparkFieldWrongValue() {
     Metadata metadata =
         new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false").build();
     StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
@@ -57,7 +57,7 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobSparkField_valid() {
+  public void testIsBlobSparkFieldValid() {
     Metadata metadata =
         new MetadataBuilder()
             .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
@@ -67,7 +67,7 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobSparkField_caseInsensitive() {
+  public void testIsBlobSparkFieldCaseInsensitive() {
     Metadata metadata =
         new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "TRUE").build();
     StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
@@ -75,18 +75,18 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobArrowField_nullField() {
+  public void testIsBlobArrowFieldNullField() {
     assertFalse(BlobUtils.isBlobArrowField(null));
   }
 
   @Test
-  public void testIsBlobArrowField_noMetadata() {
+  public void testIsBlobArrowFieldNoMetadata() {
     Field field = new Field("col", FieldType.nullable(new ArrowType.Binary()), null);
     assertFalse(BlobUtils.isBlobArrowField(field));
   }
 
   @Test
-  public void testIsBlobArrowField_noKey() {
+  public void testIsBlobArrowFieldNoKey() {
     Map<String, String> meta = new HashMap<>();
     meta.put("other-key", "value");
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
@@ -94,7 +94,7 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobArrowField_wrongValue() {
+  public void testIsBlobArrowFieldWrongValue() {
     Map<String, String> meta = new HashMap<>();
     meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false");
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
@@ -102,7 +102,7 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobArrowField_valid() {
+  public void testIsBlobArrowFieldValid() {
     Map<String, String> meta = new HashMap<>();
     meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE);
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
@@ -110,7 +110,7 @@ public class BlobUtilsTest {
   }
 
   @Test
-  public void testIsBlobArrowField_caseInsensitive() {
+  public void testIsBlobArrowFieldCaseInsensitive() {
     Map<String, String> meta = new HashMap<>();
     meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "True");
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -27,8 +27,20 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/** Unit tests for {@link BlobUtils}. */
+/**
+ * Unit tests for {@link BlobUtils}.
+ *
+ * <p>Test inputs use the literal key/value strings rather than the constants exposed by {@link
+ * BlobUtils}, so a rename of {@code LANCE_ENCODING_BLOB_KEY} or {@code LANCE_ENCODING_BLOB_VALUE}
+ * will break these tests — catching accidental drift from the wire contract.
+ *
+ * <p>Upstream convention changes (lance-core itself switching to a different key) are an
+ * integration-level concern covered by {@link org.lance.spark.BaseBlobCreateTableTest} and {@link
+ * org.lance.spark.utils.SchemaConverterTest}, which round-trip through real data.
+ */
 public class BlobUtilsTest {
+
+  private static final String BLOB_KEY = "lance-encoding:blob";
 
   @Test
   public void testIsBlobSparkFieldNullField() {
@@ -50,26 +62,17 @@ public class BlobUtilsTest {
 
   @Test
   public void testIsBlobSparkFieldWrongValue() {
-    Metadata metadata =
-        new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false").build();
+    Metadata metadata = new MetadataBuilder().putString(BLOB_KEY, "false").build();
     StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
     assertFalse(BlobUtils.isBlobSparkField(field));
   }
 
-  @Test
-  public void testIsBlobSparkFieldValid() {
-    Metadata metadata =
-        new MetadataBuilder()
-            .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
-            .build();
-    StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
-    assertTrue(BlobUtils.isBlobSparkField(field));
-  }
-
+  /**
+   * Positive match via mixed case — guards against the matcher being tightened to {@code .equals}.
+   */
   @Test
   public void testIsBlobSparkFieldCaseInsensitive() {
-    Metadata metadata =
-        new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "TRUE").build();
+    Metadata metadata = new MetadataBuilder().putString(BLOB_KEY, "TRUE").build();
     StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
     assertTrue(BlobUtils.isBlobSparkField(field));
   }
@@ -96,23 +99,15 @@ public class BlobUtilsTest {
   @Test
   public void testIsBlobArrowFieldWrongValue() {
     Map<String, String> meta = new HashMap<>();
-    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false");
+    meta.put(BLOB_KEY, "false");
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
     assertFalse(BlobUtils.isBlobArrowField(field));
   }
 
   @Test
-  public void testIsBlobArrowFieldValid() {
-    Map<String, String> meta = new HashMap<>();
-    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE);
-    Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
-    assertTrue(BlobUtils.isBlobArrowField(field));
-  }
-
-  @Test
   public void testIsBlobArrowFieldCaseInsensitive() {
     Map<String, String> meta = new HashMap<>();
-    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "True");
+    meta.put(BLOB_KEY, "True");
     Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
     assertTrue(BlobUtils.isBlobArrowField(field));
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link BlobUtils}. */
+public class BlobUtilsTest {
+
+  @Test
+  public void testIsBlobSparkField_nullField() {
+    assertFalse(BlobUtils.isBlobSparkField(null));
+  }
+
+  @Test
+  public void testIsBlobSparkField_emptyMetadata() {
+    StructField field = DataTypes.createStructField("col", DataTypes.BinaryType, true);
+    assertFalse(BlobUtils.isBlobSparkField(field));
+  }
+
+  @Test
+  public void testIsBlobSparkField_noKey() {
+    Metadata metadata = new MetadataBuilder().putString("other-key", "value").build();
+    StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
+    assertFalse(BlobUtils.isBlobSparkField(field));
+  }
+
+  @Test
+  public void testIsBlobSparkField_wrongValue() {
+    Metadata metadata =
+        new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false").build();
+    StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
+    assertFalse(BlobUtils.isBlobSparkField(field));
+  }
+
+  @Test
+  public void testIsBlobSparkField_valid() {
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
+            .build();
+    StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
+    assertTrue(BlobUtils.isBlobSparkField(field));
+  }
+
+  @Test
+  public void testIsBlobSparkField_caseInsensitive() {
+    Metadata metadata =
+        new MetadataBuilder().putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, "TRUE").build();
+    StructField field = new StructField("col", DataTypes.BinaryType, true, metadata);
+    assertTrue(BlobUtils.isBlobSparkField(field));
+  }
+
+  @Test
+  public void testIsBlobArrowField_nullField() {
+    assertFalse(BlobUtils.isBlobArrowField(null));
+  }
+
+  @Test
+  public void testIsBlobArrowField_noMetadata() {
+    Field field = new Field("col", FieldType.nullable(new ArrowType.Binary()), null);
+    assertFalse(BlobUtils.isBlobArrowField(field));
+  }
+
+  @Test
+  public void testIsBlobArrowField_noKey() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put("other-key", "value");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
+    assertFalse(BlobUtils.isBlobArrowField(field));
+  }
+
+  @Test
+  public void testIsBlobArrowField_wrongValue() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "false");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
+    assertFalse(BlobUtils.isBlobArrowField(field));
+  }
+
+  @Test
+  public void testIsBlobArrowField_valid() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE);
+    Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
+    assertTrue(BlobUtils.isBlobArrowField(field));
+  }
+
+  @Test
+  public void testIsBlobArrowField_caseInsensitive() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(BlobUtils.LANCE_ENCODING_BLOB_KEY, "True");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Binary(), null, meta), null);
+    assertTrue(BlobUtils.isBlobArrowField(field));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link LargeVarCharUtils}. */
+public class LargeVarCharUtilsTest {
+
+  @Test
+  public void testIsLargeVarCharSparkField_nullField() {
+    assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(null));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_nonStringType() {
+    // Provide valid metadata so the type-check branch (not the metadata-absent branch) is exercised
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(
+                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY,
+                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
+            .build();
+    StructField field = new StructField("col", DataTypes.IntegerType, true, metadata);
+    assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_stringNoMetadata() {
+    StructField field = DataTypes.createStructField("col", DataTypes.StringType, true);
+    assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_stringNoKey() {
+    Metadata metadata = new MetadataBuilder().putString("other-key", "value").build();
+    StructField field = new StructField("col", DataTypes.StringType, true, metadata);
+    assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_wrongValue() {
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false")
+            .build();
+    StructField field = new StructField("col", DataTypes.StringType, true, metadata);
+    assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_valid() {
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(
+                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY,
+                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
+            .build();
+    StructField field = new StructField("col", DataTypes.StringType, true, metadata);
+    assertTrue(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharSparkField_caseInsensitive() {
+    Metadata metadata =
+        new MetadataBuilder().putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "TRUE").build();
+    StructField field = new StructField("col", DataTypes.StringType, true, metadata);
+    assertTrue(LargeVarCharUtils.isLargeVarCharSparkField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_nullField() {
+    assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(null));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_noMetadata() {
+    Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
+    assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_noKey() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put("other-key", "value");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
+    assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_wrongValue() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
+    assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_valid() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(
+        LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE);
+    Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
+    assertTrue(LargeVarCharUtils.isLargeVarCharArrowField(field));
+  }
+
+  @Test
+  public void testIsLargeVarCharArrowField_caseInsensitive() {
+    Map<String, String> meta = new HashMap<>();
+    meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "True");
+    Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
+    assertTrue(LargeVarCharUtils.isLargeVarCharArrowField(field));
+  }
+
+  @Test
+  public void testCreatePropertyKey() {
+    assertEquals(
+        "my_column.arrow.large_var_char", LargeVarCharUtils.createPropertyKey("my_column"));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
@@ -27,23 +27,27 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/** Unit tests for {@link LargeVarCharUtils}. */
+/**
+ * Unit tests for {@link LargeVarCharUtils}.
+ *
+ * <p>Test inputs use the literal key/value strings rather than the exposed constants, so a rename
+ * of {@code ARROW_LARGE_VAR_CHAR_KEY} / {@code ARROW_LARGE_VAR_CHAR_VALUE} will break these tests.
+ * End-to-end validation against real lance data lives in {@link
+ * org.lance.spark.utils.SchemaConverterTest} and the LanceArrow suites.
+ */
 public class LargeVarCharUtilsTest {
+
+  private static final String LVC_KEY = "arrow:large-var-char";
 
   @Test
   public void testIsLargeVarCharSparkFieldNullField() {
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(null));
   }
 
+  /** Valid metadata on a non-String column must still return false — guards the type filter. */
   @Test
   public void testIsLargeVarCharSparkFieldNonStringType() {
-    // Provide valid metadata so the type-check branch (not the metadata-absent branch) is exercised
-    Metadata metadata =
-        new MetadataBuilder()
-            .putString(
-                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY,
-                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
-            .build();
+    Metadata metadata = new MetadataBuilder().putString(LVC_KEY, "true").build();
     StructField field = new StructField("col", DataTypes.IntegerType, true, metadata);
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
   }
@@ -63,30 +67,14 @@ public class LargeVarCharUtilsTest {
 
   @Test
   public void testIsLargeVarCharSparkFieldWrongValue() {
-    Metadata metadata =
-        new MetadataBuilder()
-            .putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false")
-            .build();
+    Metadata metadata = new MetadataBuilder().putString(LVC_KEY, "false").build();
     StructField field = new StructField("col", DataTypes.StringType, true, metadata);
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
   }
 
   @Test
-  public void testIsLargeVarCharSparkFieldValid() {
-    Metadata metadata =
-        new MetadataBuilder()
-            .putString(
-                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY,
-                LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
-            .build();
-    StructField field = new StructField("col", DataTypes.StringType, true, metadata);
-    assertTrue(LargeVarCharUtils.isLargeVarCharSparkField(field));
-  }
-
-  @Test
   public void testIsLargeVarCharSparkFieldCaseInsensitive() {
-    Metadata metadata =
-        new MetadataBuilder().putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "TRUE").build();
+    Metadata metadata = new MetadataBuilder().putString(LVC_KEY, "TRUE").build();
     StructField field = new StructField("col", DataTypes.StringType, true, metadata);
     assertTrue(LargeVarCharUtils.isLargeVarCharSparkField(field));
   }
@@ -113,24 +101,15 @@ public class LargeVarCharUtilsTest {
   @Test
   public void testIsLargeVarCharArrowFieldWrongValue() {
     Map<String, String> meta = new HashMap<>();
-    meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false");
+    meta.put(LVC_KEY, "false");
     Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
     assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(field));
   }
 
   @Test
-  public void testIsLargeVarCharArrowFieldValid() {
-    Map<String, String> meta = new HashMap<>();
-    meta.put(
-        LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE);
-    Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
-    assertTrue(LargeVarCharUtils.isLargeVarCharArrowField(field));
-  }
-
-  @Test
   public void testIsLargeVarCharArrowFieldCaseInsensitive() {
     Map<String, String> meta = new HashMap<>();
-    meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "True");
+    meta.put(LVC_KEY, "True");
     Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
     assertTrue(LargeVarCharUtils.isLargeVarCharArrowField(field));
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LargeVarCharUtilsTest.java
@@ -31,12 +31,12 @@ import static org.junit.jupiter.api.Assertions.*;
 public class LargeVarCharUtilsTest {
 
   @Test
-  public void testIsLargeVarCharSparkField_nullField() {
+  public void testIsLargeVarCharSparkFieldNullField() {
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(null));
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_nonStringType() {
+  public void testIsLargeVarCharSparkFieldNonStringType() {
     // Provide valid metadata so the type-check branch (not the metadata-absent branch) is exercised
     Metadata metadata =
         new MetadataBuilder()
@@ -49,20 +49,20 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_stringNoMetadata() {
+  public void testIsLargeVarCharSparkFieldStringNoMetadata() {
     StructField field = DataTypes.createStructField("col", DataTypes.StringType, true);
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_stringNoKey() {
+  public void testIsLargeVarCharSparkFieldStringNoKey() {
     Metadata metadata = new MetadataBuilder().putString("other-key", "value").build();
     StructField field = new StructField("col", DataTypes.StringType, true, metadata);
     assertFalse(LargeVarCharUtils.isLargeVarCharSparkField(field));
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_wrongValue() {
+  public void testIsLargeVarCharSparkFieldWrongValue() {
     Metadata metadata =
         new MetadataBuilder()
             .putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false")
@@ -72,7 +72,7 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_valid() {
+  public void testIsLargeVarCharSparkFieldValid() {
     Metadata metadata =
         new MetadataBuilder()
             .putString(
@@ -84,7 +84,7 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharSparkField_caseInsensitive() {
+  public void testIsLargeVarCharSparkFieldCaseInsensitive() {
     Metadata metadata =
         new MetadataBuilder().putString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "TRUE").build();
     StructField field = new StructField("col", DataTypes.StringType, true, metadata);
@@ -92,18 +92,18 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_nullField() {
+  public void testIsLargeVarCharArrowFieldNullField() {
     assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(null));
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_noMetadata() {
+  public void testIsLargeVarCharArrowFieldNoMetadata() {
     Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
     assertFalse(LargeVarCharUtils.isLargeVarCharArrowField(field));
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_noKey() {
+  public void testIsLargeVarCharArrowFieldNoKey() {
     Map<String, String> meta = new HashMap<>();
     meta.put("other-key", "value");
     Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
@@ -111,7 +111,7 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_wrongValue() {
+  public void testIsLargeVarCharArrowFieldWrongValue() {
     Map<String, String> meta = new HashMap<>();
     meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "false");
     Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);
@@ -119,7 +119,7 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_valid() {
+  public void testIsLargeVarCharArrowFieldValid() {
     Map<String, String> meta = new HashMap<>();
     meta.put(
         LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE);
@@ -128,7 +128,7 @@ public class LargeVarCharUtilsTest {
   }
 
   @Test
-  public void testIsLargeVarCharArrowField_caseInsensitive() {
+  public void testIsLargeVarCharArrowFieldCaseInsensitive() {
     Map<String, String> meta = new HashMap<>();
     meta.put(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY, "True");
     Field field = new Field("col", new FieldType(true, new ArrowType.Utf8(), null, meta), null);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/UtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/UtilsTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class UtilsTest {
 
   @Test
-  public void testParseVersion_validValues() {
+  public void testParseVersionValidValues() {
     assertEquals(0L, Utils.parseVersion("0"));
     assertEquals(1L, Utils.parseVersion("1"));
     assertEquals(42L, Utils.parseVersion("42"));
@@ -38,7 +38,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void testParseVersion_maxUnsigned() {
+  public void testParseVersionMaxUnsigned() {
     // -1L as unsigned = 18446744073709551615
     long maxUnsigned = -1L;
     String maxUnsignedStr = Long.toUnsignedString(maxUnsigned);
@@ -46,7 +46,7 @@ public class UtilsTest {
   }
 
   @Test
-  public void testParseVersion_invalidInput() {
+  public void testParseVersionInvalidInput() {
     assertThrows(NumberFormatException.class, () -> Utils.parseVersion("abc"));
     assertThrows(NumberFormatException.class, () -> Utils.parseVersion(""));
     assertThrows(NumberFormatException.class, () -> Utils.parseVersion("-1"));
@@ -65,54 +65,54 @@ public class UtilsTest {
   }
 
   @Test
-  public void testFindVersion_singleVersion() {
+  public void testFindVersionSingleVersion() {
     // version at epoch second 1 → timestamp 1_000_000 micros
     List<Version> versions = Collections.singletonList(version(1, 1));
     assertEquals(1L, Utils.findVersion(versions, 1_000_000L));
   }
 
   @Test
-  public void testFindVersion_exactMatch() {
+  public void testFindVersionExactMatch() {
     List<Version> versions = Arrays.asList(version(1, 1), version(2, 2), version(3, 3));
     // 2_000_000 micros = epoch second 2 → exact match on v2
     assertEquals(2L, Utils.findVersion(versions, 2_000_000L));
   }
 
   @Test
-  public void testFindVersion_betweenVersions() {
+  public void testFindVersionBetweenVersions() {
     List<Version> versions = Arrays.asList(version(1, 1), version(2, 3));
     // 2_000_000 micros (second 2) is between v1(1s) and v2(3s) → returns v1
     assertEquals(1L, Utils.findVersion(versions, 2_000_000L));
   }
 
   @Test
-  public void testFindVersion_afterAllVersions() {
+  public void testFindVersionAfterAllVersions() {
     List<Version> versions = Arrays.asList(version(1, 1), version(2, 2));
     // 5_000_000 micros (second 5) is after all versions → returns last version
     assertEquals(2L, Utils.findVersion(versions, 5_000_000L));
   }
 
   @Test
-  public void testFindVersion_beforeAllVersions_throws() {
+  public void testFindVersionBeforeAllVersionsThrows() {
     List<Version> versions = Collections.singletonList(version(1, 2));
     // 1_000_000 micros (second 1) is before v1(2s) → throws
     assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 1_000_000L));
   }
 
   @Test
-  public void testFindVersion_emptyList_throws() {
+  public void testFindVersionEmptyListThrows() {
     List<Version> versions = Collections.emptyList();
     assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 1_000_000L));
   }
 
   @Test
-  public void testFindVersion_negativeTimestamp_throws() {
+  public void testFindVersionNegativeTimestampThrows() {
     List<Version> versions = Collections.singletonList(version(1, 1));
     assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, -1L));
   }
 
   @Test
-  public void testFindVersion_zeroTimestamp_throws() {
+  public void testFindVersionZeroTimestampThrows() {
     List<Version> versions = Collections.singletonList(version(1, 1));
     assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 0L));
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/UtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/UtilsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.lance.Version;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for pure-logic methods in {@link Utils}. */
+public class UtilsTest {
+
+  @Test
+  public void testParseVersion_validValues() {
+    assertEquals(0L, Utils.parseVersion("0"));
+    assertEquals(1L, Utils.parseVersion("1"));
+    assertEquals(42L, Utils.parseVersion("42"));
+    assertEquals(Long.MAX_VALUE, Utils.parseVersion(Long.toUnsignedString(Long.MAX_VALUE)));
+  }
+
+  @Test
+  public void testParseVersion_maxUnsigned() {
+    // -1L as unsigned = 18446744073709551615
+    long maxUnsigned = -1L;
+    String maxUnsignedStr = Long.toUnsignedString(maxUnsigned);
+    assertEquals(maxUnsigned, Utils.parseVersion(maxUnsignedStr));
+  }
+
+  @Test
+  public void testParseVersion_invalidInput() {
+    assertThrows(NumberFormatException.class, () -> Utils.parseVersion("abc"));
+    assertThrows(NumberFormatException.class, () -> Utils.parseVersion(""));
+    assertThrows(NumberFormatException.class, () -> Utils.parseVersion("-1"));
+  }
+
+  /**
+   * Creates a Version with a timestamp expressed as a literal ZonedDateTime, avoiding
+   * re-implementing the production micros-to-Instant conversion inside the test helper.
+   *
+   * @param epochSeconds seconds since epoch (e.g. 1 for 1970-01-01T00:00:01Z)
+   */
+  private static Version version(long id, long epochSeconds) {
+    ZonedDateTime dateTime =
+        ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).plusSeconds(epochSeconds);
+    return new Version(id, dateTime, new TreeMap<>());
+  }
+
+  @Test
+  public void testFindVersion_singleVersion() {
+    // version at epoch second 1 → timestamp 1_000_000 micros
+    List<Version> versions = Collections.singletonList(version(1, 1));
+    assertEquals(1L, Utils.findVersion(versions, 1_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_exactMatch() {
+    List<Version> versions = Arrays.asList(version(1, 1), version(2, 2), version(3, 3));
+    // 2_000_000 micros = epoch second 2 → exact match on v2
+    assertEquals(2L, Utils.findVersion(versions, 2_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_betweenVersions() {
+    List<Version> versions = Arrays.asList(version(1, 1), version(2, 3));
+    // 2_000_000 micros (second 2) is between v1(1s) and v2(3s) → returns v1
+    assertEquals(1L, Utils.findVersion(versions, 2_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_afterAllVersions() {
+    List<Version> versions = Arrays.asList(version(1, 1), version(2, 2));
+    // 5_000_000 micros (second 5) is after all versions → returns last version
+    assertEquals(2L, Utils.findVersion(versions, 5_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_beforeAllVersions_throws() {
+    List<Version> versions = Collections.singletonList(version(1, 2));
+    // 1_000_000 micros (second 1) is before v1(2s) → throws
+    assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 1_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_emptyList_throws() {
+    List<Version> versions = Collections.emptyList();
+    assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 1_000_000L));
+  }
+
+  @Test
+  public void testFindVersion_negativeTimestamp_throws() {
+    List<Version> versions = Collections.singletonList(version(1, 1));
+    assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, -1L));
+  }
+
+  @Test
+  public void testFindVersion_zeroTimestamp_throws() {
+    List<Version> versions = Collections.singletonList(version(1, 1));
+    assertThrows(IllegalArgumentException.class, () -> Utils.findVersion(versions, 0L));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
@@ -32,18 +32,18 @@ import static org.junit.jupiter.api.Assertions.*;
 public class VectorUtilsTest {
 
   @Test
-  public void testIsVectorField_nullField() {
+  public void testIsVectorFieldNullField() {
     assertFalse(VectorUtils.isVectorField(null));
   }
 
   @Test
-  public void testIsVectorField_nonArrayType() {
+  public void testIsVectorFieldNonArrayType() {
     StructField field = DataTypes.createStructField("col", DataTypes.IntegerType, true);
     assertFalse(VectorUtils.isVectorField(field));
   }
 
   @Test
-  public void testIsVectorField_arrayOfNonNumeric() {
+  public void testIsVectorFieldArrayOfNonNumeric() {
     // Provide valid vector metadata so the element-type check (not the metadata-absent check)
     // is the branch that returns false
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
@@ -54,7 +54,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorField_arrayOfIntType() {
+  public void testIsVectorFieldArrayOfIntType() {
     // Provide valid vector metadata so the element-type check (not the metadata-absent check)
     // is the branch that returns false
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.IntegerType);
@@ -65,14 +65,14 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorField_floatArrayNoMetadata() {
+  public void testIsVectorFieldFloatArrayNoMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     StructField field = DataTypes.createStructField("col", arrayType, true);
     assertFalse(VectorUtils.isVectorField(field));
   }
 
   @Test
-  public void testIsVectorField_floatArrayWithMetadata() {
+  public void testIsVectorFieldFloatArrayWithMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
@@ -81,7 +81,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorField_doubleArrayWithMetadata() {
+  public void testIsVectorFieldDoubleArrayWithMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();
@@ -90,13 +90,13 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testGetVectorDimension_nonVectorField() {
+  public void testGetVectorDimensionNonVectorField() {
     StructField field = DataTypes.createStructField("col", DataTypes.IntegerType, true);
     assertEquals(-1, VectorUtils.getVectorDimension(field));
   }
 
   @Test
-  public void testGetVectorDimension_malformedMetadata() {
+  public void testGetVectorDimensionMalformedMetadata() {
     // Metadata key exists but is not a long → exercises the try-catch fallback to -1
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     Metadata metadata =
@@ -108,7 +108,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testGetVectorDimension_validVectorField() {
+  public void testGetVectorDimensionValidVectorField() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 256).build();
@@ -117,18 +117,18 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorArrowField_nullField() {
+  public void testIsVectorArrowFieldNullField() {
     assertFalse(VectorUtils.isVectorArrowField(null));
   }
 
   @Test
-  public void testIsVectorArrowField_nonFixedSizeList() {
+  public void testIsVectorArrowFieldNonFixedSizeList() {
     Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
     assertFalse(VectorUtils.isVectorArrowField(field));
   }
 
   @Test
-  public void testIsVectorArrowField_fixedSizeListNoChildren() {
+  public void testIsVectorArrowFieldFixedSizeListNoChildren() {
     Field field =
         new Field(
             "vec", FieldType.nullable(new ArrowType.FixedSizeList(128)), Collections.emptyList());
@@ -136,7 +136,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorArrowField_fixedSizeListNonFloatChild() {
+  public void testIsVectorArrowFieldFixedSizeListNonFloatChild() {
     Field child = new Field("item", FieldType.nullable(new ArrowType.Int(32, true)), null);
     Field field =
         new Field(
@@ -147,7 +147,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorArrowField_validFloatVector() {
+  public void testIsVectorArrowFieldValidFloatVector() {
     Field child =
         new Field(
             "item",
@@ -162,7 +162,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testIsVectorArrowField_validDoubleVector() {
+  public void testIsVectorArrowFieldValidDoubleVector() {
     Field child =
         new Field(
             "item",
@@ -177,13 +177,13 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testGetVectorArrowDimension_nonVectorField() {
+  public void testGetVectorArrowDimensionNonVectorField() {
     Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
     assertEquals(-1, VectorUtils.getVectorArrowDimension(field));
   }
 
   @Test
-  public void testGetVectorArrowDimension_validVector() {
+  public void testGetVectorArrowDimensionValidVector() {
     Field child =
         new Field(
             "item",
@@ -198,26 +198,26 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testShouldBeFixedSizeList_nullMetadata() {
+  public void testShouldBeFixedSizeListNullMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, null));
   }
 
   @Test
-  public void testShouldBeFixedSizeList_noMetadataKey() {
+  public void testShouldBeFixedSizeListNoMetadataKey() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, Metadata.empty()));
   }
 
   @Test
-  public void testShouldBeFixedSizeList_nonArrayType() {
+  public void testShouldBeFixedSizeListNonArrayType() {
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
     assertFalse(VectorUtils.shouldBeFixedSizeList(DataTypes.StringType, metadata));
   }
 
   @Test
-  public void testShouldBeFixedSizeList_arrayOfNonNumeric() {
+  public void testShouldBeFixedSizeListArrayOfNonNumeric() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
@@ -225,7 +225,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testShouldBeFixedSizeList_validFloat() {
+  public void testShouldBeFixedSizeListValidFloat() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
@@ -233,7 +233,7 @@ public class VectorUtilsTest {
   }
 
   @Test
-  public void testShouldBeFixedSizeList_validDouble() {
+  public void testShouldBeFixedSizeListValidDouble() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
     Metadata metadata =
         new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Unit tests for {@link VectorUtils}. */
+public class VectorUtilsTest {
+
+  @Test
+  public void testIsVectorField_nullField() {
+    assertFalse(VectorUtils.isVectorField(null));
+  }
+
+  @Test
+  public void testIsVectorField_nonArrayType() {
+    StructField field = DataTypes.createStructField("col", DataTypes.IntegerType, true);
+    assertFalse(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testIsVectorField_arrayOfNonNumeric() {
+    // Provide valid vector metadata so the element-type check (not the metadata-absent check)
+    // is the branch that returns false
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    StructField field = new StructField("col", arrayType, true, metadata);
+    assertFalse(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testIsVectorField_arrayOfIntType() {
+    // Provide valid vector metadata so the element-type check (not the metadata-absent check)
+    // is the branch that returns false
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.IntegerType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    StructField field = new StructField("col", arrayType, true, metadata);
+    assertFalse(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testIsVectorField_floatArrayNoMetadata() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    StructField field = DataTypes.createStructField("col", arrayType, true);
+    assertFalse(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testIsVectorField_floatArrayWithMetadata() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    StructField field = new StructField("vec", arrayType, true, metadata);
+    assertTrue(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testIsVectorField_doubleArrayWithMetadata() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();
+    StructField field = new StructField("vec", arrayType, true, metadata);
+    assertTrue(VectorUtils.isVectorField(field));
+  }
+
+  @Test
+  public void testGetVectorDimension_nonVectorField() {
+    StructField field = DataTypes.createStructField("col", DataTypes.IntegerType, true);
+    assertEquals(-1, VectorUtils.getVectorDimension(field));
+  }
+
+  @Test
+  public void testGetVectorDimension_malformedMetadata() {
+    // Metadata key exists but is not a long → exercises the try-catch fallback to -1
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, "not-a-number")
+            .build();
+    StructField field = new StructField("vec", arrayType, true, metadata);
+    assertEquals(-1, VectorUtils.getVectorDimension(field));
+  }
+
+  @Test
+  public void testGetVectorDimension_validVectorField() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 256).build();
+    StructField field = new StructField("vec", arrayType, true, metadata);
+    assertEquals(256, VectorUtils.getVectorDimension(field));
+  }
+
+  @Test
+  public void testIsVectorArrowField_nullField() {
+    assertFalse(VectorUtils.isVectorArrowField(null));
+  }
+
+  @Test
+  public void testIsVectorArrowField_nonFixedSizeList() {
+    Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
+    assertFalse(VectorUtils.isVectorArrowField(field));
+  }
+
+  @Test
+  public void testIsVectorArrowField_fixedSizeListNoChildren() {
+    Field field =
+        new Field(
+            "vec", FieldType.nullable(new ArrowType.FixedSizeList(128)), Collections.emptyList());
+    assertFalse(VectorUtils.isVectorArrowField(field));
+  }
+
+  @Test
+  public void testIsVectorArrowField_fixedSizeListNonFloatChild() {
+    Field child = new Field("item", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Field field =
+        new Field(
+            "vec",
+            FieldType.nullable(new ArrowType.FixedSizeList(128)),
+            Collections.singletonList(child));
+    assertFalse(VectorUtils.isVectorArrowField(field));
+  }
+
+  @Test
+  public void testIsVectorArrowField_validFloatVector() {
+    Field child =
+        new Field(
+            "item",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+            null);
+    Field field =
+        new Field(
+            "vec",
+            FieldType.nullable(new ArrowType.FixedSizeList(128)),
+            Collections.singletonList(child));
+    assertTrue(VectorUtils.isVectorArrowField(field));
+  }
+
+  @Test
+  public void testIsVectorArrowField_validDoubleVector() {
+    Field child =
+        new Field(
+            "item",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            null);
+    Field field =
+        new Field(
+            "vec",
+            FieldType.nullable(new ArrowType.FixedSizeList(64)),
+            Collections.singletonList(child));
+    assertTrue(VectorUtils.isVectorArrowField(field));
+  }
+
+  @Test
+  public void testGetVectorArrowDimension_nonVectorField() {
+    Field field = new Field("col", FieldType.nullable(new ArrowType.Utf8()), null);
+    assertEquals(-1, VectorUtils.getVectorArrowDimension(field));
+  }
+
+  @Test
+  public void testGetVectorArrowDimension_validVector() {
+    Field child =
+        new Field(
+            "item",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+            null);
+    Field field =
+        new Field(
+            "vec",
+            FieldType.nullable(new ArrowType.FixedSizeList(256)),
+            Collections.singletonList(child));
+    assertEquals(256, VectorUtils.getVectorArrowDimension(field));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_nullMetadata() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, null));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_noMetadataKey() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, Metadata.empty()));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_nonArrayType() {
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    assertFalse(VectorUtils.shouldBeFixedSizeList(DataTypes.StringType, metadata));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_arrayOfNonNumeric() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_validFloat() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    assertTrue(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
+  }
+
+  @Test
+  public void testShouldBeFixedSizeList_validDouble() {
+    ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
+    Metadata metadata =
+        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();
+    assertTrue(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
+  }
+
+  @Test
+  public void testCreateVectorSizePropertyKey() {
+    assertEquals(
+        "embeddings." + VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY,
+        VectorUtils.createVectorSizePropertyKey("embeddings"));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/VectorUtilsTest.java
@@ -28,8 +28,16 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/** Unit tests for {@link VectorUtils}. */
+/**
+ * Unit tests for {@link VectorUtils}.
+ *
+ * <p>Test inputs use the literal {@value #FSL_KEY} rather than {@link
+ * VectorUtils#ARROW_FIXED_SIZE_LIST_SIZE_KEY}, so a rename of the constant will break these tests —
+ * catching accidental drift from the wire contract.
+ */
 public class VectorUtilsTest {
+
+  private static final String FSL_KEY = "arrow.fixed-size-list.size";
 
   @Test
   public void testIsVectorFieldNullField() {
@@ -42,24 +50,22 @@ public class VectorUtilsTest {
     assertFalse(VectorUtils.isVectorField(field));
   }
 
+  /**
+   * Valid metadata on an array-of-String must still return false — guards the element-type filter.
+   */
   @Test
   public void testIsVectorFieldArrayOfNonNumeric() {
-    // Provide valid vector metadata so the element-type check (not the metadata-absent check)
-    // is the branch that returns false
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     StructField field = new StructField("col", arrayType, true, metadata);
     assertFalse(VectorUtils.isVectorField(field));
   }
 
+  /** Integer elements are numeric but not floating-point — must still return false. */
   @Test
   public void testIsVectorFieldArrayOfIntType() {
-    // Provide valid vector metadata so the element-type check (not the metadata-absent check)
-    // is the branch that returns false
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.IntegerType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     StructField field = new StructField("col", arrayType, true, metadata);
     assertFalse(VectorUtils.isVectorField(field));
   }
@@ -74,8 +80,7 @@ public class VectorUtilsTest {
   @Test
   public void testIsVectorFieldFloatArrayWithMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     StructField field = new StructField("vec", arrayType, true, metadata);
     assertTrue(VectorUtils.isVectorField(field));
   }
@@ -83,8 +88,7 @@ public class VectorUtilsTest {
   @Test
   public void testIsVectorFieldDoubleArrayWithMetadata() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 64).build();
     StructField field = new StructField("vec", arrayType, true, metadata);
     assertTrue(VectorUtils.isVectorField(field));
   }
@@ -95,14 +99,11 @@ public class VectorUtilsTest {
     assertEquals(-1, VectorUtils.getVectorDimension(field));
   }
 
+  /** Key present but stored as String — exercises the try/catch fallback to -1. */
   @Test
   public void testGetVectorDimensionMalformedMetadata() {
-    // Metadata key exists but is not a long → exercises the try-catch fallback to -1
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
-    Metadata metadata =
-        new MetadataBuilder()
-            .putString(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, "not-a-number")
-            .build();
+    Metadata metadata = new MetadataBuilder().putString(FSL_KEY, "not-a-number").build();
     StructField field = new StructField("vec", arrayType, true, metadata);
     assertEquals(-1, VectorUtils.getVectorDimension(field));
   }
@@ -110,8 +111,7 @@ public class VectorUtilsTest {
   @Test
   public void testGetVectorDimensionValidVectorField() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 256).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 256).build();
     StructField field = new StructField("vec", arrayType, true, metadata);
     assertEquals(256, VectorUtils.getVectorDimension(field));
   }
@@ -135,6 +135,7 @@ public class VectorUtilsTest {
     assertFalse(VectorUtils.isVectorArrowField(field));
   }
 
+  /** Int child on a FixedSizeList must return false — guards the floating-point filter. */
   @Test
   public void testIsVectorArrowFieldFixedSizeListNonFloatChild() {
     Field child = new Field("item", FieldType.nullable(new ArrowType.Int(32, true)), null);
@@ -211,39 +212,35 @@ public class VectorUtilsTest {
 
   @Test
   public void testShouldBeFixedSizeListNonArrayType() {
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     assertFalse(VectorUtils.shouldBeFixedSizeList(DataTypes.StringType, metadata));
   }
 
   @Test
   public void testShouldBeFixedSizeListArrayOfNonNumeric() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.StringType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     assertFalse(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
   }
 
   @Test
   public void testShouldBeFixedSizeListValidFloat() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.FloatType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 128).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 128).build();
     assertTrue(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
   }
 
   @Test
   public void testShouldBeFixedSizeListValidDouble() {
     ArrayType arrayType = DataTypes.createArrayType(DataTypes.DoubleType);
-    Metadata metadata =
-        new MetadataBuilder().putLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY, 64).build();
+    Metadata metadata = new MetadataBuilder().putLong(FSL_KEY, 64).build();
     assertTrue(VectorUtils.shouldBeFixedSizeList(arrayType, metadata));
   }
 
   @Test
   public void testCreateVectorSizePropertyKey() {
     assertEquals(
-        "embeddings." + VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY,
+        "embeddings.arrow.fixed-size-list.size",
         VectorUtils.createVectorSizePropertyKey("embeddings"));
   }
 }


### PR DESCRIPTION
## Summary
- Add unit tests for `BlobUtils`, `LargeVarCharUtils`, `Utils`, and `VectorUtils` covering all reachable branches in both Spark and Arrow field-checking methods
- Tests cover null inputs, missing/wrong metadata, case-insensitive value matching, type-check isolation (non-String for LargeVarChar, non-numeric for Vector), and edge cases like empty version lists and malformed metadata
- `UtilsTest` helper builds `ZonedDateTime` directly instead of re-implementing the production micros-to-Instant conversion, keeping test logic independent from source logic

## Test coverage details

| Class | Methods tested | Tests |
|-------|---------------|-------|
| `BlobUtils` | `isBlobSparkField`, `isBlobArrowField` | 12 |
| `LargeVarCharUtils` | `isLargeVarCharSparkField`, `isLargeVarCharArrowField`, `createPropertyKey` | 14 |
| `Utils` | `parseVersion`, `findVersion` | 11 |
| `VectorUtils` | `isVectorField`, `getVectorDimension`, `isVectorArrowField`, `getVectorArrowDimension`, `shouldBeFixedSizeList`, `createVectorSizePropertyKey` | 25 |

## Test plan
- [x] `mvn test -pl lance-spark-base_2.12 -Dtest="org.lance.spark.utils.*Test"` — 108 tests pass
