### PR TITLE
feat: expose blob_pack_file_size_threshold write option

### DIFF
--- a/docs/src/operations/dml/insert-into.md
+++ b/docs/src/operations/dml/insert-into.md
@@ -266,6 +266,7 @@ These options control how data is written to Lance datasets. They can be set usi
 | `use_queued_write_buffer`| Boolean | `false`  | Use pipelined write buffer for improved throughput.                                  |
 | `queue_depth`            | Integer | `8`      | Queue depth for pipelined writes (only used when `use_queued_write_buffer=true`).    |
 | `use_large_var_types`    | Boolean | `false`  | Use 64-bit offset vectors for all string/binary columns to avoid 2GB batch limit. See [Large Var Types](#large-var-types).   |
+| `blob_pack_file_size_threshold` | Long | `1073741824` (1 GiB) | Maximum size in bytes for blob v2 pack (`.blob`) sidecar files. When a pack file reaches this size, a new one is started. |
 
 ### Example: Controlling File Size
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -57,6 +57,7 @@ public class LanceSparkWriteOptions implements Serializable {
   public static final String CONFIG_ENABLE_STABLE_ROW_IDS = "enable_stable_row_ids";
   public static final String CONFIG_USE_LARGE_VAR_TYPES = "use_large_var_types";
   public static final String CONFIG_MAX_BATCH_BYTES = "max_batch_bytes";
+  public static final String CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD = "blob_pack_file_size_threshold";
 
   private static final WriteMode DEFAULT_WRITE_MODE = WriteMode.APPEND;
   private static final boolean DEFAULT_USE_QUEUED_WRITE_BUFFER = false;
@@ -82,6 +83,8 @@ public class LanceSparkWriteOptions implements Serializable {
   private final Boolean enableStableRowIds;
   private final boolean useLargeVarTypes;
   private final long maxBatchBytes;
+  // Boxed: null means "unset" so lance-core uses its own default (1 GiB as of 6.0.0-beta.1).
+  private final Long blobPackFileSizeThreshold;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -106,6 +109,7 @@ public class LanceSparkWriteOptions implements Serializable {
     this.enableStableRowIds = builder.enableStableRowIds;
     this.useLargeVarTypes = builder.useLargeVarTypes;
     this.maxBatchBytes = builder.maxBatchBytes;
+    this.blobPackFileSizeThreshold = builder.blobPackFileSizeThreshold;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -189,6 +193,11 @@ public class LanceSparkWriteOptions implements Serializable {
     return maxBatchBytes;
   }
 
+  /** Nullable: when unset, lance-core uses its own default for blob v2 pack sidecar size. */
+  public Long getBlobPackFileSizeThreshold() {
+    return blobPackFileSizeThreshold;
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -220,6 +229,7 @@ public class LanceSparkWriteOptions implements Serializable {
         .maxBatchBytes(maxBatchBytes)
         .enableStableRowIds(enableStableRowIds)
         .useLargeVarTypes(useLargeVarTypes)
+        .blobPackFileSizeThreshold(blobPackFileSizeThreshold)
         .storageOptions(storageOptions)
         .namespace(namespace)
         .tableId(tableId)
@@ -285,6 +295,9 @@ public class LanceSparkWriteOptions implements Serializable {
     if (enableStableRowIds != null) {
       builder.withEnableStableRowIds(enableStableRowIds);
     }
+    if (blobPackFileSizeThreshold != null) {
+      builder.withBlobPackFileSizeThreshold(blobPackFileSizeThreshold);
+    }
     Map<String, String> merged =
         LanceRuntime.mergeStorageOptions(storageOptions, initialStorageOptions);
     if (!merged.isEmpty()) {
@@ -309,6 +322,7 @@ public class LanceSparkWriteOptions implements Serializable {
         && Objects.equals(maxBytesPerFile, that.maxBytesPerFile)
         && Objects.equals(fileFormatVersion, that.fileFormatVersion)
         && Objects.equals(enableStableRowIds, that.enableStableRowIds)
+        && Objects.equals(blobPackFileSizeThreshold, that.blobPackFileSizeThreshold)
         && Objects.equals(storageOptions, that.storageOptions)
         && Objects.equals(tableId, that.tableId)
         && Objects.equals(version, that.version);
@@ -329,6 +343,7 @@ public class LanceSparkWriteOptions implements Serializable {
         enableStableRowIds,
         useLargeVarTypes,
         maxBatchBytes,
+        blobPackFileSizeThreshold,
         storageOptions,
         tableId,
         version);
@@ -348,6 +363,7 @@ public class LanceSparkWriteOptions implements Serializable {
     private Boolean enableStableRowIds;
     private boolean useLargeVarTypes = DEFAULT_USE_LARGE_VAR_TYPES;
     private long maxBatchBytes = DEFAULT_MAX_BATCH_BYTES;
+    private Long blobPackFileSizeThreshold;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -413,6 +429,14 @@ public class LanceSparkWriteOptions implements Serializable {
     public Builder maxBatchBytes(long maxBatchBytes) {
       Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
       this.maxBatchBytes = maxBatchBytes;
+      return this;
+    }
+
+    public Builder blobPackFileSizeThreshold(Long blobPackFileSizeThreshold) {
+      Preconditions.checkArgument(
+          blobPackFileSizeThreshold == null || blobPackFileSizeThreshold > 0,
+          "blobPackFileSizeThreshold must be positive");
+      this.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
       return this;
     }
 
@@ -482,6 +506,11 @@ public class LanceSparkWriteOptions implements Serializable {
         long parsedMaxBatchBytes = Long.parseLong(options.get(CONFIG_MAX_BATCH_BYTES));
         Preconditions.checkArgument(parsedMaxBatchBytes > 0, "max_batch_bytes must be positive");
         this.maxBatchBytes = parsedMaxBatchBytes;
+      }
+      if (options.containsKey(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD)) {
+        long parsed = Long.parseLong(options.get(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD));
+        Preconditions.checkArgument(parsed > 0, "blob_pack_file_size_threshold must be positive");
+        this.blobPackFileSizeThreshold = parsed;
       }
       return this;
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -111,55 +111,6 @@ public class LanceSparkWriteOptionsTest {
   }
 
   @Test
-  public void testBlobPackFileSizeThresholdNullByDefault() {
-    LanceSparkWriteOptions opts = LanceSparkWriteOptions.from(TEMP_URL);
-    assertNull(opts.getBlobPackFileSizeThreshold());
-  }
-
-  @Test
-  public void testBlobPackFileSizeThresholdViaBuilder() {
-    LanceSparkWriteOptions opts =
-        LanceSparkWriteOptions.builder()
-            .datasetUri(TEMP_URL)
-            .blobPackFileSizeThreshold(512L * 1024 * 1024)
-            .build();
-    assertEquals(Long.valueOf(512L * 1024 * 1024), opts.getBlobPackFileSizeThreshold());
-  }
-
-  @Test
-  public void testBlobPackFileSizeThresholdParsedFromOptions() {
-    final Map<String, String> options = new HashMap<>();
-    options.put("path", TEMP_URL);
-    options.put("blob_pack_file_size_threshold", "2147483648");
-
-    LanceSparkWriteOptions opts =
-        LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).fromOptions(options).build();
-
-    assertEquals(Long.valueOf(2147483648L), opts.getBlobPackFileSizeThreshold());
-  }
-
-  @Test
-  public void testToWriteParamsPropagatesBlobPackFileSizeThreshold() {
-    LanceSparkWriteOptions opts =
-        LanceSparkWriteOptions.builder()
-            .datasetUri(TEMP_URL)
-            .blobPackFileSizeThreshold(123L)
-            .build();
-
-    WriteParams params = opts.toWriteParams();
-    assertTrue(params.getBlobPackFileSizeThreshold().isPresent());
-    assertEquals(Long.valueOf(123L), params.getBlobPackFileSizeThreshold().get());
-  }
-
-  @Test
-  public void testToWriteParamsOmitsBlobPackFileSizeThresholdWhenNull() {
-    LanceSparkWriteOptions opts = LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).build();
-
-    WriteParams params = opts.toWriteParams();
-    assertFalse(params.getBlobPackFileSizeThreshold().isPresent());
-  }
-
-  @Test
   public void testFromOptionsWithAllWriteSettings() {
     final Map<String, String> options = new HashMap<>();
     options.put("path", TEMP_URL);
@@ -169,6 +120,7 @@ public class LanceSparkWriteOptionsTest {
     options.put("max_bytes_per_file", "1048576");
     options.put("batch_size", "256");
     options.put("enable_stable_row_ids", "true");
+    options.put("blob_pack_file_size_threshold", "2147483648");
 
     final LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).fromOptions(options).build();
@@ -179,5 +131,6 @@ public class LanceSparkWriteOptionsTest {
     assertEquals(1048576L, writeOptions.getMaxBytesPerFile());
     assertEquals(256, writeOptions.getBatchSize());
     assertTrue(writeOptions.getEnableStableRowIds());
+    assertEquals(Long.valueOf(2147483648L), writeOptions.getBlobPackFileSizeThreshold());
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -111,6 +111,55 @@ public class LanceSparkWriteOptionsTest {
   }
 
   @Test
+  public void testBlobPackFileSizeThresholdNullByDefault() {
+    LanceSparkWriteOptions opts = LanceSparkWriteOptions.from(TEMP_URL);
+    assertNull(opts.getBlobPackFileSizeThreshold());
+  }
+
+  @Test
+  public void testBlobPackFileSizeThresholdViaBuilder() {
+    LanceSparkWriteOptions opts =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .blobPackFileSizeThreshold(512L * 1024 * 1024)
+            .build();
+    assertEquals(Long.valueOf(512L * 1024 * 1024), opts.getBlobPackFileSizeThreshold());
+  }
+
+  @Test
+  public void testBlobPackFileSizeThresholdParsedFromOptions() {
+    final Map<String, String> options = new HashMap<>();
+    options.put("path", TEMP_URL);
+    options.put("blob_pack_file_size_threshold", "2147483648");
+
+    LanceSparkWriteOptions opts =
+        LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).fromOptions(options).build();
+
+    assertEquals(Long.valueOf(2147483648L), opts.getBlobPackFileSizeThreshold());
+  }
+
+  @Test
+  public void testToWriteParamsPropagatesBlobPackFileSizeThreshold() {
+    LanceSparkWriteOptions opts =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .blobPackFileSizeThreshold(123L)
+            .build();
+
+    WriteParams params = opts.toWriteParams();
+    assertTrue(params.getBlobPackFileSizeThreshold().isPresent());
+    assertEquals(Long.valueOf(123L), params.getBlobPackFileSizeThreshold().get());
+  }
+
+  @Test
+  public void testToWriteParamsOmitsBlobPackFileSizeThresholdWhenNull() {
+    LanceSparkWriteOptions opts = LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).build();
+
+    WriteParams params = opts.toWriteParams();
+    assertFalse(params.getBlobPackFileSizeThreshold().isPresent());
+  }
+
+  @Test
   public void testFromOptionsWithAllWriteSettings() {
     final Map<String, String> options = new HashMap<>();
     options.put("path", TEMP_URL);


### PR DESCRIPTION
## Summary
- lance-core 6.0.0-beta.1 added `WriteParams.withBlobPackFileSizeThreshold` for capping blob v2 pack (`.blob`) sidecar file size — this PR plumbs it through to Spark writes as `blob_pack_file_size_threshold`.
- Boxed `Long` field so leaving it unset preserves the lance-core default (1 GiB); a set value flows through `toWriteParams()` to the native write.
- Docs table updated; builder setter and `fromOptions` parser mirror the existing `max_bytes_per_file` pattern.

## Test plan
- [x] `LanceSparkWriteOptionsTest` — 5 new cases cover default-null, builder setter, parsing from options, `toWriteParams` propagation, and omission when null (15/15 tests pass in `lance-spark-base_2.12`).
- [ ] Reviewer sanity-check via DataFrame API: `df.write.format("lance").option("blob_pack_file_size_threshold", "536870912").save(path)` writes a dataset whose blob sidecars roll at the configured size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)