### PR TITLE
fix: preserve use_large_var_types on staged commit path

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -115,7 +115,8 @@ public class LanceBatchWrite implements BatchWrite {
             .flatMap(List::stream)
             .collect(Collectors.toList());
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", true);
+    Schema arrowSchema =
+        LanceArrowUtils.toArrowSchema(schema, "UTC", true, writeOptions.isUseLargeVarTypes());
     boolean isOverwrite = overwrite || writeOptions.isOverwrite();
 
     // Boxed: null means unset (inherit in lance-core); see LanceSparkWriteOptions.

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -30,6 +30,12 @@ import java.util.Map;
 public class SparkWrite implements Write {
   private final LanceSparkWriteOptions writeOptions;
   private final StructType schema;
+
+  /** Returns the write options used by this SparkWrite. Visible for testing. */
+  LanceSparkWriteOptions getWriteOptions() {
+    return writeOptions;
+  }
+
   private final boolean overwrite;
 
   /**
@@ -144,6 +150,7 @@ public class SparkWrite implements Write {
                   .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
                   .queueDepth(writeOptions.getQueueDepth())
                   .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
+                  .useLargeVarTypes(writeOptions.isUseLargeVarTypes())
                   .enableStableRowIds(writeOptions.getEnableStableRowIds())
                   .writeMode(WriteParams.WriteMode.OVERWRITE)
                   .build();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BaseSparkConnectorWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BaseSparkConnectorWriteTest.java
@@ -694,4 +694,44 @@ public abstract class BaseSparkConnectorWriteTest {
       assertEquals("0.1", ds.getLanceFileFormatVersion());
     }
   }
+
+  @Test
+  public void createOrReplacePreservesUseLargeVarTypes(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String path = TestUtils.getDatasetUri(dbPath.toString(), datasetName);
+
+    // Create data with binary column
+    StructType binarySchema =
+        new StructType().add("id", DataTypes.StringType).add("data", DataTypes.BinaryType);
+    List<Row> binaryData =
+        Arrays.asList(
+            RowFactory.create("r1", new byte[] {1, 2, 3}),
+            RowFactory.create("r2", new byte[] {4, 5, 6}));
+    Dataset<Row> binaryDf = spark.createDataFrame(binaryData, binarySchema);
+
+    // Write using writeTo().createOrReplace() with use_large_var_types=true
+    // This exercises the staged commit path where the option was previously dropped
+    binaryDf
+        .writeTo("lance.`" + path + "`")
+        .using("lance")
+        .option("use_large_var_types", "true")
+        .createOrReplace();
+
+    // Verify the Lance schema uses large types
+    try (org.lance.Dataset ds =
+        org.lance.Dataset.open().allocator(LanceRuntime.allocator()).uri(path).build()) {
+      org.apache.arrow.vector.types.pojo.Schema arrowSchema = ds.getSchema();
+      org.apache.arrow.vector.types.pojo.Field dataField = arrowSchema.findField("data");
+      assertEquals(
+          org.apache.arrow.vector.types.pojo.ArrowType.LargeBinary.INSTANCE,
+          dataField.getType(),
+          "data field should be LargeBinary when use_large_var_types=true on createOrReplace path");
+
+      org.apache.arrow.vector.types.pojo.Field idField = arrowSchema.findField("id");
+      assertEquals(
+          org.apache.arrow.vector.types.pojo.ArrowType.LargeUtf8.INSTANCE,
+          idField.getType(),
+          "id field should be LargeUtf8 when use_large_var_types=true on createOrReplace path");
+    }
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -113,4 +113,29 @@ public class SparkWriteTest {
     BatchWrite batchWrite = builder.build().toBatch();
     assertInstanceOf(LanceBatchWrite.class, batchWrite);
   }
+
+  @Test
+  public void testTruncatePreservesUseLargeVarTypes(TestInfo testInfo) {
+    String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(datasetUri)
+            .writeMode(WriteParams.WriteMode.APPEND)
+            .useLargeVarTypes(true)
+            .build();
+    SparkWrite.SparkWriteBuilder builder =
+        new SparkWrite.SparkWriteBuilder(
+            SPARK_SCHEMA,
+            writeOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            null,
+            false);
+    builder.truncate();
+    SparkWrite sparkWrite = (SparkWrite) builder.build();
+    assertTrue(
+        sparkWrite.getWriteOptions().isUseLargeVarTypes(),
+        "useLargeVarTypes should be preserved after truncate()");
+  }
 }


### PR DESCRIPTION
## Summary

- `use_large_var_types` was silently dropped when writing via `createOrReplace()` / staged commits, causing Arrow `VarBinaryVector` to use 32-bit offsets and overflow at 2GB with large binary data (e.g. images)
- **Bug 1**: `SparkWrite.build()` reconstructed options for overwrite mode but omitted `.useLargeVarTypes()`
- **Bug 2**: `LanceBatchWrite.commit()` created the table's Arrow schema using the 3-param `toArrowSchema()` which hardcodes `largeVarTypes=false`

## Test plan

- [x] Unit test: `SparkWriteTest#testTruncatePreservesUseLargeVarTypes` — verifies option survives `truncate()`
- [x] Integration test: `BaseSparkConnectorWriteTest#createOrReplacePreservesUseLargeVarTypes` — verifies end-to-end that `writeTo().createOrReplace()` with `use_large_var_types=true` produces `LargeBinary`/`LargeUtf8` schema
- [x] All 25 existing `SparkConnectorWriteTest` tests pass
- [x] All 5 existing `SparkWriteTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)