### PR TITLE
fix: implement equals/hashCode on LanceScan to enable ReusedExchange

### DIFF
--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ReusedExchangeTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ReusedExchangeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class ReusedExchangeTest extends BaseReusedExchangeTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ReusedExchangeTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ReusedExchangeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class ReusedExchangeTest extends BaseReusedExchangeTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -48,6 +48,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -397,6 +398,84 @@ public class LanceScan
   @Override
   public Statistics estimateStatistics() {
     return statistics;
+  }
+
+  /**
+   * Required for Spark's ReusedExchange: {@code BatchScanExec.equals()} compares {@code batch}
+   * objects, which delegate to this method since LanceScan implements Batch.
+   *
+   * <p>Excludes {@code scanId} (per-instance tracing UUID, not scan identity).
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LanceScan that = (LanceScan) o;
+    return Objects.equals(schema, that.schema)
+        && Objects.equals(readOptions, that.readOptions)
+        && Objects.equals(whereConditions, that.whereConditions)
+        && Objects.equals(limit, that.limit)
+        && Objects.equals(offset, that.offset)
+        && Objects.equals(topNSortOrders.toString(), that.topNSortOrders.toString())
+        && aggregationEquals(pushedAggregation, that.pushedAggregation)
+        && equivalentFilters(pushedFilters, that.pushedFilters);
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            schema, readOptions, whereConditions, limit, offset, topNSortOrders.toString());
+    result = 31 * result + Arrays.hashCode(sortedByHash(pushedFilters));
+    result = 31 * result + aggregationHashCode(pushedAggregation);
+    return result;
+  }
+
+  /**
+   * Compares two Optional&lt;Aggregation&gt; by value. {@code Aggregation}'s auto-generated {@code
+   * equals()} uses reference identity for its array components, so we sort by hashCode and compare
+   * element-wise — following {@code AggregatePushDownUtils.equivalentAggregations()}.
+   */
+  private static boolean aggregationEquals(Optional<Aggregation> a, Optional<Aggregation> b) {
+    if (a.isPresent() != b.isPresent()) {
+      return false;
+    }
+    if (!a.isPresent()) {
+      return true;
+    }
+    Aggregation agg1 = a.get();
+    Aggregation agg2 = b.get();
+    return Arrays.equals(
+            sortedByHash(agg1.aggregateExpressions()), sortedByHash(agg2.aggregateExpressions()))
+        && Arrays.equals(
+            sortedByHash(agg1.groupByExpressions()), sortedByHash(agg2.groupByExpressions()));
+  }
+
+  private static int aggregationHashCode(Optional<Aggregation> agg) {
+    if (!agg.isPresent()) {
+      return 0;
+    }
+    return Objects.hash(
+        Arrays.hashCode(sortedByHash(agg.get().aggregateExpressions())),
+        Arrays.hashCode(sortedByHash(agg.get().groupByExpressions())));
+  }
+
+  /**
+   * Returns whether two filter arrays are equivalent regardless of order. Follows Spark's {@code
+   * FileScan.equivalentFilters()}: sort by hashCode, then compare element-wise.
+   */
+  private static boolean equivalentFilters(Filter[] a, Filter[] b) {
+    return Arrays.equals(sortedByHash(a), sortedByHash(b));
+  }
+
+  private static <T> T[] sortedByHash(T[] arr) {
+    T[] copy = Arrays.copyOf(arr, arr.length);
+    Arrays.sort(copy, (x, y) -> Integer.compare(x.hashCode(), y.hashCode()));
+    return copy;
   }
 
   private static class LanceReaderFactory implements PartitionReaderFactory {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseReusedExchangeTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseReusedExchangeTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.spark.LanceDataSource;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.TestUtils;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.execution.SparkPlan;
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec;
+import org.apache.spark.sql.execution.adaptive.QueryStageExec;
+import org.apache.spark.sql.execution.exchange.Exchange;
+import org.apache.spark.sql.execution.exchange.ReusedExchangeExec;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that Spark's ReusedExchange optimization takes effect for Lance scans. Requires {@code
+ * LanceScan} to implement {@code equals}/{@code hashCode} so that {@code BatchScanExec.equals()}
+ * recognizes equivalent scans.
+ */
+public abstract class BaseReusedExchangeTest {
+  private static SparkSession spark;
+
+  @BeforeAll
+  static void setup() {
+    spark =
+        SparkSession.builder()
+            .appName("reused-exchange-test")
+            .master("local[2]")
+            .config("spark.sql.exchange.reuse", "true")
+            .config("spark.sql.autoBroadcastJoinThreshold", "-1")
+            .getOrCreate();
+
+    String dbPath = TestUtils.TestTable1Config.dbPath;
+    spark
+        .read()
+        .format(LanceDataSource.name)
+        .option(
+            LanceSparkReadOptions.CONFIG_DATASET_URI,
+            TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+        .load()
+        .createOrReplaceTempView("lance_t");
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  @Test
+  public void testSelfJoinReusesExchange() {
+    // Both sides project the same columns — exchanges should be reused.
+    Dataset<Row> result =
+        spark.sql("SELECT a.x, a.y, b.x, b.y FROM lance_t a JOIN lance_t b ON a.x = b.x");
+    result.collectAsList();
+
+    SparkPlan plan = result.queryExecution().executedPlan();
+    assertReusedExchangesReferenceExistingExchanges(plan);
+  }
+
+  @Test
+  public void testMultiWayJoinReusesExchange() {
+    // Three-way self-join — the exchange from the first scan should be reused for the other two.
+    Dataset<Row> result =
+        spark.sql(
+            "SELECT a.x, b.x, c.x "
+                + "FROM lance_t a "
+                + "JOIN lance_t b ON a.x = b.x "
+                + "JOIN lance_t c ON a.x = c.x");
+    result.collectAsList();
+
+    SparkPlan plan = result.queryExecution().executedPlan();
+    assertReusedExchangesReferenceExistingExchanges(plan);
+  }
+
+  @Test
+  public void testSelfJoinWithDifferentFiltersDoesNotReuseExchange() {
+    // Different WHERE clauses produce different scans — no exchange reuse.
+    Dataset<Row> result =
+        spark.sql(
+            "SELECT a.x, a.y, b.x, b.y "
+                + "FROM (SELECT * FROM lance_t WHERE x > 0) a "
+                + "JOIN (SELECT * FROM lance_t WHERE x <= 0) b "
+                + "ON a.y = b.y");
+    result.collectAsList();
+
+    SparkPlan plan = result.queryExecution().executedPlan();
+    List<ReusedExchangeExec> reusedExchanges = collectNodes(plan, ReusedExchangeExec.class);
+
+    assertTrue(
+        reusedExchanges.isEmpty(),
+        "Self-join with different filters should NOT produce ReusedExchange. Plan:\n" + plan);
+  }
+
+  /**
+   * Asserts that the plan contains at least one ReusedExchangeExec and that every
+   * ReusedExchangeExec references an existing Exchange node. This follows the assertion pattern in
+   * Spark's {@code ReuseExchangeAndSubquerySuite} and {@code ExchangeSuite}.
+   */
+  private void assertReusedExchangesReferenceExistingExchanges(SparkPlan plan) {
+    Set<Integer> exchangeIds = collectExchangeIds(plan);
+    List<ReusedExchangeExec> reusedExchanges = collectNodes(plan, ReusedExchangeExec.class);
+
+    assertFalse(reusedExchanges.isEmpty(), "Plan should contain ReusedExchange. Plan:\n" + plan);
+
+    for (ReusedExchangeExec reused : reusedExchanges) {
+      int reusedChildId = reused.child().id();
+      assertTrue(
+          exchangeIds.contains(reusedChildId),
+          "ReusedExchangeExec should reference an existing Exchange (id="
+              + reusedChildId
+              + "). Exchange IDs: "
+              + exchangeIds
+              + ". Plan:\n"
+              + plan);
+    }
+  }
+
+  /** Collects IDs of all Exchange nodes in the plan tree, traversing into AQE wrappers. */
+  private static Set<Integer> collectExchangeIds(SparkPlan plan) {
+    Set<Integer> ids = new java.util.HashSet<>();
+    collectExchangeIdsRecursive(plan, ids);
+    return ids;
+  }
+
+  private static void collectExchangeIdsRecursive(SparkPlan plan, Set<Integer> ids) {
+    if (plan instanceof Exchange) {
+      ids.add(plan.id());
+    }
+    for (SparkPlan child : allChildren(plan)) {
+      collectExchangeIdsRecursive(child, ids);
+    }
+  }
+
+  /**
+   * Collects all nodes of the given type from the plan tree, traversing into AQE stages and query
+   * stages. This mirrors the traversal logic of Spark's {@code AdaptiveSparkPlanHelper.collect}.
+   */
+  private static <T> List<T> collectNodes(SparkPlan plan, Class<T> nodeType) {
+    List<T> result = new ArrayList<>();
+    collectNodesRecursive(plan, nodeType, result);
+    return result;
+  }
+
+  private static <T> void collectNodesRecursive(SparkPlan plan, Class<T> nodeType, List<T> result) {
+    if (nodeType.isInstance(plan)) {
+      result.add(nodeType.cast(plan));
+    }
+    for (SparkPlan child : allChildren(plan)) {
+      collectNodesRecursive(child, nodeType, result);
+    }
+  }
+
+  /**
+   * Returns children of a plan node, traversing into AQE wrappers. Mirrors {@code
+   * AdaptiveSparkPlanHelper.allChildren}.
+   */
+  private static List<SparkPlan> allChildren(SparkPlan plan) {
+    List<SparkPlan> children = new ArrayList<>();
+    if (plan instanceof AdaptiveSparkPlanExec) {
+      children.add(((AdaptiveSparkPlanExec) plan).executedPlan());
+    } else if (plan instanceof QueryStageExec) {
+      children.add(((QueryStageExec) plan).plan());
+    } else {
+      scala.collection.Iterator<SparkPlan> it = plan.children().iterator();
+      while (it.hasNext()) {
+        children.add(it.next());
+      }
+    }
+    return children;
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -241,4 +241,57 @@ public class LanceScanTest {
     Partitioning partitioning = scan.outputPartitioning();
     assertInstanceOf(UnknownPartitioning.class, partitioning);
   }
+
+  // --- equals / hashCode (required for ReusedExchange) ---
+
+  @Test
+  public void testEqualsForIdenticalScans() {
+    LanceScan scan1 = buildScan();
+    LanceScan scan2 = buildScan();
+    assertEquals(scan1, scan2, "Two scans of the same table should be equal for ReusedExchange");
+  }
+
+  @Test
+  public void testHashCodeConsistentWithEquals() {
+    LanceScan scan1 = buildScan();
+    LanceScan scan2 = buildScan();
+    assertEquals(scan1.hashCode(), scan2.hashCode(), "Equal scans must have the same hashCode");
+  }
+
+  @Test
+  public void testNotEqualWithDifferentFilters() {
+    LanceScan scan1 = buildScan();
+
+    LanceScanBuilder builder2 =
+        new LanceScanBuilder(
+            TEST_SCHEMA,
+            TestUtils.TestTable1Config.readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    builder2.pushFilters(new Filter[] {new GreaterThan("x", 0L)});
+    LanceScan scan2 = (LanceScan) builder2.build();
+
+    assertNotEquals(scan1, scan2, "Scans with different filters should not be equal");
+  }
+
+  @Test
+  public void testNotEqualWithDifferentSchema() {
+    LanceScan scan1 = buildScan();
+
+    StructType differentSchema = new StructType().add("x", DataTypes.LongType);
+    LanceScan scan2 =
+        (LanceScan)
+            new LanceScanBuilder(
+                    differentSchema,
+                    TestUtils.TestTable1Config.readOptions,
+                    Collections.emptyMap(),
+                    null,
+                    Collections.emptyMap(),
+                    Collections.emptyMap())
+                .build();
+
+    assertNotEquals(scan1, scan2, "Scans with different schemas should not be equal");
+  }
 }


### PR DESCRIPTION
## Summary

Implement `equals()`/`hashCode()` on `LanceScan` so that Spark's `ReusedExchange` optimization takes effect when the same Lance table is scanned multiple times in a query (e.g., self-join).

## Problem

`BatchScanExec.equals()` compares `batch` objects to determine if two scans are equivalent. Since `LanceScan` implements `Batch` and did not override `equals()`, it used `Object` reference equality — two scans of the same table were never equal, and exchanges were never reused.

## Solution

Override `equals()`/`hashCode()` on `LanceScan`, comparing the fields that define scan identity: `schema`, `readOptions`, `whereConditions`, `limit`, `offset`, `topNSortOrders`, `pushedAggregation`, and `pushedFilters`.

Comparison strategies follow Spark and Iceberg conventions:
- `pushedFilters`: order-independent via sort-by-hashCode, per `FileScan.equivalentFilters()`
- `pushedAggregation`: sort array components by hashCode, per `AggregatePushDownUtils.equivalentAggregations()`
- `topNSortOrders`: `toString()` comparison since `ColumnOrdering` lacks `equals()`, per Iceberg's filter expression approach

## Test plan

- [x] Unit: identical scans are equal; different filters/schema are not; hashCode consistent
- [x] E2E (Spark 3.4 & 3.5): self-join and 3-way self-join produce `ReusedExchange` referencing existing Exchange nodes
- [x] E2E: self-join with different filters does NOT produce `ReusedExchange`
- [x] All 255 existing base module tests pass
