### PR TITLE
feat(benchmark): add TPC-DS btree index creation for fragment pruning

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -123,7 +123,7 @@ spark-submit \
   --master local[*] \
   --driver-memory 8g \
   --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
   --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \
   benchmark/target/lance-spark-benchmark-*.jar \
@@ -151,7 +151,7 @@ spark-submit \
   --executor-cores 4 \
   --num-executors 8 \
   --jars path/to/lance-spark-bundle-3.5_2.12-*.jar \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.sql.adaptive.enabled=true \
   --conf spark.hadoop.fs.s3a.access.key=YOUR_KEY \
   --conf spark.hadoop.fs.s3a.secret.key=YOUR_SECRET \

--- a/benchmark/scripts/create-indexes.sh
+++ b/benchmark/scripts/create-indexes.sh
@@ -11,13 +11,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TPC-DS data generation via Spark (using Kyuubi TPC-DS connector).
+# Create btree indexes on TPC-DS dimension tables for zonemap-based
+# fragment pruning and storage-partitioned join (SPJ) support.
 #
-# Generates TPC-DS tables in parallel across Spark executors and writes
-# them directly into the target format(s) — no intermediate files.
+# Run this after generate-data.sh and before run-benchmark.sh.
 #
 # Usage:
-#   ./generate-data.sh [SCALE_FACTOR] [FORMATS] [SPARK_MASTER]
+#   ./create-indexes.sh [SPARK_MASTER]
 
 set -euo pipefail
 
@@ -28,29 +28,16 @@ BENCHMARK_DIR="${SCRIPT_DIR}/.."
 SPARK_VERSION="${SPARK_VERSION:-3.5}"
 SCALA_VERSION="${SCALA_VERSION:-2.12}"
 
-SCALE_FACTOR="${1:-1}"
-FORMATS="${2:-parquet,lance}"
-SPARK_MASTER="${3:-local[*]}"
+SPARK_MASTER="${1:-local[*]}"
 
 # Object store / external paths — default to local when unset
 DATA_DIR="${DATA_DIR:-${BENCHMARK_DIR}/data}"
 
-echo "=== TPC-DS Data Generation ==="
-echo "Scale factor:    ${SCALE_FACTOR}"
-echo "Formats:         ${FORMATS}"
+echo "=== TPC-DS Index Creation ==="
 echo "Spark master:    ${SPARK_MASTER}"
 echo "Spark version:   ${SPARK_VERSION}"
 echo "Scala version:   ${SCALA_VERSION}"
 echo "Data dir:        ${DATA_DIR}"
-if [ -n "${FILE_FORMAT_VERSION:-}" ]; then
-  echo "File format version: ${FILE_FORMAT_VERSION}"
-fi
-if [ -n "${MAX_BYTES_PER_FILE:-}" ]; then
-  echo "Max bytes/file:  ${MAX_BYTES_PER_FILE}"
-fi
-if [ -n "${MAX_ROWS_PER_FILE:-}" ]; then
-  echo "Max rows/file:   ${MAX_ROWS_PER_FILE}"
-fi
 echo ""
 
 # Step 1: Build benchmark jar if needed
@@ -74,26 +61,22 @@ if [ -z "${BUNDLE_JAR}" ]; then
   cd "${SCRIPT_DIR}"
 fi
 
-# Step 3: Generate data via spark-submit
+# Step 3: Create indexes via spark-submit
 SPARK_SUBMIT="spark-submit"
 if [ -n "${SPARK_HOME:-}" ]; then
   SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
 fi
-
+echo "BUNDLE_JAR ${BUNDLE_JAR}"
 ${SPARK_SUBMIT} \
-  --class org.lance.spark.benchmark.TpcdsDataGenerator \
+  --class org.lance.spark.benchmark.TpcdsIndexBuilder \
   --master "${SPARK_MASTER}" \
   --driver-memory "${DRIVER_MEMORY:-4g}" \
   --executor-memory "${EXECUTOR_MEMORY:-4g}" \
   --jars "${BUNDLE_JAR}" \
   --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
-  ${MAX_BYTES_PER_FILE:+ --conf spark.sql.catalog.lance_default.max_bytes_per_file="${MAX_BYTES_PER_FILE}"} \
-  ${MAX_ROWS_PER_FILE:+ --conf spark.sql.catalog.lance_default.max_row_per_file="${MAX_ROWS_PER_FILE}"} \
   "${BENCHMARK_JAR}" \
-  --data-dir "${DATA_DIR}" \
-  --scale-factor "${SCALE_FACTOR}" \
-  --formats "${FORMATS}"${FILE_FORMAT_VERSION:+ --file-format-version "${FILE_FORMAT_VERSION}"}
+  --data-dir "${DATA_DIR}"
 
 echo ""
-echo "=== Data generation complete ==="
+echo "=== Index creation complete ==="

