### PR TITLE
fix: report post-pruning statistics to enable BroadcastHashJoin with SPJ

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -80,6 +80,12 @@ public class LanceScan
    */
   private final java.util.Map<String, List<ZoneStats>> zonemapStats;
 
+  /**
+   * Pre-computed surviving fragment IDs from zonemap pruning in LanceScanBuilder. When non-null,
+   * {@link #pruneByZonemapStats} skips re-computing and uses these directly.
+   */
+  private final Set<Integer> cachedSurvivingFragmentIds;
+
   /** Number of partitions after pruning, set during {@link #planInputPartitions()}. */
   private transient int numPartitions = -1;
 
@@ -112,6 +118,7 @@ public class LanceScan
       Filter[] pushedFilters,
       LanceStatistics statistics,
       java.util.Map<String, List<ZoneStats>> zonemapStats,
+      Set<Integer> survivingFragmentIds,
       ZonemapFragmentPruner.PartitionInfo partitionInfo,
       java.util.Map<String, String> initialStorageOptions,
       String namespaceImpl,
@@ -127,6 +134,7 @@ public class LanceScan
         pushedFilters != null ? Arrays.copyOf(pushedFilters, pushedFilters.length) : new Filter[0];
     this.statistics = statistics;
     this.zonemapStats = zonemapStats != null ? zonemapStats : Collections.emptyMap();
+    this.cachedSurvivingFragmentIds = survivingFragmentIds;
     this.partitionInfo = partitionInfo;
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
@@ -315,17 +323,19 @@ public class LanceScan
    * predicate are skipped entirely, avoiding fragment opens, scan setup, and task scheduling.
    */
   private List<LanceSplit> pruneByZonemapStats(List<LanceSplit> allSplits) {
-    if (zonemapStats.isEmpty()) {
+    // Use cached result from LanceScanBuilder if available, otherwise compute.
+    Set<Integer> allowedIds;
+    if (cachedSurvivingFragmentIds != null) {
+      allowedIds = cachedSurvivingFragmentIds;
+    } else if (!zonemapStats.isEmpty()) {
+      allowedIds = ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
+    } else {
       return allSplits;
     }
 
-    java.util.Optional<Set<Integer>> targetFragmentIds =
-        ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats);
-    if (!targetFragmentIds.isPresent()) {
+    if (allowedIds == null) {
       return allSplits;
     }
-
-    Set<Integer> allowedIds = targetFragmentIds.get();
     List<LanceSplit> pruned =
         allSplits.stream()
             .filter(split -> split.getFragments().stream().anyMatch(allowedIds::contains))

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -342,7 +342,7 @@ public class LanceScan
             .collect(Collectors.toList());
 
     if (pruned.size() < allSplits.size()) {
-      LOG.info(
+      LOG.debug(
           "Zonemap pruning: {} of {} splits retained," + " allowed fragment IDs: {}",
           pruned.size(),
           allSplits.size(),

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -138,7 +138,6 @@ public class LanceScanBuilder
 
     // Get statistics from manifest summary before closing dataset
     ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
-    LanceStatistics statistics = new LanceStatistics(summary);
 
     // Collect all columns that need zonemap stats: filter columns + partition column (if declared).
     Set<String> columnsToLoad = extractReferencedColumns(pushedFilters);
@@ -176,6 +175,37 @@ public class LanceScanBuilder
               partValues.get().size());
         }
       }
+    }
+
+    // Estimate post-pruning statistics so Spark's JoinSelection can pick BroadcastHashJoin
+    // when the pruned size is below the broadcast threshold. Without this, the full-table size
+    // causes JoinSelection to pick SortMergeJoin, which then gets locked into SPJ — preventing
+    // AQE from switching to broadcast even when one side is tiny after filter pushdown.
+    LanceStatistics statistics;
+    if (pushedFilters.length > 0 && !zonemapStats.isEmpty()) {
+      java.util.Optional<Set<Integer>> survivingIds =
+          ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats);
+      if (survivingIds.isPresent()) {
+        statistics =
+            LanceStatistics.estimatePostPruning(
+                summary.getTotalRows(),
+                summary.getTotalFilesSize(),
+                summary.getTotalFragments(),
+                survivingIds.get().size());
+        LOG.info(
+            "Estimated post-pruning statistics: {} of {} fragments survive,"
+                + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
+            survivingIds.get().size(),
+            summary.getTotalFragments(),
+            statistics.sizeInBytes(),
+            statistics.numRows(),
+            summary.getTotalFilesSize(),
+            summary.getTotalRows());
+      } else {
+        statistics = new LanceStatistics(summary);
+      }
+    } else {
+      statistics = new LanceStatistics(summary);
     }
 
     // Close the lazily opened dataset - it's no longer needed after build

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -164,46 +164,45 @@ public class LanceScanBuilder
             partitionColumn,
             TABLE_OPT_PARTITION_COLUMNS);
       } else {
-        java.util.Optional<Map<Integer, Comparable<?>>> partValues =
-            ZonemapFragmentPruner.computeFragmentPartitionValues(zonemapStats.get(partitionColumn));
-        if (partValues.isPresent()) {
-          partitionInfo =
-              new ZonemapFragmentPruner.PartitionInfo(partitionColumn, partValues.get());
+        Map<Integer, Comparable<?>> partValues =
+            ZonemapFragmentPruner.computeFragmentPartitionValues(zonemapStats.get(partitionColumn))
+                .orElse(null);
+        if (partValues != null) {
+          partitionInfo = new ZonemapFragmentPruner.PartitionInfo(partitionColumn, partValues);
           LOG.info(
               "Detected partition-compatible column '{}' with {} fragments",
               partitionColumn,
-              partValues.get().size());
+              partValues.size());
         }
       }
     }
 
