### PR TITLE
fix: add clean-bundle target for reliable source change detection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,13 @@ make test SPARK_VERSION=4.0 SCALA_VERSION=2.13
 # Build (lint + install) for a specific version
 make build
 
-# Build the runtime bundle for a specific version
+# Build the runtime bundle for a specific version (incremental)
 make bundle
 make bundle SPARK_VERSION=3.5 SCALA_VERSION=2.13
+
+# Build the runtime bundle with a clean first (use when source changes are not picked up)
+make clean-bundle
+make clean-bundle SPARK_VERSION=3.5 SCALA_VERSION=2.13
 
 # Install all modules (without tests)
 make install-all

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ clean-module:
 bundle:
 	./mvnw install -pl $(BUNDLE_MODULE) -am -DskipTests
 
+.PHONY: clean-bundle
+clean-bundle:
+	./mvnw clean install -pl $(BUNDLE_MODULE) -am -DskipTests
+
 .PHONY: install-base
 install-base:
 	./mvnw install -pl $(BASE_MODULE) -am -DskipTests
@@ -241,7 +245,8 @@ help:
 	@echo "  test           - Run tests for module"
 	@echo "  build          - Lint and install module"
 	@echo "  clean-module   - Clean module"
-	@echo "  bundle         - Build bundle module"
+	@echo "  bundle         - Build bundle module (incremental)"
+	@echo "  clean-bundle   - Clean then build bundle module (use when source changes are not picked up)"
 	@echo "  install-base   - Install base module"
 	@echo ""
 	@echo "Global commands (all modules):"


### PR DESCRIPTION
Fix for https://github.com/lance-format/lance-spark/issues/374

`make bundle` uses incremental compilation which can silently serve stale artifacts when source changes occur across modules. The `scala-maven-plugin` upgrade (https://github.com/lance-format/lance-spark/pull/388) improved within-module Zinc compilation but cross-module staleness via the Maven `.m2` cache still occurs.