--- a/benchmark/scripts/run-benchmark.sh
+++ b/benchmark/scripts/run-benchmark.sh
@@ -92,7 +92,7 @@ ${SPARK_SUBMIT} \
   --driver-memory "${DRIVER_MEMORY:-4g}" \
   --executor-memory "${EXECUTOR_MEMORY:-4g}" \
   --jars "${BUNDLE_JAR}" \
-  --conf spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
   --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
   "${BENCHMARK_JAR}" \
   --data-dir "${DATA_DIR}" \

--- a/benchmark/src/main/java/org/lance/spark/benchmark/TpcdsIndexBuilder.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/TpcdsIndexBuilder.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.spark.sql.SparkSession;
+
+/**
+ * Spark job that creates btree indexes on TPC-DS dimension tables to enable
+ * zonemap-based fragment pruning during joins.
+ *
+ * <p>The indexes cover columns that appear in filter predicates across TPC-DS
+ * queries. Each btree index carries zonemap metadata that the Lance scan
+ * builder uses for fragment pruning and storage-partitioned joins (SPJ).
+ *
+ * <p>Usage:
+ * <pre>
+ *   spark-submit --class org.lance.spark.benchmark.TpcdsIndexBuilder \
+ *     benchmark.jar \
+ *     --data-dir /path/to/tpcds/data
+ * </pre>
+ */
+public class TpcdsIndexBuilder {
+
+  /** Table names in priority order (highest-impact tables first). */
+  private static final String[] TABLE_NAMES = {
+      "date_dim", "item", "customer_demographics", "store", "promotion",
+      "customer_address", "household_demographics"
+  };
+
+  public static void main(String[] args) throws Exception {
+    String dataDir = null;
+
+    for (int i = 0; i < args.length; i++) {
+      switch (args[i]) {
+        case "--data-dir":
+          dataDir = args[++i];
+          break;
+        default:
+          System.err.println("Unknown argument: " + args[i]);
+          printUsage();
+          System.exit(1);
+      }
+    }
+
+    if (dataDir == null) {
+      System.err.println("Missing required argument: --data-dir");
+      printUsage();
+      System.exit(1);
+    }
+
+    String lanceRoot = dataDir + "/lance";
+
+    SparkSession spark =
+        SparkSession.builder().appName("TPC-DS Index").getOrCreate();
+
+    // Ensure lance_default catalog is registered for path-based table loading
+    if (!spark.conf().contains("spark.sql.catalog.lance_default")) {
+      spark.conf().set("spark.sql.catalog.lance_default",
+          "org.lance.spark.LanceNamespaceSparkCatalog");
+    }
+
+    try {
+      List<String> statements = loadIndexStatements(lanceRoot);
+
+      System.out.println("=== TPC-DS Index Builder ===");
+      System.out.println("Data dir:    " + dataDir);
+      System.out.println("Lance root:  " + lanceRoot);
+      System.out.println("Indexes:     " + statements.size());
+      System.out.println();
+      System.out.flush();
+
+      int succeeded = 0;
+      int failed = 0;
+
+      for (int i = 0; i < statements.size(); i++) {
+        String sql = statements.get(i);
+        System.out.print("[" + (i + 1) + "/" + statements.size() + "] "
+            + sql + " ...");
+        System.out.flush();
+
+        long start = System.currentTimeMillis();
+        try {
+          spark.sql(sql);
+          long elapsed = System.currentTimeMillis() - start;
+          System.out.println(" OK (" + elapsed + "ms)");
+          succeeded++;
+        } catch (Exception e) {
+          long elapsed = System.currentTimeMillis() - start;
+          System.out.println(" FAILED (" + elapsed + "ms)");
+          System.out.println("  Error: " + e.getMessage());
+          failed++;
+        }
+        System.out.flush();
+      }
+
+      System.out.println();
+      System.out.println("=== Index creation complete ===");
+      System.out.println("Succeeded: " + succeeded + ", Failed: " + failed);
+      System.out.flush();
+    } finally {
+      spark.stop();
+    }
+  }
+
+  private static List<String> loadIndexStatements(String lanceRoot) {
+    List<String> statements = new ArrayList<>();
+    for (String table : TABLE_NAMES) {
+      String tablePath =
+          TpcdsDataGenerator.toLancePath(lanceRoot + "/" + table) + ".lance";
+      String resourcePath = "/index/" + table + ".sql";
+      try (InputStream is =
+          TpcdsIndexBuilder.class.getResourceAsStream(resourcePath)) {
+        if (is == null) {
+          throw new IllegalStateException(
+              "Index resource not found: " + resourcePath);
+        }
+        try (BufferedReader reader = new BufferedReader(
+            new InputStreamReader(is, StandardCharsets.UTF_8))) {
+          for (String statement : reader.lines().collect(Collectors.joining("\n")).split(";")) {
+            String trimmed = statement.trim();
+            if (!trimmed.isEmpty()) {
+              trimmed = trimmed.replace(
+                  "ALTER TABLE " + table,
+                  "ALTER TABLE lance_default.`" + tablePath + "`");
+              statements.add(trimmed);
+            }
+          }
+        }
+      } catch (IllegalStateException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new IllegalStateException(
+            "Failed to load index resource: " + resourcePath, e);
+      }
+    }
+    return statements;
+  }
+
+  private static void printUsage() {
+    System.err.println(
+        "Usage: TpcdsIndexBuilder --data-dir <path>");
+  }
+}

