### PR TITLE
feat: zone-level SPJ partitioning

### DIFF
--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioningTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioningTest.java
@@ -13,4 +13,4 @@
  */
 package org.lance.spark.read;
 
-public class ZoneLevelPartitioning35Test extends BaseZoneLevelPartitioningTest {}
+public class ZoneLevelPartitioningTest extends BaseZoneLevelPartitioningTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioning35Test.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioning35Test.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class ZoneLevelPartitioning35Test extends BaseZoneLevelPartitioningTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioningTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZoneLevelPartitioningTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class ZoneLevelPartitioningTest extends BaseZoneLevelPartitioningTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import scala.collection.immutable.Map;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -147,6 +148,14 @@ public class LanceScan
     return this;
   }
 
+  private static org.lance.spark.utils.Optional<String> combineWhere(
+      org.lance.spark.utils.Optional<String> existing, String predicate) {
+    if (!existing.isPresent()) {
+      return org.lance.spark.utils.Optional.of(predicate);
+    }
+    return org.lance.spark.utils.Optional.of("(" + existing.get() + ") AND (" + predicate + ")");
+  }
+
   @Override
   public InputPartition[] planInputPartitions() {
     LanceSplit.ScanPlanResult planResult = LanceSplit.planScan(readOptions);
@@ -170,33 +179,67 @@ public class LanceScan
     LanceSparkReadOptions resolvedReadOptions =
         readOptions.withVersion((int) planResult.getResolvedVersion());
 
-    InputPartition[] result =
-        IntStream.range(0, finalSplits.size())
-            .mapToObj(
-                i -> {
-                  LanceSplit split = finalSplits.get(i);
-                  InternalRow partKeyRow = null;
-                  if (partitionInfo != null) {
-                    int fragId = split.getFragments().get(0);
-                    partKeyRow = partitionInfo.partitionKeyForFragment(fragId);
-                  }
-                  return new LanceInputPartition(
-                      schema,
-                      i,
-                      split,
-                      resolvedReadOptions,
-                      whereConditions,
-                      limit,
-                      offset,
-                      topNSortOrders,
-                      pushedAggregation,
-                      scanId,
-                      initialStorageOptions,
-                      namespaceImpl,
-                      namespaceProperties,
-                      partKeyRow);
-                })
-            .toArray(InputPartition[]::new);
+    InputPartition[] result;
+    if (partitionInfo == null) {
+      // Legacy path: one partition per surviving split.
+      result =
+          IntStream.range(0, finalSplits.size())
+              .mapToObj(
+                  i -> {
+                    LanceSplit split = finalSplits.get(i);
+                    InternalRow partKeyRow = null;
+                    return new LanceInputPartition(
+                        schema,
+                        i,
+                        split,
+                        resolvedReadOptions,
+                        whereConditions,
+                        limit,
+                        offset,
+                        topNSortOrders,
+                        pushedAggregation,
+                        scanId,
+                        initialStorageOptions,
+                        namespaceImpl,
+                        namespaceProperties,
+                        partKeyRow);
+                  })
+              .toArray(InputPartition[]::new);
+    } else {
+      // Zone-level path: one partition per (surviving fragment x assignment value).
+      Set<Integer> survivingFragments =
+          finalSplits.stream().flatMap(s -> s.getFragments().stream()).collect(Collectors.toSet());
+
+      List<LanceInputPartition> partitions = new ArrayList<>();
+      int partitionId = 0;
+      for (ZonemapFragmentPruner.Assignment assignment : partitionInfo.getAssignments()) {
+        if (!survivingFragments.contains(assignment.getFragmentId())) {
+          continue;
+        }
+        String predicate = partitionInfo.compilePredicate(assignment.getValue());
+        org.lance.spark.utils.Optional<String> combined = combineWhere(whereConditions, predicate);
+        InternalRow partKeyRow = partitionInfo.partitionKeyFor(assignment.getValue());
+        LanceSplit singleFragmentSplit =
+            new LanceSplit(Collections.singletonList(assignment.getFragmentId()));
+        partitions.add(
+            new LanceInputPartition(
+                schema,
+                partitionId++,
+                singleFragmentSplit,
+                resolvedReadOptions,
+                combined,
+                limit,
+                offset,
+                topNSortOrders,
+                pushedAggregation,
+                scanId,
+                initialStorageOptions,
+                namespaceImpl,
+                namespaceProperties,
+                partKeyRow));
+      }
+      result = partitions.toArray(new InputPartition[0]);
+    }
 
     this.numPartitions = result.length;
     return result;
@@ -367,13 +410,8 @@ public class LanceScan
   @Override
   public Partitioning outputPartitioning() {
     if (partitionInfo != null) {
-      // Use partition info fragment count — available before
-      // planInputPartitions() is called. This allows
-      // V2ScanPartitioningAndOrdering to see the partitioning
-      // early enough for SPJ.
-      int partCount =
-          numPartitions >= 0 ? numPartitions : partitionInfo.getFragmentPartitionValues().size();
-      Expression[] keys = new Expression[] {FieldReference.apply(partitionInfo.getColumnName())};
+      int partCount = partitionInfo.getDistinctPartitionCount();
+      Expression[] keys = new Expression[] {FieldReference.column(partitionInfo.getColumnName())};
       return new KeyGroupedPartitioning(keys, partCount);
     }
     return new UnknownPartitioning(numPartitions >= 0 ? numPartitions : 0);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -67,6 +67,7 @@ public class LanceScanBuilder
   private static final Logger LOG = LoggerFactory.getLogger(LanceScanBuilder.class);
 
   private final LanceSparkReadOptions readOptions;
+  private final StructType fullSchema;
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
@@ -101,6 +102,7 @@ public class LanceScanBuilder
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties,
       java.util.Map<String, String> tableProperties) {
+    this.fullSchema = schema;
     this.schema = schema;
     this.readOptions = readOptions;
     this.initialStorageOptions = initialStorageOptions;
@@ -152,9 +154,6 @@ public class LanceScanBuilder
     // Load zonemap stats for all requested columns in one pass.
     Map<String, List<ZoneStats>> zonemapStats = loadZonemapStats(getOrOpenDataset(), columnsToLoad);
 
-    // Detect partition-compatible columns, gated on lance.partition.columns table property.
-    // Currently a partitioned column is only valid if each fragment contains only a single
-    // value for that column (i.e., all zonemap zones have min == max with the same value).
     ZonemapFragmentPruner.PartitionInfo partitionInfo = null;
     if (partitionColumn != null) {
       if (!zonemapStats.containsKey(partitionColumn)) {
@@ -164,15 +163,41 @@ public class LanceScanBuilder
             partitionColumn,
             TABLE_OPT_PARTITION_COLUMNS);
       } else {
-        Map<Integer, Comparable<?>> partValues =
-            ZonemapFragmentPruner.computeFragmentPartitionValues(zonemapStats.get(partitionColumn))
+        ZonemapFragmentPruner.PartitionInfo candidate =
+            ZonemapFragmentPruner.computeZonePartitions(
+                    partitionColumn, zonemapStats.get(partitionColumn))
                 .orElse(null);
-        if (partValues != null) {
-          partitionInfo = new ZonemapFragmentPruner.PartitionInfo(partitionColumn, partValues);
+        if (candidate == null) {
           LOG.info(
-              "Detected partition-compatible column '{}' with {} fragments",
-              partitionColumn,
-              partValues.size());
+              "Partition column '{}' has non-single-valued zones; SPJ disabled", partitionColumn);
+        } else {
+          // Coverage check: every fragment must have at least one assignment.
+          // Unindexed fragments (appended after CREATE INDEX) would be silently
+          // dropped in planInputPartitions, causing data loss.
+          Set<Integer> allFragmentIds = new HashSet<>();
+          for (Fragment f : getOrOpenDataset().getFragments()) {
+            allFragmentIds.add(f.getId());
+          }
+          Set<Integer> assignedFragmentIds = new HashSet<>();
+          for (ZonemapFragmentPruner.Assignment a : candidate.getAssignments()) {
+            assignedFragmentIds.add(a.getFragmentId());
+          }
+          if (!assignedFragmentIds.containsAll(allFragmentIds)) {
+            Set<Integer> missing = new HashSet<>(allFragmentIds);
+            missing.removeAll(assignedFragmentIds);
+            LOG.warn(
+                "Partition column '{}' missing zone stats for fragments {};" + " SPJ disabled",
+                partitionColumn,
+                missing);
+          } else {
+            partitionInfo = candidate;
+            LOG.info(
+                "Detected zone-level partition column '{}' with {} assignments"
+                    + " across {} distinct values",
+                partitionColumn,
+                candidate.getAssignments().size(),
+                candidate.getDistinctPartitionCount());
+          }
         }
       }
     }
@@ -186,14 +211,18 @@ public class LanceScanBuilder
           ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
     }
 
