### PR TITLE
fix: race condition in QueuedArrowBatchWriteBuffer losing final batch

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/QueuedArrowBatchWriteBuffer.java
@@ -193,10 +193,11 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     if (producerFinished) {
       return;
     }
-    producerFinished = true;
 
     try {
-      // Queue any remaining partial batch
+      // Queue any remaining partial batch before signaling completion to avoid
+      // a race where the consumer sees producerFinished=true with an empty queue
+      // and exits before the final batch is enqueued.
       int remainingRows = currentBatchRowCount.get();
       if (remainingRows > 0) {
         currentArrowWriter.finish();
@@ -215,6 +216,9 @@ public class QueuedArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       }
       currentBatch = null;
       currentArrowWriter = null;
+
+      // Signal completion only after the final batch is safely in the queue
+      producerFinished = true;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new RuntimeException("Interrupted while finishing", e);


### PR DESCRIPTION
## Summary
- Fixes a race condition in `QueuedArrowBatchWriteBuffer.setFinished()` where the `producerFinished` flag was set **before** the final partial batch was enqueued
- The consumer could observe `producerFinished=true` with an empty queue and exit, silently dropping the last batch of data
- Fix moves the flag assignment to after the batch is safely in the queue

## Test plan
- [x] Existing `QueuedArrowBatchWriteBufferTest` passes
- [ ] Stress test with small batch sizes to trigger the race window
- [ ] Verify no data loss on final partial batches

🤖 Generated with [Claude Code](https://claude.com/claude-code)