### PR TITLE
feat: support compression config via Spark TBLPROPERTIES

### DIFF
--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -22,7 +22,7 @@ RUN curl -fL -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linu
 RUN python3 -m venv /opt/venv && \
     . /opt/venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install pytest pytest-timeout packaging azure-storage-blob boto3 lance
+    pip install pytest pytest-timeout packaging azure-storage-blob boto3 pylance
 
 ENV PATH="/opt/venv/bin:$PATH"
 ENV SPARK_HOME="/opt/spark"

--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -22,7 +22,7 @@ RUN curl -fL -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linu
 RUN python3 -m venv /opt/venv && \
     . /opt/venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install pytest pytest-timeout packaging azure-storage-blob boto3 pylance
+    pip install pytest pytest-timeout packaging azure-storage-blob boto3
 
 ENV PATH="/opt/venv/bin:$PATH"
 ENV SPARK_HOME="/opt/spark"

--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -22,7 +22,7 @@ RUN curl -fL -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linu
 RUN python3 -m venv /opt/venv && \
     . /opt/venv/bin/activate && \
     pip install --upgrade pip && \
-    pip install pytest pytest-timeout packaging azure-storage-blob boto3
+    pip install pytest pytest-timeout packaging azure-storage-blob boto3 lance
 
 ENV PATH="/opt/venv/bin:$PATH"
 ENV SPARK_HOME="/opt/spark"

--- a/docs/src/operations/ddl/create-table.md
+++ b/docs/src/operations/ddl/create-table.md
@@ -420,3 +420,118 @@ To create a table with large string columns, use the table property pattern `<co
         .tableProperty("content.arrow.large_var_char", "true")
         .createOrReplace();
     ```
+
+## Column Compression
+
+Lance supports per-column compression and encoding tuning via table properties. These properties
+map `<column>.lance.<key>` TBLPROPERTIES to `lance-encoding:<key>` Arrow field metadata, which the
+Lance Rust encoder reads at write time.
+
+### Supported keys (Spark connector)
+
+These five `<column>.lance.*` properties are mapped to Arrow field metadata by the connector. Other
+`lance.*` keys are ignored until implemented.
+
+| TBLPROPERTIES key | Arrow field metadata key | Valid values |
+|---|---|---|
+| `<col>.lance.compression` | `lance-encoding:compression` | `zstd`, `lz4`, `fsst`, `none` |
+| `<col>.lance.compression-level` | `lance-encoding:compression-level` | integer string (codec-specific) |
+| `<col>.lance.structural-encoding` | `lance-encoding:structural-encoding` | `miniblock`, `fullzip` |
+| `<col>.lance.rle-threshold` | `lance-encoding:rle-threshold` | float string in `(0.0, 1.0]` |
+| `<col>.lance.bss` | `lance-encoding:bss` | `off`, `on`, `auto` |
+
+Invalid values produce a clear `IllegalArgumentException` at table creation time.
+
+**Scope**: only top-level columns are supported. Nested field addressing is deferred.
+
+### Deferred keys (not wired in Spark yet)
+
+The following keys are recognized by lance-core but are not mapped from Spark TBLPROPERTIES yet.
+They are silently ignored if present:
+
+- `<col>.lance.dict-divisor`
+- `<col>.lance.dict-size-ratio`
+- `<col>.lance.dict-values-compression`
+- `<col>.lance.dict-values-compression-level`
+- `<col>.lance.minichunk-size`
+
+### ALTER TABLE Limitation
+
+`ALTER TABLE ... SET TBLPROPERTIES` does **not** mutate Arrow field metadata or change the encoding
+of previously written data. Compression properties are applied only when the table is created.
+
+### Example
+
+=== "SQL"
+    ```sql
+    CREATE TABLE events (
+        id BIGINT,
+        payload STRING,
+        ts BIGINT
+    ) USING lance
+    TBLPROPERTIES (
+        'payload.lance.compression'       = 'zstd',
+        'payload.lance.compression-level' = '3',
+        'ts.lance.compression'            = 'none'
+    );
+    ```
+
+=== "Python"
+    ```python
+    from pyspark.sql.types import StructType, StructField, LongType, StringType
+
+    schema = StructType([
+        StructField("id",      LongType(),   False),
+        StructField("payload", StringType(), True),
+        StructField("ts",      LongType(),   True),
+    ])
+    data = [(1, "hello", 1000), (2, "world", 2000)]
+    df = spark.createDataFrame(data, schema)
+
+    df.writeTo("events") \
+        .tableProperty("payload.lance.compression", "zstd") \
+        .tableProperty("payload.lance.compression-level", "3") \
+        .tableProperty("ts.lance.compression", "none") \
+        .createOrReplace()
+    ```
+
+=== "Scala"
+    ```scala
+    val schema = StructType(Seq(
+      StructField("id",      LongType,   nullable = false),
+      StructField("payload", StringType, nullable = true),
+      StructField("ts",      LongType,   nullable = true),
+    ))
+    val data = Seq((1L, "hello", 1000L), (2L, "world", 2000L))
+    val df = data.toDF("id", "payload", "ts")
+
+    df.writeTo("events")
+      .tableProperty("payload.lance.compression", "zstd")
+      .tableProperty("payload.lance.compression-level", "3")
+      .tableProperty("ts.lance.compression", "none")
+      .createOrReplace()
+    ```
+
+=== "Java"
+    ```java
+    import org.apache.spark.sql.types.*;
+
+    StructType schema = new StructType(new StructField[]{
+        DataTypes.createStructField("id",      DataTypes.LongType,   false),
+        DataTypes.createStructField("payload", DataTypes.StringType, true),
+        DataTypes.createStructField("ts",      DataTypes.LongType,   true),
+    });
+
+    List<Row> data = Arrays.asList(
+        RowFactory.create(1L, "hello", 1000L),
+        RowFactory.create(2L, "world", 2000L)
+    );
+
+    Dataset<Row> df = spark.createDataFrame(data, schema);
+
+    df.writeTo("events")
+        .tableProperty("payload.lance.compression", "zstd")
+        .tableProperty("payload.lance.compression-level", "3")
+        .tableProperty("ts.lance.compression", "none")
+        .createOrReplace();
+    ```

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -533,21 +533,6 @@ class TestDDLColumnCompression:
         result = spark.sql("SELECT id, ts FROM default.test_table").collect()
         assert result[0].ts == 1000
 
