### PR TITLE
chore: update lance dependency to v5.1.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.1</lance-spark.version>
-        <lance.version>5.0.0-beta.6</lance.version>
+        <lance.version>5.1.0-beta.3</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Update `lance.version` in `pom.xml` from `5.0.0-beta.6` to `5.1.0-beta.3`.
- Verified Docker version pins in `docker/Dockerfile`:
  - `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.4.0-beta.1`), so no change was required.
  - `LANCE_NS_VERSION` remains `0.6.1` (matching the `lance-core` dependency graph for `5.1.0-beta.3` in the upstream Lance source tag).

## Verification
- `make lint` passed.
- `make install` passed for Spark 3.5 / Scala 2.12.
  - Note: `org.lance:lance-core:5.1.0-beta.3` was not yet resolvable from Maven Central in this runner, so I installed that version to the local Maven cache from the upstream tag to complete verification.

## Triggering Tag
- refs/tags/v5.1.0-beta.3
