### PR TITLE
feat: support vector indexes via ALTER TABLE ... CREATE INDEX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Apache Spark Connector for Lance — enables Spark to read/write datasets in Lance columnar format. Implements Spark DataSource V2 API. Supports Spark 3.4–4.1 across Scala 2.12 and 2.13.
+
+## Build Commands
+
+Maven-based build with Make wrapper. Defaults: `SPARK_VERSION=3.5`, `SCALA_VERSION=2.12`.
+
+```shell
+make install                                    # Install module (skip tests)
+make install SPARK_VERSION=3.4 SCALA_VERSION=2.13  # Specific version
+make test                                       # Run unit tests for default module
+make test SPARK_VERSION=4.0 SCALA_VERSION=2.13  # Test specific version
+make install-all                                # Install all modules
+make test-all                                   # Run all tests
+make lint                                       # checkstyle + spotless check
+make format                                     # Auto-format code (spotless:apply)
+make bundle                                     # Build fat JAR for distribution
+make clean                                      # Clean all modules
+```
+
+Run a single test class:
+```shell
+./mvnw test -pl lance-spark-3.5_2.12 -Dtest=ClassName
+```
+
+## Module Structure
+
+Multi-module Maven project with 14 modules following a shared-base pattern:
+
+- **`lance-spark-base_2.{12,13}`**: Core shared logic (read/write, catalog, SQL extensions, vectorized accessors). All version-specific modules depend on this.
+- **`lance-spark-{3.4,3.5,4.0,4.1}_2.{12,13}`**: Spark version-specific modules. Inherit base test classes and extend with version-specific behavior.
+- **`lance-spark-bundle-{version}_{scala}`**: Fat JAR assembly modules for distribution.
+
+Scala 2.12 modules exist only for Spark 3.4 and 3.5. Spark 4.0+ is Scala 2.13 only.
+
+## Architecture
+
+Source lives in `lance-spark-base_2.12/src/main/` (Java + Scala):
+
+- **`org.lance.spark.LanceDataSource`** — DataSource V2 entry point (`SupportsCatalogOptions`, `DataSourceRegister`)
+- **`org.lance.spark.catalog.BaseLanceNamespaceSparkCatalog`** — Catalog implementation (DDL, namespace management)
+- **`org.lance.spark.read/`** — Vectorized batch scanning with Arrow, filter/projection/aggregation pushdown
+- **`org.lance.spark.write/`** — Staged commit protocol for ACID writes via `StagedCommit`
+- **`org.lance.spark.join.FragmentAwareJoinRule`** (Scala) — Catalyst optimizer rule for fragment-aware joins
+- **`org.lance.spark.vectorized/`** — ~62 Arrow column vector accessors for all data types
+- **`org.apache.spark.sql.catalyst.parser.extensions/`** (Scala) — SQL parser for Lance commands (`OPTIMIZE`, `VACUUM`, `ADD INDEX`, `ADD COLUMNS`, `UPDATE COLUMNS`)
+- **`org.apache.spark.sql.execution.datasources.v2/`** (Scala) — Physical execution plans for Lance operations
+
+Tests are in `lance-spark-base_2.12/src/test/` as base classes (e.g., `BaseSparkConnectorReadTest`). Version-specific modules inherit these.
+
+## Code Style
+
+- **Java**: Google Java Format (enforced by spotless)
+- **Scala**: scalafmt 3.7.5 (config in `.scalafmt.conf`)
+- **Line limit**: 100 characters
+- **Import order**: `com.lancedb.lance.*`, then others, then `javax/java`, then `scala`
+- Run `make format` before committing to fix style issues
+- CI runs `make lint` — PRs must pass checkstyle + spotless checks
+
+## Integration Tests
+
+Docker-based, run via:
+```shell
+make bundle && make docker-build-test-full && make docker-test
+```
+Integration test code is in `docker/tests/` (Python/pytest).
+
+## Key Dependencies
+
+- **lance-core**: Native Lance library (JNI)
+- **Apache Arrow**: Vectorized data exchange between Lance and Spark
+- **ANTLR 4.9.3**: SQL parser generation for Lance extensions

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -1,36 +1,59 @@
 # CREATE INDEX
 