-    def test_fsst_compression(self, spark):
-        """FSST compression is accepted for string columns."""
-        spark.sql("""
-            CREATE TABLE default.test_table (
-                id BIGINT,
-                payload STRING
-            ) USING lance
-            TBLPROPERTIES (
-                'payload.lance.compression' = 'fsst'
-            )
-        """)
-        spark.sql("INSERT INTO default.test_table VALUES (1, 'fsst-test')")
-        result = spark.sql("SELECT payload FROM default.test_table").collect()
-        assert result[0].payload == "fsst-test"
-
     def test_invalid_compression_scheme_rejected(self, spark):
         """Invalid compression scheme raises an error at table creation time."""
         with pytest.raises(Exception, match=r"invalid compression scheme"):

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -15,7 +15,6 @@ Test organization follows the Lance documentation structure:
 import os
 import time
 import pytest
-import lance
 from packaging.version import Version
 from pyspark.sql.types import StructType, StructField, IntegerType, StringType, DoubleType, BinaryType
 
@@ -597,6 +596,7 @@ class TestDDLColumnCompression:
         that the connector correctly wired the TBLPROPERTIES into Arrow field metadata
         consumed by the Rust encoder.
         """
+        lance = pytest.importorskip("lance", reason="lance-python not installed")
         if spark._lance_backend != "local":
             pytest.skip("lance-python file inspection only supported on local backend")
 

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -15,6 +15,7 @@ Test organization follows the Lance documentation structure:
 import os
 import time
 import pytest
+import lance
 from packaging.version import Version
 from pyspark.sql.types import StructType, StructField, IntegerType, StringType, DoubleType, BinaryType
 
@@ -489,6 +490,148 @@ class TestDDLAlterTableProperties:
         props = {row.key: row.value for row in rows}
 
         assert props["team"] == "data-eng"
+
+
+class TestDDLColumnCompression:
+    """Test per-column compression TBLPROPERTIES → Arrow field metadata pipeline."""
+
+    def test_create_table_with_compression(self, spark):
+        """Table with compression TBLPROPERTIES can be created and written to."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id BIGINT,
+                payload STRING,
+                ts BIGINT
+            ) USING lance
+            TBLPROPERTIES (
+                'payload.lance.compression'       = 'zstd',
+                'payload.lance.compression-level' = '3',
+                'ts.lance.compression'            = 'none'
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'hello', 1000)")
+        result = spark.sql("SELECT * FROM default.test_table").collect()
+        assert len(result) == 1
+        assert result[0].payload == "hello"
+
+    def test_all_supported_compression_tblproperties(self, spark):
+        """All five connector-supported compression TBLPROPERTIES can be set without error."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id BIGINT,
+                payload STRING,
+                ts BIGINT
+            ) USING lance
+            TBLPROPERTIES (
+                'ts.lance.compression'          = 'lz4',
+                'ts.lance.compression-level'    = '1',
+                'ts.lance.structural-encoding'  = 'miniblock',
+                'ts.lance.rle-threshold'        = '0.5',
+                'ts.lance.bss'                  = 'auto'
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'hello', 1000)")
+        result = spark.sql("SELECT id, ts FROM default.test_table").collect()
+        assert result[0].ts == 1000
+
+    def test_fsst_compression(self, spark):
+        """FSST compression is accepted for string columns."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id BIGINT,
+                payload STRING
+            ) USING lance
+            TBLPROPERTIES (
+                'payload.lance.compression' = 'fsst'
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'fsst-test')")
+        result = spark.sql("SELECT payload FROM default.test_table").collect()
+        assert result[0].payload == "fsst-test"
+
+    def test_invalid_compression_scheme_rejected(self, spark):
+        """Invalid compression scheme raises an error at table creation time."""
+        with pytest.raises(Exception, match=r"invalid compression scheme"):
+            spark.sql("""
+                CREATE TABLE default.test_table (
+                    id BIGINT,
+                    payload STRING
+                ) USING lance
+                TBLPROPERTIES (
+                    'payload.lance.compression' = 'gzip'
+                )
+            """)
+
+    def test_invalid_structural_encoding_rejected(self, spark):
+        """Invalid structural-encoding value raises an error at table creation time."""
+        with pytest.raises(Exception, match=r"invalid structural-encoding"):
+            spark.sql("""
+                CREATE TABLE default.test_table (
+                    id BIGINT,
+                    ts BIGINT
+                ) USING lance
+                TBLPROPERTIES (
+                    'ts.lance.structural-encoding' = 'rle'
+                )
+            """)
+
+    def test_deferred_dict_key_ignored(self, spark):
+        """Deferred dict-divisor TBLPROPERTY does not cause an error (silently ignored)."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id BIGINT,
+                payload STRING
+            ) USING lance
+            TBLPROPERTIES (
+                'payload.lance.dict-divisor' = '4'
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'ok')")
+        result = spark.sql("SELECT payload FROM default.test_table").collect()
+        assert result[0].payload == "ok"
+
+    def test_compression_metadata_reaches_lance_file(self, spark):
+        """Arrow field metadata with lance-encoding keys is present in the written Lance file.
+
+        Opens the dataset directly with lance-python and inspects the schema to verify
+        that the connector correctly wired the TBLPROPERTIES into Arrow field metadata
+        consumed by the Rust encoder.
+        """
+        if spark._lance_backend != "local":
+            pytest.skip("lance-python file inspection only supported on local backend")
+
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id BIGINT,
+                payload STRING,
+                ts BIGINT
+            ) USING lance
+            TBLPROPERTIES (
+                'payload.lance.compression'       = 'zstd',
+                'payload.lance.compression-level' = '3',
+                'ts.lance.compression'            = 'none'
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'hello', 1000)")
+
+        location = (
+            spark.sql("DESCRIBE EXTENDED default.test_table")
+            .filter("col_name == 'Location'")
+            .collect()[0]
+            .data_type
+        )
+        ds = lance.dataset(location)
+        schema = ds.schema
+
+        payload_meta = schema.field("payload").metadata
+        assert payload_meta.get(b"lance-encoding:compression") == b"zstd"
+        assert payload_meta.get(b"lance-encoding:compression-level") == b"3"
+
+        ts_meta = schema.field("ts").metadata
+        assert ts_meta.get(b"lance-encoding:compression") == b"none"
+
+        id_meta = schema.field("id").metadata
+        assert b"lance-encoding:compression" not in (id_meta or {})
 
 
 class TestDDLIndex:

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -293,7 +293,12 @@ public class LanceDataset
 
   @Override
   public Map<String, String> properties() {
-    return tableProperties;
+    // Spark's DescribeTableExec iterates TABLE_RESERVED_PROPERTIES and emits a capitalized row for
+    // each key present here (e.g. "location" -> col_name "Location"). Without this entry the
+    // physical URI is invisible to DESCRIBE EXTENDED and to any tooling that relies on it.
+    Map<String, String> props = new HashMap<>(tableProperties);
+    props.put("location", readOptions.getDatasetUri());
+    return props;
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -100,6 +100,7 @@ public final class LanceEncodingUtils {
     }
   }
 
+  // codec-specific upper-bound enforcement is left to the Rust encoder
   private static void validateCompressionLevel(String columnName, String value) {
     int level;
     try {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+/**
+ * Utility methods and constants for per-column Lance encoding configuration via Spark
+ * TBLPROPERTIES.
+ *
+ * <p>The TBLPROPERTIES key convention is {@code <column>.lance.<key>}. These map 1-to-1 to {@code
+ * lance-encoding:<key>} Arrow field metadata keys, which the Lance Rust encoder reads at write
+ * time.
+ *
+ * <p>Only connector-supported keys are handled (the five mapped below); dict/minichunk keys are
+ * deferred. Unmatched column names and type-incompatible combinations are silently ignored —
+ * semantic validation is left to the Lance Rust encoder.
+ */
+public final class LanceEncodingUtils {
+
+  /** Domain segment used in TBLPROPERTIES keys: {@code <column>.lance.<key>}. */
+  static final String LANCE_PROPERTY_DOMAIN = "lance";
+
+  // TBLPROPERTIES key suffixes (after "<column>.")
+  static final String COMPRESSION_SUFFIX = LANCE_PROPERTY_DOMAIN + ".compression";
+  static final String COMPRESSION_LEVEL_SUFFIX =
+      LANCE_PROPERTY_DOMAIN + ".compression-level";
+  static final String STRUCTURAL_ENCODING_SUFFIX =
+      LANCE_PROPERTY_DOMAIN + ".structural-encoding";
+  static final String RLE_THRESHOLD_SUFFIX = LANCE_PROPERTY_DOMAIN + ".rle-threshold";
+  static final String BSS_SUFFIX = LANCE_PROPERTY_DOMAIN + ".bss";
+
+  // Arrow field metadata keys
+  static final String LANCE_ENCODING_COMPRESSION = "lance-encoding:compression";
+  static final String LANCE_ENCODING_COMPRESSION_LEVEL = "lance-encoding:compression-level";
+  static final String LANCE_ENCODING_STRUCTURAL_ENCODING =
+      "lance-encoding:structural-encoding";
+  static final String LANCE_ENCODING_RLE_THRESHOLD = "lance-encoding:rle-threshold";
+  static final String LANCE_ENCODING_BSS = "lance-encoding:bss";
+
+  // Valid value sets
+  private static final Set<String> VALID_COMPRESSION_SCHEMES =
+      Set.of("zstd", "lz4", "fsst", "none");
+
+  private static final Set<String> VALID_STRUCTURAL_ENCODINGS =
+      Set.of("miniblock", "fullzip");
+
+  private static final Set<String> VALID_BSS_MODES =
+      Set.of("off", "on", "auto");
+
+  private static final List<EncodingPropertyRule> SUPPORTED_ENCODING_PROPERTY_RULES =
+      List.of(
+          rule(COMPRESSION_SUFFIX, LANCE_ENCODING_COMPRESSION, LanceEncodingUtils::validateCompressionScheme),
+          rule(COMPRESSION_LEVEL_SUFFIX, LANCE_ENCODING_COMPRESSION_LEVEL, LanceEncodingUtils::validateCompressionLevel),
+          rule(STRUCTURAL_ENCODING_SUFFIX, LANCE_ENCODING_STRUCTURAL_ENCODING, LanceEncodingUtils::validateStructuralEncoding),
+          rule(RLE_THRESHOLD_SUFFIX, LANCE_ENCODING_RLE_THRESHOLD, LanceEncodingUtils::validateRleThreshold),
+          rule(BSS_SUFFIX, LANCE_ENCODING_BSS, LanceEncodingUtils::validateBssMode));
+
+  private LanceEncodingUtils() {
+    // Utility class
+  }
+
+  static String createPropertyKey(String columnName, String propertySuffix) {
+    return columnName + "." + propertySuffix;
+  }
+
+  static List<EncodingPropertyRule> getSupportedEncodingPropertyRules() {
+    return SUPPORTED_ENCODING_PROPERTY_RULES;
+  }
+
+  private static void validateCompressionScheme(String columnName, String value) {
+    if (!VALID_COMPRESSION_SCHEMES.contains(value)) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': invalid compression scheme '"
+              + value
+              + "'. Valid values: "
+              + VALID_COMPRESSION_SCHEMES);
+    }
+  }
+
+  // Only integer parseability is checked; codec-specific range enforcement is left to the Rust encoder.
+  private static void validateCompressionLevel(String columnName, String value) {
+    try {
+      Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': invalid compression-level '"
+              + value
+              + "'. Must be an integer.");
+    }
+  }
+
+  private static void validateStructuralEncoding(String columnName, String value) {
+    if (!VALID_STRUCTURAL_ENCODINGS.contains(value)) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': invalid structural-encoding '"
+              + value
+              + "'. Valid values: "
+              + VALID_STRUCTURAL_ENCODINGS);
+    }
+  }
+
+  private static void validateRleThreshold(String columnName, String value) {
+    float threshold;
+    try {
+      threshold = Float.parseFloat(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': invalid rle-threshold '"
+              + value
+              + "'. Must be a float in (0.0, 1.0].");
+    }
+    if (threshold <= 0.0f || threshold > 1.0f) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': rle-threshold '"
+              + value
+              + "' is out of range. Must be in (0.0, 1.0].");
+    }
+  }
+
+  private static void validateBssMode(String columnName, String value) {
+    if (!VALID_BSS_MODES.contains(value)) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': invalid bss '"
+              + value
+              + "'. Valid values: "
+              + VALID_BSS_MODES);
+    }
+  }
+
+  private static EncodingPropertyRule rule(
+      String propertySuffix,
+      String arrowMetadataKey,
+      BiConsumer<String, String> validator) {
+    return new EncodingPropertyRule(propertySuffix, arrowMetadataKey, validator);
+  }
+
+  /** Rule descriptor for mapping a Spark TBLPROPERTY to an Arrow field metadata key. */
+  static class EncodingPropertyRule {
+    private final String propertySuffix;
+    private final String arrowMetadataKey;
+    private final BiConsumer<String, String> validator;
+
+    private EncodingPropertyRule(
+        String propertySuffix,
+        String arrowMetadataKey,
+        BiConsumer<String, String> validator) {
+      this.propertySuffix = propertySuffix;
+      this.arrowMetadataKey = arrowMetadataKey;
+      this.validator = validator;
+    }
+
+    String getPropertySuffix() {
+      return propertySuffix;
+    }
+
+    String getArrowMetadataKey() {
+      return arrowMetadataKey;
+    }
+
+    String createPropertyKey(String columnName) {
+      return LanceEncodingUtils.createPropertyKey(columnName, propertySuffix);
+    }
+
+    void validate(String columnName, String value) {
+      validator.accept(columnName, value);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -100,18 +100,25 @@ public final class LanceEncodingUtils {
     }
   }
 
-  // Only integer parseability is checked; codec-specific range enforcement is left to the Rust
-  // encoder.
   private static void validateCompressionLevel(String columnName, String value) {
+    int level;
     try {
-      Integer.parseInt(value);
+      level = Integer.parseInt(value);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
           "Column '"
               + columnName
               + "': invalid compression-level '"
               + value
-              + "'. Must be an integer.");
+              + "'. Must be a non-negative integer.");
+    }
+    if (level < 0) {
+      throw new IllegalArgumentException(
+          "Column '"
+              + columnName
+              + "': compression-level '"
+              + value
+              + "' must be non-negative.");
     }
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -36,18 +36,15 @@ public final class LanceEncodingUtils {
 
   // TBLPROPERTIES key suffixes (after "<column>.")
   static final String COMPRESSION_SUFFIX = LANCE_PROPERTY_DOMAIN + ".compression";
-  static final String COMPRESSION_LEVEL_SUFFIX =
-      LANCE_PROPERTY_DOMAIN + ".compression-level";
-  static final String STRUCTURAL_ENCODING_SUFFIX =
-      LANCE_PROPERTY_DOMAIN + ".structural-encoding";
+  static final String COMPRESSION_LEVEL_SUFFIX = LANCE_PROPERTY_DOMAIN + ".compression-level";
+  static final String STRUCTURAL_ENCODING_SUFFIX = LANCE_PROPERTY_DOMAIN + ".structural-encoding";
   static final String RLE_THRESHOLD_SUFFIX = LANCE_PROPERTY_DOMAIN + ".rle-threshold";
   static final String BSS_SUFFIX = LANCE_PROPERTY_DOMAIN + ".bss";
 
   // Arrow field metadata keys
   static final String LANCE_ENCODING_COMPRESSION = "lance-encoding:compression";
   static final String LANCE_ENCODING_COMPRESSION_LEVEL = "lance-encoding:compression-level";
-  static final String LANCE_ENCODING_STRUCTURAL_ENCODING =
-      "lance-encoding:structural-encoding";
+  static final String LANCE_ENCODING_STRUCTURAL_ENCODING = "lance-encoding:structural-encoding";
   static final String LANCE_ENCODING_RLE_THRESHOLD = "lance-encoding:rle-threshold";
   static final String LANCE_ENCODING_BSS = "lance-encoding:bss";
 
@@ -55,24 +52,29 @@ public final class LanceEncodingUtils {
   private static final Set<String> VALID_COMPRESSION_SCHEMES =
       Set.of("zstd", "lz4", "fsst", "none");
 
-  private static final Set<String> VALID_STRUCTURAL_ENCODINGS =
-      Set.of("miniblock", "fullzip");
+  private static final Set<String> VALID_STRUCTURAL_ENCODINGS = Set.of("miniblock", "fullzip");
 
-  private static final Set<String> VALID_BSS_MODES =
-      Set.of("off", "on", "auto");
+  private static final Set<String> VALID_BSS_MODES = Set.of("off", "on", "auto");
 
   private static final List<EncodingPropertyRule> SUPPORTED_ENCODING_PROPERTY_RULES =
       List.of(
-          rule(COMPRESSION_SUFFIX, LANCE_ENCODING_COMPRESSION,
+          rule(
+              COMPRESSION_SUFFIX,
+              LANCE_ENCODING_COMPRESSION,
               LanceEncodingUtils::validateCompressionScheme),
-          rule(COMPRESSION_LEVEL_SUFFIX, LANCE_ENCODING_COMPRESSION_LEVEL,
+          rule(
+              COMPRESSION_LEVEL_SUFFIX,
+              LANCE_ENCODING_COMPRESSION_LEVEL,
               LanceEncodingUtils::validateCompressionLevel),
-          rule(STRUCTURAL_ENCODING_SUFFIX, LANCE_ENCODING_STRUCTURAL_ENCODING,
+          rule(
+              STRUCTURAL_ENCODING_SUFFIX,
+              LANCE_ENCODING_STRUCTURAL_ENCODING,
               LanceEncodingUtils::validateStructuralEncoding),
-          rule(RLE_THRESHOLD_SUFFIX, LANCE_ENCODING_RLE_THRESHOLD,
+          rule(
+              RLE_THRESHOLD_SUFFIX,
+              LANCE_ENCODING_RLE_THRESHOLD,
               LanceEncodingUtils::validateRleThreshold),
-          rule(BSS_SUFFIX, LANCE_ENCODING_BSS,
-              LanceEncodingUtils::validateBssMode));
+          rule(BSS_SUFFIX, LANCE_ENCODING_BSS, LanceEncodingUtils::validateBssMode));
 
   private LanceEncodingUtils() {
     // Utility class
@@ -160,9 +162,7 @@ public final class LanceEncodingUtils {
   }
 
   private static EncodingPropertyRule rule(
-      String propertySuffix,
-      String arrowMetadataKey,
-      BiConsumer<String, String> validator) {
+      String propertySuffix, String arrowMetadataKey, BiConsumer<String, String> validator) {
     return new EncodingPropertyRule(propertySuffix, arrowMetadataKey, validator);
   }
 
@@ -173,9 +173,7 @@ public final class LanceEncodingUtils {
     private final BiConsumer<String, String> validator;
 
     private EncodingPropertyRule(
-        String propertySuffix,
-        String arrowMetadataKey,
-        BiConsumer<String, String> validator) {
+        String propertySuffix, String arrowMetadataKey, BiConsumer<String, String> validator) {
       this.propertySuffix = propertySuffix;
       this.arrowMetadataKey = arrowMetadataKey;
       this.validator = validator;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -115,11 +115,7 @@ public final class LanceEncodingUtils {
     }
     if (level < 0) {
       throw new IllegalArgumentException(
-          "Column '"
-              + columnName
-              + "': compression-level '"
-              + value
-              + "' must be non-negative.");
+          "Column '" + columnName + "': compression-level '" + value + "' must be non-negative.");
     }
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LanceEncodingUtils.java
@@ -63,11 +63,16 @@ public final class LanceEncodingUtils {
 
   private static final List<EncodingPropertyRule> SUPPORTED_ENCODING_PROPERTY_RULES =
       List.of(
-          rule(COMPRESSION_SUFFIX, LANCE_ENCODING_COMPRESSION, LanceEncodingUtils::validateCompressionScheme),
-          rule(COMPRESSION_LEVEL_SUFFIX, LANCE_ENCODING_COMPRESSION_LEVEL, LanceEncodingUtils::validateCompressionLevel),
-          rule(STRUCTURAL_ENCODING_SUFFIX, LANCE_ENCODING_STRUCTURAL_ENCODING, LanceEncodingUtils::validateStructuralEncoding),
-          rule(RLE_THRESHOLD_SUFFIX, LANCE_ENCODING_RLE_THRESHOLD, LanceEncodingUtils::validateRleThreshold),
-          rule(BSS_SUFFIX, LANCE_ENCODING_BSS, LanceEncodingUtils::validateBssMode));
+          rule(COMPRESSION_SUFFIX, LANCE_ENCODING_COMPRESSION,
+              LanceEncodingUtils::validateCompressionScheme),
+          rule(COMPRESSION_LEVEL_SUFFIX, LANCE_ENCODING_COMPRESSION_LEVEL,
+              LanceEncodingUtils::validateCompressionLevel),
+          rule(STRUCTURAL_ENCODING_SUFFIX, LANCE_ENCODING_STRUCTURAL_ENCODING,
+              LanceEncodingUtils::validateStructuralEncoding),
+          rule(RLE_THRESHOLD_SUFFIX, LANCE_ENCODING_RLE_THRESHOLD,
+              LanceEncodingUtils::validateRleThreshold),
+          rule(BSS_SUFFIX, LANCE_ENCODING_BSS,
+              LanceEncodingUtils::validateBssMode));
 
   private LanceEncodingUtils() {
     // Utility class
@@ -93,7 +98,8 @@ public final class LanceEncodingUtils {
     }
   }
 
-  // Only integer parseability is checked; codec-specific range enforcement is left to the Rust encoder.
+  // Only integer parseability is checked; codec-specific range enforcement is left to the Rust
+  // encoder.
   private static void validateCompressionLevel(String columnName, String value) {
     try {
       Integer.parseInt(value);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -36,7 +36,8 @@ import static org.lance.spark.utils.VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY;
 
 /**
  * Utility class that augments a Spark {@link StructType} with Lance-specific column metadata
- * (vector fixed-size-list, Float16, blob, large varchar) derived from table properties.
+ * (vector fixed-size-list, Float16, blob, large varchar, compression) derived from table
+ * properties.
  */
 public class SchemaConverter {
 
@@ -45,18 +46,20 @@ public class SchemaConverter {
   }
 
   /**
-   * Processes a Spark schema with table properties to add metadata for vector and blob columns.
+   * Processes a Spark schema with table properties to add metadata for vector, blob, large varchar,
+   * and compression columns.
    *
    * @param sparkSchema the original Spark StructType
-   * @param properties table properties that may contain vector column metadata or blob encoding
-   * @return StructType with metadata added for vector and blob columns
+   * @param properties table properties that may contain column metadata
+   * @return StructType with metadata added for matching columns
    */
   public static StructType processSchemaWithProperties(
       StructType sparkSchema, Map<String, String> properties) {
     StructType schemaWithVectors = addVectorMetadata(sparkSchema, properties);
     StructType schemaWithFloat16 = addFloat16Metadata(schemaWithVectors, properties);
     StructType schemaWithBlobs = addBlobMetadata(schemaWithFloat16, properties);
-    return addLargeVarCharMetadata(schemaWithBlobs, properties);
+    StructType schemaWithLargeVarChar = addLargeVarCharMetadata(schemaWithBlobs, properties);
+    return addCompressionMetadata(schemaWithLargeVarChar, properties);
   }
 
   /**
@@ -283,6 +286,61 @@ public class SchemaConverter {
         // Keep field as-is
         newFields[i] = field;
       }
+    }
+
+    return new StructType(newFields);
+  }
+
+  /**
+   * Adds Lance compression metadata to top-level fields based on connector-supported TBLPROPERTIES.
+   * Keys matching {@code <column>.lance.<key>} are validated and written as {@code
+   * lance-encoding:<key>} Arrow field metadata. Invalid values throw {@link
+   * IllegalArgumentException} at call time.
+   *
+   * <p>Silent-ignore cases (no exception, no metadata written):
+   *
+   * <ul>
+   *   <li>TBLPROPERTIES keys whose {@code <column>} segment does not match any top-level field —
+   *       consistent with the behavior of the other {@code addX} methods in this class.
+   *   <li>Unrecognised {@code lance.*} key suffixes (e.g. deferred dict/minichunk keys).
+   *   <li>Type-incompatible combinations (e.g. {@code fsst} on a numeric column) — semantic
+   *       validation is left to the Lance Rust encoder.
+   * </ul>
+   *
+   * <p>Only top-level fields are processed; nested column paths are not supported yet.
+   *
+   * @param sparkSchema the Spark StructType (already processed by earlier steps)
+   * @param properties table properties that may contain compression metadata
+   * @return StructType with compression metadata added for matching columns
+   */
+  private static StructType addCompressionMetadata(
+      StructType sparkSchema, Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return sparkSchema;
+    }
+
+    StructField[] newFields = new StructField[sparkSchema.fields().length];
+    for (int i = 0; i < sparkSchema.fields().length; i++) {
+      StructField field = sparkSchema.fields()[i];
+      MetadataBuilder builder = new MetadataBuilder().withMetadata(field.metadata());
+      boolean modified = false;
+
+      for (LanceEncodingUtils.EncodingPropertyRule rule :
+          LanceEncodingUtils.getSupportedEncodingPropertyRules()) {
+        String propertyKey = rule.createPropertyKey(field.name());
+        if (!properties.containsKey(propertyKey)) {
+          continue;
+        }
+        String value = properties.get(propertyKey);
+        rule.validate(field.name(), value);
+        builder.putString(rule.getArrowMetadataKey(), value);
+        modified = true;
+      }
+
+      newFields[i] =
+          modified
+              ? new StructField(field.name(), field.dataType(), field.nullable(), builder.build())
+              : field;
     }
 
     return new StructType(newFields);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LanceEncodingUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LanceEncodingUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LanceEncodingUtilsTest {
+
+  @Test
+  public void testSupportedRulesContainExpectedSuffixesInOrder() {
+    List<String> suffixes =
+        LanceEncodingUtils.getSupportedEncodingPropertyRules().stream()
+            .map(LanceEncodingUtils.EncodingPropertyRule::getPropertySuffix)
+            .collect(Collectors.toList());
+
+    assertEquals(
+        List.of(
+            LanceEncodingUtils.COMPRESSION_SUFFIX,
+            LanceEncodingUtils.COMPRESSION_LEVEL_SUFFIX,
+            LanceEncodingUtils.STRUCTURAL_ENCODING_SUFFIX,
+            LanceEncodingUtils.RLE_THRESHOLD_SUFFIX,
+            LanceEncodingUtils.BSS_SUFFIX),
+        suffixes);
+  }
+
+  @Test
+  public void testSupportedRulesContainExpectedArrowMetadataKeysInOrder() {
+    List<String> metadataKeys =
+        LanceEncodingUtils.getSupportedEncodingPropertyRules().stream()
+            .map(LanceEncodingUtils.EncodingPropertyRule::getArrowMetadataKey)
+            .collect(Collectors.toList());
+
+    assertEquals(
+        List.of(
+            LanceEncodingUtils.LANCE_ENCODING_COMPRESSION,
+            LanceEncodingUtils.LANCE_ENCODING_COMPRESSION_LEVEL,
+            LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING,
+            LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD,
+            LanceEncodingUtils.LANCE_ENCODING_BSS),
+        metadataKeys);
+  }
+
+  @Test
+  public void testCreatePropertyKey() {
+    assertEquals(
+        "payload.lance.compression",
+        LanceEncodingUtils.createPropertyKey("payload", LanceEncodingUtils.COMPRESSION_SUFFIX));
+  }
+
+  @Test
+  public void testGetSupportedEncodingPropertyRulesIsImmutable() {
+    List<LanceEncodingUtils.EncodingPropertyRule> rules =
+        LanceEncodingUtils.getSupportedEncodingPropertyRules();
+    assertThrows(UnsupportedOperationException.class, () -> rules.add(rules.get(0)));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -487,4 +487,18 @@ public class SchemaConverterTest {
         IllegalArgumentException.class,
         () -> SchemaConverter.processSchemaWithProperties(schema, properties));
   }
+
+  @Test
+  public void testNegativeCompressionLevelThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.compression-level", "-1");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -221,7 +221,8 @@ public class SchemaConverterTest {
     StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
     StructField field = result.apply("ts");
     assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
-    assertEquals("0.5", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
+    assertEquals(
+        "0.5", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
   }
 
   @Test
@@ -260,8 +261,10 @@ public class SchemaConverterTest {
     assertEquals(
         "1", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION_LEVEL));
     assertEquals(
-        "fullzip", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING));
-    assertEquals("1.0", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
+        "fullzip",
+        field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING));
+    assertEquals(
+        "1.0", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
     assertEquals("off", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_BSS));
   }
 
@@ -284,7 +287,10 @@ public class SchemaConverterTest {
         result.apply("id").metadata().contains(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
     assertEquals(
         "zstd",
-        result.apply("payload").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+        result
+            .apply("payload")
+            .metadata()
+            .getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
     assertEquals(
         "none",
         result.apply("ts").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
@@ -340,7 +346,9 @@ public class SchemaConverterTest {
 
     // No exception — metadata is written and Rust decides what to do with it
     StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
-    assertEquals("fsst", result.apply("ts").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+    assertEquals(
+        "fsst",
+        result.apply("ts").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -156,4 +156,327 @@ public class SchemaConverterTest {
         IllegalArgumentException.class,
         () -> SchemaConverter.processSchemaWithProperties(schema, properties));
   }
+
+  @Test
+  public void testCompressionMetadataIsAdded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("payload", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("payload.lance.compression", "zstd");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("payload");
+    assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+    assertEquals("zstd", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+  }
+
+  @Test
+  public void testCompressionLevelMetadataIsAdded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("payload", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("payload.lance.compression-level", "3");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("payload");
+    assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION_LEVEL));
+    assertEquals(
+        "3", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION_LEVEL));
+  }
+
+  @Test
+  public void testStructuralEncodingMetadataIsAdded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("ts", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("ts.lance.structural-encoding", "miniblock");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("ts");
+    assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING));
+    assertEquals(
+        "miniblock",
+        field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING));
+  }
+
+  @Test
+  public void testRleThresholdMetadataIsAdded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("ts", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("ts.lance.rle-threshold", "0.5");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("ts");
+    assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
+    assertEquals("0.5", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
+  }
+
+  @Test
+  public void testBssMetadataIsAdded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("ts", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("ts.lance.bss", "auto");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("ts");
+    assertTrue(field.metadata().contains(LanceEncodingUtils.LANCE_ENCODING_BSS));
+    assertEquals("auto", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_BSS));
+  }
+
+  @Test
+  public void testAllFiveCompressionKeysOnOneField() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.compression", "lz4");
+    properties.put("col.lance.compression-level", "1");
+    properties.put("col.lance.structural-encoding", "fullzip");
+    properties.put("col.lance.rle-threshold", "1.0");
+    properties.put("col.lance.bss", "off");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("col");
+    assertEquals("lz4", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+    assertEquals(
+        "1", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION_LEVEL));
+    assertEquals(
+        "fullzip", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_STRUCTURAL_ENCODING));
+    assertEquals("1.0", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_RLE_THRESHOLD));
+    assertEquals("off", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_BSS));
+  }
+
+  @Test
+  public void testMultiColumnCompressionConfig() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, false),
+              DataTypes.createStructField("payload", DataTypes.StringType, true),
+              DataTypes.createStructField("ts", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("payload.lance.compression", "zstd");
+    properties.put("ts.lance.compression", "none");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+
+    assertFalse(
+        result.apply("id").metadata().contains(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+    assertEquals(
+        "zstd",
+        result.apply("payload").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+    assertEquals(
+        "none",
+        result.apply("ts").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+  }
+
+  @Test
+  public void testUnknownLanceKeysAreIgnored() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    // dict-divisor is a deferred (unsupported) key — silently ignored, no exception thrown.
+    // Unrecognised key suffixes are part of the connector's silent-ignore policy so that
+    // future lance-core keys do not break existing Spark jobs.
+    properties.put("col.lance.dict-divisor", "4");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    // no metadata set, no exception
+    assertEquals(schema.apply("col").metadata(), result.apply("col").metadata());
+  }
+
+  @Test
+  public void testCompressionPropertyForNonExistentColumnIsIgnored() {
+    // Property whose <column> segment does not match any schema field is silently ignored.
+    // This is intentional and consistent with the other addX methods in SchemaConverter —
+    // no Spark-side error is thrown for unmatched column names.
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, false),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("nonexistent.lance.compression", "zstd");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    // schema unchanged, no exception
+    assertEquals(schema, result);
+  }
+
+  @Test
+  public void testTypeIncompatibleCompressionIsPassedThrough() {
+    // Type-incompatible combinations (e.g. fsst on a numeric column) are not rejected
+    // by the connector. Semantic validation is left to the Lance Rust encoder.
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("ts", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("ts.lance.compression", "fsst");
+
+    // No exception — metadata is written and Rust decides what to do with it
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    assertEquals("fsst", result.apply("ts").metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+  }
+
+  @Test
+  public void testCompressionMetadataCoexistsWithBlobMetadata() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("data.lance.encoding", "blob");
+    properties.put("data.lance.compression", "lz4");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("data");
+    assertEquals(
+        BlobUtils.LANCE_ENCODING_BLOB_VALUE,
+        field.metadata().getString(BlobUtils.LANCE_ENCODING_BLOB_KEY));
+    assertEquals("lz4", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+  }
+
+  @Test
+  public void testCompressionMetadataCoexistsWithLargeVarCharMetadata() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("content", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("content.arrow.large_var_char", "true");
+    properties.put("content.lance.compression", "zstd");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField field = result.apply("content");
+    assertEquals(
+        LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE,
+        field.metadata().getString(LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY));
+    assertEquals("zstd", field.metadata().getString(LanceEncodingUtils.LANCE_ENCODING_COMPRESSION));
+  }
+
+  @Test
+  public void testInvalidCompressionSchemeThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.compression", "gzip");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testInvalidStructuralEncodingThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.structural-encoding", "rle");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testInvalidBssModeThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.bss", "yes");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testNonFloatRleThresholdThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.rle-threshold", "not-a-float");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testOutOfRangeRleThresholdThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    // 0.0 is excluded from (0.0, 1.0]
+    properties.put("col.lance.rle-threshold", "0.0");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testRleThresholdAboveOneThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.LongType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.rle-threshold", "1.5");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testNonIntegerCompressionLevelThrows() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("col.lance.compression-level", "high");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
 }


### PR DESCRIPTION
## Summary
Fix for https://github.com/lance-format/lance-spark/issues/36

Lance's Rust encoder reads `lance-encoding:<key>` Arrow field metadata to configure per-column compression and encoding at write time. Until now, there was no way to set these from Spark: users could not control whether columns were compressed with zstd, lz4, or fsst, nor tune structural encoding or byte stream split behavior.

This PR closes that gap by extending the existing `SchemaConverter` pipeline to map `<column>.lance.<key>` TBLPROPERTIES to Arrow field metadata, following the same pattern already used for blob encoding, float16, and large varchar.

## What's supported

Five keys are wired in this release:

| TBLPROPERTIES key | Arrow field metadata key | Valid values |
|---|---|---|
| `<col>.lance.compression` | `lance-encoding:compression` | `zstd`, `lz4`, `fsst`, `none` |
| `<col>.lance.compression-level` | `lance-encoding:compression-level` | integer string |
| `<col>.lance.structural-encoding` | `lance-encoding:structural-encoding` | `miniblock`, `fullzip` |
| `<col>.lance.rle-threshold` | `lance-encoding:rle-threshold` | float in `(0.0, 1.0]` |
| `<col>.lance.bss` | `lance-encoding:bss` | `off`, `on`, `auto` |

Invalid values fail fast at `CREATE TABLE` time with a clear `IllegalArgumentException`. Unknown keys and unmatched column names are silently ignored, consistent with existing `SchemaConverter` behavior.

## Why only these five keys

The remaining lance-core encoding keys (`dict-divisor`, `dict-size-ratio`, `dict-values-compression`, `dict-values-compression-level`, `minichunk-size`) are deferred deliberately:

- **Dictionary keys**: dictionary encoding in lance-core is currently auto-selected based on data characteristics. Exposing manual overrides before the defaults are stable risks locking users into configurations that become suboptimal as the encoder evolves.
- **minichunk-size**: a low-level tuning parameter with non-obvious interactions with block size  and compression. Needs more usage data before surfacing in the connector API.

These keys are silently ignored if present, so they can be wired in a follow-up without a breaking change.

## Note on ALTER TABLE

`ALTER TABLE ... SET TBLPROPERTIES` does **not** change the encoding of previously written data. Compression properties take effect only when the table is created.
