### PR TITLE
chore: update lance dependency to v5.1.0-beta.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.1</lance-spark.version>
-        <lance.version>5.0.0-beta.6</lance.version>
+        <lance.version>5.1.0-beta.2</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Update `lance.version` in `pom.xml` from `5.0.0-beta.6` to `5.1.0-beta.2`.
- Verify Docker version pins in `docker/Dockerfile`:
  - `LANCE_SPARK_VERSION` already matches the current `lance-spark.version` (`0.4.0-beta.1`).
  - `LANCE_NS_VERSION` remains `0.6.1`, matching the `lance-core` transitive namespace dependency for `v5.1.0-beta.2`.

## Verification
- `make lint` passed.
- `make install` passed for the default target (`lance-spark-3.5_2.12`, `-DskipTests`).

## Notes
- Triggering tag: `refs/tags/v5.1.0-beta.2`