-    // Estimate post-pruning statistics so Spark's JoinSelection can pick BroadcastHashJoin
-    // when the pruned size is below the broadcast threshold. Without this, the full-table size
-    // causes JoinSelection to pick SortMergeJoin, which then gets locked into SPJ — preventing
-    // AQE from switching to broadcast even when one side is tiny after filter pushdown.
-    LanceStatistics statistics;
+    // Pre-compute fragment pruning so we can (a) estimate post-pruning statistics for
+    // JoinSelection (BroadcastHashJoin vs SortMergeJoin) and (b) pass the cached result
+    // to LanceScan to avoid re-computing during planInputPartitions().
+    Set<Integer> survivingFragmentIds = null;
     if (pushedFilters.length > 0 && !zonemapStats.isEmpty()) {
-      java.util.Optional<Set<Integer>> survivingIds =
-          ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats);
-      if (survivingIds.isPresent()) {
-        statistics =
-            LanceStatistics.estimatePostPruning(
-                summary.getTotalRows(),
-                summary.getTotalFilesSize(),
-                summary.getTotalFragments(),
-                survivingIds.get().size());
-        LOG.info(
-            "Estimated post-pruning statistics: {} of {} fragments survive,"
-                + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
-            survivingIds.get().size(),
-            summary.getTotalFragments(),
-            statistics.sizeInBytes(),
-            statistics.numRows(),
-            summary.getTotalFilesSize(),
-            summary.getTotalRows());
-      } else {
-        statistics = new LanceStatistics(summary);
-      }
+      survivingFragmentIds =
+          ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
+    }
+
+    LanceStatistics statistics;
+    if (survivingFragmentIds != null) {
+      statistics =
+          LanceStatistics.estimatePostPruning(
+              summary.getTotalRows(),
+              summary.getTotalFilesSize(),
+              summary.getTotalFragments(),
+              survivingFragmentIds.size());
+      LOG.debug(
+          "Estimated post-pruning statistics: {} of {} fragments survive,"
+              + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
+          survivingFragmentIds.size(),
+          summary.getTotalFragments(),
+          statistics.sizeInBytes(),
+          statistics.numRows(),
+          summary.getTotalFilesSize(),
+          summary.getTotalRows());
     } else {
       statistics = new LanceStatistics(summary);
     }
@@ -223,6 +222,7 @@ public class LanceScanBuilder
         pushedFilters,
         statistics,
         zonemapStats,
