### PR TITLE
chore: update lance dependency to v5.1.0-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.1</lance-spark.version>
-        <lance.version>5.0.0-beta.6</lance.version>
+        <lance.version>5.1.0-beta.1</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Update `lance.version` in `pom.xml` from `5.0.0-beta.6` to `5.1.0-beta.1`.
- Verify Docker hardcoded values in `docker/Dockerfile`:
  - `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.4.0-beta.1`).
  - `LANCE_NS_VERSION` remains correct at `0.6.1` for `lance-core:5.1.0-beta.1`.

## Build Verification
- `make lint`: passed.
- `make install`: initially failed due `org.lance:lance-core:5.1.0-beta.1` not yet available from Maven Central on this runner.
- Installed `lance-core:5.1.0-beta.1` locally from `lance-format/lance` tag and reran `make install`: passed.

## Trigger
- Triggering tag: `refs/tags/v5.1.0-beta.1`