--- a/benchmark/src/main/resources/index/customer_address.sql
+++ b/benchmark/src/main/resources/index/customer_address.sql
@@ -1,0 +1,2 @@
+ALTER TABLE customer_address CREATE INDEX idx_ca_state USING btree (ca_state);
+ALTER TABLE customer_address CREATE INDEX idx_ca_gmt_offset USING btree (ca_gmt_offset);

--- a/benchmark/src/main/resources/index/customer_demographics.sql
+++ b/benchmark/src/main/resources/index/customer_demographics.sql
@@ -1,0 +1,3 @@
+ALTER TABLE customer_demographics CREATE INDEX idx_cd_gender USING btree (cd_gender);
+ALTER TABLE customer_demographics CREATE INDEX idx_cd_marital_status USING btree (cd_marital_status);
+ALTER TABLE customer_demographics CREATE INDEX idx_cd_education_status USING btree (cd_education_status);

--- a/benchmark/src/main/resources/index/date_dim.sql
+++ b/benchmark/src/main/resources/index/date_dim.sql
@@ -1,0 +1,5 @@
+ALTER TABLE date_dim CREATE INDEX idx_d_year USING btree (d_year);
+ALTER TABLE date_dim CREATE INDEX idx_d_month_seq USING btree (d_month_seq);
+ALTER TABLE date_dim CREATE INDEX idx_d_date USING btree (d_date);
+ALTER TABLE date_dim CREATE INDEX idx_d_qoy USING btree (d_qoy);
+ALTER TABLE date_dim CREATE INDEX idx_d_moy USING btree (d_moy);

--- a/benchmark/src/main/resources/index/household_demographics.sql
+++ b/benchmark/src/main/resources/index/household_demographics.sql
@@ -1,0 +1,2 @@
+ALTER TABLE household_demographics CREATE INDEX idx_hd_dep_count USING btree (hd_dep_count);
+ALTER TABLE household_demographics CREATE INDEX idx_hd_buy_potential USING btree (hd_buy_potential);

--- a/benchmark/src/main/resources/index/item.sql
+++ b/benchmark/src/main/resources/index/item.sql
@@ -1,0 +1,7 @@
+ALTER TABLE item CREATE INDEX idx_i_category USING btree (i_category);
+ALTER TABLE item CREATE INDEX idx_i_class USING btree (i_class);
+ALTER TABLE item CREATE INDEX idx_i_brand USING btree (i_brand);
+ALTER TABLE item CREATE INDEX idx_i_current_price USING btree (i_current_price);
+ALTER TABLE item CREATE INDEX idx_i_color USING btree (i_color);
+ALTER TABLE item CREATE INDEX idx_i_manufact_id USING btree (i_manufact_id);
+ALTER TABLE item CREATE INDEX idx_i_manager_id USING btree (i_manager_id);

--- a/benchmark/src/main/resources/index/promotion.sql
+++ b/benchmark/src/main/resources/index/promotion.sql
@@ -1,0 +1,2 @@
+ALTER TABLE promotion CREATE INDEX idx_p_channel_tv USING btree (p_channel_tv);
+ALTER TABLE promotion CREATE INDEX idx_p_channel_email USING btree (p_channel_email);

--- a/benchmark/src/main/resources/index/store.sql
+++ b/benchmark/src/main/resources/index/store.sql
@@ -1,0 +1,2 @@
+ALTER TABLE store CREATE INDEX idx_s_state USING btree (s_state);
+ALTER TABLE store CREATE INDEX idx_s_county USING btree (s_county);


### PR DESCRIPTION
  - Add `TpcdsIndexBuilder` Spark job and `create-indexes.sh` script to create btree indexes on 7 TPC-DS dimension tables (`date_dim`, `item`, `customer_demographics`, `store`, `promotion`, `customer_address`, `household_demographics`)
  - Indexes cover columns used in TPC-DS filter predicates, enabling zonemap-based fragment pruning and storage-partitioned join (SPJ) evaluation during benchmarks
  - SQL index definitions are stored as resource files under `benchmark/src/main/resources/index/`, one per table
  - Fix stale `spark.sql.extensions` class name in benchmark scripts and README (`LanceSparkSessionExtension` → `extensions.LanceSparkSessionExtensions`)
  - Add `MAX_BYTES_PER_FILE` and `MAX_ROWS_PER_FILE` configuration support to `generate-data.sh`