-    LanceStatistics statistics;
+    // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
+    // LanceStatistics.estimateProjected apply the column-width ratio on top.
+    long projectedRows = summary.getTotalRows();
+    long projectedFullSize = summary.getTotalFilesSize();
+    if (survivingFragmentIds != null && summary.getTotalFragments() > 0) {
+      double ratio = (double) survivingFragmentIds.size() / summary.getTotalFragments();
+      projectedRows = (long) (projectedRows * ratio);
+      projectedFullSize = (long) (projectedFullSize * ratio);
+    }
+    LanceStatistics statistics =
+        LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
     if (survivingFragmentIds != null) {
-      statistics =
-          LanceStatistics.estimatePostPruning(
-              summary.getTotalRows(),
-              summary.getTotalFilesSize(),
-              summary.getTotalFragments(),
-              survivingFragmentIds.size());
       LOG.debug(
           "Estimated post-pruning statistics: {} of {} fragments survive,"
               + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
@@ -203,8 +232,6 @@ public class LanceScanBuilder
           statistics.numRows(),
           summary.getTotalFilesSize(),
           summary.getTotalRows());
-    } else {
-      statistics = new LanceStatistics(summary);
     }
 
     // Close the lazily opened dataset - it's no longer needed after build
@@ -394,7 +421,8 @@ public class LanceScanBuilder
       }
 
       for (IndexDescription idx : dataset.describeIndices()) {
-        if ("ZONEMAP".equalsIgnoreCase(idx.getIndexType())) {
+        if ("ZONEMAP".equalsIgnoreCase(idx.getIndexType())
+            || "BTREE".equalsIgnoreCase(idx.getIndexType())) {
           for (int fieldId : idx.getFieldIds()) {
             String name = fieldIdToName.get(fieldId);
             if (name != null) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -16,6 +16,8 @@ package org.lance.spark.read;
 import org.lance.ManifestSummary;
 
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
 import java.util.OptionalLong;
@@ -63,6 +65,52 @@ public class LanceStatistics implements Statistics, Serializable {
     }
     double ratio = (double) survivingFragments / totalFragments;
     return new LanceStatistics((long) (totalRows * ratio), (long) (totalFilesSize * ratio));
+  }
+
+  /**
+   * Estimate post-projection size using {@code sizeInBytes × (projectedWidths / fullWidths)}, the
+   * same formula Spark's DSv2 {@code FileScan.estimateStatistics} applies after column pruning (see
+   * {@code org.apache.spark.sql.execution.datasources.v2.FileScan}). Lets {@code JoinSelection} see
+   * a projection-aware size so broadcast decisions line up with what DSv1 Parquet produces through
+   * the optimizer's {@code Project.computeStats()} path — within the 8-byte-per-row overhead DSv1
+   * adds via {@code EstimationUtils.getSizePerRow}, which rounds estimates apart by a few percent
+   * but doesn't shift broadcast thresholds in practice.
+   *
+   * <p>Width-weighted (not {@code numRows × sumOfWidths}) on purpose: the ratio preserves the
+   * compression baked into {@code fullSizeInBytes}, whereas a row-count formula would ignore
+   * on-disk encoding and systematically over-count columnar sources.
+   *
+   * @param numRows projected row count (post fragment-pruning if any)
+   * @param fullSizeInBytes on-disk size of the full (pre-projection) dataset in bytes
+   * @param fullSchema schema of the full dataset before column pruning
+   * @param projectedSchema pruned schema containing only columns actually read by the scan
+   * @return statistics with {@code sizeInBytes} scaled by width-weighted column ratio
+   */
+  public static LanceStatistics estimateProjected(
+      long numRows, long fullSizeInBytes, StructType fullSchema, StructType projectedSchema) {
+    long projWidth = sumWidths(projectedSchema);
+    long fullWidth = sumWidths(fullSchema);
+    long sizeInBytes;
+    if (fullWidth <= 0 || projWidth <= 0 || projWidth >= fullWidth) {
+      sizeInBytes = fullSizeInBytes;
+    } else {
+      // Promote to double to avoid long overflow in fullSizeInBytes * projWidth.
+      sizeInBytes = (long) ((double) fullSizeInBytes * projWidth / fullWidth);
+    }
+    // Clamp to 1: integer truncation can round very small scaled sizes to 0, which
+    // JoinSelection reads as "below threshold" and would unintentionally force a broadcast.
+    return new LanceStatistics(numRows, Math.max(sizeInBytes, 1L));
+  }
+
+  private static long sumWidths(StructType schema) {
+    if (schema == null) {
+      return 0;
+    }
+    long sum = 0;
+    for (StructField field : schema.fields()) {
+      sum += field.dataType().defaultSize();
+    }
+    return sum;
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -34,11 +34,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -342,37 +344,70 @@ public final class ZonemapFragmentPruner {
     GREATER_THAN_OR_EQUAL
   }
 
-  /**
-   * Result of partition detection: the partition column name and a map from fragment ID to the
-   * partition value for that fragment.
-   */
-  public static final class PartitionInfo implements Serializable {
+  public static final class Assignment implements Serializable {
     private static final long serialVersionUID = 1L;
+    private final int fragmentId;
+    private final Comparable<?> value;
 
+    Assignment(int fragmentId, Comparable<?> value) {
+      this.fragmentId = fragmentId;
+      this.value = value;
+    }
+
+    public int getFragmentId() {
+      return fragmentId;
+    }
+
+    public Comparable<?> getValue() {
+      return value;
+    }
+  }
+
+  public static final class PartitionInfo implements Serializable {
+    private static final long serialVersionUID = 2L;
     private final String columnName;
-    private final Map<Integer, Comparable<?>> fragmentPartitionValues;
+    private final List<Assignment> assignments;
+    private final int distinctPartitionCount;
 
-    public PartitionInfo(String columnName, Map<Integer, Comparable<?>> fragmentPartitionValues) {
-      this.columnName = columnName;
-      this.fragmentPartitionValues = Collections.unmodifiableMap(fragmentPartitionValues);
+    public PartitionInfo(String columnName, List<Assignment> assignments) {
+      this.columnName = Objects.requireNonNull(columnName, "columnName");
+      this.assignments = Collections.unmodifiableList(new ArrayList<>(assignments));
+      Set<Object> distinct = new HashSet<>();
+      for (Assignment a : this.assignments) {
+        distinct.add(a.getValue());
+      }
+      this.distinctPartitionCount = distinct.size();
     }
 
     public String getColumnName() {
       return columnName;
     }
 
-    public Map<Integer, Comparable<?>> getFragmentPartitionValues() {
-      return fragmentPartitionValues;
+    public List<Assignment> getAssignments() {
+      return assignments;
     }
 
-    /**
-     * Returns a partition key {@link InternalRow} for the given fragment ID. The row contains a
-     * single column with the partition value, converted to a Spark-compatible type.
-     */
-    public InternalRow partitionKeyForFragment(int fragmentId) {
-      Comparable<?> value = fragmentPartitionValues.get(fragmentId);
-      Object sparkValue = toSparkValue(value);
-      return new GenericInternalRow(new Object[] {sparkValue});
+    public int getDistinctPartitionCount() {
+      return distinctPartitionCount;
+    }
+
+    /** SQL predicate for a partition value, using the same compiler as filter pushdown. */
+    public String compilePredicate(Comparable<?> value) {
+      Objects.requireNonNull(value, "partition value must not be null");
+      org.apache.spark.sql.sources.Filter filter =
+          new org.apache.spark.sql.sources.EqualTo(columnName, value);
+      org.lance.spark.utils.Optional<String> compiled =
+          FilterPushDown.compileFiltersToSqlWhereClause(
+              new org.apache.spark.sql.sources.Filter[] {filter});
+      if (!compiled.isPresent()) {
+        throw new IllegalStateException(
+            "EqualTo(" + columnName + ", " + value + ") compiled to empty SQL");
+      }
+      return compiled.get();
+    }
+
+    public InternalRow partitionKeyFor(Comparable<?> value) {
+      return new GenericInternalRow(new Object[] {toSparkValue(value)});
     }
 
     private static Object toSparkValue(Comparable<?> value) {
@@ -382,48 +417,66 @@ public final class ZonemapFragmentPruner {
       if (value instanceof String) {
         return UTF8String.fromString((String) value);
       }
-      // Long, Double, Boolean, Integer are already compatible
       return value;
     }
   }
 
-  /**
-   * Checks whether zonemap zones are partitionable — i.e., every fragment has exactly one distinct
-   * value (all zones have {@code min == max} with the same value per fragment).
-   *
-   * @param zones zonemap zones for a single column
-   * @return map from fragment ID to partition value, or empty if zones are not partitionable
-   */
-  static Optional<Map<Integer, Comparable<?>>> computeFragmentPartitionValues(
-      List<ZoneStats> zones) {
+  static final int LANCE_SPJ_MAX_ASSIGNMENTS = 10_000;
 
+  public static Optional<PartitionInfo> computeZonePartitions(
+      String columnName, List<ZoneStats> zones) {
     if (zones == null || zones.isEmpty()) {
       return Optional.empty();
     }
-
-    Map<Integer, Comparable<?>> result = new HashMap<>();
-
+    Set<Map.Entry<Integer, Comparable<?>>> seen = new HashSet<>();
+    List<Assignment> assignments = new ArrayList<>();
     for (ZoneStats zone : zones) {
       Comparable<?> min = zone.getMin();
       Comparable<?> max = zone.getMax();
-
-      if (min == null || max == null) {
+      if (min == null || max == null || !min.equals(max)) {
+        LOG.info(
+            "SPJ disabled for '{}': min!=max (frag={}, min={}, max={})",
+            columnName,
+            zone.getFragmentId(),
+            min,
+            max);
         return Optional.empty();
       }
-
-      if (!min.equals(max)) {
+      if (zone.getNullCount() > 0) {
+        LOG.info(
+            "SPJ disabled for '{}': nulls in zone (frag={}, nullCount={})",
+            columnName,
+            zone.getFragmentId(),
+            zone.getNullCount());
         return Optional.empty();
       }
-
-      int fragId = zone.getFragmentId();
-      Comparable<?> existing = result.get(fragId);
-      if (existing != null && !existing.equals(min)) {
+      if (!isPartitionValueTypeSupported(min)) {
+        LOG.info(
+            "SPJ disabled for '{}': type {} not in allowlist",
+            columnName,
+            min.getClass().getName());
         return Optional.empty();
       }
-
-      result.put(fragId, min);
+      Map.Entry<Integer, Comparable<?>> key =
+          new AbstractMap.SimpleImmutableEntry<>(zone.getFragmentId(), min);
+      if (seen.add(key)) {
+        assignments.add(new Assignment(zone.getFragmentId(), min));
+        if (assignments.size() > LANCE_SPJ_MAX_ASSIGNMENTS) {
+          LOG.warn(
+              "SPJ disabled for '{}': exceeded max assignments {}",
+              columnName,
+              LANCE_SPJ_MAX_ASSIGNMENTS);
+          return Optional.empty();
+        }
+      }
     }
+    return Optional.of(new PartitionInfo(columnName, assignments));
+  }
 
-    return Optional.of(result);
+  static boolean isPartitionValueTypeSupported(Object value) {
+    return value instanceof String
+        || value instanceof Long
+        || value instanceof Integer
+        || value instanceof Boolean;
   }
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -531,6 +531,7 @@ object IndexUtils {
     method match {
       case "btree" => IndexType.BTREE
       case "fts" => IndexType.INVERTED
+      case "zonemap" => IndexType.ZONEMAP
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZoneLevelPartitioningTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZoneLevelPartitioningTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public abstract class BaseZoneLevelPartitioningTest {
+  protected String catalogName;
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() {
+    SparkSession prior =
+        SparkSession.getDefaultSession().isDefined()
+            ? SparkSession.getDefaultSession().get()
+            : null;
+    if (prior != null) prior.stop();
+    SparkSession active =
+        SparkSession.getActiveSession().isDefined() ? SparkSession.getActiveSession().get() : null;
+    if (active != null && active != prior) active.stop();
+    SparkSession.clearDefaultSession();
+    SparkSession.clearActiveSession();
+
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    rootPath.toFile().mkdirs();
+    catalogName = "lance_zone_pt_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    spark =
+        SparkSession.builder()
+            .appName("lance-zone-partitioning-test")
+            .master("local[1]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", rootPath.toString())
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .config("spark.sql.sources.v2.bucketing.enabled", "true")
+            .config("spark.sql.sources.v2.bucketing.pushPartValues.enabled", "true")
+            .config("spark.sql.sources.v2.bucketing.partiallyClusteredDistribution.enabled", "true")
+            .config("spark.sql.shuffle.partitions", "1")
+            .config("spark.sql.autoBroadcastJoinThreshold", "-1")
+            .getOrCreate();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (spark != null) {
+      spark.close();
+      SparkSession.clearDefaultSession();
+      SparkSession.clearActiveSession();
+    }
+  }
+
+  private void createTwoZoneTable(String tableName) {
+    String fullTable = catalogName + ".default." + tableName;
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING, payload DOUBLE) USING lance"
+                + " TBLPROPERTIES ('lance.partition.columns' = 'region')",
+            fullTable));
+
+    StringBuilder values = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      if (values.length() > 0) values.append(",");
+      values.append(String.format(Locale.ROOT, "(%d, 'east', %f)", i, i * 1.5));
+    }
+    for (int i = 100; i < 200; i++) {
+      values.append(",");
+      values.append(String.format(Locale.ROOT, "(%d, 'west', %f)", i, i * 1.5));
+    }
+    spark.sql(String.format("INSERT INTO %s (id, region, payload) VALUES %s", fullTable, values));
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX region_idx USING btree (region)" + " WITH (zone_size=100)",
+            fullTable));
+  }
+
+  @Test
+  @org.junit.jupiter.api.Disabled(
+      "Requires lance-core to expose btree zone stats via getZonemapStats. "
+          + "BTree indexes internally produce zone data but describe_indices reports "
+          + "index_type='BTree' which the current JNI getZonemapStats skips "
+          + "(it matches only 'zonemap'). Enable when lance-core is updated.")
+  public void zoneLevelPartitioning_joinUsesKeyGroupedPartitioning_twoValuesOneFragment() {
+    String tableA = "a_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String tableB = "b_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    createTwoZoneTable(tableA);
+    createTwoZoneTable(tableB);
+    String fullA = catalogName + ".default." + tableA;
+    String fullB = catalogName + ".default." + tableB;
+
+    Dataset<Row> joined =
+        spark.sql(
+            String.format(
+                "SELECT /*+ MERGE(a, b) */ a.region, a.payload AS ap, b.payload AS bp"
+                    + " FROM %s a JOIN %s b USING (region)",
+                fullA, fullB));
+
+    long rowCount = joined.count();
+    assertEquals(20_000L, rowCount, "100*100 east + 100*100 west");
+
+    String plan = joined.queryExecution().executedPlan().toString();
+    assertFalse(
+        plan.contains("Exchange hashpartitioning"),
+        "SPJ should eliminate the pre-join shuffle.\nPlan:\n" + plan);
+  }
+
+  @Test
+  public void zoneLevelPartitioning_skipsColumnWithNonSingleValuedZone() {
+    String table = "t_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String full = catalogName + ".default." + table;
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING) USING lance"
+                + " TBLPROPERTIES ('lance.partition.columns' = 'region')",
+            full));
+
+    StringBuilder values = new StringBuilder();
+    for (int i = 0; i < 200; i++) {
+      if (values.length() > 0) values.append(",");
+      values.append(String.format(Locale.ROOT, "(%d, '%s')", i, i % 2 == 0 ? "east" : "west"));
+    }
+    spark.sql(String.format("INSERT INTO %s (id, region) VALUES %s", full, values));
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX idx USING btree (region) WITH (zone_size=100)", full));
+
+    assertEquals(200L, spark.sql("SELECT id FROM " + full).collectAsList().size());
+  }
+
+  @Test
+  public void unindexedFragmentAfterIndexCreation_disablesSpj_noDataLoss() {
+    String table = "u_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    String full = catalogName + ".default." + table;
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING) USING lance"
+                + " TBLPROPERTIES ('lance.partition.columns' = 'region')",
+            full));
+
+    StringBuilder first = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      if (first.length() > 0) first.append(",");
+      first.append(String.format(Locale.ROOT, "(%d, 'east')", i));
+    }
+    spark.sql(String.format("INSERT INTO %s (id, region) VALUES %s", full, first));
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX idx USING btree (region) WITH (zone_size=100)", full));
+
+    StringBuilder second = new StringBuilder();
+    for (int i = 100; i < 200; i++) {
+      if (second.length() > 0) second.append(",");
+      second.append(String.format(Locale.ROOT, "(%d, 'west')", i));
+    }
+    spark.sql(String.format("INSERT INTO %s (id, region) VALUES %s", full, second));
+
+    long readRows = spark.sql("SELECT id FROM " + full).collectAsList().size();
+    assertEquals(200L, readRows, "Unindexed-fragment rows must not be dropped");
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -33,9 +33,8 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -195,11 +194,12 @@ public class LanceScanTest {
   @Test
   public void testOutputPartitioningWithPartitionInfo() {
     // Create a LanceScan with partition info
-    Map<Integer, Comparable<?>> fragValues = new HashMap<>();
-    fragValues.put(0, "east");
-    fragValues.put(1, "west");
     ZonemapFragmentPruner.PartitionInfo partInfo =
-        new ZonemapFragmentPruner.PartitionInfo("region", fragValues);
+        new ZonemapFragmentPruner.PartitionInfo(
+            "region",
+            Arrays.asList(
+                new ZonemapFragmentPruner.Assignment(0, "east"),
+                new ZonemapFragmentPruner.Assignment(1, "west")));
 
     LanceScan scan =
         new LanceScan(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
@@ -13,6 +13,9 @@
  */
 package org.lance.spark.read;
 
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -72,5 +75,113 @@ public class LanceStatisticsTest {
     LanceStatistics stats = LanceStatistics.estimatePostPruning(1000, 50000, 0, 0);
     assertEquals(1000, stats.numRows().getAsLong());
     assertEquals(50000, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedScalesByColumnWidthRatio() {
+    // Full schema has 9 columns; project 3 of equal width → size should scale by 3/9.
+    // 24_000_000 full bytes × (3×8)/(9×8) = 8_000_000.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("c1", DataTypes.LongType, true, null),
+              new StructField("c2", DataTypes.LongType, true, null),
+              new StructField("c3", DataTypes.LongType, true, null),
+              new StructField("c4", DataTypes.LongType, true, null),
+              new StructField("c5", DataTypes.LongType, true, null),
+              new StructField("c6", DataTypes.LongType, true, null),
+              new StructField("c7", DataTypes.LongType, true, null),
+              new StructField("c8", DataTypes.LongType, true, null),
+              new StructField("c9", DataTypes.LongType, true, null)
+            });
+    StructType projected =
+        new StructType(
+            new StructField[] {
+              new StructField("c1", DataTypes.LongType, true, null),
+              new StructField("c2", DataTypes.LongType, true, null),
+              new StructField("c3", DataTypes.LongType, true, null)
+            });
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 24_000_000L, full, projected);
+    assertEquals(1000, stats.numRows().getAsLong());
+    assertEquals(8_000_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedFavorsWideColumns() {
+    // Full schema: one String (width 20) + one Int (width 4). Total width 24.
+    // Project just the String → ratio 20/24.
+    // 24_000 full bytes × 20/24 = 20_000.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("name", DataTypes.StringType, true, null),
+              new StructField("id", DataTypes.IntegerType, true, null)
+            });
+    StructType projected =
+        new StructType(
+            new StructField[] {new StructField("name", DataTypes.StringType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 24_000L, full, projected);
+    assertEquals(20_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedAllColumnsUnchanged() {
+    // Projection == full schema → no scaling.
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 50_000L, full, full);
+    assertEquals(50_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedEmptyProjectionReturnsFullSize() {
+    // Count-only scan: no columns projected. Fall back to full size rather than zero.
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    StructType projected = new StructType(new StructField[] {});
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 50_000L, full, projected);
+    assertEquals(50_000L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testEstimateProjectedNeverZero() {
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(0, 0L, full, full);
+    assertEquals(1, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void estimateProjected_unchangedByZoneLevelPartitioning() {
+    LanceStatistics stats =
+        LanceStatistics.estimateProjected(
+            1000L,
+            1_000_000L,
+            new StructType().add("a", DataTypes.LongType).add("b", DataTypes.StringType),
+            new StructType().add("a", DataTypes.LongType));
+    assertEquals(1000L, stats.numRows().getAsLong());
+    assertTrue(stats.sizeInBytes().getAsLong() <= 1_000_000L);
+  }
+
+  @Test
+  public void testEstimateProjectedTruncationClampsToOne() {
+    // Very narrow projection of a tiny table truncates to 0 after (long) cast.
+    // Clamp must restore it to 1 so JoinSelection doesn't read it as empty.
+    StructType full =
+        new StructType(
+            new StructField[] {
+              new StructField("key", DataTypes.LongType, true, null),
+              new StructField("s1", DataTypes.StringType, true, null),
+              new StructField("s2", DataTypes.StringType, true, null),
+              new StructField("s3", DataTypes.StringType, true, null),
+              new StructField("s4", DataTypes.StringType, true, null),
+              new StructField("s5", DataTypes.StringType, true, null)
+            });
+    StructType projected =
+        new StructType(new StructField[] {new StructField("key", DataTypes.LongType, true, null)});
+    // fullWidths = 8 + 5*20 = 108; projWidths = 8.
+    // 10 bytes × 8 / 108 = 0.74 → (long) cast → 0 → clamp → 1.
+    LanceStatistics stats = LanceStatistics.estimateProjected(1000, 10L, full, projected);
+    assertEquals(1L, stats.sizeInBytes().getAsLong());
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -15,7 +15,6 @@ package org.lance.spark.read;
 
 import org.lance.index.scalar.ZoneStats;
 
-import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.And;
 import org.apache.spark.sql.sources.EqualTo;
 import org.apache.spark.sql.sources.Filter;
@@ -28,12 +27,12 @@ import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -435,207 +434,111 @@ public class ZonemapFragmentPrunerTest {
     assertEquals(Set.of(0), result.get());
   }
 
-  // --- computeFragmentPartitionValues ---
+  // --- computeZonePartitions ---
 
   @Test
-  public void testComputePartitionValuesNullInput() {
-    assertEquals(Optional.empty(), ZonemapFragmentPruner.computeFragmentPartitionValues(null));
-  }
-
-  @Test
-  public void testComputePartitionValuesEmptyInput() {
-    assertEquals(
-        Optional.empty(),
-        ZonemapFragmentPruner.computeFragmentPartitionValues(Collections.emptyList()));
-  }
-
-  @Test
-  public void testComputePartitionValuesSingleFragmentSingleZone() {
-    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, "east", "east", 0));
-
-    Optional<Map<Integer, Comparable<?>>> result =
-        ZonemapFragmentPruner.computeFragmentPartitionValues(zones);
-    assertTrue(result.isPresent());
-    assertEquals(1, result.get().size());
-    assertEquals("east", result.get().get(0));
-  }
-
-  @Test
-  public void testComputePartitionValuesMultipleFragments() {
-    List<ZoneStats> zones =
-        Arrays.asList(
-            new ZoneStats(0, 0, 100, "east", "east", 0),
-            new ZoneStats(1, 0, 100, "west", "west", 0),
-            new ZoneStats(2, 0, 100, "north", "north", 0));
-
-    Optional<Map<Integer, Comparable<?>>> result =
-        ZonemapFragmentPruner.computeFragmentPartitionValues(zones);
-    assertTrue(result.isPresent());
-    assertEquals(3, result.get().size());
-    assertEquals("east", result.get().get(0));
-    assertEquals("west", result.get().get(1));
-    assertEquals("north", result.get().get(2));
-  }
-
-  @Test
-  public void testComputePartitionValuesMultipleZonesPerFragmentSameValue() {
+  public void testComputeZonePartitionsReturnsOneAssignmentPerSingleValuedZone() {
     List<ZoneStats> zones =
         Arrays.asList(
             new ZoneStats(0, 0, 50, "east", "east", 0),
             new ZoneStats(0, 50, 50, "east", "east", 0),
             new ZoneStats(1, 0, 100, "west", "west", 0));
 
-    Optional<Map<Integer, Comparable<?>>> result =
-        ZonemapFragmentPruner.computeFragmentPartitionValues(zones);
+    java.util.Optional<ZonemapFragmentPruner.PartitionInfo> result =
+        ZonemapFragmentPruner.computeZonePartitions("region", zones);
     assertTrue(result.isPresent());
-    assertEquals(2, result.get().size());
-    assertEquals("east", result.get().get(0));
-    assertEquals("west", result.get().get(1));
+    ZonemapFragmentPruner.PartitionInfo info = result.get();
+    assertEquals("region", info.getColumnName());
+    assertEquals(2, info.getDistinctPartitionCount());
+    // 2 unique (fragId, value) pairs: (0, east) and (1, west)
+    assertEquals(2, info.getAssignments().size());
   }
 
   @Test
-  public void testComputePartitionValuesFailsWhenMinNotEqualsMax() {
+  public void testComputeZonePartitionsRejectsMixedMinMaxZone() {
     List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, "east", "west", 0));
-    assertFalse(ZonemapFragmentPruner.computeFragmentPartitionValues(zones).isPresent());
+    assertFalse(ZonemapFragmentPruner.computeZonePartitions("region", zones).isPresent());
   }
 
   @Test
-  public void testComputePartitionValuesFailsWhenNullMinMax() {
+  public void testComputeZonePartitionsRejectsNullMinMax() {
     List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, null, null, 100));
-    assertFalse(ZonemapFragmentPruner.computeFragmentPartitionValues(zones).isPresent());
+    assertFalse(ZonemapFragmentPruner.computeZonePartitions("region", zones).isPresent());
   }
 
   @Test
-  public void testComputePartitionValuesFailsWhenMultipleValuesInSameFragment() {
+  public void testComputeZonePartitionsRejectsZoneWithNullsEvenWhenMinEqualsMax() {
+    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, "east", "east", 5));
+    assertFalse(ZonemapFragmentPruner.computeZonePartitions("region", zones).isPresent());
+  }
+
+  @Test
+  public void testComputeZonePartitionsRejectsUnsupportedValueTypeDouble() {
+    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, 1.5, 1.5, 0));
+    assertFalse(ZonemapFragmentPruner.computeZonePartitions("price", zones).isPresent());
+  }
+
+  @Test
+  public void testComputeZonePartitionsRejectsUnsupportedValueTypeBigDecimal() {
+    java.math.BigDecimal bd = new java.math.BigDecimal("99.99");
+    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, bd, bd, 0));
+    assertFalse(ZonemapFragmentPruner.computeZonePartitions("price", zones).isPresent());
+  }
+
+  @Test
+  public void testComputeZonePartitionsDeduplicatesSameFragmentSameValue() {
+    // Two zones in the same fragment with the same value → only one assignment
     List<ZoneStats> zones =
         Arrays.asList(
             new ZoneStats(0, 0, 50, "east", "east", 0),
-            new ZoneStats(0, 50, 50, "west", "west", 0));
-    assertFalse(ZonemapFragmentPruner.computeFragmentPartitionValues(zones).isPresent());
+            new ZoneStats(0, 50, 50, "east", "east", 0));
+
+    java.util.Optional<ZonemapFragmentPruner.PartitionInfo> result =
+        ZonemapFragmentPruner.computeZonePartitions("region", zones);
+    assertTrue(result.isPresent());
+    assertEquals(1, result.get().getAssignments().size());
+    assertEquals(1, result.get().getDistinctPartitionCount());
   }
 
   @Test
-  public void testComputePartitionValuesWithLongValues() {
+  public void testPartitionInfoCompilesPredicateForStringValue() {
+    ZonemapFragmentPruner.PartitionInfo info =
+        new ZonemapFragmentPruner.PartitionInfo(
+            "region", java.util.List.of(new ZonemapFragmentPruner.Assignment(0, "east")));
+    String predicate = info.compilePredicate("east");
+    assertEquals("(region == 'east')", predicate);
+  }
+
+  @Test
+  public void testPartitionInfoCompilesPredicateForLongValue() {
+    ZonemapFragmentPruner.PartitionInfo info =
+        new ZonemapFragmentPruner.PartitionInfo(
+            "id", java.util.List.of(new ZonemapFragmentPruner.Assignment(0, 42L)));
+    assertEquals("(id == 42)", info.compilePredicate(42L));
+  }
+
+  @Test
+  public void testComputeZonePartitionsPreservesSingleValuePerFragmentBehavior() {
+    // Each fragment has exactly one value → assignments == distinct fragments
     List<ZoneStats> zones =
         Arrays.asList(
-            new ZoneStats(0, 0, 100, 2023L, 2023L, 0), new ZoneStats(1, 0, 100, 2024L, 2024L, 0));
+            new ZoneStats(0, 0, 100, "east", "east", 0),
+            new ZoneStats(1, 0, 100, "west", "west", 0),
+            new ZoneStats(2, 0, 100, "north", "north", 0));
 
-    Optional<Map<Integer, Comparable<?>>> result =
-        ZonemapFragmentPruner.computeFragmentPartitionValues(zones);
+    java.util.Optional<ZonemapFragmentPruner.PartitionInfo> result =
+        ZonemapFragmentPruner.computeZonePartitions("region", zones);
     assertTrue(result.isPresent());
-    assertEquals(2023L, result.get().get(0));
-    assertEquals(2024L, result.get().get(1));
-  }
+    ZonemapFragmentPruner.PartitionInfo info = result.get();
+    assertEquals(3, info.getAssignments().size());
+    assertEquals(3, info.getDistinctPartitionCount());
 
-  @Test
-  public void testComputePartitionValuesSameValueAcrossAllFragments() {
-    List<ZoneStats> zones =
-        Arrays.asList(
-            new ZoneStats(0, 0, 100, "acme", "acme", 0),
-            new ZoneStats(1, 0, 100, "acme", "acme", 0),
-            new ZoneStats(2, 0, 100, "acme", "acme", 0));
-
-    Optional<Map<Integer, Comparable<?>>> result =
-        ZonemapFragmentPruner.computeFragmentPartitionValues(zones);
-    assertTrue(result.isPresent());
-    assertEquals("acme", result.get().get(0));
-    assertEquals("acme", result.get().get(1));
-    assertEquals("acme", result.get().get(2));
-  }
-
-  @Test
-  public void testComputePartitionValuesNullMin() {
-    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, null, "east", 50));
-    assertFalse(ZonemapFragmentPruner.computeFragmentPartitionValues(zones).isPresent());
-  }
-
-  @Test
-  public void testComputePartitionValuesNullMax() {
-    List<ZoneStats> zones = Arrays.asList(new ZoneStats(0, 0, 100, "east", null, 50));
-    assertFalse(ZonemapFragmentPruner.computeFragmentPartitionValues(zones).isPresent());
-  }
-
-  // --- PartitionInfo ---
-
-  @Test
-  public void testPartitionKeyForFragmentString() {
-    Map<Integer, Comparable<?>> values = new HashMap<>();
-    values.put(0, "east");
-    values.put(1, "west");
-    ZonemapFragmentPruner.PartitionInfo info =
-        new ZonemapFragmentPruner.PartitionInfo("region", values);
-
-    InternalRow row0 = info.partitionKeyForFragment(0);
-    assertNotNull(row0);
-    assertEquals(
-        UTF8String.fromString("east"),
-        row0.get(0, org.apache.spark.sql.types.DataTypes.StringType));
-
-    InternalRow row1 = info.partitionKeyForFragment(1);
-    assertEquals(
-        UTF8String.fromString("west"),
-        row1.get(0, org.apache.spark.sql.types.DataTypes.StringType));
-  }
-
-  @Test
-  public void testPartitionKeyForFragmentLong() {
-    Map<Integer, Comparable<?>> values = new HashMap<>();
-    values.put(0, 2023L);
-    values.put(1, 2024L);
-    ZonemapFragmentPruner.PartitionInfo info =
-        new ZonemapFragmentPruner.PartitionInfo("year", values);
-
-    InternalRow row0 = info.partitionKeyForFragment(0);
-    assertEquals(2023L, row0.getLong(0));
-
-    InternalRow row1 = info.partitionKeyForFragment(1);
-    assertEquals(2024L, row1.getLong(0));
-  }
-
-  @Test
-  public void testPartitionKeyForMissingFragment() {
-    Map<Integer, Comparable<?>> values = new HashMap<>();
-    values.put(0, "east");
-    ZonemapFragmentPruner.PartitionInfo info =
-        new ZonemapFragmentPruner.PartitionInfo("region", values);
-
-    InternalRow row = info.partitionKeyForFragment(99);
-    assertNotNull(row);
-    assertTrue(row.isNullAt(0));
-  }
-
-  @Test
-  public void testPartitionInfoIsSerializable() throws Exception {
-    Map<Integer, Comparable<?>> values = new HashMap<>();
-    values.put(0, "east");
-    values.put(1, "west");
-    ZonemapFragmentPruner.PartitionInfo info =
-        new ZonemapFragmentPruner.PartitionInfo("region", values);
-
-    java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-    java.io.ObjectOutputStream oos = new java.io.ObjectOutputStream(baos);
-    oos.writeObject(info);
-    oos.close();
-
-    java.io.ByteArrayInputStream bais = new java.io.ByteArrayInputStream(baos.toByteArray());
-    java.io.ObjectInputStream ois = new java.io.ObjectInputStream(bais);
-    ZonemapFragmentPruner.PartitionInfo deserialized =
-        (ZonemapFragmentPruner.PartitionInfo) ois.readObject();
-
-    assertEquals("region", deserialized.getColumnName());
-    assertEquals("east", deserialized.getFragmentPartitionValues().get(0));
-    assertEquals("west", deserialized.getFragmentPartitionValues().get(1));
-  }
-
-  @Test
-  public void testPartitionInfoImmutableMap() {
-    Map<Integer, Comparable<?>> values = new HashMap<>();
-    values.put(0, "east");
-    ZonemapFragmentPruner.PartitionInfo info =
-        new ZonemapFragmentPruner.PartitionInfo("region", values);
-
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> info.getFragmentPartitionValues().put(1, "west"));
+    Set<String> values = new HashSet<>();
+    for (ZonemapFragmentPruner.Assignment a : info.getAssignments()) {
+      values.add((String) a.getValue());
+    }
+    assertTrue(values.contains("east"));
+    assertTrue(values.contains("west"));
+    assertTrue(values.contains("north"));
   }
 }


### PR DESCRIPTION
## Summary

Implements approach (2) from #430 — partition filter injection. A single fragment can now contribute to multiple SPJ partitions when its zonemap zones carry different single-valued keys.

**Convention choice:** strict values (`min == max` per zone), not ranges. This preserves cross-format SPJ compatibility with Iceberg/Hive (which use discrete partition values). If any zone has `min != max`, SPJ is skipped and the query runs normally. Range-based partitioning can layer on top as a follow-up.

**Core changes:**

- `ZonemapFragmentPruner`: replace `computeFragmentPartitionValues` with `computeZonePartitions` — checks each zone independently, builds per-zone `(fragmentId, value)` assignments
- `LanceScan.planInputPartitions`: emit one partition per assignment with `col == V` AND-ed into the WHERE clause
- `LanceScanBuilder`: add fragment-coverage check to prevent data loss from unindexed fragments
- `LanceStatistics`: add projection-aware size estimation for accurate broadcast decisions
- `AddIndexExec`: accept `USING zonemap` in CREATE INDEX syntax

**Safety guards:** null-count rejection, type allowlist (`String`/`Long`/`Integer`/`Boolean`), fragment-coverage check, 10k assignment cap.

**Blocked on lance-core:** `getZonemapStats` can't read btree zone data — btree stores stats in `page_lookup.lance` (schema: `min`/`max`/`null_count`/`page_idx`) while `getZonemapStats` reads `zonemap.lance` (schema adds `fragment_id`/`zone_start`/`zone_length`). `USING zonemap` via SQL also doesn't work (zonemap trainer rejects fragment-based training). See [#430 comment](https://github.com/lance-format/lance-spark/issues/430#issuecomment-4260506214) for discussion on lance-core fix options. The Spark side already accepts both `"BTREE"` and `"ZONEMAP"` — once lance-core exposes zone stats from either path, the feature activates with no further Spark changes. Positive SPJ integration test is `@Disabled` pending this fix.

## Test plan

- [x] 8 new unit tests for `computeZonePartitions` (multi-value, dedup, null-count, type rejection, boundary)
- [x] 2 new unit tests for `compilePredicate` (string and long values)
- [x] 1 new test pinning `LanceStatistics.estimateProjected` behavior
- [x] 3 integration tests: non-single-valued zone fallback, unindexed-fragment coverage check, SPJ join (@Disabled)
- [x] 262 existing tests pass
- [x] Checkstyle clean