### PR TITLE
perf: report projection-aware stats so BroadcastHashJoin fires on pruned scans

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -189,7 +189,8 @@ public class LanceScanBuilder
     }
 
     // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
-    // LanceStatistics.estimateProjected apply the column-width ratio on top.
+    // LanceStatistics.estimateProjected apply the column-width ratio on top
+    // (when the projected schema is narrower than the full schema).
     long projectedRows = summary.getTotalRows();
     long projectedFullSize = summary.getTotalFilesSize();
     if (survivingFragmentIds != null && summary.getTotalFragments() > 0) {
@@ -201,7 +202,7 @@ public class LanceScanBuilder
         LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
     if (survivingFragmentIds != null) {
       LOG.debug(
-          "Estimated post-pruning statistics: {} of {} fragments survive,"
+          "Scan statistics after pruning: {} of {} fragments survive,"
               + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
           survivingFragmentIds.size(),
           summary.getTotalFragments(),

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -67,6 +67,7 @@ public class LanceScanBuilder
   private static final Logger LOG = LoggerFactory.getLogger(LanceScanBuilder.class);
 
   private final LanceSparkReadOptions readOptions;
+  private final StructType fullSchema;
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
@@ -101,6 +102,7 @@ public class LanceScanBuilder
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties,
       java.util.Map<String, String> tableProperties) {
+    this.fullSchema = schema;
     this.schema = schema;
     this.readOptions = readOptions;
     this.initialStorageOptions = initialStorageOptions;
@@ -186,14 +188,18 @@ public class LanceScanBuilder
           ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
     }
 
-    LanceStatistics statistics;
+    // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
+    // LanceStatistics.estimateProjected apply the column-width ratio on top.
+    long projectedRows = summary.getTotalRows();
+    long projectedFullSize = summary.getTotalFilesSize();
+    if (survivingFragmentIds != null && summary.getTotalFragments() > 0) {
+      double ratio = (double) survivingFragmentIds.size() / summary.getTotalFragments();
+      projectedRows = (long) (projectedRows * ratio);
+      projectedFullSize = (long) (projectedFullSize * ratio);
+    }
+    LanceStatistics statistics =
+        LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
     if (survivingFragmentIds != null) {
-      statistics =
-          LanceStatistics.estimatePostPruning(
-              summary.getTotalRows(),
-              summary.getTotalFilesSize(),
-              summary.getTotalFragments(),
-              survivingFragmentIds.size());
       LOG.debug(
           "Estimated post-pruning statistics: {} of {} fragments survive,"
               + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
@@ -203,8 +209,6 @@ public class LanceScanBuilder
           statistics.numRows(),
           summary.getTotalFilesSize(),
           summary.getTotalRows());
-    } else {
-      statistics = new LanceStatistics(summary);
     }
 
     // Close the lazily opened dataset - it's no longer needed after build

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -16,6 +16,8 @@ package org.lance.spark.read;
 import org.lance.ManifestSummary;
 
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
 import java.util.OptionalLong;
@@ -63,6 +65,52 @@ public class LanceStatistics implements Statistics, Serializable {
     }
     double ratio = (double) survivingFragments / totalFragments;
     return new LanceStatistics((long) (totalRows * ratio), (long) (totalFilesSize * ratio));
+  }
+
+  /**
+   * Estimate post-projection size using {@code sizeInBytes × (projectedWidths / fullWidths)}, the
+   * same formula Spark's DSv2 {@code FileScan.estimateStatistics} applies after column pruning (see
+   * {@code org.apache.spark.sql.execution.datasources.v2.FileScan}). Lets {@code JoinSelection} see
+   * a projection-aware size so broadcast decisions line up with what DSv1 Parquet produces through
+   * the optimizer's {@code Project.computeStats()} path — within the 8-byte-per-row overhead DSv1
+   * adds via {@code EstimationUtils.getSizePerRow}, which rounds estimates apart by a few percent
+   * but doesn't shift broadcast thresholds in practice.
+   *
+   * <p>Width-weighted (not {@code numRows × sumOfWidths}) on purpose: the ratio preserves the
+   * compression baked into {@code fullSizeInBytes}, whereas a row-count formula would ignore
+   * on-disk encoding and systematically over-count columnar sources.
+   *
+   * @param numRows projected row count (post fragment-pruning if any)
+   * @param fullSizeInBytes on-disk size of the full (pre-projection) dataset in bytes
+   * @param fullSchema schema of the full dataset before column pruning
+   * @param projectedSchema pruned schema containing only columns actually read by the scan
+   * @return statistics with {@code sizeInBytes} scaled by width-weighted column ratio
+   */
+  public static LanceStatistics estimateProjected(
+      long numRows, long fullSizeInBytes, StructType fullSchema, StructType projectedSchema) {
+    long projWidth = sumWidths(projectedSchema);
+    long fullWidth = sumWidths(fullSchema);
+    long sizeInBytes;
+    if (fullWidth <= 0 || projWidth <= 0 || projWidth >= fullWidth) {
+      sizeInBytes = fullSizeInBytes;
+    } else {
+      // Promote to double to avoid long overflow in fullSizeInBytes * projWidth.
+      sizeInBytes = (long) ((double) fullSizeInBytes * projWidth / fullWidth);
+    }
+    // Clamp to 1: integer truncation can round very small scaled sizes to 0, which
+    // JoinSelection reads as "below threshold" and would unintentionally force a broadcast.
+    return new LanceStatistics(numRows, Math.max(sizeInBytes, 1L));
+  }
+
+  private static long sumWidths(StructType schema) {
+    if (schema == null) {
+      return 0;
+    }
+    long sum = 0;
+    for (StructField field : schema.fields()) {
+      sum += field.dataType().defaultSize();
+    }
+    return sum;
   }
 
   @Override

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
@@ -13,6 +13,9 @@
  */
 package org.lance.spark.read;
 
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -72,5 +75,101 @@ public class LanceStatisticsTest {
     LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 0, 0);
     assertEquals(1000, stats.numRows().getAsLong());
     assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedScalesByColumnWidthRatio() {
+    // Full schema has 9 columns; project 3 of equal width → size should scale by 3/9.
+    // 24_000_000 full bytes × (3×8)/(9×8) = 8_000_000.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("c1", DataTypes.LongType, true, null),
+              new StructField("c2", DataTypes.LongType, true, null),
+              new StructField("c3", DataTypes.LongType, true, null),
+              new StructField("c4", DataTypes.LongType, true, null),
+              new StructField("c5", DataTypes.LongType, true, null),
+              new StructField("c6", DataTypes.LongType, true, null),
+              new StructField("c7", DataTypes.LongType, true, null),
+              new StructField("c8", DataTypes.LongType, true, null),
+              new StructField("c9", DataTypes.LongType, true, null)
+            });
+    StructType projected =
+        new StructType(
+            new StructField[] {
+              new StructField("c1", DataTypes.LongType, true, null),
+              new StructField("c2", DataTypes.LongType, true, null),
+              new StructField("c3", DataTypes.LongType, true, null)
+            });
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 24_000_000L, full, projected);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(8_000_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedFavorsWideColumns() {
+    // Full schema: one String (width 20) + one Int (width 4). Total width 24.
+    // Project just the String → ratio 20/24.
+    // 24_000 full bytes × 20/24 = 20_000.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("name", DataTypes.StringType, true, null),
+              new StructField("id", DataTypes.IntegerType, true, null)
+            });
+    StructType projected =
+        new StructType(
+            new StructField[] {new StructField("name", DataTypes.StringType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 24_000L, full, projected);
+    assertEquals(20_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedAllColumnsUnchanged() {
+    // Projection == full schema → no scaling.
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 50_000L, full, full);
+    assertEquals(50_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedEmptyProjectionReturnsFullSize() {
+    // Count-only scan: no columns projected. Fall back to full size rather than zero.
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    StructType projected = new StructType(new StructField[] {});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 50_000L, full, projected);
+    assertEquals(50_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedNeverZero() {
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(0, 0L, full, full);
+    assertEquals(1, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedTruncationClampsToOne() {
+    // Very narrow projection of a tiny table truncates to 0 after (long) cast.
+    // Clamp must restore it to 1 so JoinSelection doesn't read it as empty.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("key", DataTypes.LongType, true, null),
+              new StructField("s1", DataTypes.StringType, true, null),
+              new StructField("s2", DataTypes.StringType, true, null),
+              new StructField("s3", DataTypes.StringType, true, null),
+              new StructField("s4", DataTypes.StringType, true, null),
+              new StructField("s5", DataTypes.StringType, true, null)
+            });
+    StructType projected =
+        new StructType(new StructField[] {new StructField("key", DataTypes.LongType, true, null)});
+    // fullWidths = 8 + 5*20 = 108; projWidths = 8.
+    // 10 bytes × 8 / 108 = 0.74 → (long) cast → 0 → clamp → 1.
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 10L, full, projected);
+    assertEquals(1L, stats.sizeInBytes().getAsLong());
   }
 }


### PR DESCRIPTION
## Summary

- `LanceStatistics.estimateProjected` scales `sizeInBytes` by the width-weighted column ratio, matching Spark's own DSv2 file source (`FileScan.estimateStatistics`) and aligning broadcast decisions with the post-projection size Parquet users observe via DSv1's optimizer.
- `LanceScanBuilder` captures the full schema at construction (before `pruneColumns` mutates it) and passes both `fullSchema` and the pruned `schema` to `estimateProjected` inside `build()`.
- Zonemap fragment-pruning composes: row count and full size scale by the surviving-fragment ratio first, then the column-width ratio applies on top.

## Why

DSv1 sources like Parquet get projection-aware stats "for free": the `Project` node sits in the plan above `LogicalRelation` (column pruning isn't pushed into the relation itself), and `Project.computeStats()` scales the child `sizeInBytes` by the ratio of projected column widths. DSv2 scans do pushdown inside the scan itself — `pruneColumns` absorbs the projection, leaving no `Project` node for the optimizer to scale against — so the scan must report the scaled size directly from `estimateStatistics()`.

Spark already does exactly this in its own DSv2 file-source implementation (`FileScan.estimateStatistics`). Lance had simply never replicated it — `LanceStatistics` returned `ManifestSummary.totalFilesSize` regardless of projection. `JoinSelection` saw the full-table byte count, decided the dimension table was too big to broadcast, and fell back to `SortMergeJoin`. Parquet running the same query via DSv1 reported a post-projection size through the optimizer and got `BroadcastHashJoin`.

## Formula

```
sizeInBytes = fullSizeInBytes × (sumProjectedWidths / sumFullWidths)
```

Widths come from each field's `DataType.defaultSize()`. This is the same shape Spark uses in its own DSv2 file source at `FileScan.estimateStatistics`:

```scala
size = compressionFactor * fileIndex.sizeInBytes /
       (dataSchema.defaultSize + partitionSchema.defaultSize) *
       (readDataSchema.defaultSize + readPartitionSchema.defaultSize)
```

For Lance that Scala formula collapses to the one-liner we implement — `compressionFactor` defaults to 1.0, and Lance doesn't have Hive-style partition columns so `partitionSchema.defaultSize = 0`.

Width-weighted (not `numRows × sumProjectedWidths`, the CBO-style formula): the ratio preserves the compression baked into `fullSizeInBytes`, whereas a row-count formula would ignore on-disk encoding and systematically over-count columnar sources.

Degenerate cases (all fall back to `fullSizeInBytes`, or clamp to 1, to keep `JoinSelection` from mistaking the scan as empty):
- `fullSchema` or `projectedSchema` is `null` / empty → no width info to scale with.
- `projWidth >= fullWidth` → projection is the whole schema or larger (not strictly narrower).
- Scaled size truncates to 0 on very tiny tables → clamp to 1.
- `fullSizeInBytes * projWidth` could overflow `long` → compute in `double`.

## Which Spark path we match

Spark has two places where projection-size arithmetic lives, and they are **not** identical:

| path | where | formula |
|---|---|---|
| **DSv1** | `SizeInBytesOnlyStatsPlanVisitor.visitUnaryNode` (called by `visitProject`) | `childSize × (8 + projWidths) / (8 + fullWidths)` — `getSizePerRow` adds an 8-byte row overhead |
| **DSv2** | `FileScan.estimateStatistics` (`FileScan.scala`) | `fileSize × readDataSchema.defaultSize / dataSchema.defaultSize` — no row overhead |

We match **DSv2 exactly**, for two reasons:

1. **We're a DSv2 scan.** `LanceScan` implements `SupportsReportStatistics`; the natural peer is Spark's own DSv2 file source, not a DSv1 optimizer rule that ships its result through a different code path.
2. **The DSv1 contrast is negligible in practice.** DSv1's `+8` is a generic in-memory Row-object overhead; on a multi-MB dimension table it shifts the estimate by a few percent, not enough to move a scan across the default 10 MB broadcast boundary.

Example — `customer_demographics` (24 MB on disk, project 3 of 9 columns with total widths 48 vs 104):

| path | estimate |
|---|---|
| DSv1 via optimizer | `24 MB × (8+48) / (8+104) = 12.00 MB` |
| DSv2 FileScan (this PR) | `24 MB × 48 / 104 = 11.08 MB` |

Both exceed the 10 MB default threshold; both resolve at a 15 MB bump. The flip-resolution outcome is the same either way.

Note that DSv1 Parquet is what most users actually run at query time (`spark.sql.sources.useV1SourceList` includes `parquet` by default, so `FileScan` is dead code for Parquet). We still match DSv2 because we're a DSv2 source — it's just worth knowing that the "Parquet baseline users see" runs through a slightly different formula.

## Results — TPC-DS sf=1

All 103 queries pass with matching row counts across formats.

**SMJ-vs-BHJ divergence from Parquet baseline** (default `spark.sql.autoBroadcastJoinThreshold=10 MB`):

| config | flips vs Parquet | regressions |
|---|---|---|
| before | 30 / 103 | — |
| **after (this PR)** | **11 / 103** | **0** |

19 queries now match Parquet's join strategy with no over-broadcast regressions.

**With modest threshold bumps**, this PR closes more cases cleanly (still zero regressions in spot-check):

| threshold | flips remaining |
|---|---|
| 10 MB (default) | 11 |
| 15 MB | 3 |
| 30 MB | 0 |

The 11 that remain at default threshold are queries where a dimension table lands in the 11–30 MB range after width-weighted scaling — usually `customer_demographics` at 11 MB (3/9 cols) or 21 MB (6/9 cols), with a couple involving `web_sales` projected to a few columns (~10–13 MB). These are closed by raising the threshold; because this PR now reports projection-accurate sizes, raising the threshold no longer risks over-broadcasting genuinely large scans (as it would have before).

## What this doesn't fix

- **At sf=1, Lance's on-disk size is ~3× Parquet's for low-cardinality string dimensions** (`customer_demographics` is 24 MB vs Parquet's 7.6 MB). That gap is a Lance storage-compression issue, not a stats issue. This PR makes the stats projection-aware, but the raw byte-count gap persists until Lance compression catches up. Behavior at larger scale factors hasn't been measured here.
- **Filter-selectivity scaling** still rides on zonemap fragment pruning — `LanceScanBuilder` scales rows and full size by the surviving-fragment ratio before this PR's width scaling. Closing more filter cases would need per-column histograms or NDV estimates, which lance-core doesn't yet expose.

## Why this formula over alternatives

| formula | note |
|---|---|
| **width-weighted ratio** (this PR) | Identical to Spark's DSv2 `FileScan.estimateStatistics`. Approximates DSv1 `SizeInBytesOnlyStatsPlanVisitor.visitProject` within an 8-byte-per-row overhead (see "Which Spark path we match" above). Preserves on-disk compression. |
| column-count ratio (`count(proj) / count(full)`) | Ignores per-column width variance. Fine for uniform-type tables, under-reports for projections of wide String/Binary columns on narrow-Int tables — OOM risk on broadcast. |
| CBO-style (`numRows × sumProjectedWidths`) | What Iceberg does. Ignores compression entirely; over-reports for columnar formats (e.g. 92 MB estimated vs 24 MB actual for `customer_demographics`). Would resolve fewer TPC-DS flips than this PR. |

## Test plan

- [x] `make lint` — clean
- [x] `lance-spark-base_2.12` tests: 268/268 passing (6 new tests in `LanceStatisticsTest` covering width-weighted scaling, mixed-width projections, all/empty projection fallback, zero-row clamp, and truncation-to-zero clamp)
- [x] TPC-DS sf=1 plan capture on Spark 4.0.2 — 30 → 11 flips vs Parquet, 0 regressions
- [x] Spot-checked threshold bumps (15 MB, 30 MB) close the remaining flips with no regressions on the tested queries

## Recommended deployment guidance

- **Default 10 MB threshold is fine for most workloads** — this PR resolves the majority of small-dimension broadcast cases automatically.
- **If you observe unexpected `SortMergeJoin` on dimension tables**, use `EXPLAIN COST` to read the reported `sizeInBytes` on the `RelationV2` node. If it's within 2× of the threshold, raise `spark.sql.autoBroadcastJoinThreshold` (per-query `SET` is safer than changing the global default). A 15–30 MB threshold works for TPC-DS sf=1 without over-broadcast risk because sizes are now projection-accurate.