+        survivingFragmentIds,
         partitionInfo,
         initialStorageOptions,
         namespaceImpl,
@@ -379,7 +379,7 @@ public class LanceScanBuilder
     }
 
     if (!result.isEmpty()) {
-      LOG.info("Loaded zonemap stats for {} columns: {}", result.size(), result.keySet());
+      LOG.debug("Loaded zonemap stats for {} columns: {}", result.size(), result.keySet());
     }
 
     return result;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -36,8 +36,33 @@ public class LanceStatistics implements Statistics, Serializable {
    * @param summary the manifest summary containing pre-computed statistics
    */
   public LanceStatistics(ManifestSummary summary) {
-    this.numRows = summary.getTotalRows();
-    this.sizeInBytes = summary.getTotalFilesSize();
+    this(summary.getTotalRows(), summary.getTotalFilesSize());
+  }
+
+  /** Create statistics with explicit values (e.g., after scaling for pruned fragments). */
+  public LanceStatistics(long numRows, long sizeInBytes) {
+    this.numRows = numRows;
+    this.sizeInBytes = sizeInBytes;
+  }
+
+  /**
+   * Estimate post-pruning statistics by scaling full-table stats by the ratio of surviving
+   * fragments. This enables Spark's JoinSelection to pick BroadcastHashJoin when the post-pruning
+   * size is below the broadcast threshold, rather than defaulting to SortMergeJoin + SPJ.
+   *
+   * @param totalRows total rows in the dataset
+   * @param totalFilesSize total file size in bytes
+   * @param totalFragments total number of fragments in the dataset
+   * @param survivingFragments number of fragments that survive zonemap pruning
+   * @return scaled statistics, or full-table statistics if scaling is not applicable
+   */
+  public static LanceStatistics estimatePostPruning(
+      long totalRows, long totalFilesSize, long totalFragments, int survivingFragments) {
+    if (totalFragments <= 0 || survivingFragments >= totalFragments) {
+      return new LanceStatistics(totalRows, totalFilesSize);
+    }
+    double ratio = (double) survivingFragments / totalFragments;
+    return new LanceStatistics((long) (totalRows * ratio), (long) (totalFilesSize * ratio));
   }
 
   @Override

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSpjBroadcastTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSpjBroadcastTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test verifying that post-pruning statistics enable BroadcastHashJoin when one side of
+ * an SPJ-eligible join is small after filter pushdown.
+ *
+ * <p>Setup: Two Lance tables with a "region" column, each with multiple fragments where each
+ * fragment contains a single region value (min==max in zonemap). A btree index on "region" provides
+ * zonemap stats. The table property {@code lance.partition.columns=region} enables SPJ.
+ *
+ * <p>Expected behavior:
+ *
+ * <ul>
+ *   <li>Unfiltered join: SortMergeJoin with SPJ (both sides large, no broadcast)
+ *   <li>Filtered join (one side pruned to 1 fragment): BroadcastHashJoin (pruned side is small
+ *       enough to broadcast, JoinSelection picks broadcast before EnsureRequirements considers SPJ)
+ * </ul>
+ */
+public abstract class BaseSpjBroadcastTest {
+  protected String catalogName = "lance_spj_test";
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    spark =
+        SparkSession.builder()
+            .appName("lance-spj-broadcast-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            // Enable V2 bucketing (required for SPJ)
+            .config("spark.sql.sources.v2.bucketing.enabled", "true")
+            // Set a small broadcast threshold so the test is meaningful
+            .config("spark.sql.autoBroadcastJoinThreshold", "1048576") // 1MB
+            .getOrCreate();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.close();
+    }
+  }
+
+  /**
+   * Creates a table with a region column where each INSERT creates a separate fragment with a
+   * single region value — making the column SPJ-compatible (zonemap min==max per fragment).
+   */
+  private void createRegionTable(String tableName) {
+    String fullTable = catalogName + ".default." + tableName;
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING, value DOUBLE) USING lance "
+                + "TBLPROPERTIES ('lance.partition.columns' = 'region')",
+            fullTable));
+
+    // Insert data region-by-region to create one fragment per region
+    String[] regions = {"east", "west", "north", "south", "central"};
+    for (int r = 0; r < regions.length; r++) {
+      String region = regions[r];
+      int baseId = r * 20;
+      String values =
+          IntStream.range(baseId, baseId + 20)
+              .mapToObj(i -> String.format("(%d, '%s', %f)", i, region, i * 1.5))
+              .collect(Collectors.joining(","));
+      spark.sql(String.format("INSERT INTO %s (id, region, value) VALUES %s", fullTable, values));
+    }
+
+    // Create btree index on region to generate zonemap stats
+    spark.sql(
+        String.format("ALTER TABLE %s CREATE INDEX region_idx USING btree (region)", fullTable));
+  }
+
+  @Test
+  public void testFilteredJoinUsesBroadcast() {
+    String tableA = "spj_table_a_" + UUID.randomUUID().toString().replace("-", "");
+    String tableB = "spj_table_b_" + UUID.randomUUID().toString().replace("-", "");
+    createRegionTable(tableA);
+    createRegionTable(tableB);
+
+    String fullA = catalogName + ".default." + tableA;
+    String fullB = catalogName + ".default." + tableB;
+
+    // Filtered join: one side is pruned to a single fragment (region = 'east')
+    // With accurate post-pruning stats, JoinSelection should pick BroadcastHashJoin
+    Dataset<Row> joined =
+        spark.sql(
+            String.format(
+                "SELECT a.id, a.region, b.value "
+                    + "FROM %s a JOIN %s b ON a.region = b.region "
+                    + "WHERE a.region = 'east'",
+                fullA, fullB));
+
+    String physicalPlan = joined.queryExecution().executedPlan().toString();
+    System.out.println("=== Physical Plan (filtered join) ===");
+    System.out.println(physicalPlan);
+
+    // Verify results are correct
+    long count = joined.count();
+    assertTrue(count > 0, "Filtered join should return results");
+
+    // With post-pruning statistics, the filtered side should be small enough for broadcast.
+    // The plan should contain BroadcastHashJoin or BroadcastExchange.
+    // If it falls back to SortMergeJoin, the statistics estimation is not working.
+    boolean hasBroadcast =
+        physicalPlan.contains("BroadcastHashJoin") || physicalPlan.contains("BroadcastExchange");
+    boolean hasSMJ = physicalPlan.contains("SortMergeJoin");
+
+    // Log for debugging even if assertion passes
+    if (hasBroadcast) {
+      System.out.println("SUCCESS: Filtered join uses BroadcastHashJoin as expected");
+    } else if (hasSMJ) {
+      System.out.println(
+          "WARNING: Filtered join uses SortMergeJoin — post-pruning stats may not be working");
+    }
+
+    assertTrue(
+        hasBroadcast,
+        "Filtered join should use BroadcastHashJoin when one side is small after pruning. "
+            + "Plan: "
+            + physicalPlan);
+  }
+
+  @Test
+  public void testUnfilteredJoinUsesSortMerge() {
+    String tableA = "spj_unfiltered_a_" + UUID.randomUUID().toString().replace("-", "");
+    String tableB = "spj_unfiltered_b_" + UUID.randomUUID().toString().replace("-", "");
+    createRegionTable(tableA);
+    createRegionTable(tableB);
+
+    String fullA = catalogName + ".default." + tableA;
+    String fullB = catalogName + ".default." + tableB;
+
+    // Unfiltered join: both sides are full tables
+    // Should use SortMergeJoin (potentially with SPJ if stats exceed broadcast threshold)
+    Dataset<Row> joined =
+        spark.sql(
+            String.format(
+                "SELECT a.id, a.region, b.value " + "FROM %s a JOIN %s b ON a.region = b.region",
+                fullA, fullB));
+
+    String physicalPlan = joined.queryExecution().executedPlan().toString();
+    System.out.println("=== Physical Plan (unfiltered join) ===");
+    System.out.println(physicalPlan);
+
+    long count = joined.count();
+    assertTrue(count > 0, "Unfiltered join should return results");
+
+    // For such a small dataset, Spark may still use BroadcastHashJoin.
+    // The key assertion is that the query works correctly regardless.
+    System.out.println("Unfiltered join completed with " + count + " rows");
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSpjBroadcastTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSpjBroadcastTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -53,9 +52,9 @@ public abstract class BaseSpjBroadcastTest {
   @TempDir Path tempDir;
 
   @BeforeEach
-  public void setup() throws IOException {
+  public void setup() {
     Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
-    Files.createDirectories(rootPath);
+    rootPath.toFile().mkdirs();
     String testRoot = rootPath.toString();
     spark =
         SparkSession.builder()
@@ -76,7 +75,7 @@ public abstract class BaseSpjBroadcastTest {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
     if (spark != null) {
       spark.close();
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -213,6 +213,7 @@ public class LanceScanTest {
             new Filter[0],
             null,
             Collections.emptyMap(),
+            null,
             partInfo,
             Collections.emptyMap(),
             null,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LanceStatisticsTest {
+
+  @Test
+  public void testExplicitConstructor() {
+    LanceStatistics stats = new LanceStatistics(1000, 50000);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningScalesCorrectly() {
+    // 10 fragments, 3 survive → 30% of totals
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 10000, 10, 3);
+    assertEquals(300, stats.numRows().getAsLong());
+    assertEquals(3000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningSingleSurviveOfMany() {
+    // 100 fragments, 1 survives → 1% of totals
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(10000, 100000, 100, 1);
+    assertEquals(100, stats.numRows().getAsLong());
+    assertEquals(1000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningAllSurvive() {
+    // All fragments survive → full-table stats
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 10, 10);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningMoreThanTotalSurvive() {
+    // Edge case: surviving > total (shouldn't happen, but be safe) → full-table stats
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 10, 15);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningZeroSurvive() {
+    // Zero fragments survive → zero stats
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 10, 0);
+    assertEquals(0, stats.numRows().getAsLong());
+    assertEquals(0, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimatePostPruningZeroTotalFragments() {
+    // Edge case: zero total fragments → returns full-table stats (guard against division by zero)
+    LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 0, 0);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+}


### PR DESCRIPTION
## Summary
- **Fix SPJ + BroadcastHashJoin incompatibility**: When SPJ is active and one side of a join becomes tiny after filter pushdown, Spark's AQE cannot fall back to BroadcastHashJoin because SPJ removes all shuffle Exchange nodes (no materialization points for AQE to re-evaluate). The root cause is that `LanceStatistics` always reported full-table size from `ManifestSummary`, so `JoinSelection` always picked SortMergeJoin for large tables — which then got locked into SPJ.
- **Estimate post-pruning statistics at build time**: In `LanceScanBuilder.build()`, run `ZonemapFragmentPruner.pruneFragments()` against pushed filters and zonemap stats to get the surviving fragment count, then scale full-table stats by `survivingFragments / totalFragments`. When the pruned size falls below Spark's `autoBroadcastJoinThreshold` (default 10MB), `JoinSelection` picks BroadcastHashJoin *before* `EnsureRequirements` considers SPJ.

### How Spark's planning order makes this work
1. `JoinSelection` checks `estimateStatistics().sizeInBytes()` → picks BroadcastHashJoin (if small) or SortMergeJoin (if large)
2. `EnsureRequirements` checks `outputPartitioning()` → only applies SPJ to SortMergeJoin
3. AQE cannot override SPJ→broadcast because SPJ removes all Exchange nodes

So accurate post-pruning statistics let JoinSelection pick broadcast before SPJ is ever considered. SPJ still activates for large joins where both sides are big.

### Expected benchmark impact
From the PR #396 benchmark: filtered join (`region = 'east'`) was 31.4s with SPJ vs 16.2s without. With this fix, the filtered join should use BroadcastHashJoin (matching the 16.2s baseline) while the unfiltered full inner join continues to use SPJ (27.3s, 12.1x speedup).

## Test plan
- [x] 7 new unit tests for `LanceStatistics.estimatePostPruning()` covering: scaling arithmetic, all-survive, none-survive, zero-total-fragments, more-surviving-than-total
- [x] All 258 existing tests pass
- [x] Spotless clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)