-Creates a scalar index on a Lance table to accelerate queries.
+Creates a scalar or vector index on a Lance table to accelerate queries.
 
 !!! warning "Spark Extension Required"
     This feature requires the Lance Spark SQL extension to be enabled. See [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
 
 ## Overview
 
-The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. Depending on the index method, Lance Spark either uses a fragment-parallel build path or a driver-coordinated commit flow after parallel executor builds.
+The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns or run nearest-neighbour search on vector columns. Scalar index building is performed in a distributed manner, with one task per fragment in parallel (some methods then use a driver-coordinated commit flow after the parallel executor builds); vector index training is performed in a single driver-side step (see [How It Works](#how-it-works) below).
 
 ## Basic Usage
 
-The command uses the `ALTER TABLE` syntax to add an index.
+The command uses the `ALTER TABLE` syntax to add an index. The same statement covers both scalar and vector indexes — only the `USING` method changes.
 
-=== "SQL"
+=== "SQL — scalar"
     ```sql
     ALTER TABLE lance.db.users CREATE INDEX user_id_idx USING btree (id);
+    ```
+
+=== "SQL — vector"
+    ```sql
+    ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_pq (embedding)
+      WITH (num_partitions = 256, num_sub_vectors = 16, metric = 'cosine');
     ```
 
 ## Index Methods
 
 The following index methods are supported:
 
-| Method  | Description                                                                 |
-|---------|-----------------------------------------------------------------------------|
-| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
-| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
-| `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| Method          | Kind   | Description                                                                  |
+|-----------------|--------|------------------------------------------------------------------------------|
+| `zonemap`       | scalar | Lightweight min/max index for fragment pruning on a scalar column.            |
+| `btree`         | scalar | B-tree index for efficient range queries and point lookups on scalar columns. |
+| `fts`           | scalar | Full-text search (inverted) index for text search on string columns.          |
+| `ivf_flat`      | vector | IVF with full-precision vectors. Largest index, best recall.                  |
+| `ivf_pq`        | vector | IVF with PQ-compressed vectors. Smallest index, good recall.                  |
+| `ivf_hnsw_pq`   | vector | HNSW graph + PQ codes. Fast and compressed; latency-sensitive on large corpora. |
+| `ivf_hnsw_sq`   | vector | HNSW graph + scalar quantisation. Fast, medium size; balanced workloads.      |
+
+A vector index requires a **vector column** (see [CREATE TABLE → Vector Columns](create-table.md)): an `ARRAY<FLOAT>` or `ARRAY<DOUBLE>` with the `arrow.fixed-size-list.size` property set to the vector dimension. Asking for a vector index on a scalar column fails fast with a clear error.
+
+## Distance Metrics
+
+Vector indexes accept a `metric` option under the `WITH (...)` clause. The metric is stored in the index — queries that don't specify a metric will use the index-stored default, but they can override it in the [`lance_vector_search`](../dql/vector-search.md) TVF call if needed.
+
+| Metric    | Alias                       | Notes                                                         |
+|-----------|-----------------------------|---------------------------------------------------------------|
+| `l2`      | `euclidean`                 | Default. Euclidean distance.                                  |
+| `cosine`  | —                           | Cosine distance (implemented as L2 on normalised vectors).    |
+| `dot`     | `inner_product`, `ip`       | Negative inner product — larger magnitude ⇒ *closer*.         |
+| `hamming` | —                           | Hamming distance over binary-encoded vectors.                 |
 
 ## Options
 
-The `CREATE INDEX` command supports options via the `WITH` clause to control index creation. These options are specific to the chosen index method.
+The `CREATE INDEX` command supports options via the `WITH` clause. These options are specific to the chosen index method.
 
 ### ZoneMap Options
 
@@ -43,7 +66,7 @@ For the `zonemap` method, the following options are supported:
 
 ### BTree Options
 
-For the `btree` method, the following options are supported:
+For the `btree` method:
 
 | Option           | Type   | Description                                                                                                                                                                                              |
 |------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -82,9 +105,50 @@ Lance FTS index format v2 is selected by the Lance runtime environment variable 
 
 Spark SQL currently does not expose a per-index `fts_version` option. Use `USING fts` with the normal FTS options shown above; Spark records the index details and version returned by Lance.
 
+### Vector Index Options
+
+All options go under the `WITH (...)` clause. Every knob is optional; unspecified values fall back to the Lance defaults, which are chosen to work well for most workloads.
+
+#### Shared IVF options
+
+| Option           | Type    | Default     | Meaning                                    |
+|------------------|---------|-------------|--------------------------------------------|
+| `metric`         | String  | `l2`        | See [Distance Metrics](#distance-metrics) above. |
+| `num_partitions` | Integer | `256`       | IVF centroid count (k-means training).     |
+| `sample_rate`    | Integer | `256`       | Training sample ratio.                     |
+| `max_iterations` | Integer | `50`        | Max k-means / PQ training iterations.      |
+
+#### Additional `ivf_pq`, `ivf_hnsw_pq` options
+
+| Option            | Type    | Default         | Meaning                                   |
+|-------------------|---------|-----------------|-------------------------------------------|
+| `num_sub_vectors` | Integer | `dim / 16`      | Number of PQ subquantisers. Must divide `dim` evenly. |
+| `num_bits`        | Integer | `8`             | Bits per PQ code (4 or 8).                |
+
+#### Additional `ivf_hnsw_sq` options
+
+| Option            | Type    | Default | Meaning                                    |
+|-------------------|---------|---------|--------------------------------------------|
+| `num_bits`        | Integer | `8`     | Bits of scalar quantisation.               |
+
+#### Additional HNSW options (`ivf_hnsw_*`)
+
+| Option            | Type    | Default | Meaning                                    |
+|-------------------|---------|---------|--------------------------------------------|
+| `m`               | Integer | `20`    | HNSW graph degree.                         |
+| `ef_construction` | Integer | `300`   | Build-time candidate list size.            |
+
+## Supported Vector Data Types
+
+| Spark type               | Metadata                                         | Spark support                  |
+|--------------------------|--------------------------------------------------|--------------------------------|
+| `ARRAY<FLOAT>`           | `'<col>.arrow.fixed-size-list.size' = '<dim>'`   | All (3.4, 3.5, 4.0, 4.1).      |
+| `ARRAY<DOUBLE>`          | `'<col>.arrow.fixed-size-list.size' = '<dim>'`   | All (3.4, 3.5, 4.0, 4.1).      |
+| `ARRAY<FLOAT>` (float16) | add `'<col>.arrow.float16' = 'true'`             | Spark 4.0+ only (Arrow 18+).   |
+
 ## Examples
 
-### Basic Index Creation
+### Basic scalar index
 
 Create a simple B-tree index on a single column:
 
@@ -95,7 +159,7 @@ Create a simple B-tree index on a single column:
 
 ### Indexing Multiple Columns
 
-Create a composite index on multiple columns.
+Create a composite scalar index on multiple columns.
 
 === "SQL"
     ```sql
@@ -113,7 +177,7 @@ Create a zonemap index when you want lightweight min/max-based fragment pruning:
 
 ### Indexing with Options
 
-Create an index and specify the `zone_size` for the B-tree:
+Create a B-tree index and specify the `zone_size`:
 
 === "SQL"
     ```sql
@@ -147,6 +211,40 @@ Create an FTS index on a text column:
     );
     ```
 
+### IVF-PQ vector index with cosine similarity
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_pq (embedding)
+  WITH (num_partitions = 256, num_sub_vectors = 16, metric = 'cosine');
+```
+
+### IVF-Flat vector index on a small corpus
+
+Highest recall, largest footprint:
+
+```sql
+ALTER TABLE lance.db.small CREATE INDEX emb_idx USING ivf_flat (embedding)
+  WITH (num_partitions = 32, metric = 'l2');
+```
+
+### IVF-HNSW-PQ for latency-sensitive search
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_hnsw_pq (embedding)
+  WITH (num_partitions = 256, num_sub_vectors = 16, m = 32, ef_construction = 200);
+```
+
+### IVF-HNSW-SQ with scalar quantisation
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_hnsw_sq (embedding)
+  WITH (num_partitions = 128, num_bits = 8, m = 16);
+```
+
+### Rebuild (replace) an existing index
+
+Running `CREATE INDEX` with the same name **replaces** the previous index atomically. There is no separate "rebuild" statement.
+
 ## Output
 
 The `CREATE INDEX` command returns the following information about the operation:
@@ -158,22 +256,38 @@ The `CREATE INDEX` command returns the following information about the operation
 
 ## When to Use an Index
 
-Consider creating an index when:
+Consider creating a **scalar** index when:
 
 - You frequently filter a large table on a specific column.
 - You want lightweight fragment pruning based on per-zone min/max statistics.
 - Your queries involve point lookups or small range scans.
 
+Consider creating a **vector** index when:
+
+- You run nearest-neighbour search on a vector column ([`lance_vector_search`](../dql/vector-search.md)) and want sub-linear lookup time.
+- The corpus is large enough that a brute-force scan exceeds your latency budget.
+
 ## How It Works
 
-The `CREATE INDEX` command operates as follows:
+### Scalar indexes (`btree`, `fts`)
 
 1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. `zonemap` publishes those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
+### Vector indexes (`ivf_*`)
+
+1. **Driver-side validation** — the column is verified to be a vector column (correct dtype + `arrow.fixed-size-list.size` metadata). Misconfigured columns fail fast.
+2. **Driver-side training + encoding** — Lance trains the IVF / PQ / HNSW / SQ parameters in a single call on the driver. Distributed per-fragment training requires pre-computed centroids and is not yet enabled in this connector.
+3. **Transactional commit** — the new index is committed in a single Lance transaction; existing readers continue to see the previous version until they refresh.
+
 ## Notes and Limitations
 
-- **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
+- **Index Methods**: scalar (`zonemap`, `btree`, `fts`) and vector (`ivf_flat`, `ivf_pq`, `ivf_hnsw_pq`, `ivf_hnsw_sq`) are supported.
 - **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
-- **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one.
+- **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.
+- **Vector — column arity**: vector indexes take exactly **one vector column**. Composite vector indexes are not supported.
+- **Vector — dimension**: the `arrow.fixed-size-list.size` metadata must be set on the column. Without it the DDL refuses to build the index.
+- **Vector — `num_sub_vectors`** must divide the vector dimension. A dimension of 128 is compatible with `num_sub_vectors ∈ {1, 2, 4, 8, 16, 32, 64, 128}`.
+- **Vector — float16**: requires Spark 4.0+ (Arrow 18+). On earlier Spark versions, use `ARRAY<FLOAT>` without the `arrow.float16` property.
+- **Vector — interaction with OPTIMIZE/VACUUM**: both commands preserve vector indexes. Running `OPTIMIZE` after large writes is recommended so the ANN search sees a consolidated layout.

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class LanceVectorIndexTest extends BaseLanceVectorIndexTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class LanceVectorIndexTest extends BaseLanceVectorIndexTest {}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -33,7 +33,7 @@ import org.lance.index.scalar.{BTreeIndexParams, ScalarIndexParams}
 import org.lance.operation.{CreateIndex => AddIndexOperation}
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 import org.lance.spark.arrow.LanceArrowWriter
-import org.lance.spark.utils.{CloseableUtil, Utils}
+import org.lance.spark.utils.{CloseableUtil, Utils, VectorUtils}
 import org.lance.spark.write.SingleBatchArrowReader
 
 import java.time.Instant
@@ -64,6 +64,22 @@ case class AddIndexExec(
     val lanceDataset = catalog.loadTable(ident) match {
       case d: LanceDataset => d
       case _ => throw new UnsupportedOperationException("AddIndex only supports LanceDataset")
+    }
+
+    if (IndexUtils.isVectorMethod(method)) {
+      val schema = lanceDataset.schema()
+      columns.foreach { colName =>
+        val field = schema.fields.find(_.name == colName).getOrElse(
+          throw new IllegalArgumentException(
+            s"Column '$colName' does not exist in table ${ident.toString}"))
+        if (!VectorUtils.isVectorField(field)) {
+          throw new IllegalArgumentException(
+            s"Column '$colName' is not a vector column: vector index method '$method' requires " +
+              s"an ARRAY<FLOAT|DOUBLE> column with metadata key " +
+              s"'${VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY}' set to the vector dimension.")
+        }
+      }
+      return runVectorIndex(lanceDataset)
     }
 
     val readOptions = lanceDataset.readOptions()
@@ -204,6 +220,49 @@ case class AddIndexExec(
     Seq(new GenericInternalRow(Array[Any](
       fragmentIds.size.toLong,
       UTF8String.fromString(indexName))))
+  }
+
+  /**
+   * Single-shot, driver-side build for vector (ANN) indexes.
+   *
+   * Unlike scalar indexes, Lance's distributed vector-index path requires pre-computed IVF
+   * centroids — per-fragment tasks cannot train a global codebook on their own and the native
+   * code rejects the call with
+   * "Build Distributed Vector Index: missing precomputed IVF centroids".
+   *
+   * For the first cut, we sidestep that by letting Lance's native `createIndex` do the whole
+   * training + commit in one call on the driver. This forgoes the Spark-level fan-out but is the
+   * only working path today; a follow-up can precompute centroids in a Spark job and re-enable
+   * the per-fragment build through `IvfBuildParams.Builder.setCentroids`.
+   */
+  private def runVectorIndex(lanceDataset: LanceDataset): Seq[InternalRow] = {
+    val readOptions = lanceDataset.readOptions()
+    val argsJson = IndexUtils.toJson(args)
+    val indexType = IndexUtils.buildIndexType(method)
+    val params = IndexParams
+      .builder()
+      .setVectorIndexParams(VectorIndexParamsBuilder.build(method, argsJson))
+      .build()
+
+    val dataset = Utils.openDatasetBuilder(readOptions).build()
+    try {
+      val fragmentCount = dataset.getFragments.size().toLong
+      if (fragmentCount == 0L) {
+        return Seq(new GenericInternalRow(Array[Any](0L, UTF8String.fromString(indexName))))
+      }
+      val indexOptions = IndexOptions
+        .builder(columns.asJava, indexType, params)
+        .replace(true)
+        .withIndexName(indexName)
+        .withIndexUUID(UUID.randomUUID().toString)
+        .build()
+      dataset.createIndex(indexOptions)
+      Seq(new GenericInternalRow(Array[Any](
+        fragmentCount,
+        UTF8String.fromString(indexName))))
+    } finally {
+      dataset.close()
+    }
   }
 
   // Lance core's commitExistingIndexSegments handles atomic replacement:
@@ -396,11 +455,17 @@ case class FragmentIndexTask(
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
     val indexType = IndexUtils.buildIndexType(method)
-    val params = IndexParams.builder()
-      .setScalarIndexParams(ScalarIndexParams.create(
-        IndexUtils.buildScalarIndexParamType(method),
-        argsJson))
-      .build()
+    val params = if (VectorIndexParamsBuilder.isVectorMethod(method)) {
+      IndexParams.builder()
+        .setVectorIndexParams(VectorIndexParamsBuilder.build(method, argsJson))
+        .build()
+    } else {
+      IndexParams.builder()
+        .setScalarIndexParams(ScalarIndexParams.create(
+          IndexUtils.buildScalarIndexParamType(method),
+          argsJson))
+        .build()
+    }
 
     val indexOptions = IndexOptions
       .builder(java.util.Arrays.asList(columns: _*), indexType, params)
@@ -762,6 +827,10 @@ object IndexUtils {
       case "btree" => IndexType.BTREE
       case "zonemap" => IndexType.ZONEMAP
       case "fts" => IndexType.INVERTED
+      case "ivf_flat" => IndexType.IVF_FLAT
+      case "ivf_pq" => IndexType.IVF_PQ
+      case "ivf_hnsw_pq" => IndexType.IVF_HNSW_PQ
+      case "ivf_hnsw_sq" => IndexType.IVF_HNSW_SQ
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }
@@ -830,6 +899,13 @@ object IndexUtils {
 
     first
   }
+
+  /**
+   * True iff the given method is one of the ANN vector index kinds. Kept here so callers outside
+   * this file can branch cleanly between the scalar and vector parameter-building paths.
+   */
+  def isVectorMethod(method: String): Boolean =
+    VectorIndexParamsBuilder.isVectorMethod(method)
 
   def toJson(args: Seq[LanceNamedArgument]): String = {
     if (args.isEmpty) {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorIndexParamsBuilder.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorIndexParamsBuilder.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods.parse
+import org.lance.index.DistanceType
+import org.lance.index.vector.{HnswBuildParams, IvfBuildParams, PQBuildParams, SQBuildParams, VectorIndexParams}
+import org.lance.spark.read.DistanceTypes
+
+/**
+ * Builds a [[VectorIndexParams]] from the user-supplied `WITH (...)` arguments serialised
+ * as a JSON object (see [[IndexUtils.toJson]]).
+ *
+ * The scalar path can just call `ScalarIndexParams.create(method, json)` — Lance parses the
+ * JSON itself. The vector path has no equivalent factory, so the arguments must be parsed
+ * explicitly and threaded through the per-kind builder APIs.
+ *
+ * Recognised keys (all optional; defaults come from Lance):
+ *   - metric          : "l2" | "cosine" | "dot" | "hamming"
+ *   - num_partitions  : Int                    (IVF)
+ *   - sample_rate     : Int                    (IVF / PQ / SQ)
+ *   - max_iterations  : Int                    (IVF / PQ)
+ *   - num_sub_vectors : Int                    (PQ)
+ *   - num_bits        : Int                    (PQ or SQ; method-dependent)
+ *   - m               : Int                    (HNSW)
+ *   - ef_construction : Int                    (HNSW)
+ */
+object VectorIndexParamsBuilder {
+
+  def isVectorMethod(method: String): Boolean = method.toLowerCase match {
+    case "ivf_flat" | "ivf_pq" | "ivf_hnsw_pq" | "ivf_hnsw_sq" => true
+    case _ => false
+  }
+
+  def build(method: String, argsJson: String): VectorIndexParams = {
+    val args = parseArgs(argsJson)
+    val distance = parseDistance(args.get("metric"))
+    val ivf = buildIvf(args)
+
+    val builder = new VectorIndexParams.Builder(ivf).setDistanceType(distance)
+
+    method.toLowerCase match {
+      case "ivf_flat" =>
+        // nothing extra — IVF centroids alone are enough for a flat index
+        ()
+      case "ivf_pq" =>
+        builder.setPqParams(buildPq(args))
+      case "ivf_hnsw_pq" =>
+        builder.setHnswParams(buildHnsw(args))
+        builder.setPqParams(buildPq(args))
+      case "ivf_hnsw_sq" =>
+        builder.setHnswParams(buildHnsw(args))
+        builder.setSqParams(buildSq(args))
+      case other =>
+        throw new IllegalArgumentException(
+          s"Unsupported vector index method: '$other'. " +
+            "Expected one of: ivf_flat, ivf_pq, ivf_hnsw_pq, ivf_hnsw_sq")
+    }
+
+    builder.build()
+  }
+
+  private def parseArgs(argsJson: String): Map[String, JValue] = {
+    if (argsJson == null || argsJson.trim.isEmpty || argsJson.trim == "{}") {
+      return Map.empty
+    }
+    parse(argsJson) match {
+      case JObject(fields) => fields.toMap
+      case other =>
+        throw new IllegalArgumentException(
+          s"Expected JSON object for index arguments, got: $other")
+    }
+  }
+
+  private def parseDistance(value: Option[JValue]): DistanceType = value match {
+    case None | Some(JNull) => DistanceType.L2
+    case Some(JString(s)) => DistanceTypes.parse(s, "vector index")
+    case Some(other) =>
+      throw new IllegalArgumentException(
+        s"Metric must be a string, got: $other")
+  }
+
+  private def buildIvf(args: Map[String, JValue]): IvfBuildParams = {
+    val b = new IvfBuildParams.Builder()
+    asInt(args, "num_partitions").foreach(b.setNumPartitions)
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    asInt(args, "max_iterations").foreach(b.setMaxIters)
+    b.build()
+  }
+
+  private def buildPq(args: Map[String, JValue]): PQBuildParams = {
+    val b = new PQBuildParams.Builder()
+    asInt(args, "num_sub_vectors").foreach(b.setNumSubVectors)
+    asInt(args, "num_bits").foreach(b.setNumBits)
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    asInt(args, "max_iterations").foreach(b.setMaxIters)
+    b.build()
+  }
+
+  private def buildSq(args: Map[String, JValue]): SQBuildParams = {
+    val b = new SQBuildParams.Builder()
+    asInt(args, "num_bits").foreach(n => b.setNumBits(n.toShort))
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    b.build()
+  }
+
+  private def buildHnsw(args: Map[String, JValue]): HnswBuildParams = {
+    val b = new HnswBuildParams.Builder()
+    asInt(args, "m").foreach(b.setM)
+    asInt(args, "ef_construction").foreach(b.setEfConstruction)
+    b.build()
+  }
+
+  private def asInt(args: Map[String, JValue], key: String): Option[Int] =
+    args.get(key).flatMap {
+      case JInt(n) => Some(n.toInt)
+      case JLong(n) => Some(n.toInt)
+      case JDouble(d) if d == d.toInt => Some(d.toInt)
+      case JDecimal(d) if d.isValidInt => Some(d.toInt)
+      case JNull => None
+      case other =>
+        throw new IllegalArgumentException(
+          s"Index argument '$key' must be an integer, got: $other")
+    }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/DistanceTypes.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/DistanceTypes.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.lance.index.DistanceType
+
+object DistanceTypes {
+
+  val Supported: Seq[String] = Seq("l2", "cosine", "dot", "hamming")
+
+  def parse(metric: String, errPrefix: String): DistanceType =
+    metric.trim.toLowerCase match {
+      case "l2" | "euclidean" => DistanceType.L2
+      case "cosine" => DistanceType.Cosine
+      case "dot" | "inner_product" | "ip" => DistanceType.Dot
+      case "hamming" => DistanceType.Hamming
+      case other =>
+        throw new IllegalArgumentException(
+          s"$errPrefix: unsupported metric '$other'. " +
+            s"Expected one of: ${Supported.mkString(", ")}.")
+    }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseLanceVectorIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseLanceVectorIndexTest.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+import org.lance.index.DistanceType;
+import org.lance.index.Index;
+import org.lance.ipc.Query;
+import org.lance.spark.LanceDataSource;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.utils.QueryUtils;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * End-to-end coverage for the {@code ivf_*} vector index DDL.
+ *
+ * <p>The matrix is deliberately narrow — one representative cell per (index × metric × dtype)
+ * combination — because training an IVF/HNSW index is substantially more expensive than a scalar
+ * one and the Spark side of each case is identical. What we really care about is that
+ *
+ * <ul>
+ *   <li>each supported index type builds without error;
+ *   <li>each supported metric is accepted and returns results in the right order;
+ *   <li>each supported vector dtype (float32 / float64 / float16) round-trips through the index;
+ *   <li>asking for a vector index on a non-vector column is rejected with a useful message.
+ * </ul>
+ *
+ * <p>Index correctness is verified through the existing DataFrame API path (the {@code "nearest"}
+ * read option backed by {@code LanceSparkReadOptions#CONFIG_NEAREST}), so this test class has no
+ * dependency on the {@code lance_vector_search} SQL table-valued function.
+ *
+ * <p>Tests that exercise features only available on Spark 4.0+ (e.g. {@code arrow.float16}) call
+ * {@link #assumeArrow18Available()} up front so they are skipped on 3.x without failure.
+ */
+public abstract class BaseLanceVectorIndexTest {
+
+  protected static final int DIM = 16;
+  protected static final int ROWS = 256;
+  protected static final long SEED = 1234567L;
+
+  protected String catalogName = "lance_vec";
+  protected String tableName;
+  protected String fullTable;
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  protected String tableDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    this.spark =
+        SparkSession.builder()
+            .appName("lance-vector-index-test")
+            .master("local[2]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .getOrCreate();
+    this.tableName = "vec_" + UUID.randomUUID().toString().replace("-", "");
+    this.fullTable = catalogName + ".default." + this.tableName;
+    this.tableDir =
+        FileSystems.getDefault().getPath(testRoot, this.tableName + ".lance").toString();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+    }
+  }
+
+  // ─── Tests: DDL × index type ──────────────────────────────────────────────
+
+  @Test
+  public void testIvfFlatIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex("idx_ivf_flat", "ivf_flat", "num_partitions=4, metric='l2'");
+    assertIndexExists("idx_ivf_flat");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfPqIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_pq", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_ivf_pq");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfHnswPqIndexCosineFloat32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_hnsw_pq",
+        "ivf_hnsw_pq",
+        "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='cosine', "
+            + "m=8, ef_construction=40");
+    assertIndexExists("idx_ivf_hnsw_pq");
+    // Re-search with the 'cosine' metric so the expected neighbour matches the index.
+    assertNearestReturnsPlantedNeighbor("cosine");
+  }
+
+  @Test
+  public void testIvfHnswSqIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_hnsw_sq",
+        "ivf_hnsw_sq",
+        "num_partitions=4, num_bits=8, metric='l2', m=8, ef_construction=40");
+    assertIndexExists("idx_ivf_hnsw_sq");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  // ─── Tests: vector dtype ──────────────────────────────────────────────────
+
+  @Test
+  public void testIvfPqOnFloat64Column() {
+    prepareDataset(/* useDouble= */ true, /* useFloat16= */ false);
+    createVectorIndex(
+        "idx_pq_f64", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_pq_f64");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfPqOnFloat16Column() {
+    // float16 via `arrow.float16` metadata requires Arrow 18+ which is bundled with Spark 4.0+.
+    assumeArrow18Available();
+    prepareDataset(/* useDouble= */ false, /* useFloat16= */ true);
+    createVectorIndex(
+        "idx_pq_f16", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_pq_f16");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  // ─── Tests: input validation ──────────────────────────────────────────────
+
+  @Test
+  public void testCreateVectorIndexOnScalarColumnFails() {
+    prepareFloat32Dataset();
+    IllegalArgumentException ex =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                spark
+                    .sql(
+                        String.format(
+                            "ALTER TABLE %s CREATE INDEX bad_idx USING ivf_pq (id) "
+                                + "WITH (num_partitions=4)",
+                            fullTable))
+                    .collect());
+    Assertions.assertTrue(
+        ex.getMessage().toLowerCase(Locale.ROOT).contains("vector"),
+        "Error should mention vector requirement, got: " + ex.getMessage());
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  protected void prepareFloat32Dataset() {
+    prepareDataset(/* useDouble= */ false, /* useFloat16= */ false);
+  }
+
+  /**
+   * Creates a table with a 16-dim vector column plus two scalar columns (id, category), inserts
+   * {@link #ROWS} deterministic rows, and "plants" the neighbour closest to {@link #queryVector()}
+   * at {@link #plantedRowId()}. Data is split across two inserts to force at least two fragments.
+   */
+  protected void prepareDataset(boolean useDouble, boolean useFloat16) {
+    String elementType = useDouble ? "DOUBLE" : "FLOAT";
+    StringBuilder tblProps = new StringBuilder();
+    tblProps.append("'emb.arrow.fixed-size-list.size' = '").append(DIM).append("'");
+    if (useFloat16) {
+      tblProps.append(", 'emb.arrow.float16' = 'true'");
+    }
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT NOT NULL, category STRING, emb ARRAY<%s> NOT NULL) "
+                + "USING lance TBLPROPERTIES (%s)",
+            fullTable, elementType, tblProps));
+
+    int half = ROWS / 2;
+    insertRange(0, half, useDouble);
+    insertRange(half, ROWS, useDouble);
+  }
+
+  private void insertRange(int from, int to, boolean useDouble) {
+    Random rng = new Random(SEED + from);
+    StringBuilder sql = new StringBuilder();
+    sql.append("INSERT INTO ").append(fullTable).append(" VALUES ");
+    boolean first = true;
+    for (int i = from; i < to; i++) {
+      if (!first) {
+        sql.append(", ");
+      }
+      first = false;
+      String cat = (i % 2 == 0) ? "even" : "odd";
+      sql.append("(")
+          .append(i)
+          .append(", '")
+          .append(cat)
+          .append("', array(")
+          .append(vectorLiteral(i, rng, useDouble))
+          .append("))");
+    }
+    spark.sql(sql.toString());
+  }
+
+  /**
+   * Generates a vector for row {@code i}. The row at {@link #plantedRowId()} is made very close to
+   * the query vector so that any correctly-working search must surface it.
+   */
+  private String vectorLiteral(int i, Random rng, boolean useDouble) {
+    float[] query = queryVector();
+    StringBuilder sb = new StringBuilder();
+    for (int d = 0; d < DIM; d++) {
+      if (d > 0) sb.append(", ");
+      float v;
+      if (i == plantedRowId()) {
+        // Same direction as the query, tiny perturbation.
+        v = query[d] + ((rng.nextFloat() - 0.5f) * 0.001f);
+      } else {
+        v = rng.nextFloat() * 10.0f - 5.0f;
+      }
+      if (useDouble) {
+        sb.append(Double.toString(v));
+      } else {
+        sb.append(Float.toString(v)).append("f");
+      }
+    }
+    return sb.toString();
+  }
+
+  protected int plantedRowId() {
+    return 42;
+  }
+
+  protected float[] queryVector() {
+    float[] v = new float[DIM];
+    for (int i = 0; i < DIM; i++) {
+      v[i] = (float) (0.1 * (i + 1));
+    }
+    return v;
+  }
+
+  protected void createVectorIndex(String indexName, String method, String withClause) {
+    Dataset<Row> out =
+        spark.sql(
+            String.format(
+                "ALTER TABLE %s CREATE INDEX %s USING %s (emb) WITH (%s)",
+                fullTable, indexName, method, withClause));
+    Row row = out.collectAsList().get(0);
+    Assertions.assertEquals(indexName, row.getString(1));
+    Assertions.assertTrue(row.getLong(0) >= 1, "Expected at least one fragment indexed");
+  }
+
+  protected void assertIndexExists(String indexName) {
+    org.lance.Dataset ds = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      List<Index> indexes = ds.getIndexes();
+      Set<String> names = indexes.stream().map(Index::name).collect(Collectors.toSet());
+      Assertions.assertTrue(
+          names.contains(indexName), "Expected index '" + indexName + "' in " + names);
+    } finally {
+      ds.close();
+    }
+  }
+
+  protected void assertVectorSearchReturnsPlantedNeighbor() {
+    assertNearestReturnsPlantedNeighbor("l2");
+  }
+
+  /**
+   * Runs a kNN search through the existing DataFrame read path ({@code option("nearest", …)}) and
+   * asserts the planted row appears in the top-k. Intentionally avoids the {@code
+   * lance_vector_search} SQL TVF so this test class stays independent of that PR.
+   */
+  protected void assertNearestReturnsPlantedNeighbor(String metric) {
+    Query query =
+        new Query.Builder()
+            .setColumn("emb")
+            .setKey(queryVector())
+            .setK(10)
+            .setDistanceType(parseDistance(metric))
+            .setUseIndex(true)
+            .build();
+    Dataset<Row> df =
+        spark
+            .read()
+            .format(LanceDataSource.name)
+            .option(LanceSparkReadOptions.CONFIG_NEAREST, QueryUtils.queryToString(query))
+            .option(LanceSparkReadOptions.CONFIG_DATASET_URI, tableDir)
+            .load()
+            .select("id");
+    Set<Integer> ids =
+        df.collectAsList().stream().map(r -> r.getInt(0)).collect(Collectors.toSet());
+    Assertions.assertTrue(
+        ids.contains(plantedRowId()),
+        "Planted neighbour id=" + plantedRowId() + " missing from top-k results " + ids);
+  }
+
+  private static DistanceType parseDistance(String metric) {
+    switch (metric.toLowerCase(Locale.ROOT)) {
+      case "l2":
+        return DistanceType.L2;
+      case "cosine":
+        return DistanceType.Cosine;
+      case "dot":
+        return DistanceType.Dot;
+      case "hamming":
+        return DistanceType.Hamming;
+      default:
+        throw new IllegalArgumentException("Unknown metric: " + metric);
+    }
+  }
+
+  /**
+   * Skips the current test if the Arrow version on the classpath is older than 18 (where the
+   * canonical half-precision float type landed) — i.e. on Spark 3.x. Subclasses may override to
+   * force-enable on newer Spark versions.
+   */
+  protected void assumeArrow18Available() {
+    boolean available;
+    try {
+      Class.forName("org.apache.arrow.vector.Float2Vector");
+      available = true;
+    } catch (ClassNotFoundException e) {
+      available = false;
+    }
+    Assumptions.assumeTrue(available, "Arrow 18+ required for float16 vectors (Spark 4.0+)");
+  }
+}

--- a/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorIndexParamsBuilderTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorIndexParamsBuilderTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.apache.spark.sql.execution.datasources.v2.VectorIndexParamsBuilder
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.lance.index.DistanceType
+
+class VectorIndexParamsBuilderTest {
+
+  // ─── DistanceTypes ─────────────────────────────────────────────────────────
+
+  @Test def distanceTypesAcceptsAllAliases(): Unit = {
+    assertEquals(DistanceType.L2, DistanceTypes.parse("l2", "ctx"))
+    assertEquals(DistanceType.L2, DistanceTypes.parse("L2", "ctx"))
+    assertEquals(DistanceType.L2, DistanceTypes.parse("euclidean", "ctx"))
+    assertEquals(DistanceType.Cosine, DistanceTypes.parse("cosine", "ctx"))
+    assertEquals(DistanceType.Cosine, DistanceTypes.parse("Cosine", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("dot", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("inner_product", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("ip", "ctx"))
+    assertEquals(DistanceType.Hamming, DistanceTypes.parse("hamming", "ctx"))
+  }
+
+  @Test def distanceTypesRejectsUnknown(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => DistanceTypes.parse("manhattan", "myctx"))
+    assertTrue(ex.getMessage.contains("myctx"))
+    assertTrue(ex.getMessage.contains("manhattan"))
+  }
+
+  // ─── VectorIndexParamsBuilder ──────────────────────────────────────────────
+
+  @Test def isVectorMethodRecognisesSupportedKinds(): Unit = {
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_flat"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("IVF_PQ"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_hnsw_pq"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_hnsw_sq"))
+    assertFalse(VectorIndexParamsBuilder.isVectorMethod("btree"))
+    assertFalse(VectorIndexParamsBuilder.isVectorMethod("fts"))
+  }
+
+  @Test def buildHandlesEmptyArgs(): Unit = {
+    Seq(null.asInstanceOf[String], "", "  ", "{}").foreach { json =>
+      val params = VectorIndexParamsBuilder.build("ivf_flat", json)
+      assertNotNull(params, s"build(ivf_flat, '$json') returned null")
+    }
+  }
+
+  @Test def buildAcceptsMixedNumericTypes(): Unit = {
+    val json =
+      """{"num_partitions": 4, "sample_rate": 256, "num_sub_vectors": 2.0, "num_bits": 8}"""
+    val params = VectorIndexParamsBuilder.build("ivf_pq", json)
+    assertNotNull(params)
+  }
+
+  @Test def buildRejectsNonIntegerForIntArg(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_pq", """{"num_partitions": "four"}"""))
+    assertTrue(ex.getMessage.contains("num_partitions"))
+  }
+
+  @Test def buildRejectsUnknownMethod(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("hnsw", "{}"))
+    assertTrue(ex.getMessage.toLowerCase.contains("unsupported vector index method"))
+  }
+
+  @Test def buildRejectsBadMetric(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_flat", """{"metric": "manhattan"}"""))
+    assertTrue(ex.getMessage.contains("manhattan"))
+  }
+
+  @Test def buildRejectsNonObjectJson(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_flat", "[1, 2, 3]"))
+    assertTrue(ex.getMessage.toLowerCase.contains("json object"))
+  }
+}


### PR DESCRIPTION
Part of #65 (vector search SQL extension).

This is one of three PRs that supersede #436, splitting it per [reviewer feedback](https://github.com/lance-format/lance-spark/pull/436#pullrequestreview-4133774667).

## Summary

Extends the existing `ALTER TABLE … CREATE INDEX … USING method (...)` statement (grammar rule `LanceSqlExtensions.g4#createIndex`) to accept vector index methods (`ivf_flat`, `ivf_pq`, `ivf_hnsw_pq`, `ivf_hnsw_sq`) alongside the existing scalar methods (`btree`, `fts`). **No new SQL statement is introduced** — the grammar rule is unchanged; only the `method` parameter accepts new values, exactly as the reviewer suggested.

Example:

\`\`\`sql
ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_pq (embedding)
  WITH (num_partitions = 256, num_sub_vectors = 16, metric = 'cosine');
\`\`\`

Vector index training currently runs single-shot on the driver (\`AddIndexExec.runVectorIndex\`) because Lance's distributed vector-index path requires pre-computed IVF centroids — per-fragment tasks cannot train a global codebook on their own and the native code rejects the call with *\"Build Distributed Vector Index: missing precomputed IVF centroids\"*. A follow-up can precompute centroids in a Spark job and re-enable the per-fragment build via \`IvfBuildParams.Builder.setCentroids\`.

\`DistanceTypes\` is shared infrastructure for parsing user-facing metric strings (\`l2\` / \`cosine\` / \`dot\` / \`hamming\`) into the \`DistanceType\` enum from lance-core.

Index correctness is verified through the existing DataFrame API path (the \`\"nearest\"\` read option backed by \`LanceSparkReadOptions.CONFIG_NEAREST\`), so this PR has **no dependency** on the SQL TVF PR — the two can be merged in any order.

## Test plan
- [x] \`make test SPARK_VERSION=3.5 SCALA_VERSION=2.12 -Dtest=LanceVectorIndexTest\` — 6 integration tests pass (1 skipped on 3.x: float16 needs Arrow 18+)
- [x] \`make test SPARK_VERSION=3.5 -Dtest=VectorIndexParamsBuilderTest\` — 9 unit tests pass
- [x] \`make lint\` — checkstyle + spotless clean
- [ ] \`make test-all\` — please run on CI to verify all version modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)