### PR TITLE
feat: require clustered distribution on write for SPJ

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
@@ -28,4 +28,7 @@ public class LanceConstant {
 
   public static final String BACKFILL_COLUMNS_KEY = "backfill_columns";
   public static final String UPDATE_COLUMNS_KEY = "update_columns";
+
+  /** Table property that declares the partition column(s) for SPJ. */
+  public static final String TABLE_OPT_PARTITION_COLUMNS = "lance.partition.columns";
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -368,7 +368,8 @@ public class LanceDataset
             namespaceImpl,
             namespaceProperties,
             readOptions.getTableId(),
-            managedVersioning);
+            managedVersioning,
+            tableProperties);
 
     if (stagedCommit != null) {
       builder.setStagedCommit(stagedCommit);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -92,8 +92,6 @@ public class LanceScanBuilder
 
   private final java.util.Map<String, String> tableProperties;
 
-  static final String TABLE_OPT_PARTITION_COLUMNS = LanceConstant.TABLE_OPT_PARTITION_COLUMNS;
-
   public LanceScanBuilder(
       StructType schema,
       LanceSparkReadOptions readOptions,
@@ -142,7 +140,7 @@ public class LanceScanBuilder
 
     // Collect all columns that need zonemap stats: filter columns + partition column (if declared).
     Set<String> columnsToLoad = extractReferencedColumns(pushedFilters);
-    String partitionColumn = tableProperties.get(TABLE_OPT_PARTITION_COLUMNS);
+    String partitionColumn = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
     if (partitionColumn != null && !partitionColumn.trim().isEmpty()) {
       partitionColumn = partitionColumn.trim();
       columnsToLoad.add(partitionColumn);
@@ -163,7 +161,7 @@ public class LanceScanBuilder
             "Partition column '{}' declared in {} has no zonemap index or stats;"
                 + " partition detection disabled",
             partitionColumn,
-            TABLE_OPT_PARTITION_COLUMNS);
+            LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
       } else {
         Map<Integer, Comparable<?>> partValues =
             ZonemapFragmentPruner.computeFragmentPartitionValues(zonemapStats.get(partitionColumn))

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -20,6 +20,7 @@ import org.lance.index.IndexDescription;
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
 import org.lance.schema.LanceField;
+import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Optional;
 import org.lance.spark.utils.Utils;
@@ -91,7 +92,7 @@ public class LanceScanBuilder
 
   private final java.util.Map<String, String> tableProperties;
 
-  static final String TABLE_OPT_PARTITION_COLUMNS = "lance.partition.columns";
+  static final String TABLE_OPT_PARTITION_COLUMNS = LanceConstant.TABLE_OPT_PARTITION_COLUMNS;
 
   public LanceScanBuilder(
       StructType schema,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -14,20 +14,38 @@
 package org.lance.spark.write;
 
 import org.lance.WriteParams;
+import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkWriteOptions;
 
+import org.apache.spark.sql.connector.distributions.Distribution;
+import org.apache.spark.sql.connector.distributions.Distributions;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.NullOrdering;
+import org.apache.spark.sql.connector.expressions.SortDirection;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering;
 import org.apache.spark.sql.connector.write.SupportsTruncate;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.connector.write.streaming.StreamingWrite;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/** Spark write builder. */
-public class SparkWrite implements Write {
+/**
+ * Spark write implementation for Lance tables.
+ *
+ * <p>When the table property {@code lance.partition.columns} is set, this write requires Spark to
+ * cluster (partition) the input data by those columns before writing. This ensures each Lance
+ * fragment contains exactly one distinct value for the partition column(s), which is the
+ * prerequisite for Storage-Partitioned Joins (SPJ) on the read path.
+ */
+public class SparkWrite implements Write, RequiresDistributionAndOrdering {
   private final LanceSparkWriteOptions writeOptions;
   private final StructType schema;
 
@@ -51,6 +69,7 @@ public class SparkWrite implements Write {
   private final List<String> tableId;
   private final boolean managedVersioning;
   private final StagedCommit stagedCommit;
+  private final Map<String, String> tableProperties;
 
   SparkWrite(
       StructType schema,
@@ -61,7 +80,8 @@ public class SparkWrite implements Write {
       Map<String, String> namespaceProperties,
       List<String> tableId,
       boolean managedVersioning,
-      StagedCommit stagedCommit) {
+      StagedCommit stagedCommit,
+      Map<String, String> tableProperties) {
     this.schema = schema;
     this.writeOptions = writeOptions;
     this.overwrite = overwrite;
@@ -71,6 +91,48 @@ public class SparkWrite implements Write {
     this.tableId = tableId;
     this.managedVersioning = managedVersioning;
     this.stagedCommit = stagedCommit;
+    this.tableProperties =
+        tableProperties != null
+            ? Collections.unmodifiableMap(tableProperties)
+            : Collections.emptyMap();
+  }
+
+  /** Returns the write options used by this SparkWrite. Visible for testing. */
+  LanceSparkWriteOptions getWriteOptions() {
+    return writeOptions;
+  }
+
+  @Override
+  public Distribution requiredDistribution() {
+    String partitionColumns = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
+    if (partitionColumns != null && !partitionColumns.trim().isEmpty()) {
+      NamedReference[] refs =
+          Arrays.stream(partitionColumns.split(","))
+              .map(String::trim)
+              .filter(s -> !s.isEmpty())
+              .map(Expressions::column)
+              .toArray(NamedReference[]::new);
+      if (refs.length > 0) {
+        return Distributions.clustered(refs);
+      }
+    }
+    return Distributions.unspecified();
+  }
+
+  @Override
+  public SortOrder[] requiredOrdering() {
+    String partitionColumns = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
+    if (partitionColumns != null && !partitionColumns.trim().isEmpty()) {
+      return Arrays.stream(partitionColumns.split(","))
+          .map(String::trim)
+          .filter(s -> !s.isEmpty())
+          .map(
+              col ->
+                  Expressions.sort(
+                      Expressions.column(col), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST))
+          .toArray(SortOrder[]::new);
+    }
+    return new SortOrder[0];
   }
 
   @Override
@@ -111,6 +173,7 @@ public class SparkWrite implements Write {
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
     private final boolean managedVersioning;
+    private final Map<String, String> tableProperties;
 
     public SparkWriteBuilder(
         StructType schema,
@@ -119,7 +182,8 @@ public class SparkWrite implements Write {
         String namespaceImpl,
         Map<String, String> namespaceProperties,
         List<String> tableId,
-        boolean managedVersioning) {
+        boolean managedVersioning,
+        Map<String, String> tableProperties) {
       this.schema = schema;
       this.writeOptions = writeOptions;
       this.initialStorageOptions = initialStorageOptions;
@@ -127,6 +191,7 @@ public class SparkWrite implements Write {
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
       this.managedVersioning = managedVersioning;
+      this.tableProperties = tableProperties;
     }
 
     public void setStagedCommit(StagedCommit stagedCommit) {
@@ -164,7 +229,8 @@ public class SparkWrite implements Write {
           namespaceProperties,
           tableId,
           managedVersioning,
-          stagedCommit);
+          stagedCommit,
+          tableProperties);
     }
 
     @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -97,11 +97,6 @@ public class SparkWrite implements Write, RequiresDistributionAndOrdering {
             : Collections.emptyMap();
   }
 
-  /** Returns the write options used by this SparkWrite. Visible for testing. */
-  LanceSparkWriteOptions getWriteOptions() {
-    return writeOptions;
-  }
-
   @Override
   public Distribution requiredDistribution() {
     String partitionColumns = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BasePartitionedWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BasePartitionedWriteTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test verifying that writes with {@code lance.partition.columns} produce fragments
+ * where data is clustered by the partition column. When the number of Spark write tasks exceeds the
+ * number of distinct partition values, each fragment contains exactly one partition value.
+ */
+public abstract class BasePartitionedWriteTest {
+  protected String catalogName = "lance_part_write_test";
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    rootPath.toFile().mkdirs();
+    String testRoot = rootPath.toString();
+    spark =
+        SparkSession.builder()
+            .appName("lance-partitioned-write-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .getOrCreate();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (spark != null) {
+      spark.close();
+    }
+  }
+
+  @Test
+  public void testWriteWithPartitionColumnClustersData() {
+    String tableName = "part_write_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTable = catalogName + ".default." + tableName;
+
+    // Create table with partition column property
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING, value DOUBLE) USING lance "
+                + "TBLPROPERTIES ('lance.partition.columns' = 'region')",
+            fullTable));
+
+    // Insert data with multiple regions in a single INSERT — the write distribution
+    // should cluster rows by region so each fragment gets one region value.
+    String[] regions = {"east", "west", "north", "south", "central"};
+    StringBuilder values = new StringBuilder();
+    for (int r = 0; r < regions.length; r++) {
+      for (int i = 0; i < 10; i++) {
+        if (values.length() > 0) {
+          values.append(",");
+        }
+        int id = r * 10 + i;
+        values.append(String.format("(%d, '%s', %f)", id, regions[r], id * 1.5));
+      }
+    }
+    spark.sql(String.format("INSERT INTO %s (id, region, value) VALUES %s", fullTable, values));
+
+    // Verify all data was written correctly
+    Dataset<Row> result = spark.sql("SELECT * FROM " + fullTable);
+    assertEquals(50, result.count());
+
+    // Verify that data is clustered: within each fragment, there should be
+    // at most one distinct region value. We check this by reading with _fragid
+    // and verifying the count of distinct regions per fragment.
+    Dataset<Row> fragRegions =
+        spark.sql(
+            String.format(
+                "SELECT _fragid, COUNT(DISTINCT region) as distinct_regions "
+                    + "FROM %s GROUP BY _fragid",
+                fullTable));
+
+    List<Row> rows = fragRegions.collectAsList();
+    assertFalse(rows.isEmpty(), "Should have at least one fragment");
+
+    for (Row row : rows) {
+      long distinctRegions = row.getLong(1);
+      assertEquals(
+          1,
+          distinctRegions,
+          String.format(
+              "Fragment %d has %d distinct regions; expected 1 for partition-clustered write",
+              row.getInt(0), distinctRegions));
+    }
+  }
+
+  @Test
+  public void testWriteWithoutPartitionColumnNoDistribution() {
+    String tableName = "no_part_write_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTable = catalogName + ".default." + tableName;
+
+    // Create table WITHOUT partition column property
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT, region STRING, value DOUBLE) USING lance", fullTable));
+
+    // Insert data
+    String values =
+        IntStream.range(0, 20)
+            .mapToObj(
+                i -> {
+                  String region = i % 2 == 0 ? "east" : "west";
+                  return String.format("(%d, '%s', %f)", i, region, i * 1.5);
+                })
+            .collect(Collectors.joining(","));
+    spark.sql(String.format("INSERT INTO %s (id, region, value) VALUES %s", fullTable, values));
+
+    // Just verify data was written correctly — no clustering guarantee
+    Dataset<Row> result = spark.sql("SELECT * FROM " + fullTable);
+    assertEquals(20, result.count());
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -24,6 +24,9 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.connector.distributions.ClusteredDistribution;
+import org.apache.spark.sql.connector.distributions.Distribution;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.Write;
 import org.apache.spark.sql.types.StructType;
@@ -35,6 +38,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -133,11 +138,73 @@ public class SparkWriteTest {
             null,
             Collections.emptyMap(),
             null,
-            false);
+            false,
+            Collections.emptyMap());
     builder.truncate();
     SparkWrite sparkWrite = (SparkWrite) builder.build();
     assertTrue(
         sparkWrite.getWriteOptions().isUseLargeVarTypes(),
         "useLargeVarTypes should be preserved after truncate()");
+  }
+
+  // --- requiredDistribution / requiredOrdering tests ---
+
+  private SparkWrite createWriteWithTableProperties(
+      String datasetUri, Map<String, String> tableProps) {
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+    SparkWrite.SparkWriteBuilder builder =
+        new SparkWrite.SparkWriteBuilder(
+            SPARK_SCHEMA,
+            writeOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Arrays.asList("default", "test_table"),
+            false,
+            tableProps);
+    return (SparkWrite) builder.build();
+  }
+
+  @Test
+  public void testRequiredDistributionWithPartitionColumn(TestInfo testInfo) {
+    String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    Map<String, String> props = new HashMap<>();
+    props.put("lance.partition.columns", "name");
+    SparkWrite write = createWriteWithTableProperties(datasetUri, props);
+
+    Distribution dist = write.requiredDistribution();
+    assertInstanceOf(ClusteredDistribution.class, dist);
+    ClusteredDistribution clustered = (ClusteredDistribution) dist;
+    assertEquals(1, clustered.clustering().length);
+  }
+
+  @Test
+  public void testRequiredDistributionWithoutPartitionColumn(TestInfo testInfo) {
+    String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    SparkWrite write = createWriteWithTableProperties(datasetUri, Collections.emptyMap());
+
+    Distribution dist = write.requiredDistribution();
+    // Unspecified distribution — no clustering required
+    assertFalse(dist instanceof ClusteredDistribution);
+  }
+
+  @Test
+  public void testRequiredOrderingWithPartitionColumn(TestInfo testInfo) {
+    String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    Map<String, String> props = new HashMap<>();
+    props.put("lance.partition.columns", "name");
+    SparkWrite write = createWriteWithTableProperties(datasetUri, props);
+
+    SortOrder[] ordering = write.requiredOrdering();
+    assertEquals(1, ordering.length);
+  }
+
+  @Test
+  public void testRequiredOrderingWithoutPartitionColumn(TestInfo testInfo) {
+    String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    SparkWrite write = createWriteWithTableProperties(datasetUri, Collections.emptyMap());
+
+    SortOrder[] ordering = write.requiredOrdering();
+    assertEquals(0, ordering.length);
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -68,7 +68,8 @@ public class SparkWriteTest {
         null,
         Collections.emptyMap(),
         Arrays.asList("default", "test_table"),
-        false);
+        false,
+        Collections.emptyMap());
   }
 
   @Test
@@ -108,7 +109,8 @@ public class SparkWriteTest {
             null,
             Collections.emptyMap(),
             null,
-            false);
+            false,
+            Collections.emptyMap());
     assertSame(builder, builder.truncate());
     BatchWrite batchWrite = builder.build().toBatch();
     assertInstanceOf(LanceBatchWrite.class, batchWrite);


### PR DESCRIPTION
## Summary

Adds `RequiresDistributionAndOrdering` to `SparkWrite` so that when `lance.partition.columns` is set, Spark clusters and sorts the write data by the partition column(s). This ensures each Lance fragment contains exactly one distinct partition value — the prerequisite for Storage-Partitioned Joins (SPJ) on the read path.

### Changes
- `SparkWrite` implements `RequiresDistributionAndOrdering` — returns `Distributions.clustered()` and ascending `SortOrder` for partition columns
- `LanceConstant.TABLE_OPT_PARTITION_COLUMNS` centralizes the table property key
- `LanceScanBuilder` uses `LanceConstant` directly (no duplicate constant)
- Thread `tableProperties` through `SparkWriteBuilder` → `SparkWrite`

### Tests
- Unit tests for `requiredDistribution()` / `requiredOrdering()` with and without partition columns
- `BasePartitionedWriteTest` integration test verifying that fragments written with partition columns each contain exactly one distinct partition value

🤖 Generated with [Claude Code](https://claude.com/claude-code)