### PR TITLE
docs: fixed repo name from lancedb/lance-spark to lance-format/lance-spark

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Spark Lance Connector
 
-The Spark Lance connector codebase is at [lancedb/lance-spark](https://github.com/lance-format/lance-spark).
+The Spark Lance connector codebase is at [lance-format/lance-spark](https://github.com/lance-format/lance-spark).
 
 ## Build Commands
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,7 @@ site_description: The Apache Spark Connector for Lance allows Apache Spark to ef
 site_url: https://lance.org/integrations/spark/
 docs_dir: src
 
-repo_name: lancedb/lance-spark
+repo_name: lance-format/lance-spark
 repo_url: https://github.com/lance-format/lance-spark
 
 theme:


### PR DESCRIPTION
Fixed inconsistency in docs (contributing.md) between repo name and actual repo link.