### PR TITLE
fix: pass namespace and storage parameters for add/update column

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -249,6 +249,10 @@ public class LanceDataset
     return namespaceProperties;
   }
 
+  public boolean getManagedVersioning() {
+    return managedVersioning;
+  }
+
   public String getFileFormatVersion() {
     return fileFormatVersion;
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -59,11 +59,11 @@ case class AddColumnsBackfillExec(
       new LanceDataset(
         originalTable.readOptions(),
         actualQuery.schema,
-        null,
-        null,
-        null,
-        false,
-        originalTable.getFileFormatVersion()),
+        originalTable.getInitialStorageOptions,
+        originalTable.getNamespaceImpl,
+        originalTable.getNamespaceProperties,
+        originalTable.getManagedVersioning,
+        originalTable.getFileFormatVersion),
       Some(catalog),
       Some(ident))
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
@@ -67,11 +67,11 @@ case class UpdateColumnsBackfillExec(
       new LanceDataset(
         originalTable.readOptions(),
         actualQuery.schema,
-        null,
-        null,
-        null,
-        false,
-        originalTable.getFileFormatVersion()),
+        originalTable.getInitialStorageOptions,
+        originalTable.getNamespaceImpl,
+        originalTable.getNamespaceProperties,
+        originalTable.getManagedVersioning,
+        originalTable.getFileFormatVersion),
       Some(catalog),
       Some(ident))
 


### PR DESCRIPTION
Currently vended credentials aren't being used properly when adding or updating columns w/ backfill. This PR passes the namespace and storage parameters from the source table when initializing the new LanceDataset, so the vended credentials will be used correctly.