### PR TITLE
feat: add byte-based batch flushing to prevent OOM on large rows

### DIFF
--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -72,6 +72,33 @@ df.write \
     .saveAsTable("my_table")
 ```
 
+### Max Batch Bytes
+
+Set via Spark write option `max_batch_bytes` (default: 268435456, i.e. 256MB).
+
+Controls the maximum in-memory size of each Arrow batch before it is flushed.
+Batches are flushed when either the row count reaches `batch_size` or the allocated memory
+reaches `max_batch_bytes`, whichever comes first.
+
+This prevents OOM when writing tables with very large rows — wide schemas, large binary/string
+columns, or high-dimensional vector embeddings — where even a modest number of rows can exhaust
+memory before the row-count threshold is reached.
+
+Small-row workloads are unaffected because the row-count limit is hit first.
+
+!!!note
+      When using the queued write buffer, total in-flight Arrow memory can be roughly
+      `queue_depth * max_batch_bytes`. You may need to tune `queue_depth` and `max_batch_bytes`
+      together to stay within memory limits.
+
+```python
+df.write \
+    .format("lance") \
+    .option("max_batch_bytes", "134217728") \
+    .mode("append") \
+    .saveAsTable("my_table")  # 128MB per batch
+```
+
 ### Max Rows Per File
 
 Set via Spark write option `max_row_per_file` (default: 1,000,000).

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -56,6 +56,7 @@ public class LanceSparkWriteOptions implements Serializable {
   public static final String CONFIG_BATCH_SIZE = "batch_size";
   public static final String CONFIG_ENABLE_STABLE_ROW_IDS = "enable_stable_row_ids";
   public static final String CONFIG_USE_LARGE_VAR_TYPES = "use_large_var_types";
+  public static final String CONFIG_MAX_BATCH_BYTES = "max_batch_bytes";
 
   private static final WriteMode DEFAULT_WRITE_MODE = WriteMode.APPEND;
   private static final boolean DEFAULT_USE_QUEUED_WRITE_BUFFER = false;
@@ -63,6 +64,9 @@ public class LanceSparkWriteOptions implements Serializable {
   // Changed from 512 to 8192 for better write performance consistency with read path
   private static final int DEFAULT_BATCH_SIZE = 8192;
   private static final boolean DEFAULT_USE_LARGE_VAR_TYPES = false;
+  // Default max bytes per batch (256MB). Batches flush when either row count or byte size
+  // is reached, whichever comes first. This prevents OOM when rows are very large.
+  public static final long DEFAULT_MAX_BATCH_BYTES = 256L * 1024 * 1024;
 
   private final String datasetUri;
   private final WriteMode writeMode;
@@ -77,6 +81,7 @@ public class LanceSparkWriteOptions implements Serializable {
   // inherits from the manifest (e.g. append without re-specifying). Staged commit uses primitives.
   private final Boolean enableStableRowIds;
   private final boolean useLargeVarTypes;
+  private final long maxBatchBytes;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -100,6 +105,7 @@ public class LanceSparkWriteOptions implements Serializable {
     this.batchSize = builder.batchSize;
     this.enableStableRowIds = builder.enableStableRowIds;
     this.useLargeVarTypes = builder.useLargeVarTypes;
+    this.maxBatchBytes = builder.maxBatchBytes;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -179,6 +185,10 @@ public class LanceSparkWriteOptions implements Serializable {
     return useLargeVarTypes;
   }
 
+  public long getMaxBatchBytes() {
+    return maxBatchBytes;
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -207,6 +217,9 @@ public class LanceSparkWriteOptions implements Serializable {
         .useQueuedWriteBuffer(useQueuedWriteBuffer)
         .queueDepth(queueDepth)
         .batchSize(batchSize)
+        .maxBatchBytes(maxBatchBytes)
+        .enableStableRowIds(enableStableRowIds)
+        .useLargeVarTypes(useLargeVarTypes)
         .storageOptions(storageOptions)
         .namespace(namespace)
         .tableId(tableId)
@@ -288,6 +301,7 @@ public class LanceSparkWriteOptions implements Serializable {
         && queueDepth == that.queueDepth
         && batchSize == that.batchSize
         && useLargeVarTypes == that.useLargeVarTypes
+        && maxBatchBytes == that.maxBatchBytes
         && Objects.equals(datasetUri, that.datasetUri)
         && writeMode == that.writeMode
         && Objects.equals(maxRowsPerFile, that.maxRowsPerFile)
@@ -314,6 +328,7 @@ public class LanceSparkWriteOptions implements Serializable {
         batchSize,
         enableStableRowIds,
         useLargeVarTypes,
+        maxBatchBytes,
         storageOptions,
         tableId,
         version);
@@ -332,6 +347,7 @@ public class LanceSparkWriteOptions implements Serializable {
     private int batchSize = DEFAULT_BATCH_SIZE;
     private Boolean enableStableRowIds;
     private boolean useLargeVarTypes = DEFAULT_USE_LARGE_VAR_TYPES;
+    private long maxBatchBytes = DEFAULT_MAX_BATCH_BYTES;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -391,6 +407,12 @@ public class LanceSparkWriteOptions implements Serializable {
 
     public Builder useLargeVarTypes(boolean useLargeVarTypes) {
       this.useLargeVarTypes = useLargeVarTypes;
+      return this;
+    }
+
+    public Builder maxBatchBytes(long maxBatchBytes) {
+      Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
+      this.maxBatchBytes = maxBatchBytes;
       return this;
     }
 
@@ -455,6 +477,11 @@ public class LanceSparkWriteOptions implements Serializable {
       }
       if (options.containsKey(CONFIG_USE_LARGE_VAR_TYPES)) {
         this.useLargeVarTypes = Boolean.parseBoolean(options.get(CONFIG_USE_LARGE_VAR_TYPES));
+      }
+      if (options.containsKey(CONFIG_MAX_BATCH_BYTES)) {
+        long parsedMaxBatchBytes = Long.parseLong(options.get(CONFIG_MAX_BATCH_BYTES));
+        Preconditions.checkArgument(parsedMaxBatchBytes > 0, "max_batch_bytes must be positive");
+        this.maxBatchBytes = parsedMaxBatchBytes;
       }
       return this;
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -133,6 +133,7 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
       boolean useLargeVarTypes = writeOptions.isUseLargeVarTypes();
+      long maxBatchBytes = writeOptions.getMaxBatchBytes();
 
       // Merge initial storage options with write options
       WriteParams params = writeOptions.toWriteParams(initialStorageOptions);
@@ -142,9 +143,11 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
         writeBuffer =
-            new QueuedArrowBatchWriteBuffer(schema, batchSize, queueDepth, useLargeVarTypes);
+            new QueuedArrowBatchWriteBuffer(
+                schema, batchSize, queueDepth, useLargeVarTypes, maxBatchBytes);
       } else {
-        writeBuffer = new SemaphoreArrowBatchWriteBuffer(schema, batchSize, useLargeVarTypes);
+        writeBuffer =
+            new SemaphoreArrowBatchWriteBuffer(schema, batchSize, useLargeVarTypes, maxBatchBytes);
       }
 
       // Create fragment in background thread

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -14,6 +14,7 @@
 package org.lance.spark.write;
 
 import org.lance.spark.LanceRuntime;
+import org.lance.spark.LanceSparkWriteOptions;
 
 import com.google.common.base.Preconditions;
 import org.apache.arrow.memory.BufferAllocator;
@@ -37,6 +38,16 @@ import java.util.concurrent.atomic.AtomicInteger;
  * simultaneously. This enables better pipelining between Spark row ingestion and Lance fragment
  * creation.
  *
+ * <p>Batches are flushed when either the row count reaches {@code batchSize} or the allocated
+ * memory for the current batch exceeds {@code maxBatchBytes}, whichever comes first. This limits
+ * the size of each individual batch when rows are very large (e.g., rows with large binary/string
+ * columns or embeddings).
+ *
+ * <p>Because this implementation is queue-based, multiple completed batches can be buffered at the
+ * same time. As a result, total in-flight Arrow memory can be roughly {@code queueDepth *
+ * maxBatchBytes}, plus the current producer batch and allocator overhead. Users may need to tune
+ * {@code queueDepth} and {@code maxBatchBytes} together to stay within memory limits.
+ *
  * <p>Architecture:
  *
  * <pre>
@@ -53,16 +64,23 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private final Schema schema;
   private final StructType sparkSchema;
   private final int batchSize;
+  private final long maxBatchBytes;
   private final int queueDepth;
 
-  /** Queue holding completed batches ready for consumption. */
-  private final BlockingQueue<VectorSchemaRoot> batchQueue;
+  /**
+   * Queue holding completed batches ready for consumption. Each entry pairs a VectorSchemaRoot with
+   * its dedicated child allocator, so the consumer can free both when done.
+   */
+  private final BlockingQueue<BatchEntry> batchQueue;
 
   /** Child allocator for producer batches (shares root with consumer for buffer transfer). */
   private final BufferAllocator producerAllocator;
 
   /** Current batch being filled by producer. */
   private VectorSchemaRoot currentBatch;
+
+  /** Child allocator dedicated to the current batch for accurate byte tracking. */
+  private BufferAllocator currentBatchAllocator;
 
   /** Arrow writer for current batch. */
   private org.lance.spark.arrow.LanceArrowWriter currentArrowWriter;
@@ -77,11 +95,36 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private volatile boolean consumerFinished = false;
 
   /** Current batch being read by consumer (for ArrowReader interface). */
-  private VectorSchemaRoot consumerCurrentBatch;
+  private BatchEntry consumerCurrentEntry;
+
+  /** Pairs a VectorSchemaRoot with its allocator for proper lifecycle management. */
+  private static class BatchEntry {
+    final VectorSchemaRoot batch;
+    final BufferAllocator allocator;
+
+    BatchEntry(VectorSchemaRoot batch, BufferAllocator allocator) {
+      this.batch = batch;
+      this.allocator = allocator;
+    }
+
+    void close() {
+      try {
+        batch.close();
+      } finally {
+        allocator.close();
+      }
+    }
+  }
 
   public QueuedArrowBatchWriteBuffer(
       BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
-    this(allocator, schema, sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH);
+    this(
+        allocator,
+        schema,
+        sparkSchema,
+        batchSize,
+        DEFAULT_QUEUE_DEPTH,
+        LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
@@ -91,18 +134,34 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, int queueDepth) {
-    this(sparkSchema, batchSize, queueDepth, false);
+    this(sparkSchema, batchSize, queueDepth, false, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
   /** Simplified constructor with large var types support. */
   public QueuedArrowBatchWriteBuffer(
       StructType sparkSchema, int batchSize, int queueDepth, boolean useLargeVarTypes) {
     this(
+        sparkSchema,
+        batchSize,
+        queueDepth,
+        useLargeVarTypes,
+        LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
+  }
+
+  /** Simplified constructor with all tuning parameters. */
+  public QueuedArrowBatchWriteBuffer(
+      StructType sparkSchema,
+      int batchSize,
+      int queueDepth,
+      boolean useLargeVarTypes,
+      long maxBatchBytes) {
+    this(
         LanceRuntime.allocator(),
         LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, useLargeVarTypes),
         sparkSchema,
         batchSize,
-        queueDepth);
+        queueDepth,
+        maxBatchBytes);
   }
 
   public QueuedArrowBatchWriteBuffer(
@@ -111,14 +170,32 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       StructType sparkSchema,
       int batchSize,
       int queueDepth) {
+    this(
+        allocator,
+        schema,
+        sparkSchema,
+        batchSize,
+        queueDepth,
+        LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
+  }
+
+  public QueuedArrowBatchWriteBuffer(
+      BufferAllocator allocator,
+      Schema schema,
+      StructType sparkSchema,
+      int batchSize,
+      int queueDepth,
+      long maxBatchBytes) {
     super(allocator);
     Preconditions.checkNotNull(schema);
     Preconditions.checkArgument(batchSize > 0, "Batch size must be positive");
     Preconditions.checkArgument(queueDepth > 0, "Queue depth must be positive");
+    Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
 
     this.schema = schema;
     this.sparkSchema = sparkSchema;
     this.batchSize = batchSize;
+    this.maxBatchBytes = maxBatchBytes;
     this.queueDepth = queueDepth;
     this.batchQueue = new ArrayBlockingQueue<>(queueDepth);
 
@@ -133,16 +210,35 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   /** Allocates a new batch for the producer to fill. */
   private void allocateNewBatch() {
-    currentBatch = VectorSchemaRoot.create(schema, producerAllocator);
-    currentBatch.allocateNew();
+    // Each batch gets its own child allocator so getAllocatedMemory() accurately reflects
+    // only this batch's memory, unaffected by concurrent consumer freeing of older batches.
+    currentBatchAllocator = producerAllocator.newChildAllocator("batch", 0, Long.MAX_VALUE);
+    try {
+      currentBatch = VectorSchemaRoot.create(schema, currentBatchAllocator);
+      currentBatch.allocateNew();
+    } catch (Exception e) {
+      if (currentBatch != null) {
+        currentBatch.close();
+      }
+      currentBatchAllocator.close();
+      throw e;
+    }
     currentArrowWriter =
         org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(currentBatch, sparkSchema);
     currentBatchRowCount.set(0);
   }
 
+  /** Returns whether the current batch should be flushed based on byte size. */
+  private boolean isBatchFullByBytes() {
+    if (maxBatchBytes == Long.MAX_VALUE) {
+      return false;
+    }
+    return currentBatchAllocator.getAllocatedMemory() >= maxBatchBytes;
+  }
+
   /**
-   * Writes a row to the current batch. When the batch is full, it is queued for consumption and a
-   * new batch is allocated.
+   * Writes a row to the current batch. When the batch is full (by row count or byte size), it is
+   * queued for consumption and a new batch is allocated.
    *
    * <p>This method only blocks if the queue is full, allowing the producer to continue writing
    * while the consumer processes previous batches.
@@ -161,18 +257,19 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
       int count = currentBatchRowCount.incrementAndGet();
 
-      if (count >= batchSize) {
+      if (count >= batchSize || (count > 0 && isBatchFullByBytes())) {
         // Batch is full - finalize and queue it
         currentArrowWriter.finish();
         currentBatch.setRowCount(count);
 
+        BatchEntry entry = new BatchEntry(currentBatch, currentBatchAllocator);
         // Put in queue, periodically checking for consumer errors
         try {
-          while (!batchQueue.offer(currentBatch, 100, TimeUnit.MILLISECONDS)) {
+          while (!batchQueue.offer(entry, 100, TimeUnit.MILLISECONDS)) {
             checkForError();
           }
         } catch (RuntimeException e) {
-          currentBatch.close();
+          entry.close();
           throw e;
         }
 
@@ -201,19 +298,22 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       if (remainingRows > 0) {
         currentArrowWriter.finish();
         currentBatch.setRowCount(remainingRows);
+        BatchEntry entry = new BatchEntry(currentBatch, currentBatchAllocator);
         try {
-          while (!batchQueue.offer(currentBatch, 100, TimeUnit.MILLISECONDS)) {
+          while (!batchQueue.offer(entry, 100, TimeUnit.MILLISECONDS)) {
             checkForError();
           }
         } catch (RuntimeException e) {
-          currentBatch.close();
+          entry.close();
           throw e;
         }
       } else {
-        // No remaining rows, close the empty batch
+        // No remaining rows, close the empty batch and its allocator
         currentBatch.close();
+        currentBatchAllocator.close();
       }
       currentBatch = null;
+      currentBatchAllocator = null;
       currentArrowWriter = null;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -231,18 +331,18 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
     try {
       // Close previous batch if any
-      if (consumerCurrentBatch != null) {
-        consumerCurrentBatch.close();
-        consumerCurrentBatch = null;
+      if (consumerCurrentEntry != null) {
+        consumerCurrentEntry.close();
+        consumerCurrentEntry = null;
       }
 
       // Try to get next batch from queue
       while (true) {
         // Use poll with timeout to check for producer finished
-        VectorSchemaRoot batch = batchQueue.poll(100, TimeUnit.MILLISECONDS);
+        BatchEntry entry = batchQueue.poll(100, TimeUnit.MILLISECONDS);
 
-        if (batch != null) {
-          consumerCurrentBatch = batch;
+        if (entry != null) {
+          consumerCurrentEntry = entry;
           return true;
         }
 
@@ -260,8 +360,8 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   @Override
   public VectorSchemaRoot getVectorSchemaRoot() {
-    if (consumerCurrentBatch != null) {
-      return consumerCurrentBatch;
+    if (consumerCurrentEntry != null) {
+      return consumerCurrentEntry.batch;
     }
     // Return an empty root for initial schema access
     try {
@@ -284,15 +384,15 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   @Override
   protected void closeReadSource() throws IOException {
     // Close any remaining batch
-    if (consumerCurrentBatch != null) {
-      consumerCurrentBatch.close();
-      consumerCurrentBatch = null;
+    if (consumerCurrentEntry != null) {
+      consumerCurrentEntry.close();
+      consumerCurrentEntry = null;
     }
 
     // Drain and close any batches left in queue
-    VectorSchemaRoot batch;
-    while ((batch = batchQueue.poll()) != null) {
-      batch.close();
+    BatchEntry entry;
+    while ((entry = batchQueue.poll()) != null) {
+      entry.close();
     }
 
     // Close producer allocator

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -128,16 +128,11 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
-  public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize) {
-    this(sparkSchema, batchSize, DEFAULT_QUEUE_DEPTH);
-  }
-
-  /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public QueuedArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, int queueDepth) {
     this(sparkSchema, batchSize, queueDepth, false, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
-  /** Simplified constructor with large var types support. */
+  /** Constructor with large var types support, using LanceRuntime allocator. */
   public QueuedArrowBatchWriteBuffer(
       StructType sparkSchema, int batchSize, int queueDepth, boolean useLargeVarTypes) {
     this(
@@ -148,7 +143,7 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
         LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
-  /** Simplified constructor with all tuning parameters. */
+  /** Constructor with all tuning parameters, using LanceRuntime allocator. */
   public QueuedArrowBatchWriteBuffer(
       StructType sparkSchema,
       int batchSize,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -14,6 +14,7 @@
 package org.lance.spark.write;
 
 import org.lance.spark.LanceRuntime;
+import org.lance.spark.LanceSparkWriteOptions;
 
 import com.google.common.base.Preconditions;
 import org.apache.arrow.memory.BufferAllocator;
@@ -35,12 +36,29 @@ import java.util.concurrent.locks.ReentrantLock;
  * pulling batches via ArrowReader interface). It uses a lock with conditions to synchronize between
  * the two threads - the producer blocks until the consumer is ready for more data, and vice versa.
  *
- * @see QueuedArrowBatchWriteBuffer for a queue-based alternative with better pipelining
+ * <p>Batches are flushed when either the row count reaches {@code batchSize} or the total allocator
+ * memory exceeds {@code maxBatchBytes}, whichever comes first. This prevents OOM when individual
+ * rows are very large (e.g., rows with large binary/string columns or embeddings).
+ *
+ * <p>Note: because this buffer reuses a single VectorSchemaRoot across batches, the allocator
+ * retains capacity from previous batches. The byte-based flush triggers when the allocator's total
+ * memory exceeds the threshold, which is conservative but safe — it bounds total memory regardless
+ * of how Arrow internally manages buffer capacity.
+ *
+ * @see QueuedArrowBatchWriteBuffer for a queue-based alternative with per-batch allocators
  */
 public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private final Schema schema;
   private final StructType sparkSchema;
   private final int batchSize;
+  private final long maxBatchBytes;
+
+  /**
+   * Child allocator used to track memory for this buffer. Since the parent allocator may be shared
+   * globally, we use a child allocator so that {@code getAllocatedMemory()} reflects only this
+   * buffer's memory.
+   */
+  private final BufferAllocator batchAllocator;
 
   private final ReentrantLock lock = new ReentrantLock();
   private final Condition canWrite = lock.newCondition();
@@ -55,16 +73,29 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private org.lance.spark.arrow.LanceArrowWriter arrowWriter = null;
 
   public SemaphoreArrowBatchWriteBuffer(
-      BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
-    super(allocator);
+      BufferAllocator allocator,
+      Schema schema,
+      StructType sparkSchema,
+      int batchSize,
+      long maxBatchBytes) {
+    // Pass a child allocator to ArrowReader so VectorSchemaRoot allocation is tracked
+    super(allocator.newChildAllocator("semaphore-buffer", 0, Long.MAX_VALUE));
     Preconditions.checkNotNull(schema);
     Preconditions.checkArgument(batchSize > 0);
+    Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
     this.schema = schema;
     this.sparkSchema = sparkSchema;
     this.batchSize = batchSize;
+    this.maxBatchBytes = maxBatchBytes;
+    this.batchAllocator = this.allocator;
     // Start with count = batchSize so the writer blocks on canWrite.await() until the
     // reader's prepareLoadNextBatch() initializes arrowWriter and resets count to 0.
     this.count = batchSize;
+  }
+
+  public SemaphoreArrowBatchWriteBuffer(
+      BufferAllocator allocator, Schema schema, StructType sparkSchema, int batchSize) {
+    this(allocator, schema, sparkSchema, batchSize, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
@@ -75,11 +106,23 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   /** Simplified constructor with large var types support. */
   public SemaphoreArrowBatchWriteBuffer(
       StructType sparkSchema, int batchSize, boolean useLargeVarTypes) {
+    this(sparkSchema, batchSize, useLargeVarTypes, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
+  }
+
+  /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
+  public SemaphoreArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, long maxBatchBytes) {
+    this(sparkSchema, batchSize, false, maxBatchBytes);
+  }
+
+  /** Simplified constructor with large var types and maxBatchBytes support. */
+  public SemaphoreArrowBatchWriteBuffer(
+      StructType sparkSchema, int batchSize, boolean useLargeVarTypes, long maxBatchBytes) {
     this(
         LanceRuntime.allocator(),
         LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false, useLargeVarTypes),
         sparkSchema,
-        batchSize);
+        batchSize,
+        maxBatchBytes);
   }
 
   @Override
@@ -93,6 +136,19 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     }
   }
 
+  /** Returns whether the current batch should be flushed based on byte size. */
+  private boolean isBatchFullByBytes() {
+    if (maxBatchBytes == Long.MAX_VALUE) {
+      return false;
+    }
+    return batchAllocator.getAllocatedMemory() >= maxBatchBytes;
+  }
+
+  /** Returns whether the current batch should be flushed (by row count or byte size). */
+  private boolean isBatchFull() {
+    return count >= batchSize || (count > 0 && isBatchFullByBytes());
+  }
+
   @Override
   public void write(InternalRow row) {
     Preconditions.checkNotNull(row);
@@ -101,7 +157,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       checkForError();
 
       // wait until prepareLoadNextBatch signals that writes are available
-      while (count >= batchSize) {
+      while (isBatchFull()) {
         canWrite.await();
         checkForError();
       }
@@ -109,7 +165,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       arrowWriter.write(row);
       count++;
 
-      if (count == batchSize) {
+      if (isBatchFull()) {
         batchReady.signal();
       }
     } catch (InterruptedException e) {
@@ -156,8 +212,8 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
         return false;
       }
 
-      // wait until batch is full or finished
-      while (count < batchSize && !finished) {
+      // wait until batch is full (by rows or bytes) or finished
+      while (!isBatchFull() && !finished) {
         batchReady.await();
         checkForError();
       }
@@ -184,7 +240,9 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   @Override
   protected synchronized void closeReadSource() throws IOException {
-    // Implement if needed
+    // Close the child allocator that was created for byte tracking.
+    // The VectorSchemaRoot is closed by ArrowReader.close() before this is called.
+    batchAllocator.close();
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -36,14 +36,15 @@ import java.util.concurrent.locks.ReentrantLock;
  * pulling batches via ArrowReader interface). It uses a lock with conditions to synchronize between
  * the two threads - the producer blocks until the consumer is ready for more data, and vice versa.
  *
- * <p>Batches are flushed when either the row count reaches {@code batchSize} or the total allocator
- * memory exceeds {@code maxBatchBytes}, whichever comes first. This prevents OOM when individual
- * rows are very large (e.g., rows with large binary/string columns or embeddings).
+ * <p>Batches are flushed when either the row count reaches {@code batchSize} or the cumulative
+ * bytes written in the current batch exceeds {@code maxBatchBytes}, whichever comes first. This
+ * prevents OOM when individual rows are very large (e.g., rows with large binary/string columns or
+ * embeddings).
  *
- * <p>Note: because this buffer reuses a single VectorSchemaRoot across batches, the allocator
- * retains capacity from previous batches. The byte-based flush triggers when the allocator's total
- * memory exceeds the threshold, which is conservative but safe — it bounds total memory regardless
- * of how Arrow internally manages buffer capacity.
+ * <p>Because this buffer reuses a single VectorSchemaRoot across batches, the allocator retains
+ * buffer capacity from previous batches. The byte-based flush tracks per-row allocator growth
+ * (before/after each write) to accurately measure each batch's memory usage regardless of retained
+ * capacity.
  *
  * @see QueuedArrowBatchWriteBuffer for a queue-based alternative with per-batch allocators
  */
@@ -62,6 +63,17 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   @GuardedBy("lock")
   private int count;
+
+  /**
+   * Tracks per-batch memory usage for byte-based flushing. {@code batchStartBytes} captures the
+   * allocator memory after {@code clear()+allocateNew()}, and {@code currentBatchBytes} is the
+   * delta from that baseline. This is necessary because the shared allocator retains capacity from
+   * previous batches, so absolute memory is not reliable for per-batch tracking.
+   */
+  @GuardedBy("lock")
+  private long currentBatchBytes;
+
+  private long batchStartBytes;
 
   private org.lance.spark.arrow.LanceArrowWriter arrowWriter = null;
 
@@ -128,7 +140,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     if (maxBatchBytes == Long.MAX_VALUE) {
       return false;
     }
-    return this.allocator.getAllocatedMemory() >= maxBatchBytes;
+    return currentBatchBytes >= maxBatchBytes;
   }
 
   /** Returns whether the current batch should be flushed (by row count or byte size). */
@@ -150,6 +162,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       }
 
       arrowWriter.write(row);
+      currentBatchBytes = this.allocator.getAllocatedMemory() - batchStartBytes;
       count++;
 
       if (isBatchFull()) {
@@ -177,13 +190,24 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   @Override
   public void prepareLoadNextBatch() throws IOException {
-    super.prepareLoadNextBatch();
-    arrowWriter =
-        org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(
-            this.getVectorSchemaRoot(), sparkSchema);
+    // Don't call super.prepareLoadNextBatch() which does clear()+allocateNew().
+    // Arrow's allocateNew() remembers previous allocation sizes and pre-allocates
+    // that much capacity, which defeats per-batch byte tracking (the delta stays 0
+    // because writes fit within pre-allocated capacity). Instead, reset each vector
+    // (releasing memory and clearing allocation hints) then allocateNew() from scratch.
+    org.apache.arrow.vector.VectorSchemaRoot root = this.getVectorSchemaRoot();
+    for (org.apache.arrow.vector.FieldVector v : root.getFieldVectors()) {
+      v.clear();
+      v.setInitialCapacity(1);
+      v.allocateNew();
+    }
+    root.setRowCount(0);
+    arrowWriter = org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(root, sparkSchema);
     lock.lock();
     try {
       count = 0;
+      currentBatchBytes = 0;
+      batchStartBytes = this.allocator.getAllocatedMemory();
       canWrite.signalAll();
     } finally {
       lock.unlock();

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -53,13 +53,6 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   private final int batchSize;
   private final long maxBatchBytes;
 
-  /**
-   * Child allocator used to track memory for this buffer. Since the parent allocator may be shared
-   * globally, we use a child allocator so that {@code getAllocatedMemory()} reflects only this
-   * buffer's memory.
-   */
-  private final BufferAllocator batchAllocator;
-
   private final ReentrantLock lock = new ReentrantLock();
   private final Condition canWrite = lock.newCondition();
   private final Condition batchReady = lock.newCondition();
@@ -87,7 +80,6 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     this.sparkSchema = sparkSchema;
     this.batchSize = batchSize;
     this.maxBatchBytes = maxBatchBytes;
-    this.batchAllocator = this.allocator;
     // Start with count = batchSize so the writer blocks on canWrite.await() until the
     // reader's prepareLoadNextBatch() initializes arrowWriter and resets count to 0.
     this.count = batchSize;
@@ -100,21 +92,16 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
 
   /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
   public SemaphoreArrowBatchWriteBuffer(StructType sparkSchema, int batchSize) {
-    this(sparkSchema, batchSize, false);
+    this(sparkSchema, batchSize, false, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
-  /** Simplified constructor with large var types support. */
+  /** Constructor with large var types support, using LanceRuntime allocator. */
   public SemaphoreArrowBatchWriteBuffer(
       StructType sparkSchema, int batchSize, boolean useLargeVarTypes) {
     this(sparkSchema, batchSize, useLargeVarTypes, LanceSparkWriteOptions.DEFAULT_MAX_BATCH_BYTES);
   }
 
-  /** Simplified constructor that uses LanceRuntime allocator and converts Spark schema to Arrow. */
-  public SemaphoreArrowBatchWriteBuffer(StructType sparkSchema, int batchSize, long maxBatchBytes) {
-    this(sparkSchema, batchSize, false, maxBatchBytes);
-  }
-
-  /** Simplified constructor with large var types and maxBatchBytes support. */
+  /** Constructor with all tuning parameters, using LanceRuntime allocator. */
   public SemaphoreArrowBatchWriteBuffer(
       StructType sparkSchema, int batchSize, boolean useLargeVarTypes, long maxBatchBytes) {
     this(
@@ -141,7 +128,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     if (maxBatchBytes == Long.MAX_VALUE) {
       return false;
     }
-    return batchAllocator.getAllocatedMemory() >= maxBatchBytes;
+    return this.allocator.getAllocatedMemory() >= maxBatchBytes;
   }
 
   /** Returns whether the current batch should be flushed (by row count or byte size). */
@@ -209,6 +196,8 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     lock.lock();
     try {
       if (finished && count == 0) {
+        // Clear any buffers allocated by prepareLoadNextBatch() since no rows were written
+        this.getVectorSchemaRoot().clear();
         return false;
       }
 
@@ -242,7 +231,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   protected synchronized void closeReadSource() throws IOException {
     // Close the child allocator that was created for byte tracking.
     // The VectorSchemaRoot is closed by ArrowReader.close() before this is called.
-    batchAllocator.close();
+    this.allocator.close();
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -18,6 +18,8 @@ import org.lance.spark.LanceSparkWriteOptions;
 
 import com.google.common.base.Preconditions;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
@@ -195,8 +197,8 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     // that much capacity, which defeats per-batch byte tracking (the delta stays 0
     // because writes fit within pre-allocated capacity). Instead, reset each vector
     // (releasing memory and clearing allocation hints) then allocateNew() from scratch.
-    org.apache.arrow.vector.VectorSchemaRoot root = this.getVectorSchemaRoot();
-    for (org.apache.arrow.vector.FieldVector v : root.getFieldVectors()) {
+    VectorSchemaRoot root = this.getVectorSchemaRoot();
+    for (FieldVector v : root.getFieldVectors()) {
       v.clear();
       v.setInitialCapacity(1);
       v.allocateNew();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/QueuedArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/QueuedArrowBatchWriteBufferTest.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -83,10 +84,11 @@ public class QueuedArrowBatchWriteBufferTest {
                         new GenericInternalRow(new Object[] {rowsWritten.incrementAndGet()});
                     writeBuffer.write(row);
                   }
-                  writeBuffer.setFinished();
                 } catch (Throwable e) {
                   writerError.set(e);
                   e.printStackTrace();
+                } finally {
+                  writeBuffer.setFinished();
                 }
               });
 
@@ -577,6 +579,254 @@ public class QueuedArrowBatchWriteBufferTest {
 
       assertEquals(batchSize, rowsWritten.get());
       assertEquals(batchSize, rowsRead.get());
+      writeBuffer.close();
+    }
+  }
+
+  // ========== Byte-based flush tests ==========
+
+  private Schema createStringSchema() {
+    Field field =
+        new Field(
+            "data",
+            FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()),
+            null);
+    return new Schema(Collections.singletonList(field));
+  }
+
+  private StructType createStringSparkSchema() {
+    return new StructType(
+        new StructField[] {DataTypes.createStructField("data", DataTypes.StringType, true)});
+  }
+
+  /** Generate a string of approximately the given size in bytes. */
+  private UTF8String generateLargeString(int sizeBytes) {
+    byte[] data = new byte[sizeBytes];
+    java.util.Arrays.fill(data, (byte) 'A');
+    return UTF8String.fromBytes(data);
+  }
+
+  @Test
+  public void testByteBasedFlush() throws Exception {
+    // Each row is ~100KB. With batchSize=1000 (would be 100MB), but maxBatchBytes=256KB,
+    // we should see batches flush after ~2-3 rows instead of waiting for 1000.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createStringSchema();
+      StructType sparkSchema = createStringSparkSchema();
+
+      final int totalRows = 20;
+      final int batchSize = 1000; // High row limit - should never be reached
+      final long maxBatchBytes = 256 * 1024; // 256KB - should trigger flush after ~2 rows
+      final int rowSizeBytes = 100 * 1024; // ~100KB per row
+      final int queueDepth = 4;
+      final QueuedArrowBatchWriteBuffer writeBuffer =
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger batchCount = new AtomicInteger(0);
+      AtomicInteger maxRowsInBatch = new AtomicInteger(0);
+      AtomicReference<Throwable> writerError = new AtomicReference<>();
+      AtomicReference<Throwable> readerError = new AtomicReference<>();
+
+      Thread writerThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int i = 0; i < totalRows; i++) {
+                    UTF8String largeValue = generateLargeString(rowSizeBytes);
+                    InternalRow row = new GenericInternalRow(new Object[] {largeValue});
+                    writeBuffer.write(row);
+                    rowsWritten.incrementAndGet();
+                  }
+                } catch (Throwable e) {
+                  writerError.set(e);
+                  e.printStackTrace();
+                } finally {
+                  writeBuffer.setFinished();
+                }
+              });
+
+      Thread readerThread =
+          new Thread(
+              () -> {
+                try {
+                  while (writeBuffer.loadNextBatch()) {
+                    VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+                    int rowCount = root.getRowCount();
+                    rowsRead.addAndGet(rowCount);
+                    batchCount.incrementAndGet();
+                    maxRowsInBatch.updateAndGet(prev -> Math.max(prev, rowCount));
+                  }
+                } catch (Throwable e) {
+                  readerError.set(e);
+                  e.printStackTrace();
+                }
+              });
+
+      writerThread.start();
+      readerThread.start();
+      writerThread.join();
+      readerThread.join();
+
+      assertNull(writerError.get(), "Writer thread should not have errors");
+      assertNull(readerError.get(), "Reader thread should not have errors");
+      assertEquals(totalRows, rowsWritten.get());
+      assertEquals(totalRows, rowsRead.get());
+      // With 100KB rows and 256KB limit, each batch should have at most ~3 rows.
+      // Without byte-based flush, we'd get 1 batch of 20 rows (since batchSize=1000).
+      assertTrue(
+          batchCount.get() > 1,
+          "Should have multiple batches due to byte-based flushing, but got " + batchCount.get());
+      assertTrue(
+          maxRowsInBatch.get() < batchSize,
+          "Max rows per batch ("
+              + maxRowsInBatch.get()
+              + ") should be less than batchSize ("
+              + batchSize
+              + ") due to byte-based flushing");
+      writeBuffer.close();
+    }
+  }
+
+  @Test
+  public void testByteBasedFlushWithSmallRows() throws Exception {
+    // With small rows, the row count limit should be reached before byte limit.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createIntSchema();
+      StructType sparkSchema = createIntSparkSchema();
+
+      final int totalRows = 100;
+      final int batchSize = 25;
+      final long maxBatchBytes = 100 * 1024 * 1024; // 100MB - should never be reached
+      final int queueDepth = 4;
+      final QueuedArrowBatchWriteBuffer writeBuffer =
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger batchCount = new AtomicInteger(0);
+      AtomicReference<Throwable> writerError = new AtomicReference<>();
+      AtomicReference<Throwable> readerError = new AtomicReference<>();
+
+      Thread writerThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int i = 0; i < totalRows; i++) {
+                    InternalRow row =
+                        new GenericInternalRow(new Object[] {rowsWritten.incrementAndGet()});
+                    writeBuffer.write(row);
+                  }
+                } catch (Throwable e) {
+                  writerError.set(e);
+                  e.printStackTrace();
+                } finally {
+                  writeBuffer.setFinished();
+                }
+              });
+
+      Thread readerThread =
+          new Thread(
+              () -> {
+                try {
+                  while (writeBuffer.loadNextBatch()) {
+                    VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+                    rowsRead.addAndGet(root.getRowCount());
+                    batchCount.incrementAndGet();
+                  }
+                } catch (Throwable e) {
+                  readerError.set(e);
+                  e.printStackTrace();
+                }
+              });
+
+      writerThread.start();
+      readerThread.start();
+      writerThread.join();
+      readerThread.join();
+
+      assertNull(writerError.get(), "Writer thread should not have errors");
+      assertNull(readerError.get(), "Reader thread should not have errors");
+      assertEquals(totalRows, rowsWritten.get());
+      assertEquals(totalRows, rowsRead.get());
+      // Should have exactly 4 batches of 25 rows (row-count based flushing)
+      assertEquals(4, batchCount.get());
+      writeBuffer.close();
+    }
+  }
+
+  @Test
+  public void testByteBasedFlushSingleLargeRow() throws Exception {
+    // A single row exceeds maxBatchBytes - should flush after each row.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createStringSchema();
+      StructType sparkSchema = createStringSparkSchema();
+
+      final int totalRows = 5;
+      final int batchSize = 1000;
+      final long maxBatchBytes = 1024; // 1KB - each row will exceed this
+      final int rowSizeBytes = 10 * 1024; // 10KB per row
+      final int queueDepth = 4;
+      final QueuedArrowBatchWriteBuffer writeBuffer =
+          new QueuedArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, queueDepth, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger batchCount = new AtomicInteger(0);
+      AtomicReference<Throwable> writerError = new AtomicReference<>();
+      AtomicReference<Throwable> readerError = new AtomicReference<>();
+
+      Thread writerThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int i = 0; i < totalRows; i++) {
+                    UTF8String largeValue = generateLargeString(rowSizeBytes);
+                    InternalRow row = new GenericInternalRow(new Object[] {largeValue});
+                    writeBuffer.write(row);
+                    rowsWritten.incrementAndGet();
+                  }
+                } catch (Throwable e) {
+                  writerError.set(e);
+                  e.printStackTrace();
+                } finally {
+                  writeBuffer.setFinished();
+                }
+              });
+
+      Thread readerThread =
+          new Thread(
+              () -> {
+                try {
+                  while (writeBuffer.loadNextBatch()) {
+                    VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+                    rowsRead.addAndGet(root.getRowCount());
+                    batchCount.incrementAndGet();
+                  }
+                } catch (Throwable e) {
+                  readerError.set(e);
+                  e.printStackTrace();
+                }
+              });
+
+      writerThread.start();
+      readerThread.start();
+      writerThread.join();
+      readerThread.join();
+
+      assertNull(writerError.get(), "Writer thread should not have errors");
+      assertNull(readerError.get(), "Reader thread should not have errors");
+      assertEquals(totalRows, rowsWritten.get());
+      assertEquals(totalRows, rowsRead.get());
+      // Each row should produce its own batch since each exceeds the byte limit
+      assertEquals(
+          totalRows,
+          batchCount.get(),
+          "Each row should be its own batch when row size exceeds maxBatchBytes");
       writeBuffer.close();
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
@@ -316,4 +316,145 @@ public class SemaphoreArrowBatchWriteBufferTest {
       }
     }
   }
+
+  @Test
+  public void testByteBasedFlush() throws Exception {
+    // Each row is ~100KB. With batchSize=1000 (would be 100MB), but maxBatchBytes=256KB,
+    // we should see batches flush after ~2-3 rows instead of waiting for 1000.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createStringSchema();
+      StructType sparkSchema = createStringSparkSchema();
+
+      final int totalRows = 20;
+      final int batchSize = 1000; // High row limit - should never be reached
+      final long maxBatchBytes = 256 * 1024; // 256KB - should trigger flush after ~2 rows
+      final int rowSizeBytes = 100 * 1024; // ~100KB per row
+      final SemaphoreArrowBatchWriteBuffer writeBuffer =
+          new SemaphoreArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger batchCount = new AtomicInteger(0);
+      AtomicInteger maxRowsInBatch = new AtomicInteger(0);
+
+      Thread writerThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int i = 0; i < totalRows; i++) {
+                    UTF8String largeValue = generateLargeString(rowSizeBytes);
+                    InternalRow row = new GenericInternalRow(new Object[] {largeValue});
+                    writeBuffer.write(row);
+                    rowsWritten.incrementAndGet();
+                  }
+                } finally {
+                  writeBuffer.setFinished();
+                }
+              });
+
+      Callable<Void> readerCallable =
+          () -> {
+            while (writeBuffer.loadNextBatch()) {
+              VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+              int rowCount = root.getRowCount();
+              rowsRead.addAndGet(rowCount);
+              batchCount.incrementAndGet();
+              maxRowsInBatch.updateAndGet(prev -> Math.max(prev, rowCount));
+            }
+            return null;
+          };
+
+      FutureTask<Void> readerTask = writeBuffer.createTrackedTask(readerCallable);
+      Thread readerThread = new Thread(readerTask);
+      writerThread.start();
+      readerThread.start();
+      writerThread.join();
+      readerThread.join();
+
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+        // With 100KB rows and 256KB limit, each batch should have at most ~3 rows.
+        // Without byte-based flush, we'd get 1 batch of 20 rows (since batchSize=1000).
+        Assertions.assertTrue(
+            batchCount.get() > 1,
+            "Should have multiple batches due to byte-based flushing, but got " + batchCount.get());
+        Assertions.assertTrue(
+            maxRowsInBatch.get() < batchSize,
+            "Max rows per batch ("
+                + maxRowsInBatch.get()
+                + ") should be less than batchSize ("
+                + batchSize
+                + ") due to byte-based flushing");
+      } finally {
+        writeBuffer.close();
+      }
+    }
+  }
+
+  @Test
+  public void testByteBasedFlushSingleLargeRow() throws Exception {
+    // A single row exceeds maxBatchBytes - should flush after each row.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createStringSchema();
+      StructType sparkSchema = createStringSparkSchema();
+
+      final int totalRows = 5;
+      final int batchSize = 1000;
+      final long maxBatchBytes = 1024; // 1KB - each row will exceed this
+      final int rowSizeBytes = 10 * 1024; // 10KB per row
+      final SemaphoreArrowBatchWriteBuffer writeBuffer =
+          new SemaphoreArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+      AtomicInteger batchCount = new AtomicInteger(0);
+
+      Thread writerThread =
+          new Thread(
+              () -> {
+                try {
+                  for (int i = 0; i < totalRows; i++) {
+                    UTF8String largeValue = generateLargeString(rowSizeBytes);
+                    InternalRow row = new GenericInternalRow(new Object[] {largeValue});
+                    writeBuffer.write(row);
+                    rowsWritten.incrementAndGet();
+                  }
+                } finally {
+                  writeBuffer.setFinished();
+                }
+              });
+
+      Callable<Void> readerCallable =
+          () -> {
+            while (writeBuffer.loadNextBatch()) {
+              VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
+              rowsRead.addAndGet(root.getRowCount());
+              batchCount.incrementAndGet();
+            }
+            return null;
+          };
+
+      FutureTask<Void> readerTask = writeBuffer.createTrackedTask(readerCallable);
+      Thread readerThread = new Thread(readerTask);
+      writerThread.start();
+      readerThread.start();
+      writerThread.join();
+      readerThread.join();
+
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+        // Each row should produce its own batch since each exceeds the byte limit
+        assertEquals(
+            totalRows,
+            batchCount.get(),
+            "Each row should be its own batch when row size exceeds maxBatchBytes");
+      } finally {
+        writeBuffer.close();
+      }
+    }
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -111,9 +112,12 @@ public class SemaphoreArrowBatchWriteBufferTest {
 
       runWriterReader(writeBuffer, totalRows, rowsWritten, rowsRead);
 
-      assertEquals(totalRows, rowsWritten.get());
-      assertEquals(totalRows, rowsRead.get());
-      writeBuffer.close();
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+      } finally {
+        writeBuffer.close();
+      }
     }
   }
 
@@ -167,9 +171,12 @@ public class SemaphoreArrowBatchWriteBufferTest {
 
       runWriterReader(writeBuffer, totalRows, rowsWritten, rowsRead);
 
-      assertEquals(totalRows, rowsWritten.get());
-      assertEquals(totalRows, rowsRead.get());
-      writeBuffer.close();
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+      } finally {
+        writeBuffer.close();
+      }
     }
   }
 
@@ -189,9 +196,12 @@ public class SemaphoreArrowBatchWriteBufferTest {
 
       runWriterReader(writeBuffer, totalRows, rowsWritten, rowsRead);
 
-      assertEquals(totalRows, rowsWritten.get());
-      assertEquals(totalRows, rowsRead.get());
-      writeBuffer.close();
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+      } finally {
+        writeBuffer.close();
+      }
     }
   }
 
@@ -252,6 +262,58 @@ public class SemaphoreArrowBatchWriteBufferTest {
       assertEquals(batchSize, rowsWritten.get());
       assertEquals(batchSize, rowsRead.get());
       writeBuffer.close();
+    }
+  }
+
+  // ========== Byte-based flush tests ==========
+
+  private Schema createStringSchema() {
+    Field field =
+        new Field(
+            "data",
+            FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.VARCHAR.getType()),
+            null);
+    return new Schema(Collections.singletonList(field));
+  }
+
+  private StructType createStringSparkSchema() {
+    return new StructType(
+        new StructField[] {DataTypes.createStructField("data", DataTypes.StringType, true)});
+  }
+
+  /** Generate a string of approximately the given size in bytes. */
+  private UTF8String generateLargeString(int sizeBytes) {
+    byte[] data = new byte[sizeBytes];
+    java.util.Arrays.fill(data, (byte) 'A');
+    return UTF8String.fromBytes(data);
+  }
+
+  @Test
+  public void testByteBasedFlushWithSmallRows() throws Exception {
+    // With small rows, the row count limit should be reached before byte limit.
+    // This verifies that maxBatchBytes does not interfere with normal row-count flushing.
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Schema schema = createIntSchema();
+      StructType sparkSchema = createIntSparkSchema();
+
+      final int totalRows = 100;
+      final int batchSize = 25;
+      final long maxBatchBytes = 100 * 1024 * 1024; // 100MB - should never be reached
+      final SemaphoreArrowBatchWriteBuffer writeBuffer =
+          new SemaphoreArrowBatchWriteBuffer(
+              allocator, schema, sparkSchema, batchSize, maxBatchBytes);
+
+      AtomicInteger rowsWritten = new AtomicInteger(0);
+      AtomicInteger rowsRead = new AtomicInteger(0);
+
+      runWriterReader(writeBuffer, totalRows, rowsWritten, rowsRead);
+
+      try {
+        assertEquals(totalRows, rowsWritten.get());
+        assertEquals(totalRows, rowsRead.get());
+      } finally {
+        writeBuffer.close();
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `max_batch_bytes` write option (default 256MB) that flushes Arrow batches when byte size is reached, in addition to the existing row-count threshold (`batch_size`)
- Prevents OOM when writing tables with large rows (wide schemas, large binary/string columns, high-dimensional vector embeddings, etc.) where even a modest number of rows can exhaust memory
- Both `SemaphoreArrowBatchWriteBuffer` and `QueuedArrowBatchWriteBuffer` now use dedicated child allocators for accurate per-batch memory tracking

## Problem

The batch flush decision was purely row-count based (default `batch_size=8192`). For tables with large rows, a single batch could accumulate gigabytes of Arrow memory before flushing, causing OOM long before the row count threshold was reached.

## Solution

Batches now flush when **either** condition is met:
- Row count reaches `batch_size` (existing behavior, unchanged)
- Allocated memory reaches `max_batch_bytes` (new)

This is transparent — small-row workloads behave exactly as before since the row count limit is hit first. Large-row workloads get automatic memory protection.

### Usage

```python
df.write.format("lance") \
    .option("max_batch_bytes", "268435456") \  # 256MB (default)
    .save(path)
```

### Key implementation details

- **SemaphoreArrowBatchWriteBuffer**: now uses a child allocator (instead of the shared global one) so `getAllocatedMemory()` accurately reflects only this buffer's batch memory
- **QueuedArrowBatchWriteBuffer**: each batch gets its own child allocator via a `BatchEntry` wrapper, ensuring accurate byte tracking independent of concurrent consumer freeing of older batches
- **Backward compatible**: default `max_batch_bytes=256MB` with `Long.MAX_VALUE` meaning unlimited (matching previous behavior when not configured)

## Test plan

- [x] `testByteBasedFlush` — 100KB rows with 256KB byte limit → verifies batches flush with ~2-3 rows instead of waiting for row count
- [x] `testByteBasedFlushWithSmallRows` — small rows with high byte limit → verifies row-count flushing still works as before
- [x] `testByteBasedFlushSingleLargeRow` — each row exceeds byte limit → verifies 1 row per batch
- [x] All existing buffer tests pass (20 tests total)
- [x] `LanceDataWriterTest` end-to-end tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)