### PR TITLE
refactor: migrate filter pushdown from V1 Filter to V2 Predicate API

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -209,12 +209,18 @@ public class FilterPushDown {
     if (value instanceof String) {
       return "'" + ((String) value).replace("'", "''") + "'";
     }
+    if (value instanceof org.apache.spark.sql.types.Decimal) {
+      return formatDecimalCast(((org.apache.spark.sql.types.Decimal) value).toJavaBigDecimal());
+    }
     if (value instanceof BigDecimal) {
-      BigDecimal bd = (BigDecimal) value;
-      int scale = bd.scale();
-      int precision = Math.max(bd.precision(), scale);
-      return "CAST(" + bd.toPlainString() + " AS DECIMAL(" + precision + ", " + scale + "))";
+      return formatDecimalCast((BigDecimal) value);
     }
     return value.toString();
+  }
+
+  private static String formatDecimalCast(BigDecimal bd) {
+    int scale = bd.scale();
+    int precision = Math.max(bd.precision(), scale);
+    return "CAST(" + bd.toPlainString() + " AS DECIMAL(" + precision + ", " + scale + "))";
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -15,195 +15,206 @@ package org.lance.spark.read;
 
 import org.lance.spark.utils.Optional;
 
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualNullSafe;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.IsNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
-import org.apache.spark.sql.sources.StringContains;
-import org.apache.spark.sql.sources.StringEndsWith;
-import org.apache.spark.sql.sources.StringStartsWith;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Literal;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.And;
+import org.apache.spark.sql.connector.expressions.filter.Not;
+import org.apache.spark.sql.connector.expressions.filter.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataTypes;
 
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class FilterPushDown {
   /**
-   * Create SQL 'where clause' from Spark filters.
+   * Create SQL 'where clause' from Spark V2 predicates.
    *
-   * @param filters Supported spark filters
-   * @return where clause, or Optional.empty() if filters do not exist
+   * @param predicates Supported V2 predicates
+   * @return where clause, or Optional.empty() if no predicates compile to SQL
    */
-  public static Optional<String> compileFiltersToSqlWhereClause(Filter[] filters) {
-    if (filters.length == 0) {
+  public static Optional<String> compileFiltersToSqlWhereClause(Predicate[] predicates) {
+    if (predicates.length == 0) {
       return Optional.empty();
     }
-    List<String> compiledFilters = new ArrayList<>();
-    for (Filter filter : filters) {
-      compileFilter(filter).ifPresent(compiledFilters::add);
+    List<String> compiled = new ArrayList<>();
+    for (Predicate predicate : predicates) {
+      compilePredicate(predicate).ifPresent(compiled::add);
+    }
+    if (compiled.isEmpty()) {
+      return Optional.empty();
     }
     String whereClause =
-        compiledFilters.stream()
-            .map(filter -> "(" + filter + ")")
-            .collect(Collectors.joining(" AND "));
+        compiled.stream().map(p -> "(" + p + ")").collect(Collectors.joining(" AND "));
     return Optional.of(whereClause);
   }
 
   /**
-   * @param filters filters to see if Lance supported the filter push down
-   * @return the accepted push down filters (row 0) and rejected post scan filters (row 1)
+   * @param predicates predicates to check for Lance push-down support
+   * @return accepted push-down predicates (row 0) and rejected post-scan predicates (row 1)
    */
-  public static Filter[][] processFilters(Filter[] filters) {
-    List<Filter> acceptedFilters = new ArrayList<>();
-    List<Filter> rejectedFilters = new ArrayList<>();
+  public static Predicate[][] processPredicates(Predicate[] predicates) {
+    List<Predicate> accepted = new ArrayList<>();
+    List<Predicate> rejected = new ArrayList<>();
 
-    for (Filter filter : filters) {
-      if (isFilterSupported(filter)) {
-        acceptedFilters.add(filter);
+    for (Predicate predicate : predicates) {
+      if (isPredicateSupported(predicate)) {
+        accepted.add(predicate);
       } else {
-        rejectedFilters.add(filter);
+        rejected.add(predicate);
       }
     }
 
-    Filter[] acceptedArray = acceptedFilters.toArray(new Filter[0]);
-    Filter[] rejectedArray = rejectedFilters.toArray(new Filter[0]);
-
-    return new Filter[][] {acceptedArray, rejectedArray};
+    return new Predicate[][] {
+      accepted.toArray(new Predicate[0]), rejected.toArray(new Predicate[0])
+    };
   }
 
-  public static boolean isFilterSupported(Filter filter) {
-    if (filter instanceof EqualTo) {
-      return true;
-    } else if (filter instanceof EqualNullSafe) {
-      return false;
-    } else if (filter instanceof In) {
-      return true;
-    } else if (filter instanceof LessThan) {
-      return true;
-    } else if (filter instanceof LessThanOrEqual) {
-      return true;
-    } else if (filter instanceof GreaterThan) {
-      return true;
-    } else if (filter instanceof GreaterThanOrEqual) {
-      return true;
-    } else if (filter instanceof IsNull) {
-      return true;
-    } else if (filter instanceof IsNotNull) {
-      return true;
-    } else if (filter instanceof StringStartsWith) {
-      return false;
-    } else if (filter instanceof StringEndsWith) {
-      return false;
-    } else if (filter instanceof StringContains) {
-      return false;
-    } else if (filter instanceof Not) {
-      Not f = (Not) filter;
-      return isFilterSupported(f.child());
-    } else if (filter instanceof Or) {
-      Or f = (Or) filter;
-      return isFilterSupported(f.left()) && isFilterSupported(f.right());
-    } else if (filter instanceof And) {
-      And f = (And) filter;
-      return isFilterSupported(f.left()) && isFilterSupported(f.right());
-    } else {
-      return false;
+  public static boolean isPredicateSupported(Predicate predicate) {
+    if (predicate instanceof And) {
+      And and = (And) predicate;
+      return isPredicateSupported(and.left()) && isPredicateSupported(and.right());
+    }
+    if (predicate instanceof Or) {
+      Or or = (Or) predicate;
+      return isPredicateSupported(or.left()) && isPredicateSupported(or.right());
+    }
+    if (predicate instanceof Not) {
+      Not not = (Not) predicate;
+      return isPredicateSupported(not.child());
+    }
+    switch (predicate.name()) {
+      case "=":
+      case "<":
+      case "<=":
+      case ">":
+      case ">=":
+      case "IS_NULL":
+      case "IS_NOT_NULL":
+      case "IN":
+        return isColumnLiteralShape(predicate);
+      default:
+        return false;
     }
   }
 
-  private static Optional<String> compileFilter(Filter filter) {
-    if (filter instanceof GreaterThan) {
-      GreaterThan f = (GreaterThan) filter;
-      return Optional.of(f.attribute() + " > " + compileValue(f.value()));
-    } else if (filter instanceof LessThan) {
-      LessThan f = (LessThan) filter;
-      return Optional.of(f.attribute() + " < " + compileValue(f.value()));
-    } else if (filter instanceof LessThanOrEqual) {
-      LessThanOrEqual f = (LessThanOrEqual) filter;
-      return Optional.of(f.attribute() + " <= " + compileValue(f.value()));
-    } else if (filter instanceof GreaterThanOrEqual) {
-      GreaterThanOrEqual f = (GreaterThanOrEqual) filter;
-      return Optional.of(f.attribute() + " >= " + compileValue(f.value()));
-    } else if (filter instanceof EqualTo) {
-      EqualTo f = (EqualTo) filter;
-      return Optional.of(f.attribute() + " == " + compileValue(f.value()));
-    } else if (filter instanceof Or) {
-      Or f = (Or) filter;
-      Optional<String> left = compileFilter(f.left());
-      Optional<String> right = compileFilter(f.right());
-      if (left.isEmpty()) return right;
-      if (right.isEmpty()) return left;
-      return Optional.of(String.format("(%s) OR (%s)", left.get(), right.get()));
-    } else if (filter instanceof And) {
-      And f = (And) filter;
-      Optional<String> left = compileFilter(f.left());
-      Optional<String> right = compileFilter(f.right());
+  private static boolean isColumnLiteralShape(Predicate predicate) {
+    Expression[] children = predicate.children();
+    if (children.length == 0) {
+      return false;
+    }
+    if (!(children[0] instanceof NamedReference)) {
+      return false;
+    }
+    for (int i = 1; i < children.length; i++) {
+      if (!(children[i] instanceof Literal)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Optional<String> compilePredicate(Predicate predicate) {
+    if (predicate instanceof And) {
+      And and = (And) predicate;
+      Optional<String> left = compilePredicate(and.left());
+      Optional<String> right = compilePredicate(and.right());
       if (left.isEmpty()) return right;
       if (right.isEmpty()) return left;
       return Optional.of(String.format("(%s) AND (%s)", left.get(), right.get()));
-    } else if (filter instanceof IsNull) {
-      IsNull f = (IsNull) filter;
-      return Optional.of(String.format("%s IS NULL", f.attribute()));
-    } else if (filter instanceof IsNotNull) {
-      IsNotNull f = (IsNotNull) filter;
-      return Optional.of(String.format("%s IS NOT NULL", f.attribute()));
-    } else if (filter instanceof Not) {
-      Not f = (Not) filter;
-      Optional<String> child = compileFilter(f.child());
+    }
+    if (predicate instanceof Or) {
+      Or or = (Or) predicate;
+      Optional<String> left = compilePredicate(or.left());
+      Optional<String> right = compilePredicate(or.right());
+      if (left.isEmpty()) return right;
+      if (right.isEmpty()) return left;
+      return Optional.of(String.format("(%s) OR (%s)", left.get(), right.get()));
+    }
+    if (predicate instanceof Not) {
+      Not not = (Not) predicate;
+      Optional<String> child = compilePredicate(not.child());
       if (child.isEmpty()) return child;
       return Optional.of(String.format("NOT (%s)", child.get()));
-    } else if (filter instanceof In) {
-      In in = (In) filter;
-      String values =
-          Arrays.stream(in.values())
-              .map(FilterPushDown::compileValue)
-              .collect(Collectors.joining(","));
-      return Optional.of(String.format("%s IN (%s)", in.attribute(), values));
     }
 
-    return Optional.empty();
+    Expression[] children = predicate.children();
+    switch (predicate.name()) {
+      case "=":
+        return binaryOp(children, "==");
+      case "<":
+        return binaryOp(children, "<");
+      case "<=":
+        return binaryOp(children, "<=");
+      case ">":
+        return binaryOp(children, ">");
+      case ">=":
+        return binaryOp(children, ">=");
+      case "IS_NULL":
+        return Optional.of(String.format("%s IS NULL", columnName(children[0])));
+      case "IS_NOT_NULL":
+        return Optional.of(String.format("%s IS NOT NULL", columnName(children[0])));
+      case "IN":
+        String values =
+            java.util.Arrays.stream(children)
+                .skip(1)
+                .map(c -> compileLiteral(((Literal<?>) c)))
+                .collect(Collectors.joining(","));
+        return Optional.of(String.format("%s IN (%s)", columnName(children[0]), values));
+      default:
+        return Optional.empty();
+    }
   }
 
-  private static String compileValue(Object value) {
+  private static Optional<String> binaryOp(Expression[] children, String op) {
+    if (children.length != 2) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        columnName(children[0]) + " " + op + " " + compileLiteral((Literal<?>) children[1]));
+  }
+
+  private static String columnName(Expression expr) {
+    return String.join(".", ((NamedReference) expr).fieldNames());
+  }
+
+  private static String compileLiteral(Literal<?> literal) {
+    Object value = literal.value();
     if (value == null) {
       return "NULL";
-    } else if (value instanceof Date) {
+    }
+    if (literal.dataType() == DataTypes.DateType && value instanceof Integer) {
+      return "date '" + java.time.LocalDate.ofEpochDay((Integer) value) + "'";
+    }
+    if (literal.dataType() == DataTypes.TimestampType && value instanceof Long) {
+      long micros = (Long) value;
+      java.time.Instant instant =
+          java.time.Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1_000);
+      return "timestamp '" + Timestamp.from(instant) + "'";
+    }
+    if (value instanceof Date) {
       return "date '" + value.toString().replace("'", "''") + "'";
-    } else if (value instanceof Timestamp) {
+    }
+    if (value instanceof Timestamp) {
       return "timestamp '" + value.toString().replace("'", "''") + "'";
-    } else if (value instanceof String) {
+    }
+    if (value instanceof org.apache.spark.unsafe.types.UTF8String) {
+      return "'" + value.toString().replace("'", "''") + "'";
+    }
+    if (value instanceof String) {
       return "'" + ((String) value).replace("'", "''") + "'";
-    } else if (value instanceof BigDecimal) {
+    }
+    if (value instanceof BigDecimal) {
       BigDecimal bd = (BigDecimal) value;
       int scale = bd.scale();
-      // Java returns precision=1 for zero regardless of scale (e.g. 0.00 → precision=1, scale=2).
-      // Arrow requires precision >= scale, so clamp precision up if needed.
       int precision = Math.max(bd.precision(), scale);
       return "CAST(" + bd.toPlainString() + " AS DECIMAL(" + precision + ", " + scale + "))";
-    } else if (value instanceof Object[]) {
-      Object[] array = (Object[]) value;
-      StringBuilder sb = new StringBuilder();
-      for (Object obj : array) {
-        if (sb.length() > 0) {
-          sb.append(", ");
-        }
-        sb.append(compileValue(obj));
-      }
-      return sb.toString();
-    } else {
-      return value.toString();
     }
+    return value.toString();
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -26,6 +26,7 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.metric.CustomMetric;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
@@ -39,7 +40,6 @@ import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
 import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
 import org.apache.spark.sql.internal.connector.SupportsMetadata;
-import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.slf4j.Logger;
@@ -73,7 +73,7 @@ public class LanceScan
   private final Optional<Integer> offset;
   private final Optional<List<ColumnOrdering>> topNSortOrders;
   private final Optional<Aggregation> pushedAggregation;
-  private final Filter[] pushedFilters;
+  private final Predicate[] pushedPredicates;
   private final LanceStatistics statistics;
   private final String scanId = UUID.randomUUID().toString();
 
@@ -118,7 +118,7 @@ public class LanceScan
       Optional<Integer> offset,
       Optional<List<ColumnOrdering>> topNSortOrders,
       Optional<Aggregation> pushedAggregation,
-      Filter[] pushedFilters,
+      Predicate[] pushedPredicates,
       LanceStatistics statistics,
       java.util.Map<String, List<ZoneStats>> zonemapStats,
       Set<Integer> survivingFragmentIds,
@@ -133,8 +133,10 @@ public class LanceScan
     this.offset = offset;
     this.topNSortOrders = topNSortOrders;
     this.pushedAggregation = pushedAggregation;
-    this.pushedFilters =
-        pushedFilters != null ? Arrays.copyOf(pushedFilters, pushedFilters.length) : new Filter[0];
+    this.pushedPredicates =
+        pushedPredicates != null
+            ? Arrays.copyOf(pushedPredicates, pushedPredicates.length)
+            : new Predicate[0];
     this.statistics = statistics;
     this.zonemapStats = zonemapStats != null ? zonemapStats : Collections.emptyMap();
     this.cachedSurvivingFragmentIds = survivingFragmentIds;
@@ -219,7 +221,7 @@ public class LanceScan
    */
   private List<LanceSplit> pruneByRowAddrFilters(List<LanceSplit> allSplits) {
     java.util.Optional<Set<Integer>> targetFragmentIds =
-        RowAddressFilterAnalyzer.extractTargetFragmentIds(pushedFilters);
+        RowAddressFilterAnalyzer.extractTargetFragmentIds(pushedPredicates);
     if (!targetFragmentIds.isPresent()) {
       return allSplits;
     }
@@ -331,7 +333,8 @@ public class LanceScan
     if (cachedSurvivingFragmentIds != null) {
       allowedIds = cachedSurvivingFragmentIds;
     } else if (!zonemapStats.isEmpty()) {
-      allowedIds = ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
+      allowedIds =
+          ZonemapFragmentPruner.pruneFragments(pushedPredicates, zonemapStats).orElse(null);
     } else {
       return allSplits;
     }
@@ -439,7 +442,7 @@ public class LanceScan
         && Objects.equals(offset, that.offset)
         && Objects.equals(topNSortOrders.toString(), that.topNSortOrders.toString())
         && aggregationEquals(pushedAggregation, that.pushedAggregation)
-        && equivalentFilters(pushedFilters, that.pushedFilters);
+        && equivalentPredicates(pushedPredicates, that.pushedPredicates);
   }
 
   @Override
@@ -447,7 +450,7 @@ public class LanceScan
     int result =
         Objects.hash(
             schema, readOptions, whereConditions, limit, offset, topNSortOrders.toString());
-    result = 31 * result + Arrays.hashCode(sortedByHash(pushedFilters));
+    result = 31 * result + Arrays.hashCode(sortedByHash(pushedPredicates));
     result = 31 * result + aggregationHashCode(pushedAggregation);
     return result;
   }
@@ -482,10 +485,10 @@ public class LanceScan
   }
 
   /**
-   * Returns whether two filter arrays are equivalent regardless of order. Follows Spark's {@code
+   * Returns whether two predicate arrays are equivalent regardless of order. Follows Spark's {@code
    * FileScan.equivalentFilters()}: sort by hashCode, then compare element-wise.
    */
-  private static boolean equivalentFilters(Filter[] a, Filter[] b) {
+  private static boolean equivalentPredicates(Predicate[] a, Predicate[] b) {
     return Arrays.equals(sortedByHash(a), sortedByHash(b));
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -29,20 +29,21 @@ import org.lance.spark.utils.Utils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.NullOrdering;
 import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.SupportsPushDownAggregates;
-import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownOffset;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsPushDownTopN;
-import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.connector.read.SupportsPushDownV2Filters;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
@@ -59,7 +60,7 @@ import java.util.stream.Collectors;
 
 public class LanceScanBuilder
     implements SupportsPushDownRequiredColumns,
-        SupportsPushDownFilters,
+        SupportsPushDownV2Filters,
         SupportsPushDownLimit,
         SupportsPushDownOffset,
         SupportsPushDownTopN,
@@ -73,7 +74,7 @@ public class LanceScanBuilder
 
   private StructType schema;
 
-  private Filter[] pushedFilters = new Filter[0];
+  private Predicate[] pushedPredicates = new Predicate[0];
   private Optional<Integer> limit = Optional.empty();
   private Optional<Integer> offset = Optional.empty();
   private Optional<List<ColumnOrdering>> topNSortOrders = Optional.empty();
@@ -143,7 +144,7 @@ public class LanceScanBuilder
     ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
 
     // Collect all columns that need zonemap stats: filter columns + partition column (if declared).
-    Set<String> columnsToLoad = extractReferencedColumns(pushedFilters);
+    Set<String> columnsToLoad = extractReferencedColumns(pushedPredicates);
     String partitionColumn = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
     if (partitionColumn != null && !partitionColumn.trim().isEmpty()) {
       partitionColumn = partitionColumn.trim();
@@ -184,9 +185,9 @@ public class LanceScanBuilder
     // JoinSelection (BroadcastHashJoin vs SortMergeJoin) and (b) pass the cached result
     // to LanceScan to avoid re-computing during planInputPartitions().
     Set<Integer> survivingFragmentIds = null;
-    if (pushedFilters.length > 0 && !zonemapStats.isEmpty()) {
+    if (pushedPredicates.length > 0 && !zonemapStats.isEmpty()) {
       survivingFragmentIds =
-          ZonemapFragmentPruner.pruneFragments(pushedFilters, zonemapStats).orElse(null);
+          ZonemapFragmentPruner.pruneFragments(pushedPredicates, zonemapStats).orElse(null);
     }
 
     // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
@@ -216,7 +217,8 @@ public class LanceScanBuilder
     // Close the lazily opened dataset - it's no longer needed after build
     closeLazyDataset();
 
-    Optional<String> whereCondition = FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters);
+    Optional<String> whereCondition =
+        FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);
     return new LanceScan(
         schema,
         readOptions,
@@ -225,7 +227,7 @@ public class LanceScanBuilder
         offset,
         topNSortOrders,
         pushedAggregation,
-        pushedFilters,
+        pushedPredicates,
         statistics,
         zonemapStats,
         survivingFragmentIds,
@@ -241,18 +243,18 @@ public class LanceScanBuilder
   }
 
   @Override
-  public Filter[] pushFilters(Filter[] filters) {
+  public Predicate[] pushPredicates(Predicate[] predicates) {
     if (!readOptions.isPushDownFilters()) {
-      return filters;
+      return predicates;
     }
-    Filter[][] processFilters = FilterPushDown.processFilters(filters);
-    pushedFilters = processFilters[0];
-    return processFilters[1];
+    Predicate[][] processed = FilterPushDown.processPredicates(predicates);
+    pushedPredicates = processed[0];
+    return processed[1];
   }
 
   @Override
-  public Filter[] pushedFilters() {
-    return pushedFilters;
+  public Predicate[] pushedPredicates() {
+    return pushedPredicates;
   }
 
   @Override
@@ -313,7 +315,7 @@ public class LanceScanBuilder
     }
     if (funcs.length == 1 && funcs[0] instanceof CountStar) {
       // Check if we can use metadata-based count (no filters pushed)
-      if (pushedFilters.length == 0) {
+      if (pushedPredicates.length == 0) {
         Optional<Long> metadataCount = getCountFromMetadata(getOrOpenDataset());
         if (metadataCount.isPresent()) {
           // Create LocalScan with pre-computed count result
@@ -404,11 +406,12 @@ public class LanceScanBuilder
     return columns;
   }
 
-  private static Set<String> extractReferencedColumns(Filter[] filters) {
+  private static Set<String> extractReferencedColumns(Predicate[] predicates) {
     Set<String> columns = new HashSet<>();
-    for (Filter filter : filters) {
-      for (String attr : filter.references()) {
-        columns.add(attr);
+    for (Predicate predicate : predicates) {
+      for (NamedReference ref : predicate.references()) {
+        String[] names = ref.fieldNames();
+        columns.add(names.length == 1 ? names[0] : String.join(".", names));
       }
     }
     return columns;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/RowAddressFilterAnalyzer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/RowAddressFilterAnalyzer.java
@@ -16,12 +16,13 @@ package org.lance.spark.read;
 import org.lance.spark.LanceConstant;
 import org.lance.spark.join.FragmentAwareJoinUtils;
 
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Literal;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.And;
+import org.apache.spark.sql.connector.expressions.filter.Not;
+import org.apache.spark.sql.connector.expressions.filter.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,8 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Analyzes pushed Spark filters to extract target fragment IDs from {@code _rowaddr} constraints.
+ * Analyzes pushed Spark predicates to extract target fragment IDs from {@code _rowaddr}
+ * constraints.
  *
  * <p>Since {@code _rowaddr = (fragment_id << 32) | row_index}, we can extract the fragment ID from
  * any {@code _rowaddr} constant value and prune fragments that cannot match. This provides
@@ -51,26 +53,22 @@ public final class RowAddressFilterAnalyzer {
   private RowAddressFilterAnalyzer() {}
 
   /**
-   * Extracts the set of fragment IDs that could match the given pushed filters based on {@code
-   * _rowaddr} constraints. Multiple filters are treated as conjuncts (implicit AND); their fragment
-   * sets are intersected.
+   * Extracts the set of fragment IDs that could match the given pushed predicates based on {@code
+   * _rowaddr} constraints. Multiple predicates are treated as conjuncts (implicit AND); their
+   * fragment sets are intersected.
    *
-   * @param filters the pushed Spark filters
+   * @param predicates the pushed V2 predicates
    * @return present with the set of matching fragment IDs if pruning is possible; empty if no
    *     pruning can be applied
    */
-  public static Optional<Set<Integer>> extractTargetFragmentIds(Filter[] filters) {
-    if (filters == null || filters.length == 0) {
+  public static Optional<Set<Integer>> extractTargetFragmentIds(Predicate[] predicates) {
+    if (predicates == null || predicates.length == 0) {
       return Optional.empty();
     }
 
-    // Multiple top-level filters are implicitly ANDed by Spark. We intersect the fragment sets
-    // from each filter that provides one. If two top-level _rowaddr constraints target different
-    // fragments (e.g. [EqualTo("_rowaddr", 0L), EqualTo("_rowaddr", 4294967296L)]), the
-    // intersection will be empty, correctly producing zero results.
     Set<Integer> result = null;
-    for (Filter filter : filters) {
-      Optional<Set<Integer>> fragmentIds = analyzeFilter(filter);
+    for (Predicate predicate : predicates) {
+      Optional<Set<Integer>> fragmentIds = analyzePredicate(predicate);
       if (fragmentIds.isPresent()) {
         if (result == null) {
           result = new HashSet<>(fragmentIds.get());
@@ -87,44 +85,47 @@ public final class RowAddressFilterAnalyzer {
   }
 
   /**
-   * Recursively analyzes a single filter to extract fragment IDs from {@code _rowaddr} constraints.
+   * Recursively analyzes a single predicate to extract fragment IDs from {@code _rowaddr}
+   * constraints.
    *
    * <p>CONTRACT: when present, the returned Set is always a fresh mutable {@link HashSet} that is
-   * not aliased by any other reference. Callers (including {@link #extractTargetFragmentIds} and
-   * {@link #analyzeAnd}) may freely mutate it (e.g. via {@code retainAll} or {@code addAll})
-   * without affecting other results.
-   *
-   * @param filter the filter to analyze
-   * @return present with the set of matching fragment IDs; empty if no pruning can be derived
+   * not aliased by any other reference. Callers may freely mutate it (e.g. via {@code retainAll} or
+   * {@code addAll}) without affecting other results.
    */
-  private static Optional<Set<Integer>> analyzeFilter(Filter filter) {
-    if (filter instanceof EqualTo) {
-      return analyzeEqualTo((EqualTo) filter);
-    } else if (filter instanceof In) {
-      return analyzeIn((In) filter);
-    } else if (filter instanceof And) {
-      return analyzeAnd((And) filter);
-    } else if (filter instanceof Or) {
-      return analyzeOr((Or) filter);
-    } else if (filter instanceof Not) {
-      // Cannot safely prune for NOT filters — any fragment might match the negation.
+  private static Optional<Set<Integer>> analyzePredicate(Predicate predicate) {
+    if (predicate instanceof And) {
+      return analyzeAnd((And) predicate);
+    }
+    if (predicate instanceof Or) {
+      return analyzeOr((Or) predicate);
+    }
+    if (predicate instanceof Not) {
+      // Cannot safely prune for NOT predicates — any fragment might match the negation.
       return Optional.empty();
-    } else {
-      // TODO: Range filters (GreaterThan, LessThan, etc.) on _rowaddr could compute the
-      //  range of fragment IDs covered and prune accordingly (e.g. _rowaddr >= X AND
-      //  _rowaddr < Y). We conservatively skip pruning for these types.
-      return Optional.empty();
+    }
+    switch (predicate.name()) {
+      case "=":
+        return analyzeEqualTo(predicate);
+      case "IN":
+        return analyzeIn(predicate);
+      default:
+        // Range predicates on _rowaddr could in principle compute the range of fragment IDs
+        // covered (e.g. _rowaddr >= X AND _rowaddr < Y). Conservatively skipped for now.
+        return Optional.empty();
     }
   }
 
-  private static Optional<Set<Integer>> analyzeEqualTo(EqualTo filter) {
-    // Case-sensitive comparison: Spark resolves column names against the schema before pushing
-    // filters, so filter.attribute() matches the schema's original column name ("_rowaddr").
-    // If a user writes uppercase (e.g. _ROWADDR), Spark normalizes it before pushdown.
-    if (!ROW_ADDR_COLUMN.equals(filter.attribute())) {
+  private static Optional<Set<Integer>> analyzeEqualTo(Predicate predicate) {
+    Expression[] children = predicate.children();
+    if (children.length != 2
+        || !(children[0] instanceof NamedReference)
+        || !(children[1] instanceof Literal)) {
       return Optional.empty();
     }
-    Optional<Long> rowAddr = toLong(filter.value());
+    if (!ROW_ADDR_COLUMN.equals(columnName((NamedReference) children[0]))) {
+      return Optional.empty();
+    }
+    Optional<Long> rowAddr = toLong(((Literal<?>) children[1]).value());
     if (!rowAddr.isPresent()) {
       return Optional.empty();
     }
@@ -134,19 +135,24 @@ public final class RowAddressFilterAnalyzer {
     return Optional.of(result);
   }
 
-  private static Optional<Set<Integer>> analyzeIn(In filter) {
-    if (!ROW_ADDR_COLUMN.equals(filter.attribute())) {
+  private static Optional<Set<Integer>> analyzeIn(Predicate predicate) {
+    Expression[] children = predicate.children();
+    if (children.length == 0 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    if (!ROW_ADDR_COLUMN.equals(columnName((NamedReference) children[0]))) {
       return Optional.empty();
     }
     Set<Integer> fragmentIds = new HashSet<>();
-    // An empty values array yields Optional.of(emptySet), meaning zero fragments can match —
-    // correct because IN([]) is unsatisfiable. This differs from Optional.empty() which means
-    // "no pruning info available, pass all fragments through". Spark is unlikely to push
-    // IN([]), but we handle it defensively.
-    for (Object value : filter.values()) {
-      Optional<Long> rowAddr = toLong(value);
+    // Empty values list → Optional.of(emptySet) means "no fragment can match" (IN([]) is
+    // unsatisfiable). Optional.empty() means "no pruning info available". Spark is unlikely
+    // to push IN([]), but we handle it defensively.
+    for (int i = 1; i < children.length; i++) {
+      if (!(children[i] instanceof Literal)) {
+        return Optional.empty();
+      }
+      Optional<Long> rowAddr = toLong(((Literal<?>) children[i]).value());
       if (!rowAddr.isPresent()) {
-        // Non-numeric value in _rowaddr IN list — unexpected for a bigint column, skip pruning
         return Optional.empty();
       }
       fragmentIds.add(FragmentAwareJoinUtils.extractFragmentId(rowAddr.get()));
@@ -154,27 +160,15 @@ public final class RowAddressFilterAnalyzer {
     return Optional.of(fragmentIds);
   }
 
-  private static Optional<Set<Integer>> analyzeAnd(And filter) {
-    Optional<Set<Integer>> left = analyzeFilter(filter.left());
-    Optional<Set<Integer>> right = analyzeFilter(filter.right());
+  private static Optional<Set<Integer>> analyzeAnd(And predicate) {
+    Optional<Set<Integer>> left = analyzePredicate(predicate.left());
+    Optional<Set<Integer>> right = analyzePredicate(predicate.right());
 
     if (left.isPresent() && right.isPresent()) {
-      // Intersect both sides (new HashSet — safe from aliasing). If the result is empty
-      // (e.g. _rowaddr = 0 AND _rowaddr = 1<<32), that's intentional — no fragment can satisfy
-      // contradictory constraints, yielding an empty scan with zero rows.
       Set<Integer> intersection = new HashSet<>(left.get());
       intersection.retainAll(right.get());
       return Optional.of(intersection);
     }
-    // Only one side constrains _rowaddr — return that side's set directly.
-    // This is safe because the non-_rowaddr side may reduce rows further within those
-    // fragments, but cannot expand to other fragments (AND can only narrow).
-    // This includes cases like NOT(condition) AND _rowaddr = 0: the Not returns empty()
-    // (no pruning info), so the _rowaddr side's constraint is used — which is correct
-    // because in an AND, the Not side can only further restrict rows within the fragments
-    // already selected by the _rowaddr constraint; it cannot cause matches in additional
-    // fragments.
-    // No copy needed: the CONTRACT on analyzeFilter guarantees a fresh mutable HashSet.
     if (left.isPresent()) {
       return left;
     }
@@ -184,12 +178,12 @@ public final class RowAddressFilterAnalyzer {
     return Optional.empty();
   }
 
-  private static Optional<Set<Integer>> analyzeOr(Or filter) {
-    Optional<Set<Integer>> left = analyzeFilter(filter.left());
-    Optional<Set<Integer>> right = analyzeFilter(filter.right());
+  private static Optional<Set<Integer>> analyzeOr(Or predicate) {
+    Optional<Set<Integer>> left = analyzePredicate(predicate.left());
+    Optional<Set<Integer>> right = analyzePredicate(predicate.right());
 
-    // For OR, both sides must constrain _rowaddr to allow pruning.
-    // If either side is unconstrained, any fragment could match.
+    // For OR, both sides must constrain _rowaddr to allow pruning — otherwise any fragment
+    // could match via the unconstrained side.
     if (left.isPresent() && right.isPresent()) {
       Set<Integer> union = new HashSet<>(left.get());
       union.addAll(right.get());
@@ -198,12 +192,16 @@ public final class RowAddressFilterAnalyzer {
     return Optional.empty();
   }
 
+  private static String columnName(NamedReference ref) {
+    String[] names = ref.fieldNames();
+    return names.length == 1 ? names[0] : String.join(".", names);
+  }
+
   /**
-   * Safely converts a filter value to long. Only accepts integral types (Long, Integer, Short,
-   * Byte) to avoid silent truncation of floating-point values. Returns empty for any other type
-   * (Float, Double, BigDecimal, BigInteger, String, etc.), falling back to no-pruning rather than
-   * crashing the query. BigInteger values that fit in a long are also rejected for simplicity —
-   * Spark does not push BigInteger filter values for bigint columns.
+   * Safely converts a predicate literal value to long. Only accepts integral types (Long, Integer,
+   * Short, Byte) to avoid silent truncation of floating-point values. Returns empty for any other
+   * type (Float, Double, BigDecimal, BigInteger, String, etc.), falling back to no-pruning rather
+   * than crashing the query.
    */
   private static Optional<Long> toLong(Object value) {
     if (value instanceof Long) {
@@ -215,8 +213,6 @@ public final class RowAddressFilterAnalyzer {
     } else if (value instanceof Byte) {
       return Optional.of(((Byte) value).longValue());
     }
-    // All other types (Float, Double, BigDecimal, BigInteger, String, etc.) → no pruning.
-    // We prefer false negatives (no pruning) over incorrect pruning from truncation.
     LOG.warn(
         "Unsupported _rowaddr value type for fragment pruning: {}",
         value != null ? value.getClass().getSimpleName() : "null");

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -17,18 +17,13 @@ import org.lance.index.scalar.ZoneStats;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.IsNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Literal;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.filter.And;
+import org.apache.spark.sql.connector.expressions.filter.Not;
+import org.apache.spark.sql.connector.expressions.filter.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,19 +38,20 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Analyzes pushed Spark filters against zonemap index statistics to determine which fragments can
- * be pruned.
+ * Analyzes pushed Spark predicates against zonemap index statistics to determine which fragments
+ * can be pruned.
  *
  * <p>This is analogous to partition pruning in traditional data sources: if all zones within a
- * fragment provably cannot match a filter predicate, that fragment is eliminated from the scan —
- * avoiding fragment opens, scan setup, and task scheduling.
+ * fragment provably cannot match a predicate, that fragment is eliminated from the scan — avoiding
+ * fragment opens, scan setup, and task scheduling.
  *
  * <p>Zonemap pruning is inexact (conservative): it may include fragments that ultimately contain no
  * matching rows, but it will never exclude fragments that do contain matching rows.
  *
- * <p>Multiple filters are treated as conjuncts (implicit AND); their fragment sets are intersected.
- * For each column that has both a pushed filter and zonemap stats, we evaluate which fragments
- * could possibly match. Multiple columns produce independent fragment sets that are intersected.
+ * <p>Multiple predicates are treated as conjuncts (implicit AND); their fragment sets are
+ * intersected. For each column that has both a pushed predicate and zonemap stats, we evaluate
+ * which fragments could possibly match. Multiple columns produce independent fragment sets that are
+ * intersected.
  */
 public final class ZonemapFragmentPruner {
 
@@ -66,26 +62,24 @@ public final class ZonemapFragmentPruner {
   /**
    * Prune fragments using zonemap statistics.
    *
-   * @param pushedFilters the filters pushed down by Spark
+   * @param pushedPredicates the V2 predicates pushed down by Spark
    * @param zonemapStatsByColumn map from column name to its zonemap zone stats
    * @return present with the set of fragment IDs that might match; empty if no pruning can be
    *     derived
    */
   public static Optional<Set<Integer>> pruneFragments(
-      Filter[] pushedFilters, Map<String, List<ZoneStats>> zonemapStatsByColumn) {
+      Predicate[] pushedPredicates, Map<String, List<ZoneStats>> zonemapStatsByColumn) {
 
-    if (pushedFilters == null
-        || pushedFilters.length == 0
+    if (pushedPredicates == null
+        || pushedPredicates.length == 0
         || zonemapStatsByColumn == null
         || zonemapStatsByColumn.isEmpty()) {
       return Optional.empty();
     }
 
-    // Multiple top-level filters are implicitly ANDed by Spark.
-    // We intersect the fragment sets from each filter that provides one.
     Set<Integer> result = null;
-    for (Filter filter : pushedFilters) {
-      Optional<Set<Integer>> fragmentIds = analyzeFilter(filter, zonemapStatsByColumn);
+    for (Predicate predicate : pushedPredicates) {
+      Optional<Set<Integer>> fragmentIds = analyzePredicate(predicate, zonemapStatsByColumn);
       if (fragmentIds.isPresent()) {
         if (result == null) {
           result = new HashSet<>(fragmentIds.get());
@@ -103,68 +97,59 @@ public final class ZonemapFragmentPruner {
   }
 
   /**
-   * Recursively analyzes a single filter to extract fragment IDs from zonemap constraints.
+   * Recursively analyzes a single predicate to extract fragment IDs from zonemap constraints.
    *
    * <p>CONTRACT: when present, the returned Set is always a fresh mutable {@link HashSet} that is
    * not aliased by any other reference. Callers may freely mutate it.
    */
-  private static Optional<Set<Integer>> analyzeFilter(
-      Filter filter, Map<String, List<ZoneStats>> statsByColumn) {
+  private static Optional<Set<Integer>> analyzePredicate(
+      Predicate predicate, Map<String, List<ZoneStats>> statsByColumn) {
 
-    if (filter instanceof EqualTo) {
-      return analyzeComparison(
-          ((EqualTo) filter).attribute(),
-          ((EqualTo) filter).value(),
-          statsByColumn,
-          ComparisonType.EQUALS);
-    } else if (filter instanceof LessThan) {
-      return analyzeComparison(
-          ((LessThan) filter).attribute(),
-          ((LessThan) filter).value(),
-          statsByColumn,
-          ComparisonType.LESS_THAN);
-    } else if (filter instanceof LessThanOrEqual) {
-      return analyzeComparison(
-          ((LessThanOrEqual) filter).attribute(),
-          ((LessThanOrEqual) filter).value(),
-          statsByColumn,
-          ComparisonType.LESS_THAN_OR_EQUAL);
-    } else if (filter instanceof GreaterThan) {
-      return analyzeComparison(
-          ((GreaterThan) filter).attribute(),
-          ((GreaterThan) filter).value(),
-          statsByColumn,
-          ComparisonType.GREATER_THAN);
-    } else if (filter instanceof GreaterThanOrEqual) {
-      return analyzeComparison(
-          ((GreaterThanOrEqual) filter).attribute(),
-          ((GreaterThanOrEqual) filter).value(),
-          statsByColumn,
-          ComparisonType.GREATER_THAN_OR_EQUAL);
-    } else if (filter instanceof In) {
-      return analyzeIn(((In) filter).attribute(), ((In) filter).values(), statsByColumn);
-    } else if (filter instanceof IsNull) {
-      return analyzeIsNull(((IsNull) filter).attribute(), statsByColumn);
-    } else if (filter instanceof IsNotNull) {
-      return analyzeIsNotNull(((IsNotNull) filter).attribute(), statsByColumn);
-    } else if (filter instanceof And) {
-      return analyzeAnd((And) filter, statsByColumn);
-    } else if (filter instanceof Or) {
-      return analyzeOr((Or) filter, statsByColumn);
-    } else if (filter instanceof Not) {
-      // Cannot safely prune for NOT filters — any fragment might match the negation.
+    if (predicate instanceof And) {
+      return analyzeAnd((And) predicate, statsByColumn);
+    }
+    if (predicate instanceof Or) {
+      return analyzeOr((Or) predicate, statsByColumn);
+    }
+    if (predicate instanceof Not) {
       return Optional.empty();
     }
 
-    return Optional.empty();
+    Expression[] children = predicate.children();
+    String name = predicate.name();
+    switch (name) {
+      case "=":
+        return analyzeComparison(children, statsByColumn, ComparisonType.EQUALS);
+      case "<":
+        return analyzeComparison(children, statsByColumn, ComparisonType.LESS_THAN);
+      case "<=":
+        return analyzeComparison(children, statsByColumn, ComparisonType.LESS_THAN_OR_EQUAL);
+      case ">":
+        return analyzeComparison(children, statsByColumn, ComparisonType.GREATER_THAN);
+      case ">=":
+        return analyzeComparison(children, statsByColumn, ComparisonType.GREATER_THAN_OR_EQUAL);
+      case "IN":
+        return analyzeIn(children, statsByColumn);
+      case "IS_NULL":
+        return analyzeIsNull(children, statsByColumn);
+      case "IS_NOT_NULL":
+        return analyzeIsNotNull(children, statsByColumn);
+      default:
+        return Optional.empty();
+    }
   }
 
   @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeComparison(
-      String column,
-      Object value,
-      Map<String, List<ZoneStats>> statsByColumn,
-      ComparisonType type) {
+      Expression[] children, Map<String, List<ZoneStats>> statsByColumn, ComparisonType type) {
+
+    if (children.length != 2
+        || !(children[0] instanceof NamedReference)
+        || !(children[1] instanceof Literal)) {
+      return Optional.empty();
+    }
+    String column = columnName((NamedReference) children[0]);
+    Object value = normalizeLiteral(((Literal<?>) children[1]).value());
 
     List<ZoneStats> stats = statsByColumn.get(column);
     if (stats == null || value == null) {
@@ -175,7 +160,7 @@ public final class ZonemapFragmentPruner {
     try {
       target = (Comparable<Object>) value;
     } catch (ClassCastException e) {
-      LOG.warn("Cannot cast filter value {} to Comparable for zonemap pruning", value);
+      LOG.warn("Cannot cast predicate value {} to Comparable for zonemap pruning", value);
       return Optional.empty();
     }
 
@@ -205,10 +190,8 @@ public final class ZonemapFragmentPruner {
     try {
       switch (type) {
         case EQUALS:
-          // target ∈ [min, max]
           return target.compareTo(min) >= 0 && target.compareTo(max) <= 0;
         case LESS_THAN:
-          // ∃ row < target  ⟺  zone.min < target
           return min.compareTo(target) < 0;
         case LESS_THAN_OR_EQUAL:
           return min.compareTo(target) <= 0;
@@ -217,10 +200,9 @@ public final class ZonemapFragmentPruner {
         case GREATER_THAN_OR_EQUAL:
           return max.compareTo(target) >= 0;
         default:
-          return true; // conservative
+          return true;
       }
     } catch (ClassCastException e) {
-      // Type mismatch between filter value and zone stats — be conservative
       LOG.warn("Type mismatch in zonemap comparison, skipping pruning for zone", e);
       return true;
     }
@@ -228,8 +210,12 @@ public final class ZonemapFragmentPruner {
 
   @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeIn(
-      String column, Object[] values, Map<String, List<ZoneStats>> statsByColumn) {
+      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
 
+    if (children.length < 1 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    String column = columnName((NamedReference) children[0]);
     List<ZoneStats> stats = statsByColumn.get(column);
     if (stats == null) {
       return Optional.empty();
@@ -237,7 +223,11 @@ public final class ZonemapFragmentPruner {
 
     Set<Integer> matchingFragments = new HashSet<>();
     for (ZoneStats zone : stats) {
-      for (Object value : values) {
+      for (int i = 1; i < children.length; i++) {
+        if (!(children[i] instanceof Literal)) {
+          continue;
+        }
+        Object value = normalizeLiteral(((Literal<?>) children[i]).value());
         if (value == null) {
           if (zone.getNullCount() > 0) {
             matchingFragments.add(zone.getFragmentId());
@@ -251,7 +241,6 @@ public final class ZonemapFragmentPruner {
               break;
             }
           } catch (ClassCastException e) {
-            // Non-comparable value, conservatively include
             matchingFragments.add(zone.getFragmentId());
             break;
           }
@@ -263,8 +252,12 @@ public final class ZonemapFragmentPruner {
   }
 
   private static Optional<Set<Integer>> analyzeIsNull(
-      String column, Map<String, List<ZoneStats>> statsByColumn) {
+      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
 
+    if (children.length != 1 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    String column = columnName((NamedReference) children[0]);
     List<ZoneStats> stats = statsByColumn.get(column);
     if (stats == null) {
       return Optional.empty();
@@ -281,8 +274,12 @@ public final class ZonemapFragmentPruner {
   }
 
   private static Optional<Set<Integer>> analyzeIsNotNull(
-      String column, Map<String, List<ZoneStats>> statsByColumn) {
+      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
 
+    if (children.length != 1 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    String column = columnName((NamedReference) children[0]);
     List<ZoneStats> stats = statsByColumn.get(column);
     if (stats == null) {
       return Optional.empty();
@@ -291,9 +288,7 @@ public final class ZonemapFragmentPruner {
     Set<Integer> matchingFragments = new HashSet<>();
     for (ZoneStats zone : stats) {
       // Zone has non-null rows if zoneLength exceeds nullCount.
-      // zoneLength is the row offset span (may include gaps from deletions),
-      // so this is conservative: we include a zone even if only the offset range
-      // implies there might be non-null values.
+      // Conservative: zoneLength may include gaps from deletions.
       if (zone.getNullCount() < zone.getZoneLength()) {
         matchingFragments.add(zone.getFragmentId());
       }
@@ -303,35 +298,48 @@ public final class ZonemapFragmentPruner {
   }
 
   private static Optional<Set<Integer>> analyzeAnd(
-      And filter, Map<String, List<ZoneStats>> statsByColumn) {
-    Optional<Set<Integer>> left = analyzeFilter(filter.left(), statsByColumn);
-    Optional<Set<Integer>> right = analyzeFilter(filter.right(), statsByColumn);
+      And predicate, Map<String, List<ZoneStats>> statsByColumn) {
+    Optional<Set<Integer>> left = analyzePredicate(predicate.left(), statsByColumn);
+    Optional<Set<Integer>> right = analyzePredicate(predicate.right(), statsByColumn);
 
     if (left.isPresent() && right.isPresent()) {
-      // Intersect both sides
       Set<Integer> intersection = new HashSet<>(left.get());
       intersection.retainAll(right.get());
       return Optional.of(intersection);
     }
-    // Only one side constrains — return that side
     if (left.isPresent()) return left;
     if (right.isPresent()) return right;
     return Optional.empty();
   }
 
   private static Optional<Set<Integer>> analyzeOr(
-      Or filter, Map<String, List<ZoneStats>> statsByColumn) {
-    Optional<Set<Integer>> left = analyzeFilter(filter.left(), statsByColumn);
-    Optional<Set<Integer>> right = analyzeFilter(filter.right(), statsByColumn);
+      Or predicate, Map<String, List<ZoneStats>> statsByColumn) {
+    Optional<Set<Integer>> left = analyzePredicate(predicate.left(), statsByColumn);
+    Optional<Set<Integer>> right = analyzePredicate(predicate.right(), statsByColumn);
 
-    // For OR, both sides must constrain to allow pruning.
-    // If either side is unconstrained, any fragment could match.
     if (left.isPresent() && right.isPresent()) {
       Set<Integer> union = new HashSet<>(left.get());
       union.addAll(right.get());
       return Optional.of(union);
     }
     return Optional.empty();
+  }
+
+  private static String columnName(NamedReference ref) {
+    String[] names = ref.fieldNames();
+    return names.length == 1 ? names[0] : String.join(".", names);
+  }
+
+  /**
+   * V2 {@link Literal} exposes values in Spark's internal representation ({@code UTF8String} for
+   * strings). Zone stats from lance-core store String values — normalize here so {@code compareTo}
+   * against min/max works.
+   */
+  private static Object normalizeLiteral(Object value) {
+    if (value instanceof UTF8String) {
+      return value.toString();
+    }
+    return value;
   }
 
   private enum ComparisonType {
@@ -382,7 +390,6 @@ public final class ZonemapFragmentPruner {
       if (value instanceof String) {
         return UTF8String.fromString((String) value);
       }
-      // Long, Double, Boolean, Integer are already compatible
       return value;
     }
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -208,7 +209,6 @@ public final class ZonemapFragmentPruner {
     }
   }
 
-  @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeIn(
       Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
 
@@ -221,13 +221,17 @@ public final class ZonemapFragmentPruner {
       return Optional.empty();
     }
 
+    // Hoist literal extraction out of the per-zone loop: invariant across zones.
+    List<Object> normalizedValues = new ArrayList<>(children.length - 1);
+    for (int i = 1; i < children.length; i++) {
+      if (children[i] instanceof Literal) {
+        normalizedValues.add(normalizeLiteral(((Literal<?>) children[i]).value()));
+      }
+    }
+
     Set<Integer> matchingFragments = new HashSet<>();
     for (ZoneStats zone : stats) {
-      for (int i = 1; i < children.length; i++) {
-        if (!(children[i] instanceof Literal)) {
-          continue;
-        }
-        Object value = normalizeLiteral(((Literal<?>) children[i]).value());
+      for (Object value : normalizedValues) {
         if (value == null) {
           if (zone.getNullCount() > 0) {
             matchingFragments.add(zone.getFragmentId());
@@ -235,6 +239,7 @@ public final class ZonemapFragmentPruner {
           }
         } else {
           try {
+            @SuppressWarnings("unchecked")
             Comparable<Object> target = (Comparable<Object>) value;
             if (zoneMatchesComparison(zone, target, ComparisonType.EQUALS)) {
               matchingFragments.add(zone.getFragmentId());

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -222,11 +222,14 @@ public final class ZonemapFragmentPruner {
     }
 
     // Hoist literal extraction out of the per-zone loop: invariant across zones.
+    // Bail (no pruning) on any non-Literal child rather than silently dropping it,
+    // which would shrink the IN list and risk excluding fragments that actually match.
     List<Object> normalizedValues = new ArrayList<>(children.length - 1);
     for (int i = 1; i < children.length; i++) {
-      if (children[i] instanceof Literal) {
-        normalizedValues.add(normalizeLiteral(((Literal<?>) children[i]).value()));
+      if (!(children[i] instanceof Literal)) {
+        return Optional.empty();
       }
+      normalizedValues.add(normalizeLiteral(((Literal<?>) children[i]).value()));
     }
 
     Set<Integer> matchingFragments = new HashSet<>();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
@@ -159,6 +159,35 @@ public abstract class BaseSparkDataTypeRoundtripTest {
   }
 
   @Test
+  public void testDecimalFilterPushDownEndToEnd() {
+    // Regression test for the Decimal CAST wrapper that gets pushed to Lance's DataFusion parser.
+    // Spark V2 LiteralValue stores decimals as Catalyst's internal Decimal (not BigDecimal), so
+    // without an explicit CAST, bare numeric literals are inferred as Float64 and fail type
+    // resolution against Decimal128 columns. This drives a real Spark predicate pushdown — unlike
+    // FilterPushDownTest, which builds synthetic predicates via TestPredicates.
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("v", DataTypes.createDecimalType(10, 2), true);
+    List<Row> data =
+        Arrays.asList(
+            RowFactory.create(0, new BigDecimal("50.00")),
+            RowFactory.create(1, new BigDecimal("100.00")),
+            RowFactory.create(2, new BigDecimal("250.50")),
+            RowFactory.create(3, null));
+    List<Row> out =
+        writeAndRead(schema, data, "decimal_pushdown")
+            .filter("v >= 100.00")
+            .orderBy("id")
+            .collectAsList();
+    assertEquals(2, out.size());
+    assertEquals(1, out.get(0).getInt(0));
+    assertEquals(new BigDecimal("100.00"), out.get(0).getDecimal(1));
+    assertEquals(2, out.get(1).getInt(0));
+    assertEquals(new BigDecimal("250.50"), out.get(1).getDecimal(1));
+  }
+
+  @Test
   public void testDecimalSystemDefaultRoundtrip() {
     StructType schema =
         new StructType()

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
@@ -15,7 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.spark.utils.Optional;
 
-import org.apache.spark.sql.sources.*;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -28,48 +28,51 @@ public class FilterPushDownTest {
   @Test
   public void testCompileFiltersToSqlWhereClause() {
     // Test case 1: GreaterThan, LessThanOrEqual, IsNotNull
-    Filter[] filters1 =
-        new Filter[] {
-          new GreaterThan("age", 30), new LessThanOrEqual("salary", 100000), new IsNotNull("name")
+    Predicate[] filters1 =
+        new Predicate[] {
+          TestPredicates.gt("age", 30),
+          TestPredicates.lte("salary", 100000),
+          TestPredicates.isNotNull("name")
         };
     Optional<String> whereClause1 = FilterPushDown.compileFiltersToSqlWhereClause(filters1);
     assertTrue(whereClause1.isPresent());
     assertEquals("(age > 30) AND (salary <= 100000) AND (name IS NOT NULL)", whereClause1.get());
 
     // Test case 2: GreaterThan, StringContains, LessThan
-    Filter[] filters2 =
-        new Filter[] {
-          new GreaterThan("age", 30),
-          new StringContains("name", "John"),
-          new LessThan("salary", 50000)
+    Predicate[] filters2 =
+        new Predicate[] {
+          TestPredicates.gt("age", 30),
+          TestPredicates.contains("name", "John"),
+          TestPredicates.lt("salary", 50000)
         };
     Optional<String> whereClause2 = FilterPushDown.compileFiltersToSqlWhereClause(filters2);
     assertTrue(whereClause2.isPresent());
     assertEquals("(age > 30) AND (salary < 50000)", whereClause2.get());
 
     // Test case 3: Empty filters array
-    Filter[] filters3 = new Filter[] {};
+    Predicate[] filters3 = new Predicate[] {};
     Optional<String> whereClause3 = FilterPushDown.compileFiltersToSqlWhereClause(filters3);
     assertFalse(whereClause3.isPresent());
 
     // Test case 4: Mixed supported and unsupported filters
-    Filter[] filters4 =
-        new Filter[] {
-          new GreaterThan("age", 30),
-          new StringContains("name", "John"),
-          new IsNull("address"),
-          new EqualTo("country", "USA")
+    Predicate[] filters4 =
+        new Predicate[] {
+          TestPredicates.gt("age", 30),
+          TestPredicates.contains("name", "John"),
+          TestPredicates.isNull("address"),
+          TestPredicates.eq("country", "USA")
         };
     Optional<String> whereClause4 = FilterPushDown.compileFiltersToSqlWhereClause(filters4);
     assertTrue(whereClause4.isPresent());
     assertEquals("(age > 30) AND (address IS NULL) AND (country == 'USA')", whereClause4.get());
 
     // Test case 5: Not, Or, And combinations
-    Filter[] filters5 =
-        new Filter[] {
-          new Not(new GreaterThan("age", 30)),
-          new Or(new IsNotNull("name"), new IsNull("address")),
-          new And(new LessThan("salary", 100000), new GreaterThanOrEqual("salary", 50000))
+    Predicate[] filters5 =
+        new Predicate[] {
+          TestPredicates.not(TestPredicates.gt("age", 30)),
+          TestPredicates.or(TestPredicates.isNotNull("name"), TestPredicates.isNull("address")),
+          TestPredicates.and(
+              TestPredicates.lt("salary", 100000), TestPredicates.gte("salary", 50000))
         };
     Optional<String> whereClause5 = FilterPushDown.compileFiltersToSqlWhereClause(filters5);
     assertTrue(whereClause5.isPresent());
@@ -80,7 +83,7 @@ public class FilterPushDownTest {
 
   @Test
   public void testCompileFiltersToSqlWhereClauseWithEmptyFilters() {
-    Filter[] filters = new Filter[] {};
+    Predicate[] filters = new Predicate[] {};
 
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertFalse(whereClause.isPresent());
@@ -91,7 +94,8 @@ public class FilterPushDownTest {
     Object[] values = new Object[2];
     values[0] = 500;
     values[1] = 600;
-    Filter[] filters = new Filter[] {new GreaterThan("age", 30), new In("salary", values)};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.gt("age", 30), TestPredicates.in("salary", values)};
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals("(age > 30) AND (salary IN (500,600))", whereClause.get());
@@ -102,7 +106,8 @@ public class FilterPushDownTest {
     Object[] values = new Object[2];
     values[0] = "500";
     values[1] = "600";
-    Filter[] filters = new Filter[] {new GreaterThan("age", 30), new In("salary", values)};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.gt("age", 30), TestPredicates.in("salary", values)};
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals("(age > 30) AND (salary IN ('500','600'))", whereClause.get());
@@ -110,7 +115,7 @@ public class FilterPushDownTest {
 
   @Test
   public void testStringValueWithSingleQuoteEscaping() {
-    Filter[] filters = new Filter[] {new EqualTo("name", "O'Brien")};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("name", "O'Brien")};
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals("(name == 'O''Brien')", whereClause.get());
@@ -119,7 +124,7 @@ public class FilterPushDownTest {
   @Test
   public void testStringInFilterWithSingleQuoteEscaping() {
     Object[] values = new Object[] {"O'Brien", "D'Angelo"};
-    Filter[] filters = new Filter[] {new In("name", values)};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("name", values)};
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals("(name IN ('O''Brien','D''Angelo'))", whereClause.get());
@@ -129,10 +134,10 @@ public class FilterPushDownTest {
   public void testDecimalFilterPushDown() {
     // Decimal comparisons must use CAST so Lance's DataFusion parser produces Decimal128,
     // not Float64, which would fail type resolution against Decimal columns.
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThanOrEqual("net_profit", new BigDecimal("100.00")),
-          new LessThanOrEqual("net_profit", new BigDecimal("200.00"))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.gte("net_profit", new BigDecimal("100.00")),
+          TestPredicates.lte("net_profit", new BigDecimal("200.00"))
         };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
@@ -145,7 +150,7 @@ public class FilterPushDownTest {
   public void testDecimalInFilterPushDown() {
     Object[] values =
         new Object[] {new BigDecimal("100.00"), new BigDecimal("150.00"), new BigDecimal("200.00")};
-    Filter[] filters = new Filter[] {new In("price", values)};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("price", values)};
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals(
@@ -156,10 +161,10 @@ public class FilterPushDownTest {
   @Test
   public void testDecimalWithVaryingScaleAndPrecision() {
     // Verify precision/scale are taken from the BigDecimal value itself
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThan("amount", new BigDecimal("1234567.89")),
-          new LessThan("amount", new BigDecimal("0.5"))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.gt("amount", new BigDecimal("1234567.89")),
+          TestPredicates.lt("amount", new BigDecimal("0.5"))
         };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
@@ -173,10 +178,10 @@ public class FilterPushDownTest {
     // Java's BigDecimal returns precision=1 for zero regardless of scale, e.g.
     // new BigDecimal("0.00") has precision=1 and scale=2. Arrow rejects DECIMAL(1,2) because
     // scale > precision is invalid. The fix clamps: precision = max(precision, scale).
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThan("net_paid", new BigDecimal("0.00")),
-          new GreaterThan("net_profit", new BigDecimal("1.00"))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.gt("net_paid", new BigDecimal("0.00")),
+          TestPredicates.gt("net_profit", new BigDecimal("1.00"))
         };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
@@ -189,10 +194,10 @@ public class FilterPushDownTest {
   public void testDateFilterPushDown() {
     // Date literals must use the 'date' keyword so Lance's DataFusion parser produces Date32,
     // not Utf8, which would fail type resolution against Date columns.
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThanOrEqual("d_date", Date.valueOf("2000-08-23")),
-          new LessThanOrEqual("d_date", Date.valueOf("2000-09-06"))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.gte("d_date", Date.valueOf("2000-08-23")),
+          TestPredicates.lte("d_date", Date.valueOf("2000-09-06"))
         };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
@@ -204,8 +209,10 @@ public class FilterPushDownTest {
   public void testTimestampFilterPushDown() {
     // Timestamp literals must use the 'timestamp' keyword so Lance's DataFusion parser produces
     // Timestamp, not Utf8.
-    Filter[] filters =
-        new Filter[] {new EqualTo("created_at", Timestamp.valueOf("2024-01-15 10:30:00.0"))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.eq("created_at", Timestamp.valueOf("2024-01-15 10:30:00.0"))
+        };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
     assertEquals("(created_at == timestamp '2024-01-15 10:30:00.0')", whereClause.get());

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
@@ -25,12 +25,8 @@ import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
 import org.apache.spark.sql.connector.expressions.aggregate.Sum;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.Scan;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
@@ -79,59 +75,55 @@ public class LanceScanBuilderTest {
     assertEquals(emptySchema, scan.readSchema());
   }
 
-  // --- pushFilters ---
+  // --- pushPredicates ---
 
   @Test
-  public void testPushFiltersAllSupported() {
+  public void testPushPredicatesAllSupported() {
     LanceScanBuilder builder = createBuilder();
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThan("x", 1L), new LessThan("y", 10L), new IsNotNull("b"),
-        };
-    Filter[] postScanFilters = builder.pushFilters(filters);
-    assertEquals(0, postScanFilters.length);
-    assertEquals(3, builder.pushedFilters().length);
+    Predicate[] predicates = {
+      TestPredicates.gt("x", 1L), TestPredicates.lt("y", 10L), TestPredicates.isNotNull("b"),
+    };
+    Predicate[] postScan = builder.pushPredicates(predicates);
+    assertEquals(0, postScan.length);
+    assertEquals(3, builder.pushedPredicates().length);
   }
 
   @Test
-  public void testPushFiltersMixedSupportedAndUnsupported() {
+  public void testPushPredicatesMixedSupportedAndUnsupported() {
     LanceScanBuilder builder = createBuilder();
-    // StringContains is not supported for push-down
-    Filter[] filters =
-        new Filter[] {
-          new GreaterThan("x", 1L), new StringContains("b", "test"),
-        };
-    Filter[] postScanFilters = builder.pushFilters(filters);
-    assertEquals(1, postScanFilters.length);
-    assertInstanceOf(StringContains.class, postScanFilters[0]);
-    assertEquals(1, builder.pushedFilters().length);
-    assertInstanceOf(GreaterThan.class, builder.pushedFilters()[0]);
+    // CONTAINS is not supported for push-down
+    Predicate[] predicates = {TestPredicates.gt("x", 1L), TestPredicates.contains("b", "test")};
+    Predicate[] postScan = builder.pushPredicates(predicates);
+    assertEquals(1, postScan.length);
+    assertEquals("CONTAINS", postScan[0].name());
+    assertEquals(1, builder.pushedPredicates().length);
+    assertEquals(">", builder.pushedPredicates()[0].name());
   }
 
   @Test
-  public void testPushFiltersEmptyArray() {
+  public void testPushPredicatesEmptyArray() {
     LanceScanBuilder builder = createBuilder();
-    Filter[] result = builder.pushFilters(new Filter[0]);
+    Predicate[] result = builder.pushPredicates(new Predicate[0]);
     assertEquals(0, result.length);
-    assertEquals(0, builder.pushedFilters().length);
+    assertEquals(0, builder.pushedPredicates().length);
   }
 
   @Test
-  public void testPushFiltersDisabledByConfig() {
+  public void testPushPredicatesDisabledByConfig() {
     LanceSparkReadOptions options =
         LanceSparkReadOptions.from(
             Collections.singletonMap(LanceSparkReadOptions.CONFIG_PUSH_DOWN_FILTERS, "false"),
             TestUtils.TestTable1Config.datasetUri);
     LanceScanBuilder builder =
         new LanceScanBuilder(TEST_SCHEMA, options, Collections.emptyMap(), null, null, null);
-    Filter[] filters = new Filter[] {new GreaterThan("x", 1L)};
-    Filter[] result = builder.pushFilters(filters);
+    Predicate[] predicates = {TestPredicates.gt("x", 1L)};
+    Predicate[] result = builder.pushPredicates(predicates);
     assertEquals(1, result.length);
-    assertEquals(0, builder.pushedFilters().length);
+    assertEquals(0, builder.pushedPredicates().length);
   }
 
   @Test
-  public void testPushFiltersWithNestedArrayOfStruct() {
+  public void testPushPredicatesWithNestedArrayOfStruct() {
     // Filters on non-Array<Struct> columns should be pushed down normally.
     StructType nestedSchema =
         new StructType(
@@ -155,10 +147,10 @@ public class LanceScanBuilderTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    Filter[] filters = new Filter[] {new GreaterThan("id", 1L)};
-    Filter[] result = builder.pushFilters(filters);
+    Predicate[] predicates = {TestPredicates.gt("id", 1L)};
+    Predicate[] result = builder.pushPredicates(predicates);
     assertEquals(0, result.length);
-    assertEquals(1, builder.pushedFilters().length);
+    assertEquals(1, builder.pushedPredicates().length);
   }
 
   // --- pushLimit ---
@@ -252,10 +244,10 @@ public class LanceScanBuilderTest {
   @Test
   public void testPushAggregationCountStarWithFiltersFallsBackToScanner() {
     LanceScanBuilder builder = createBuilder();
-    builder.pushFilters(new Filter[] {new GreaterThan("x", 0L)});
+    builder.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
     Aggregation countStar =
         new Aggregation(new AggregateFunc[] {new CountStar()}, new Expression[] {});
-    // With pushed filters, metadata count cannot be used; falls back to scanner-based count
+    // With pushed predicates, metadata count cannot be used; falls back to scanner-based count
     assertTrue(builder.pushAggregation(countStar));
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -21,14 +21,13 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.HasPartitionKey;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.partitioning.KeyGroupedPartitioning;
 import org.apache.spark.sql.connector.read.partitioning.Partitioning;
 import org.apache.spark.sql.connector.read.partitioning.UnknownPartitioning;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
@@ -70,7 +69,7 @@ public class LanceScanTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    builder.pushFilters(new Filter[] {new GreaterThan("x", 0L)});
+    builder.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
     builder.pushAggregation(
         new Aggregation(new AggregateFunc[] {new CountStar()}, new Expression[] {}));
     // With filters, COUNT(*) falls back to scanner-based (returns LanceScan, not LanceLocalScan)
@@ -101,7 +100,7 @@ public class LanceScanTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    builder.pushFilters(new Filter[] {new GreaterThan("x", 0L)});
+    builder.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
     LanceScan scan = (LanceScan) builder.build();
     LanceInputPartition partition = (LanceInputPartition) scan.planInputPartitions()[0];
     assertTrue(partition.getWhereCondition().isPresent());
@@ -205,12 +204,12 @@ public class LanceScanTest {
         new LanceScan(
             TEST_SCHEMA,
             TestUtils.TestTable1Config.readOptions,
-            org.lance.spark.utils.Optional.empty(),
-            org.lance.spark.utils.Optional.empty(),
-            org.lance.spark.utils.Optional.empty(),
-            org.lance.spark.utils.Optional.empty(),
-            org.lance.spark.utils.Optional.empty(),
-            new Filter[0],
+            org.lance.spark.utils.Optional.empty() /* whereConditions */,
+            org.lance.spark.utils.Optional.empty() /* limit */,
+            org.lance.spark.utils.Optional.empty() /* offset */,
+            org.lance.spark.utils.Optional.empty() /* topNSortOrders */,
+            org.lance.spark.utils.Optional.empty() /* pushedAggregation */,
+            new Predicate[0],
             null,
             Collections.emptyMap(),
             null,
@@ -271,7 +270,7 @@ public class LanceScanTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    builder2.pushFilters(new Filter[] {new GreaterThan("x", 0L)});
+    builder2.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
     LanceScan scan2 = (LanceScan) builder2.build();
 
     assertNotEquals(scan1, scan2, "Scans with different filters should not be equal");

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/RowAddressFilterAnalyzerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/RowAddressFilterAnalyzerTest.java
@@ -13,13 +13,7 @@
  */
 package org.lance.spark.read;
 
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -32,7 +26,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testEqualToFragmentZero() {
     // _rowaddr = 0 → fragment 0, row index 0
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 0L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", 0L)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -41,7 +35,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testEqualToFragmentOne() {
     // _rowaddr = 1L << 32 = 4294967296L → fragment 1
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 4294967296L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", 4294967296L)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(1), result.get());
@@ -50,8 +44,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testInMultipleFragments() {
     // _rowaddr IN (0L, 8589934592L) → fragments {0, 2} (8589934592L = 2L << 32)
-    Object[] values = new Object[] {0L, 8589934592L};
-    Filter[] filters = new Filter[] {new In("_rowaddr", values)};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("_rowaddr", 0L, 8589934592L)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0, 2), result.get());
@@ -60,8 +53,10 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testAndWithRowAddrAndOtherFilter() {
     // _rowaddr = 0 AND name = 'Alice' → fragment 0
-    Filter[] filters =
-        new Filter[] {new And(new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice"))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.and(TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice"))
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -70,8 +65,11 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testOrWithTwoRowAddrFilters() {
     // _rowaddr = 0 OR _rowaddr = 4294967296L → fragments {0, 1}
-    Filter[] filters =
-        new Filter[] {new Or(new EqualTo("_rowaddr", 0L), new EqualTo("_rowaddr", 4294967296L))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(
+              TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("_rowaddr", 4294967296L))
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0, 1), result.get());
@@ -80,8 +78,10 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testOrWithOneNonRowAddrSide() {
     // _rowaddr = 0 OR name = 'Alice' → no pruning (either side could match any fragment)
-    Filter[] filters =
-        new Filter[] {new Or(new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice"))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice"))
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -89,7 +89,8 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testNonRowAddrFilters() {
     // Filters on other columns → no pruning
-    Filter[] filters = new Filter[] {new EqualTo("name", "Alice"), new GreaterThan("age", 30)};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.eq("name", "Alice"), TestPredicates.gt("age", 30)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -97,14 +98,14 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testRangeFilterOnRowAddr() {
     // GreaterThan on _rowaddr → no pruning (conservative)
-    Filter[] filters = new Filter[] {new GreaterThan("_rowaddr", 0L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.gt("_rowaddr", 0L)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
 
   @Test
   public void testEmptyFilters() {
-    Filter[] filters = new Filter[] {};
+    Predicate[] filters = new Predicate[] {};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -118,9 +119,9 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testMultipleTopLevelFiltersIntersect() {
     // _rowaddr = 0L AND _rowaddr IN (0L, 4294967296L) → fragment {0} (intersection)
-    Filter[] filters =
-        new Filter[] {
-          new EqualTo("_rowaddr", 0L), new In("_rowaddr", new Object[] {0L, 4294967296L})
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.eq("_rowaddr", 0L), TestPredicates.in("_rowaddr", 0L, 4294967296L)
         };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
@@ -131,8 +132,10 @@ public class RowAddressFilterAnalyzerTest {
   public void testTopLevelContradictoryFiltersYieldEmptySet() {
     // Two separate top-level EqualTo filters targeting different fragments → empty set.
     // This exercises the retainAll path in the extractTargetFragmentIds loop (not analyzeAnd).
-    Filter[] filters =
-        new Filter[] {new EqualTo("_rowaddr", 0L), new EqualTo("_rowaddr", 4294967296L)};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("_rowaddr", 4294967296L)
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertTrue(result.get().isEmpty());
@@ -141,7 +144,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testNotFilter() {
     // NOT(_rowaddr = 0) → no pruning (conservative)
-    Filter[] filters = new Filter[] {new Not(new EqualTo("_rowaddr", 0L))};
+    Predicate[] filters = new Predicate[] {TestPredicates.not(TestPredicates.eq("_rowaddr", 0L))};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -150,8 +153,7 @@ public class RowAddressFilterAnalyzerTest {
   public void testInSameFragment() {
     // Multiple _rowaddr values in the same fragment
     // 0L and 1L are both in fragment 0
-    Object[] values = new Object[] {0L, 1L, 2L};
-    Filter[] filters = new Filter[] {new In("_rowaddr", values)};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("_rowaddr", 0L, 1L, 2L)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -160,7 +162,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testIntegerValue() {
     // Integer value (not Long) should also work — use 0 for fragment 0
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 0)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", 0)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -170,7 +172,7 @@ public class RowAddressFilterAnalyzerTest {
   public void testIntegerValueNonZeroRowIndex() {
     // Integer.MAX_VALUE = 2^31 - 1 < 2^32, so an Integer _rowaddr always lands in fragment 0
     // (upper 32 bits are 0). This test verifies the int→long widening path in toLong().
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 1024)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", 1024)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -180,8 +182,11 @@ public class RowAddressFilterAnalyzerTest {
   public void testContradictoryAndYieldsEmptySet() {
     // Contradictory constraints inside a single And filter → empty set
     // This exercises the retainAll path inside analyzeAnd (both sides present).
-    Filter[] filters =
-        new Filter[] {new And(new EqualTo("_rowaddr", 0L), new EqualTo("_rowaddr", 4294967296L))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.and(
+              TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("_rowaddr", 4294967296L))
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertTrue(result.get().isEmpty());
@@ -190,7 +195,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testInWithEmptyValuesArray() {
     // Defensive: Spark never pushes IN([]), but we handle it correctly — empty set, no matches
-    Filter[] filters = new Filter[] {new In("_rowaddr", new Object[] {})};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("_rowaddr")};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertTrue(result.get().isEmpty());
@@ -199,7 +204,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testNonNumericValueFallsBackToNoPruning() {
     // Non-numeric _rowaddr value → no pruning (graceful fallback)
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", "not-a-number")};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", "not-a-number")};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -207,7 +212,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testInWithNonNumericValueFallsBackToNoPruning() {
     // IN list containing a non-numeric value → no pruning (graceful fallback)
-    Filter[] filters = new Filter[] {new In("_rowaddr", new Object[] {0L, "bad"})};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("_rowaddr", 0L, "bad")};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -215,7 +220,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testFloatingPointValueFallsBackToNoPruning() {
     // Double _rowaddr value → no pruning (reject to avoid silent truncation)
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 3.7)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", 3.7)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -223,9 +228,11 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testNotCompoundOrFallsBackToNoPruning() {
     // NOT(_rowaddr = 0 OR _rowaddr = 4294967296L) → no pruning (conservative)
-    Filter[] filters =
-        new Filter[] {
-          new Not(new Or(new EqualTo("_rowaddr", 0L), new EqualTo("_rowaddr", 4294967296L)))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.not(
+              TestPredicates.or(
+                  TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("_rowaddr", 4294967296L)))
         };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
@@ -234,8 +241,12 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testNotCompoundAndFallsBackToNoPruning() {
     // NOT(_rowaddr = 0 AND name = 'Alice') → no pruning (conservative)
-    Filter[] filters =
-        new Filter[] {new Not(new And(new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice")))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.not(
+              TestPredicates.and(
+                  TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice")))
+        };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }
@@ -243,7 +254,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testShortValue() {
     // Short max (32767) << 2^32, so fragment ID is always 0. Exercises toLong(Short) path.
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", (short) 0)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", (short) 0)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -252,7 +263,7 @@ public class RowAddressFilterAnalyzerTest {
   @Test
   public void testByteValue() {
     // Byte max (127) << 2^32, so fragment ID is always 0. Exercises toLong(Byte) path.
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", (byte) 0)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", (byte) 0)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -262,11 +273,12 @@ public class RowAddressFilterAnalyzerTest {
   public void testNestedAndInsideOr() {
     // Or(And(EqualTo("_rowaddr", 0L), EqualTo("name", "Alice")), EqualTo("_rowaddr", 1<<32))
     // → {0, 1}: And yields {0}, Or unions with {1}
-    Filter[] filters =
-        new Filter[] {
-          new Or(
-              new And(new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice")),
-              new EqualTo("_rowaddr", 4294967296L))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(
+              TestPredicates.and(
+                  TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice")),
+              TestPredicates.eq("_rowaddr", 4294967296L))
         };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
@@ -277,11 +289,12 @@ public class RowAddressFilterAnalyzerTest {
   public void testNestedAndInsideAnd() {
     // And(And(EqualTo("_rowaddr", 0L), EqualTo("name", "Alice")), EqualTo("age", 30))
     // → {0}: inner And yields {0}, outer And passes through
-    Filter[] filters =
-        new Filter[] {
-          new And(
-              new And(new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice")),
-              new EqualTo("age", 30))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.and(
+              TestPredicates.and(
+                  TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice")),
+              TestPredicates.eq("age", 30))
         };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
@@ -292,7 +305,7 @@ public class RowAddressFilterAnalyzerTest {
   public void testLargeFragmentId() {
     // fragmentId = Integer.MAX_VALUE → _rowaddr = (long) Integer.MAX_VALUE << 32
     long rowAddr = (long) Integer.MAX_VALUE << 32;
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", rowAddr)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", rowAddr)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(Integer.MAX_VALUE), result.get());
@@ -302,11 +315,12 @@ public class RowAddressFilterAnalyzerTest {
   public void testNestedOrInsideOrWithNonRowAddr() {
     // Or(Or(_rowaddr=0, _rowaddr=1<<32), non_rowaddr) → no pruning
     // The inner Or yields {0,1}, but the outer Or has an unconstrained side
-    Filter[] filters =
-        new Filter[] {
-          new Or(
-              new Or(new EqualTo("_rowaddr", 0L), new EqualTo("_rowaddr", 4294967296L)),
-              new EqualTo("name", "Alice"))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(
+              TestPredicates.or(
+                  TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("_rowaddr", 4294967296L)),
+              TestPredicates.eq("name", "Alice"))
         };
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
@@ -316,7 +330,8 @@ public class RowAddressFilterAnalyzerTest {
   public void testTopLevelMixedRowAddrAndNonRowAddrFilters() {
     // Top-level: [EqualTo("_rowaddr", 0L), EqualTo("name", "Alice")]
     // The non-_rowaddr filter is ignored; only the _rowaddr filter's set is used.
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", 0L), new EqualTo("name", "Alice")};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.eq("_rowaddr", 0L), TestPredicates.eq("name", "Alice")};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
@@ -326,7 +341,7 @@ public class RowAddressFilterAnalyzerTest {
   public void testNullValueFallsBackToNoPruning() {
     // Spark shouldn't push null literal filters, but toLong(null) falls through all
     // instanceof checks and returns Optional.empty() — correct graceful fallback.
-    Filter[] filters = new Filter[] {new EqualTo("_rowaddr", null)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("_rowaddr", null)};
     Optional<Set<Integer>> result = RowAddressFilterAnalyzer.extractTargetFragmentIds(filters);
     assertFalse(result.isPresent());
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
@@ -22,6 +22,7 @@ import org.apache.spark.sql.connector.expressions.filter.Or;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.math.BigDecimal;
@@ -120,6 +121,7 @@ final class TestPredicates {
       int scale = bd.scale();
       int precision = Math.max(bd.precision(), scale);
       type = DataTypes.createDecimalType(precision, scale);
+      normalized = Decimal.apply(bd);
     } else if (value instanceof Date) {
       // Spark V2 represents Date as int epoch days
       type = DataTypes.DateType;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.LiteralValue;
+import org.apache.spark.sql.connector.expressions.filter.And;
+import org.apache.spark.sql.connector.expressions.filter.Not;
+import org.apache.spark.sql.connector.expressions.filter.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+
+/**
+ * Test-only factory for building canonical V2 {@link Predicate} instances with the same shape Spark
+ * produces via {@code SupportsPushDownV2Filters}.
+ */
+final class TestPredicates {
+  private TestPredicates() {}
+
+  static Predicate eq(String column, Object value) {
+    return new Predicate("=", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate lt(String column, Object value) {
+    return new Predicate("<", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate lte(String column, Object value) {
+    return new Predicate("<=", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate gt(String column, Object value) {
+    return new Predicate(">", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate gte(String column, Object value) {
+    return new Predicate(">=", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate isNull(String column) {
+    return new Predicate("IS_NULL", new Expression[] {FieldReference.apply(column)});
+  }
+
+  static Predicate isNotNull(String column) {
+    return new Predicate("IS_NOT_NULL", new Expression[] {FieldReference.apply(column)});
+  }
+
+  static Predicate in(String column, Object... values) {
+    Expression[] children = new Expression[values.length + 1];
+    children[0] = FieldReference.apply(column);
+    for (int i = 0; i < values.length; i++) {
+      children[i + 1] = literalOf(values[i]);
+    }
+    return new Predicate("IN", children);
+  }
+
+  static Predicate contains(String column, String value) {
+    return new Predicate(
+        "CONTAINS", new Expression[] {FieldReference.apply(column), literalOf(value)});
+  }
+
+  static Predicate and(Predicate left, Predicate right) {
+    return new And(left, right);
+  }
+
+  static Predicate or(Predicate left, Predicate right) {
+    return new Or(left, right);
+  }
+
+  static Predicate not(Predicate child) {
+    return new Not(child);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  static LiteralValue literalOf(Object value) {
+    if (value == null) {
+      return new LiteralValue(null, DataTypes.NullType);
+    }
+    DataType type;
+    Object normalized = value;
+    if (value instanceof Long) {
+      type = DataTypes.LongType;
+    } else if (value instanceof Integer) {
+      type = DataTypes.IntegerType;
+    } else if (value instanceof Short) {
+      type = DataTypes.ShortType;
+    } else if (value instanceof Byte) {
+      type = DataTypes.ByteType;
+    } else if (value instanceof Double) {
+      type = DataTypes.DoubleType;
+    } else if (value instanceof Float) {
+      type = DataTypes.FloatType;
+    } else if (value instanceof Boolean) {
+      type = DataTypes.BooleanType;
+    } else if (value instanceof String) {
+      type = DataTypes.StringType;
+      normalized = UTF8String.fromString((String) value);
+    } else if (value instanceof UTF8String) {
+      type = DataTypes.StringType;
+    } else if (value instanceof BigDecimal) {
+      BigDecimal bd = (BigDecimal) value;
+      int scale = bd.scale();
+      int precision = Math.max(bd.precision(), scale);
+      type = DataTypes.createDecimalType(precision, scale);
+    } else if (value instanceof Date) {
+      // Spark V2 represents Date as int epoch days
+      type = DataTypes.DateType;
+      normalized = (int) ((Date) value).toLocalDate().toEpochDay();
+    } else if (value instanceof Timestamp) {
+      // Spark V2 represents Timestamp as long epoch micros
+      type = DataTypes.TimestampType;
+      Timestamp ts = (Timestamp) value;
+      long seconds = ts.toInstant().getEpochSecond();
+      long nanos = ts.toInstant().getNano();
+      normalized = seconds * 1_000_000L + nanos / 1_000L;
+    } else {
+      throw new IllegalArgumentException("Unsupported literal type: " + value.getClass().getName());
+    }
+    return new LiteralValue(normalized, type);
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -16,6 +16,8 @@ package org.lance.spark.read;
 import org.lance.index.scalar.ZoneStats;
 
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
@@ -159,6 +161,25 @@ public class ZonemapFragmentPrunerTest {
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
     assertTrue(result.get().isEmpty());
+  }
+
+  @Test
+  public void testInWithNonLiteralChildBailsOut() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    // x IN (50, <non-Literal expression>) — 50 alone matches only fragment 0,
+    // but the non-Literal child could match anything, so the pruner must not
+    // narrow to {0}. It must bail out (Optional.empty()) so the scan reads all
+    // fragments. Silently dropping the non-Literal would be a correctness bug.
+    Expression[] children =
+        new Expression[] {
+          FieldReference.apply("x"), TestPredicates.literalOf(50L), FieldReference.apply("y")
+        };
+    Predicate[] filters = new Predicate[] {new Predicate("IN", children)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertFalse(
+        result.isPresent(),
+        "IN with a non-Literal child must bail out instead of pruning on the remaining literals");
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -16,18 +16,7 @@ package org.lance.spark.read;
 import org.lance.index.scalar.ZoneStats;
 
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.sources.And;
-import org.apache.spark.sql.sources.EqualTo;
-import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.sources.GreaterThan;
-import org.apache.spark.sql.sources.GreaterThanOrEqual;
-import org.apache.spark.sql.sources.In;
-import org.apache.spark.sql.sources.IsNotNull;
-import org.apache.spark.sql.sources.IsNull;
-import org.apache.spark.sql.sources.LessThan;
-import org.apache.spark.sql.sources.LessThanOrEqual;
-import org.apache.spark.sql.sources.Not;
-import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +57,7 @@ public class ZonemapFragmentPrunerTest {
   @Test
   public void testEqualToMatchesOneFragment() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
-    Filter[] filters = new Filter[] {new EqualTo("x", 150L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 150L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -78,7 +67,7 @@ public class ZonemapFragmentPrunerTest {
   @Test
   public void testEqualToMatchesNoFragment() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
-    Filter[] filters = new Filter[] {new EqualTo("x", 500L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 500L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -89,7 +78,7 @@ public class ZonemapFragmentPrunerTest {
   public void testEqualToMatchesBoundary() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // Value at exact boundary between fragment 0 and 1
-    Filter[] filters = new Filter[] {new EqualTo("x", 99L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 99L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -99,7 +88,7 @@ public class ZonemapFragmentPrunerTest {
   @Test
   public void testEqualToMatchesExactMin() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
-    Filter[] filters = new Filter[] {new EqualTo("x", 100L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 100L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -110,7 +99,7 @@ public class ZonemapFragmentPrunerTest {
   public void testLessThanPrunesHighFragments() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x < 50 → only fragment 0's min (0) < 50
-    Filter[] filters = new Filter[] {new LessThan("x", 50L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.lt("x", 50L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -121,7 +110,7 @@ public class ZonemapFragmentPrunerTest {
   public void testLessThanOrEqualIncludesBoundary() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x <= 100 → fragment 0 (min=0 <= 100) and fragment 1 (min=100 <= 100)
-    Filter[] filters = new Filter[] {new LessThanOrEqual("x", 100L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.lte("x", 100L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -132,7 +121,7 @@ public class ZonemapFragmentPrunerTest {
   public void testGreaterThanPrunesLowFragments() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x > 250 → only fragment 2's max (299) > 250
-    Filter[] filters = new Filter[] {new GreaterThan("x", 250L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.gt("x", 250L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -143,7 +132,7 @@ public class ZonemapFragmentPrunerTest {
   public void testGreaterThanOrEqualIncludesBoundary() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x >= 199 → fragment 1 (max=199 >= 199) and fragment 2 (max=299 >= 199)
-    Filter[] filters = new Filter[] {new GreaterThanOrEqual("x", 199L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.gte("x", 199L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -154,7 +143,7 @@ public class ZonemapFragmentPrunerTest {
   public void testInWithMultipleValues() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x IN (50, 250) → fragment 0 and fragment 2
-    Filter[] filters = new Filter[] {new In("x", new Object[] {50L, 250L})};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("x", 50L, 250L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -165,7 +154,7 @@ public class ZonemapFragmentPrunerTest {
   public void testInWithNoMatchingValues() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x IN (500, 600) → no fragments match
-    Filter[] filters = new Filter[] {new In("x", new Object[] {500L, 600L})};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("x", 500L, 600L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -176,7 +165,7 @@ public class ZonemapFragmentPrunerTest {
   public void testIsNullWithNoNulls() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // All zones have nullCount=0
-    Filter[] filters = new Filter[] {new IsNull("x")};
+    Predicate[] filters = new Predicate[] {TestPredicates.isNull("x")};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -193,7 +182,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(1, 0, 100, 100L, 199L, 5), // has nulls
             new ZoneStats(2, 0, 100, 200L, 299L, 0)));
 
-    Filter[] filters = new Filter[] {new IsNull("x")};
+    Predicate[] filters = new Predicate[] {TestPredicates.isNull("x")};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -210,7 +199,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(1, 0, 100, null, null, 100), // all nulls
             new ZoneStats(2, 0, 100, 200L, 299L, 50))); // some nulls
 
-    Filter[] filters = new Filter[] {new IsNotNull("x")};
+    Predicate[] filters = new Predicate[] {TestPredicates.isNotNull("x")};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -221,8 +210,10 @@ public class ZonemapFragmentPrunerTest {
   public void testAndIntersectsFragments() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x >= 50 AND x <= 150 → intersection of {0,1,2} and {0,1}
-    Filter[] filters =
-        new Filter[] {new And(new GreaterThanOrEqual("x", 50L), new LessThanOrEqual("x", 150L))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.and(TestPredicates.gte("x", 50L), TestPredicates.lte("x", 150L))
+        };
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -233,7 +224,10 @@ public class ZonemapFragmentPrunerTest {
   public void testOrUnionsFragments() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x = 50 OR x = 250 → {0} ∪ {2}
-    Filter[] filters = new Filter[] {new Or(new EqualTo("x", 50L), new EqualTo("x", 250L))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(TestPredicates.eq("x", 50L), TestPredicates.eq("x", 250L))
+        };
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -244,7 +238,10 @@ public class ZonemapFragmentPrunerTest {
   public void testOrWithUnconstainedSideReturnsEmpty() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x = 50 OR name = 'Alice' → no pruning (name has no zonemap)
-    Filter[] filters = new Filter[] {new Or(new EqualTo("x", 50L), new EqualTo("name", "Alice"))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(TestPredicates.eq("x", 50L), TestPredicates.eq("name", "Alice"))
+        };
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertFalse(result.isPresent());
@@ -253,7 +250,7 @@ public class ZonemapFragmentPrunerTest {
   @Test
   public void testNotReturnsNoPruning() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
-    Filter[] filters = new Filter[] {new Not(new EqualTo("x", 50L))};
+    Predicate[] filters = new Predicate[] {TestPredicates.not(TestPredicates.eq("x", 50L))};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertFalse(result.isPresent());
@@ -263,7 +260,7 @@ public class ZonemapFragmentPrunerTest {
   public void testNonIndexedColumnReturnsNoPruning() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // Filter on column 'y' which has no zonemap stats
-    Filter[] filters = new Filter[] {new EqualTo("y", 50L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("y", 50L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertFalse(result.isPresent());
@@ -272,7 +269,7 @@ public class ZonemapFragmentPrunerTest {
   @Test
   public void testEmptyFilters() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
-    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(new Filter[] {}, stats);
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(new Predicate[] {}, stats);
     assertFalse(result.isPresent());
   }
 
@@ -285,7 +282,7 @@ public class ZonemapFragmentPrunerTest {
 
   @Test
   public void testEmptyStats() {
-    Filter[] filters = new Filter[] {new EqualTo("x", 50L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 50L)};
     Optional<Set<Integer>> result =
         ZonemapFragmentPruner.pruneFragments(filters, Collections.emptyMap());
     assertFalse(result.isPresent());
@@ -296,7 +293,8 @@ public class ZonemapFragmentPrunerTest {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // Two separate top-level filters: x >= 50 and x < 150
     // First: {0,1,2}, Second: {0}
-    Filter[] filters = new Filter[] {new GreaterThanOrEqual("x", 50L), new LessThan("x", 150L)};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.gte("x", 50L), TestPredicates.lt("x", 150L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -326,7 +324,8 @@ public class ZonemapFragmentPrunerTest {
 
     // x = 50 (matches frag 0) AND y = 1200 (matches frag 2)
     // intersection = empty
-    Filter[] filters = new Filter[] {new EqualTo("x", 50L), new EqualTo("y", 1200L)};
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.eq("x", 50L), TestPredicates.eq("y", 1200L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -346,7 +345,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(1, 0, 100, 100L, 199L, 0)));
 
     // x = 75 → matches second zone of fragment 0 → fragment 0 survives
-    Filter[] filters = new Filter[] {new EqualTo("x", 75L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 75L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -364,7 +363,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(2, 0, 100, "iaa", "zzz", 0)));
 
     // name = 'foo' → falls in [eaa, hzz] → fragment 1
-    Filter[] filters = new Filter[] {new EqualTo("name", "foo")};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("name", "foo")};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -381,7 +380,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(1, 0, 100, 100L, 199L, 5))); // fragment 1 has nulls
 
     // x IN (null, 50) → fragment 0 (has 50) and fragment 1 (has nulls)
-    Filter[] filters = new Filter[] {new In("x", new Object[] {null, 50L})};
+    Predicate[] filters = new Predicate[] {TestPredicates.in("x", null, 50L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -392,7 +391,10 @@ public class ZonemapFragmentPrunerTest {
   public void testContradictoryAndYieldsEmptySet() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     // x > 300 AND x < 0 → both constrain; intersection is empty
-    Filter[] filters = new Filter[] {new And(new GreaterThan("x", 300L), new LessThan("x", 0L))};
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.and(TestPredicates.gt("x", 300L), TestPredicates.lt("x", 0L))
+        };
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
@@ -406,11 +408,11 @@ public class ZonemapFragmentPrunerTest {
     // Left AND: {0,1,2} ∩ {0} = {0}
     // Right: {2}
     // OR: {0,2}
-    Filter[] filters =
-        new Filter[] {
-          new Or(
-              new And(new GreaterThanOrEqual("x", 50L), new LessThanOrEqual("x", 99L)),
-              new EqualTo("x", 250L))
+    Predicate[] filters =
+        new Predicate[] {
+          TestPredicates.or(
+              TestPredicates.and(TestPredicates.gte("x", 50L), TestPredicates.lte("x", 99L)),
+              TestPredicates.eq("x", 250L))
         };
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
@@ -428,7 +430,7 @@ public class ZonemapFragmentPrunerTest {
             new ZoneStats(1, 0, 100, null, null, 100))); // all nulls
 
     // x = 50 → fragment 0 matches, fragment 1 (all null) does not
-    Filter[] filters = new Filter[] {new EqualTo("x", 50L)};
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("x", 50L)};
 
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());


### PR DESCRIPTION
## Summary

- Replace `SupportsPushDownFilters` with `SupportsPushDownV2Filters` in `LanceScanBuilder`, and migrate the downstream filter-analysis utilities (`FilterPushDown`, `RowAddressFilterAnalyzer`, `ZonemapFragmentPruner`) from the sealed `org.apache.spark.sql.sources.Filter` hierarchy to the extensible `org.apache.spark.sql.connector.expressions.filter.Predicate`.
- V1 `Filter` is legacy in Spark 3.3+; V2 `Predicate` is the current recommended API and supports arbitrary named predicates, making future extensions (e.g. custom functions) straightforward.
- No external behavior changes — SQL filter semantics, zonemap pruning, `_rowaddr` fragment pruning, and the compiled SQL `WHERE` clause are preserved.

## Notable details

- V2 `Literal.value()` returns `UTF8String` for strings; normalized to `String` in `ZonemapFragmentPruner` before `compareTo` against zone min/max stats (which store native `String`).
- Column access via `NamedReference.fieldNames()` joined with `"."` for nested paths (drop-in for V1 `Filter.references()` flat names).
- Test helper `TestPredicates` builds canonical V2 predicates with the same shape Spark produces via `SupportsPushDownV2Filters`, including UTF8String/Date-epoch-days/Timestamp-epoch-micros conversion matching Spark's V2 literal representation.

## Test plan

- [x] `make install` — builds successfully
- [x] `make test` — 619 tests pass (0 failures, 0 errors)
- [x] `make lint` — checkstyle + spotless pass
- [x] No remaining references to V1 Filter API anywhere in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>