### PR TITLE
feat: surface _distance virtual column from vector search

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -1,39 +1,62 @@
 # CREATE INDEX
 
-Creates a scalar index on a Lance table to accelerate queries.
+Creates a scalar or vector index on a Lance table to accelerate queries.
 
 !!! warning "Spark Extension Required"
     This feature requires the Lance Spark SQL extension to be enabled. See [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
 
 ## Overview
 
-The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. This operation is performed in a distributed manner, building indexes for each data fragment in parallel.
+The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns or run nearest-neighbour search on vector columns. Scalar index building is performed in a distributed manner, with one task per fragment in parallel; vector index training is performed in a single driver-side step (see [How It Works](#how-it-works) below).
 
 ## Basic Usage
 
-The command uses the `ALTER TABLE` syntax to add an index.
+The command uses the `ALTER TABLE` syntax to add an index. The same statement covers both scalar and vector indexes — only the `USING` method changes.
 
-=== "SQL"
+=== "SQL — scalar"
     ```sql
     ALTER TABLE lance.db.users CREATE INDEX user_id_idx USING btree (id);
+    ```
+
+=== "SQL — vector"
+    ```sql
+    ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_pq (embedding)
+      WITH (num_partitions = 256, num_sub_vectors = 16, metric = 'cosine');
     ```
 
 ## Index Methods
 
 The following index methods are supported:
 
-| Method  | Description                                                                 |
-|---------|-----------------------------------------------------------------------------|
-| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
-| `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| Method          | Kind   | Description                                                                  |
+|-----------------|--------|------------------------------------------------------------------------------|
+| `btree`         | scalar | B-tree index for efficient range queries and point lookups on scalar columns. |
+| `fts`           | scalar | Full-text search (inverted) index for text search on string columns.          |
+| `ivf_flat`      | vector | IVF with full-precision vectors. Largest index, best recall.                  |
+| `ivf_pq`        | vector | IVF with PQ-compressed vectors. Smallest index, good recall.                  |
+| `ivf_hnsw_pq`   | vector | HNSW graph + PQ codes. Fast and compressed; latency-sensitive on large corpora. |
+| `ivf_hnsw_sq`   | vector | HNSW graph + scalar quantisation. Fast, medium size; balanced workloads.      |
+
+A vector index requires a **vector column** (see [CREATE TABLE → Vector Columns](create-table.md)): an `ARRAY<FLOAT>` or `ARRAY<DOUBLE>` with the `arrow.fixed-size-list.size` property set to the vector dimension. Asking for a vector index on a scalar column fails fast with a clear error.
+
+## Distance Metrics
+
+Vector indexes accept a `metric` option under the `WITH (...)` clause. The metric is stored in the index — queries that don't specify a metric will use the index-stored default, but they can override it in the [`lance_vector_search`](../dql/vector-search.md) TVF call if needed.
+
+| Metric    | Alias                       | Notes                                                         |
+|-----------|-----------------------------|---------------------------------------------------------------|
+| `l2`      | `euclidean`                 | Default. Euclidean distance.                                  |
+| `cosine`  | —                           | Cosine distance (implemented as L2 on normalised vectors).    |
+| `dot`     | `inner_product`, `ip`       | Negative inner product — larger magnitude ⇒ *closer*.         |
+| `hamming` | —                           | Hamming distance over binary-encoded vectors.                 |
 
 ## Options
 
-The `CREATE INDEX` command supports options via the `WITH` clause to control index creation. These options are specific to the chosen index method.
+The `CREATE INDEX` command supports options via the `WITH` clause. These options are specific to the chosen index method.
 
 ### BTree Options
 
-For the `btree` method, the following options are supported:
+For the `btree` method:
 
 | Option      | Type   | Description                                  |
 |-------------|--------|----------------------------------------------|
@@ -57,9 +80,50 @@ For the `fts` method, the following options are required:
 
 For advanced tokenizer configuration, refer to the [Lance FTS documentation](https://lance.org/format/table/index/scalar/fts/#tokenizers).
 
+### Vector Index Options
+
+All options go under the `WITH (...)` clause. Every knob is optional; unspecified values fall back to the Lance defaults, which are chosen to work well for most workloads.
+
+#### Shared IVF options
+
+| Option           | Type    | Default     | Meaning                                    |
+|------------------|---------|-------------|--------------------------------------------|
+| `metric`         | String  | `l2`        | See [Distance Metrics](#distance-metrics) above. |
+| `num_partitions` | Integer | `256`       | IVF centroid count (k-means training).     |
+| `sample_rate`    | Integer | `256`       | Training sample ratio.                     |
+| `max_iterations` | Integer | `50`        | Max k-means / PQ training iterations.      |
+
+#### Additional `ivf_pq`, `ivf_hnsw_pq` options
+
+| Option            | Type    | Default         | Meaning                                   |
+|-------------------|---------|-----------------|-------------------------------------------|
+| `num_sub_vectors` | Integer | `dim / 16`      | Number of PQ subquantisers. Must divide `dim` evenly. |
+| `num_bits`        | Integer | `8`             | Bits per PQ code (4 or 8).                |
+
+#### Additional `ivf_hnsw_sq` options
+
+| Option            | Type    | Default | Meaning                                    |
+|-------------------|---------|---------|--------------------------------------------|
+| `num_bits`        | Integer | `8`     | Bits of scalar quantisation.               |
+
+#### Additional HNSW options (`ivf_hnsw_*`)
+
+| Option            | Type    | Default | Meaning                                    |
+|-------------------|---------|---------|--------------------------------------------|
+| `m`               | Integer | `20`    | HNSW graph degree.                         |
+| `ef_construction` | Integer | `300`   | Build-time candidate list size.            |
+
+## Supported Vector Data Types
+
+| Spark type               | Metadata                                         | Spark support                  |
+|--------------------------|--------------------------------------------------|--------------------------------|
+| `ARRAY<FLOAT>`           | `'<col>.arrow.fixed-size-list.size' = '<dim>'`   | All (3.4, 3.5, 4.0, 4.1).      |
+| `ARRAY<DOUBLE>`          | `'<col>.arrow.fixed-size-list.size' = '<dim>'`   | All (3.4, 3.5, 4.0, 4.1).      |
+| `ARRAY<FLOAT>` (float16) | add `'<col>.arrow.float16' = 'true'`             | Spark 4.0+ only (Arrow 18+).   |
+
 ## Examples
 
-### Basic Index Creation
+### Basic scalar index
 
 Create a simple B-tree index on a single column:
 
@@ -70,7 +134,7 @@ Create a simple B-tree index on a single column:
 
 ### Indexing Multiple Columns
 
-Create a composite index on multiple columns.
+Create a composite scalar index on multiple columns.
 
 === "SQL"
     ```sql
@@ -79,7 +143,7 @@ Create a composite index on multiple columns.
 
 ### Indexing with Options
 
-Create an index and specify the `zone_size` for the B-tree:
+Create a B-tree index and specify the `zone_size`:
 
 === "SQL"
     ```sql
@@ -103,6 +167,41 @@ Create an FTS index on a text column:
         with_position = true
     );
     ```
+
+### IVF-PQ vector index with cosine similarity
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_pq (embedding)
+  WITH (num_partitions = 256, num_sub_vectors = 16, metric = 'cosine');
+```
+
+### IVF-Flat vector index on a small corpus
+
+Highest recall, largest footprint:
+
+```sql
+ALTER TABLE lance.db.small CREATE INDEX emb_idx USING ivf_flat (embedding)
+  WITH (num_partitions = 32, metric = 'l2');
+```
+
+### IVF-HNSW-PQ for latency-sensitive search
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_hnsw_pq (embedding)
+  WITH (num_partitions = 256, num_sub_vectors = 16, m = 32, ef_construction = 200);
+```
+
+### IVF-HNSW-SQ with scalar quantisation
+
+```sql
+ALTER TABLE lance.db.items CREATE INDEX emb_idx USING ivf_hnsw_sq (embedding)
+  WITH (num_partitions = 128, num_bits = 8, m = 16);
+```
+
+### Rebuild (replace) an existing index
+
+Running `CREATE INDEX` with the same name **replaces** the previous index atomically. There is no separate "rebuild" statement.
+
 ## Output
 
 The `CREATE INDEX` command returns the following information about the operation:
@@ -114,20 +213,36 @@ The `CREATE INDEX` command returns the following information about the operation
 
 ## When to Use an Index
 
-Consider creating an index when:
+Consider creating a **scalar** index when:
 
 - You frequently filter a large table on a specific column.
 - Your queries involve point lookups or small range scans.
 
+Consider creating a **vector** index when:
+
+- You run nearest-neighbour search on a vector column ([`lance_vector_search`](../dql/vector-search.md)) and want sub-linear lookup time.
+- The corpus is large enough that a brute-force scan exceeds your latency budget.
+
 ## How It Works
 
-The `CREATE INDEX` command operates as follows:
+### Scalar indexes (`btree`, `fts`)
 
 1.  **Distributed Index Building**: For each fragment in the Lance dataset, a separate task is launched to build an index on the specified column(s).
 2.  **Metadata Merging**: Once all per-fragment indexes are built, their metadata is collected and merged.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
+### Vector indexes (`ivf_*`)
+
+1. **Driver-side validation** — the column is verified to be a vector column (correct dtype + `arrow.fixed-size-list.size` metadata). Misconfigured columns fail fast.
+2. **Driver-side training + encoding** — Lance trains the IVF / PQ / HNSW / SQ parameters in a single call on the driver. Distributed per-fragment training requires pre-computed centroids and is not yet enabled in this connector.
+3. **Transactional commit** — the new index is committed in a single Lance transaction; existing readers continue to see the previous version until they refresh.
+
 ## Notes and Limitations
 
-- **Index Methods**: The `btree` and `fts` methods are supported for scalar index creation.
+- **Index Methods**: scalar (`btree`, `fts`) and vector (`ivf_flat`, `ivf_pq`, `ivf_hnsw_pq`, `ivf_hnsw_sq`) are supported.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.
+- **Vector — column arity**: vector indexes take exactly **one vector column**. Composite vector indexes are not supported.
+- **Vector — dimension**: the `arrow.fixed-size-list.size` metadata must be set on the column. Without it the DDL refuses to build the index.
+- **Vector — `num_sub_vectors`** must divide the vector dimension. A dimension of 128 is compatible with `num_sub_vectors ∈ {1, 2, 4, 8, 16, 32, 64, 128}`.
+- **Vector — float16**: requires Spark 4.0+ (Arrow 18+). On earlier Spark versions, use `ARRAY<FLOAT>` without the `arrow.float16` property.
+- **Vector — interaction with OPTIMIZE/VACUUM**: both commands preserve vector indexes. Running `OPTIMIZE` after large writes is recommended so the ANN search sees a consolidated layout.

--- a/docs/src/operations/dql/vector-search.md
+++ b/docs/src/operations/dql/vector-search.md
@@ -9,7 +9,7 @@ Implemented as a **table-valued function**, so it composes cleanly with `WHERE`,
     [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
 
 !!! tip "Also see"
-    - [CREATE VECTOR INDEX](../ddl/create-vector-index.md) — build the index the search uses.
+    - [CREATE INDEX](../ddl/create-index.md) — build the vector (`ivf_*`) index the search uses.
     - [Select](select.md) — general read path.
 
 ## Syntax
@@ -84,7 +84,7 @@ smaller than `k` (or the pre-filter eliminates enough rows).
 
 ### `metric`
 Which distance metric to use. See the metric table in
-[CREATE VECTOR INDEX → Distance Metrics](../ddl/create-vector-index.md#distance-metrics).
+[CREATE INDEX → Distance Metrics](../ddl/create-index.md#distance-metrics).
 If omitted, the metric stored inside the index is used.
 
 ### `nprobes`

--- a/docs/src/operations/dql/vector-search.md
+++ b/docs/src/operations/dql/vector-search.md
@@ -181,5 +181,9 @@ A common starting recipe for IVF-PQ on a few million rows:
 - **Query vector is a driver-side literal**: Spark evaluates the `query` expression on the driver
   when planning the scan. Non-foldable expressions (e.g. a column reference) are rejected.
 - **Named arguments**: require Spark 3.5+. On Spark 3.4 pass all arguments positionally.
-- **`_distance` column**: not yet exposed in the TVF's output schema — see the roadmap issue for
-  progress.
+- **`_distance` column**: the TVF surfaces the per-row distance as a non-nullable `FLOAT`
+  column named `_distance`. Its units depend on the `metric` argument: `l2` returns squared
+  L2 distance, `cosine` returns `1 − cos(θ)`, `dot` returns negative inner product, and
+  `hamming` returns integer Hamming distance (cast to FLOAT). Filters referencing
+  `_distance` (e.g. `WHERE _distance < 0.5`) are evaluated by Spark after the scan; they are
+  not pushed into the Lance native WHERE.

--- a/docs/src/operations/dql/vector-search.md
+++ b/docs/src/operations/dql/vector-search.md
@@ -1,0 +1,185 @@
+# Vector Search (`lance_vector_search`)
+
+Executes an Approximate-Nearest-Neighbour (kNN) search over a Lance vector column from Spark SQL.
+Implemented as a **table-valued function**, so it composes cleanly with `WHERE`, `JOIN`,
+`GROUP BY`, and projections — no grammar extension required.
+
+!!! warning "Spark Extension Required"
+    This feature requires the Lance Spark SQL extension to be enabled. See
+    [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
+
+!!! tip "Also see"
+    - [CREATE VECTOR INDEX](../ddl/create-vector-index.md) — build the index the search uses.
+    - [Select](select.md) — general read path.
+
+## Syntax
+
+The function takes four required positional arguments plus five optional ones:
+
+```
+lance_vector_search(
+  table,           -- STRING   required    catalog-qualified name OR filesystem URI
+  column,          -- STRING   required    name of the vector column
+  query,           -- ARRAY<FLOAT|DOUBLE> required    query vector, dimension must match column
+  k,               -- INT      required    number of neighbours (> 0)
+  [metric],        -- STRING   optional    l2 (default) | cosine | dot | hamming
+  [nprobes],       -- INT      optional    IVF probe count, default 20
+  [refine_factor], -- INT      optional    PQ re-rank factor, default 1
+  [ef],            -- INT      optional    HNSW search depth
+  [use_index]      -- BOOLEAN  optional    default true; false = brute force
+)
+```
+
+Spark 3.5+ also accepts **named** arguments (`query => array(...)`, `k => 10`, …).
+Spark 3.4 only accepts positional arguments.
+
+## Basic Usage
+
+=== "SQL"
+    ```sql
+    SELECT id, category
+    FROM lance_vector_search(
+      'lance.db.items',
+      'embedding',
+      array(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8),
+      10
+    );
+    ```
+
+=== "PySpark"
+    ```python
+    from pyspark.sql import functions as F
+
+    q = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    spark.sql(f"""
+        SELECT id, category
+        FROM lance_vector_search(
+          'lance.db.items',
+          'embedding',
+          array({', '.join(str(x) for x in q)}),
+          10
+        )
+    """).show()
+    ```
+
+## Arguments
+
+### `table`
+A catalog-qualified name (e.g. `lance.db.items`) **or** a filesystem URI
+(e.g. `s3://bucket/path/to/items.lance`). Catalog-qualified names are resolved through the
+currently configured Spark catalog; URIs are passed straight through to the Lance DataSource.
+
+### `column`
+The name of the vector column to search. Must be a vector column (see
+[CREATE TABLE → Vector Columns](../ddl/create-table.md)).
+
+### `query`
+The query vector, as a Spark `ARRAY<FLOAT>` or `ARRAY<DOUBLE>` literal / foldable expression. The
+length must match the column's `arrow.fixed-size-list.size` metadata, otherwise Lance raises an
+error at scan time. Double-precision arrays are automatically down-cast to float32.
+
+### `k`
+Number of neighbours to return. Must be positive. Lance may return fewer rows if the table is
+smaller than `k` (or the pre-filter eliminates enough rows).
+
+### `metric`
+Which distance metric to use. See the metric table in
+[CREATE VECTOR INDEX → Distance Metrics](../ddl/create-vector-index.md#distance-metrics).
+If omitted, the metric stored inside the index is used.
+
+### `nprobes`
+Number of IVF partitions to probe. Higher values improve recall at the cost of latency. Default
+`20`. Only relevant for IVF-family indexes.
+
+### `refine_factor`
+PQ re-rank factor. The scan returns `k × refine_factor` PQ-approximate candidates, then re-ranks
+them using the exact codebook centroids. `1` (default) disables re-ranking.
+
+### `ef`
+HNSW candidate-list size at search time. Higher values improve recall. Relevant for
+`ivf_hnsw_*` indexes.
+
+### `use_index`
+`true` (default) uses the ANN index; `false` forces a brute-force scan of every fragment. Useful
+for recall evaluation or when no index exists yet.
+
+## Composing with the Rest of SQL
+
+### Projection
+
+Project any subset of the source columns after the TVF:
+
+```sql
+SELECT id FROM lance_vector_search('lance.db.items', 'embedding', array(...), 10);
+```
+
+### Pre-filters
+
+Filters on scalar columns that sit directly above the TVF are pushed into Lance and applied
+**before** the kNN search — meaning `k` applies to the filtered subset, not the whole table.
+
+```sql
+SELECT id, category
+FROM lance_vector_search('lance.db.items', 'embedding', array(...), 10)
+WHERE category = 'books' AND price < 50.0;
+```
+
+### Joins / group-by
+
+The TVF result is a regular Dataset, so all downstream operators work unchanged:
+
+```sql
+SELECT s.id, s.category, i.name
+FROM lance_vector_search('lance.db.items', 'embedding', array(...), 50) s
+JOIN lance.db.inventory i ON i.id = s.id
+WHERE i.in_stock;
+```
+
+## Brute Force vs. Indexed Search
+
+When you want ground truth — for recall evaluation or for tables that are too small to justify an
+index — pass `use_index => false`:
+
+```sql
+SELECT id
+FROM lance_vector_search('lance.db.items', 'embedding', array(...), 10, 'l2', 20, 1, 64, false);
+```
+
+Brute force scans every row in every fragment. It returns exact top-k per fragment; Spark unions
+the per-fragment results.
+
+## Tuning Recall vs. Latency
+
+| Knob              | Effect on recall | Effect on latency |
+|-------------------|------------------|-------------------|
+| `nprobes` ↑       | ↑                | ↑                 |
+| `ef` ↑            | ↑                | ↑                 |
+| `refine_factor` ↑ | ↑                | ↑                 |
+| `num_partitions` ↑ at index time | neutral | ↓ (each probe is smaller) |
+| `m` / `ef_construction` ↑ at index time | ↑ | neutral (one-time cost) |
+
+A common starting recipe for IVF-PQ on a few million rows:
+`num_partitions = 256`, `num_sub_vectors = 16`, `nprobes = 20`, `refine_factor = 10`.
+
+## Errors
+
+| Condition                                              | Result                                                        |
+|--------------------------------------------------------|---------------------------------------------------------------|
+| `k <= 0`                                               | `IllegalArgumentException("… 'k' must be positive")`          |
+| Unknown metric (`'manhattan'`, etc.)                   | `IllegalArgumentException("… unsupported metric …")`          |
+| Non-constant `query` / `k` / `column`                  | `IllegalArgumentException("… must be a constant expression")` |
+| `column` not a vector column                           | Raised by Lance at scan time (dimension mismatch).            |
+| `table` not found                                      | `IllegalArgumentException("… could not resolve table …")`     |
+
+## Notes and Limitations
+
+- **Fragment-local top-k**: the scan today performs search per fragment and unions the results, so
+  the raw TVF output may contain up to `k × num_fragments` rows. Add a global
+  `ORDER BY … LIMIT k` on top if you need the true global top-k.
+- **Single column**: the `column` argument is a single string — you cannot combine two vector
+  columns in one call.
+- **Query vector is a driver-side literal**: Spark evaluates the `query` expression on the driver
+  when planning the scan. Non-foldable expressions (e.g. a column reference) are rejected.
+- **Named arguments**: require Spark 3.5+. On Spark 3.4 pass all arguments positionally.
+- **`_distance` column**: not yet exposed in the TVF's output schema — see the roadmap issue for
+  progress.

--- a/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -17,6 +17,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.optimizer.LanceFragmentAwareJoinRule
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.lance.spark.read.LanceVectorSearchTableFunction
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
@@ -28,5 +29,12 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())
 
     extensions.injectPlannerStrategy(LanceDataSourceV2Strategy(_))
+
+    // lance_vector_search(table, column, query, k, ...) table-valued function
+    extensions.injectTableFunction(
+      (
+        LanceVectorSearchTableFunction.IDENTIFIER,
+        LanceVectorSearchTableFunction.INFO,
+        LanceVectorSearchTableFunction.BUILDER))
   }
 }

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/LanceVectorSearchTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/LanceVectorSearchTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class LanceVectorSearchTest extends BaseLanceVectorSearchTest {}

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class LanceVectorIndexTest extends BaseLanceVectorIndexTest {}

--- a/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -17,6 +17,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.optimizer.LanceFragmentAwareJoinRule
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.lance.spark.read.LanceVectorSearchTableFunction
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
@@ -28,5 +29,12 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())
 
     extensions.injectPlannerStrategy(LanceDataSourceV2Strategy(_))
+
+    // lance_vector_search(table, column, query, k, ...) table-valued function
+    extensions.injectTableFunction(
+      (
+        LanceVectorSearchTableFunction.IDENTIFIER,
+        LanceVectorSearchTableFunction.INFO,
+        LanceVectorSearchTableFunction.BUILDER))
   }
 }

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/LanceVectorSearchTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/LanceVectorSearchTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class LanceVectorSearchTest extends BaseLanceVectorSearchTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceVectorIndexTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class LanceVectorIndexTest extends BaseLanceVectorIndexTest {}

--- a/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -17,6 +17,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.optimizer.LanceFragmentAwareJoinRule
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.lance.spark.read.LanceVectorSearchTableFunction
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
@@ -28,5 +29,12 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())
 
     extensions.injectPlannerStrategy(LanceDataSourceV2Strategy(_))
+
+    // lance_vector_search(table, column, query, k, ...) table-valued function
+    extensions.injectTableFunction(
+      (
+        LanceVectorSearchTableFunction.IDENTIFIER,
+        LanceVectorSearchTableFunction.INFO,
+        LanceVectorSearchTableFunction.BUILDER))
   }
 }

--- a/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -17,6 +17,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.optimizer.LanceFragmentAwareJoinRule
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.lance.spark.read.LanceVectorSearchTableFunction
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
@@ -28,5 +29,12 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())
 
     extensions.injectPlannerStrategy(LanceDataSourceV2Strategy(_))
+
+    // lance_vector_search(table, column, query, k, ...) table-valued function
+    extensions.injectTableFunction(
+      (
+        LanceVectorSearchTableFunction.IDENTIFIER,
+        LanceVectorSearchTableFunction.INFO,
+        LanceVectorSearchTableFunction.BUILDER))
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
@@ -18,6 +18,13 @@ public class LanceConstant {
   public static final String ROW_ID = "_rowid";
   public static final String ROW_ADDRESS = "_rowaddr";
 
+  /**
+   * Virtual column Lance auto-appends to each batch when {@code ScanOptions.nearest(…)} is set.
+   * Carries the Float32 distance (per selected metric) between the row's vector and the query
+   * vector. Only present on the vector-search read path.
+   */
+  public static final String DISTANCE = "_distance";
+
   // CDF (Change Data Feed) version tracking columns
   public static final String ROW_CREATED_AT_VERSION = "_row_created_at_version";
   public static final String ROW_LAST_UPDATED_AT_VERSION = "_row_last_updated_at_version";

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -194,7 +194,9 @@ public class LanceFragmentScanner implements AutoCloseable {
       schemaFields.add(field.name());
     }
 
-    // Regular data columns (exclude all special/metadata columns)
+    // Regular data columns (exclude all special/metadata columns).
+    // _distance is auto-appended by Lance when nearest(...) is set on the scanner — asking for it
+    // explicitly in .columns(...) would cause the native side to reject it as an unknown column.
     List<String> columns =
         Arrays.stream(schema.fields())
             .map(StructField::name)
@@ -205,6 +207,7 @@ public class LanceFragmentScanner implements AutoCloseable {
                         && !name.equals(LanceConstant.ROW_ADDRESS)
                         && !name.equals(LanceConstant.ROW_CREATED_AT_VERSION)
                         && !name.equals(LanceConstant.ROW_LAST_UPDATED_AT_VERSION)
+                        && !name.equals(LanceConstant.DISTANCE)
                         && !name.endsWith(LanceConstant.BLOB_POSITION_SUFFIX)
                         && !name.endsWith(LanceConstant.BLOB_SIZE_SUFFIX))
             .collect(Collectors.toList());

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -20,6 +20,7 @@ import org.lance.index.IndexDescription;
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
 import org.lance.schema.LanceField;
+import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Optional;
 import org.lance.spark.utils.Utils;
@@ -237,9 +238,39 @@ public class LanceScanBuilder
     if (!readOptions.isPushDownFilters()) {
       return filters;
     }
-    Filter[][] processFilters = FilterPushDown.processFilters(filters);
+    // _distance is a virtual column auto-appended by the Lance native scanner in vector-search
+    // mode. Lance's SQL WHERE evaluator has no concept of it, so pushing filters that reference
+    // _distance would fail at scan time. Hold such filters back as residuals so Spark applies
+    // them post-scan.
+    List<Filter> pushable = new ArrayList<>(filters.length);
+    List<Filter> residual = new ArrayList<>();
+    for (Filter filter : filters) {
+      if (referencesDistance(filter)) {
+        residual.add(filter);
+      } else {
+        pushable.add(filter);
+      }
+    }
+    Filter[][] processFilters = FilterPushDown.processFilters(pushable.toArray(new Filter[0]));
     pushedFilters = processFilters[0];
-    return processFilters[1];
+    if (residual.isEmpty()) {
+      return processFilters[1];
+    }
+    Filter[] remaining = new Filter[processFilters[1].length + residual.size()];
+    System.arraycopy(processFilters[1], 0, remaining, 0, processFilters[1].length);
+    for (int i = 0; i < residual.size(); i++) {
+      remaining[processFilters[1].length + i] = residual.get(i);
+    }
+    return remaining;
+  }
+
+  private static boolean referencesDistance(Filter filter) {
+    for (String ref : filter.references()) {
+      if (LanceConstant.DISTANCE.equals(ref)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -280,19 +311,26 @@ public class LanceScanBuilder
     if (!readOptions.isTopNPushDown()) {
       return false;
     }
-    this.limit = Optional.of(limit);
     List<ColumnOrdering> topNSortOrders = new ArrayList<>();
     for (SortOrder sortOrder : orders) {
-      ColumnOrdering.Builder builder = new ColumnOrdering.Builder();
-      builder.setNullFirst(sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST);
-      builder.setAscending(sortOrder.direction() == SortDirection.ASCENDING);
       if (!(sortOrder.expression() instanceof FieldReference)) {
         return false;
       }
       FieldReference reference = (FieldReference) sortOrder.expression();
-      builder.setColumnName(reference.fieldNames()[0]);
+      String columnName = reference.fieldNames()[0];
+      // _distance is a virtual column auto-appended by the native scanner; it is not a
+      // sortable field in Lance's SQL-level column list. Let Spark apply this sort above
+      // the scan.
+      if (LanceConstant.DISTANCE.equals(columnName)) {
+        return false;
+      }
+      ColumnOrdering.Builder builder = new ColumnOrdering.Builder();
+      builder.setNullFirst(sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST);
+      builder.setAscending(sortOrder.direction() == SortDirection.ASCENDING);
+      builder.setColumnName(columnName);
       topNSortOrders.add(builder.build());
     }
+    this.limit = Optional.of(limit);
     this.topNSortOrders = Optional.of(topNSortOrders);
     return true;
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceVirtualColumnsTable.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceVirtualColumnsTable.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.spark.LanceDataset;
+
+import org.apache.spark.sql.connector.catalog.MetadataColumn;
+import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Read-only decorator around {@link LanceDataset} that surfaces extra virtual columns in {@link
+ * #schema()}, so Spark's analyzer can resolve references to them in {@code SELECT}, {@code ORDER
+ * BY}, and {@code WHERE}. Used today by the vector-search read path to expose the {@code _distance}
+ * column auto-appended by Lance's native scanner; the same mechanism applies to any future
+ * per-batch virtual columns (e.g. {@code _score} for FTS, {@code _score_explain}).
+ *
+ * <p>The virtual columns are appended at the tail of each Arrow batch by Lance native — appending
+ * them to the Spark schema in the same position keeps {@code requiredSchema} → Arrow column layout
+ * aligned without changes to the batch reader.
+ */
+public class LanceVirtualColumnsTable implements SupportsRead, SupportsMetadataColumns {
+
+  private static final Set<TableCapability> CAPABILITIES =
+      Collections.singleton(TableCapability.BATCH_READ);
+
+  private final LanceDataset inner;
+  private final List<StructField> virtualColumns;
+  private final StructType augmentedSchema;
+  private final String tag;
+
+  public LanceVirtualColumnsTable(
+      LanceDataset inner, List<StructField> virtualColumns, String tag) {
+    this.inner = inner;
+    this.virtualColumns = virtualColumns;
+    this.tag = tag;
+    StructType s = inner.schema();
+    for (StructField f : virtualColumns) {
+      s = s.add(f);
+    }
+    this.augmentedSchema = s;
+  }
+
+  @Override
+  public String name() {
+    return inner.name() + "[" + tag + "]";
+  }
+
+  @Override
+  public StructType schema() {
+    return augmentedSchema;
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return inner.properties();
+  }
+
+  @Override
+  public Set<TableCapability> capabilities() {
+    return CAPABILITIES;
+  }
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    // Delegate to the inner dataset. Spark's V2ScanRelationPushDown always invokes
+    // pruneColumns(requiredSchema) before build(), where requiredSchema is derived from this
+    // Table's schema() — so the augmented schema (including virtual columns) is propagated through
+    // the scan builder, scan, and input partition without further intervention.
+    return inner.newScanBuilder(options);
+  }
+
+  @Override
+  public MetadataColumn[] metadataColumns() {
+    return inner.metadataColumns();
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -32,7 +32,7 @@ import org.lance.index.scalar.{BTreeIndexParams, ScalarIndexParams}
 import org.lance.operation.{CreateIndex => AddIndexOperation}
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 import org.lance.spark.arrow.LanceArrowWriter
-import org.lance.spark.utils.{CloseableUtil, Utils}
+import org.lance.spark.utils.{CloseableUtil, Utils, VectorUtils}
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.{Collections, Optional, UUID}
@@ -62,6 +62,22 @@ case class AddIndexExec(
     val lanceDataset = catalog.loadTable(ident) match {
       case d: LanceDataset => d
       case _ => throw new UnsupportedOperationException("AddIndex only supports LanceDataset")
+    }
+
+    if (IndexUtils.isVectorMethod(method)) {
+      val schema = lanceDataset.schema()
+      columns.foreach { colName =>
+        val field = schema.fields.find(_.name == colName).getOrElse(
+          throw new IllegalArgumentException(
+            s"Column '$colName' does not exist in table ${ident.toString}"))
+        if (!VectorUtils.isVectorField(field)) {
+          throw new IllegalArgumentException(
+            s"Column '$colName' is not a vector column: vector index method '$method' requires " +
+              s"an ARRAY<FLOAT|DOUBLE> column with metadata key " +
+              s"'${VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY}' set to the vector dimension.")
+        }
+      }
+      return runVectorIndex(lanceDataset)
     }
 
     val readOptions = lanceDataset.readOptions()
@@ -137,6 +153,49 @@ case class AddIndexExec(
     Seq(new GenericInternalRow(Array[Any](
       fragmentIds.size.toLong,
       UTF8String.fromString(indexName))))
+  }
+
+  /**
+   * Single-shot, driver-side build for vector (ANN) indexes.
+   *
+   * Unlike scalar indexes, Lance's distributed vector-index path requires pre-computed IVF
+   * centroids — per-fragment tasks cannot train a global codebook on their own and the native
+   * code rejects the call with
+   * "Build Distributed Vector Index: missing precomputed IVF centroids".
+   *
+   * For the first cut, we sidestep that by letting Lance's native `createIndex` do the whole
+   * training + commit in one call on the driver. This forgoes the Spark-level fan-out but is the
+   * only working path today; a follow-up can precompute centroids in a Spark job and re-enable
+   * the per-fragment build through `IvfBuildParams.Builder.setCentroids`.
+   */
+  private def runVectorIndex(lanceDataset: LanceDataset): Seq[InternalRow] = {
+    val readOptions = lanceDataset.readOptions()
+    val argsJson = IndexUtils.toJson(args)
+    val indexType = IndexUtils.buildIndexType(method)
+    val params = IndexParams
+      .builder()
+      .setVectorIndexParams(VectorIndexParamsBuilder.build(method, argsJson))
+      .build()
+
+    val dataset = Utils.openDatasetBuilder(readOptions).build()
+    try {
+      val fragmentCount = dataset.getFragments.size().toLong
+      if (fragmentCount == 0L) {
+        return Seq(new GenericInternalRow(Array[Any](0L, UTF8String.fromString(indexName))))
+      }
+      val indexOptions = IndexOptions
+        .builder(columns.asJava, indexType, params)
+        .replace(true)
+        .withIndexName(indexName)
+        .withIndexUUID(UUID.randomUUID().toString)
+        .build()
+      dataset.createIndex(indexOptions)
+      Seq(new GenericInternalRow(Array[Any](
+        fragmentCount,
+        UTF8String.fromString(indexName))))
+    } finally {
+      dataset.close()
+    }
   }
 
   private def createIndexJob(
@@ -294,9 +353,15 @@ case class FragmentIndexTask(
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
     val indexType = IndexUtils.buildIndexType(method)
-    val params = IndexParams.builder()
-      .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
-      .build()
+    val params = if (VectorIndexParamsBuilder.isVectorMethod(method)) {
+      IndexParams.builder()
+        .setVectorIndexParams(VectorIndexParamsBuilder.build(method, argsJson))
+        .build()
+    } else {
+      IndexParams.builder()
+        .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
+        .build()
+    }
 
     val indexOptions = IndexOptions
       .builder(java.util.Arrays.asList(columns: _*), indexType, params)
@@ -528,12 +593,23 @@ object IndexUtils {
    * @throws UnsupportedOperationException if the method is not supported
    */
   def buildIndexType(method: String): IndexType = {
-    method match {
+    method.toLowerCase match {
       case "btree" => IndexType.BTREE
       case "fts" => IndexType.INVERTED
+      case "ivf_flat" => IndexType.IVF_FLAT
+      case "ivf_pq" => IndexType.IVF_PQ
+      case "ivf_hnsw_pq" => IndexType.IVF_HNSW_PQ
+      case "ivf_hnsw_sq" => IndexType.IVF_HNSW_SQ
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }
+
+  /**
+   * True iff the given method is one of the ANN vector index kinds. Kept here so callers outside
+   * this file can branch cleanly between the scalar and vector parameter-building paths.
+   */
+  def isVectorMethod(method: String): Boolean =
+    VectorIndexParamsBuilder.isVectorMethod(method)
 
   def toJson(args: Seq[LanceNamedArgument]): String = {
     if (args.isEmpty) {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorIndexParamsBuilder.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VectorIndexParamsBuilder.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.json4s.JsonAST._
+import org.json4s.jackson.JsonMethods.parse
+import org.lance.index.DistanceType
+import org.lance.index.vector.{HnswBuildParams, IvfBuildParams, PQBuildParams, SQBuildParams, VectorIndexParams}
+import org.lance.spark.read.DistanceTypes
+
+/**
+ * Builds a [[VectorIndexParams]] from the user-supplied `WITH (...)` arguments serialised
+ * as a JSON object (see [[IndexUtils.toJson]]).
+ *
+ * The scalar path can just call `ScalarIndexParams.create(method, json)` — Lance parses the
+ * JSON itself. The vector path has no equivalent factory, so the arguments must be parsed
+ * explicitly and threaded through the per-kind builder APIs.
+ *
+ * Recognised keys (all optional; defaults come from Lance):
+ *   - metric          : "l2" | "cosine" | "dot" | "hamming"
+ *   - num_partitions  : Int                    (IVF)
+ *   - sample_rate     : Int                    (IVF / PQ / SQ)
+ *   - max_iterations  : Int                    (IVF / PQ)
+ *   - num_sub_vectors : Int                    (PQ)
+ *   - num_bits        : Int                    (PQ or SQ; method-dependent)
+ *   - m               : Int                    (HNSW)
+ *   - ef_construction : Int                    (HNSW)
+ */
+object VectorIndexParamsBuilder {
+
+  def isVectorMethod(method: String): Boolean = method.toLowerCase match {
+    case "ivf_flat" | "ivf_pq" | "ivf_hnsw_pq" | "ivf_hnsw_sq" => true
+    case _ => false
+  }
+
+  def build(method: String, argsJson: String): VectorIndexParams = {
+    val args = parseArgs(argsJson)
+    val distance = parseDistance(args.get("metric"))
+    val ivf = buildIvf(args)
+
+    val builder = new VectorIndexParams.Builder(ivf).setDistanceType(distance)
+
+    method.toLowerCase match {
+      case "ivf_flat" =>
+        // nothing extra — IVF centroids alone are enough for a flat index
+        ()
+      case "ivf_pq" =>
+        builder.setPqParams(buildPq(args))
+      case "ivf_hnsw_pq" =>
+        builder.setHnswParams(buildHnsw(args))
+        builder.setPqParams(buildPq(args))
+      case "ivf_hnsw_sq" =>
+        builder.setHnswParams(buildHnsw(args))
+        builder.setSqParams(buildSq(args))
+      case other =>
+        throw new IllegalArgumentException(
+          s"Unsupported vector index method: '$other'. " +
+            "Expected one of: ivf_flat, ivf_pq, ivf_hnsw_pq, ivf_hnsw_sq")
+    }
+
+    builder.build()
+  }
+
+  private def parseArgs(argsJson: String): Map[String, JValue] = {
+    if (argsJson == null || argsJson.trim.isEmpty || argsJson.trim == "{}") {
+      return Map.empty
+    }
+    parse(argsJson) match {
+      case JObject(fields) => fields.toMap
+      case other =>
+        throw new IllegalArgumentException(
+          s"Expected JSON object for index arguments, got: $other")
+    }
+  }
+
+  private def parseDistance(value: Option[JValue]): DistanceType = value match {
+    case None | Some(JNull) => DistanceType.L2
+    case Some(JString(s)) => DistanceTypes.parse(s, "vector index")
+    case Some(other) =>
+      throw new IllegalArgumentException(
+        s"Metric must be a string, got: $other")
+  }
+
+  private def buildIvf(args: Map[String, JValue]): IvfBuildParams = {
+    val b = new IvfBuildParams.Builder()
+    asInt(args, "num_partitions").foreach(b.setNumPartitions)
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    asInt(args, "max_iterations").foreach(b.setMaxIters)
+    b.build()
+  }
+
+  private def buildPq(args: Map[String, JValue]): PQBuildParams = {
+    val b = new PQBuildParams.Builder()
+    asInt(args, "num_sub_vectors").foreach(b.setNumSubVectors)
+    asInt(args, "num_bits").foreach(b.setNumBits)
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    asInt(args, "max_iterations").foreach(b.setMaxIters)
+    b.build()
+  }
+
+  private def buildSq(args: Map[String, JValue]): SQBuildParams = {
+    val b = new SQBuildParams.Builder()
+    asInt(args, "num_bits").foreach(n => b.setNumBits(n.toShort))
+    asInt(args, "sample_rate").foreach(b.setSampleRate)
+    b.build()
+  }
+
+  private def buildHnsw(args: Map[String, JValue]): HnswBuildParams = {
+    val b = new HnswBuildParams.Builder()
+    asInt(args, "m").foreach(b.setM)
+    asInt(args, "ef_construction").foreach(b.setEfConstruction)
+    b.build()
+  }
+
+  private def asInt(args: Map[String, JValue], key: String): Option[Int] =
+    args.get(key).flatMap {
+      case JInt(n) => Some(n.toInt)
+      case JLong(n) => Some(n.toInt)
+      case JDouble(d) if d == d.toInt => Some(d.toInt)
+      case JDecimal(d) if d.isValidInt => Some(d.toInt)
+      case JNull => None
+      case other =>
+        throw new IllegalArgumentException(
+          s"Index argument '$key' must be an integer, got: $other")
+    }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/DistanceTypes.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/DistanceTypes.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.lance.index.DistanceType
+
+object DistanceTypes {
+
+  val Supported: Seq[String] = Seq("l2", "cosine", "dot", "hamming")
+
+  def parse(metric: String, errPrefix: String): DistanceType =
+    metric.trim.toLowerCase match {
+      case "l2" | "euclidean" => DistanceType.L2
+      case "cosine" => DistanceType.Cosine
+      case "dot" | "inner_product" | "ip" => DistanceType.Dot
+      case "hamming" => DistanceType.Hamming
+      case other =>
+        throw new IllegalArgumentException(
+          s"$errPrefix: unsupported metric '$other'. " +
+            s"Expected one of: ${Supported.mkString(", ")}.")
+    }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/LanceVectorSearchTableFunction.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/LanceVectorSearchTableFunction.scala
@@ -19,10 +19,10 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, Li
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
-import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType, LongType}
+import org.apache.spark.sql.types.{DataTypes, DoubleType, FloatType, IntegerType, LongType, Metadata, StructField}
 import org.apache.spark.unsafe.types.UTF8String
 import org.lance.ipc.Query
-import org.lance.spark.{LanceDataset, LanceDataSource, LanceSparkReadOptions}
+import org.lance.spark.{LanceConstant, LanceDataset, LanceDataSource, LanceSparkReadOptions}
 import org.lance.spark.utils.QueryUtils
 
 import scala.collection.JavaConverters._
@@ -102,7 +102,24 @@ object LanceVectorSearchTableFunction {
     storageOptions.foreach { case (k, v) => reader.option(k, v) }
     reader.option(LanceSparkReadOptions.CONFIG_NEAREST, queryJson)
 
-    reader.load(datasetUri).queryExecution.analyzed
+    val analyzed = reader.load(datasetUri).queryExecution.analyzed
+    // Wrap the underlying LanceDataset in a decorator that surfaces the virtual `_distance`
+    // column in the relation's schema. Done here (not in `LanceDataSource.getTable`) because
+    // `SupportsCatalogOptions` routes `.load()` through `catalog.loadTable(ident)`, which
+    // bypasses `getTable` and never sees the per-read `nearest` option.
+    val distanceField = new StructField(
+      LanceConstant.DISTANCE,
+      DataTypes.FloatType,
+      /* nullable = */ false,
+      Metadata.empty)
+    analyzed.transformUp {
+      case rel: DataSourceV2Relation if rel.table.isInstanceOf[LanceDataset] =>
+        val wrapped = new LanceVirtualColumnsTable(
+          rel.table.asInstanceOf[LanceDataset],
+          java.util.Collections.singletonList(distanceField),
+          "vector_search")
+        DataSourceV2Relation.create(wrapped, rel.catalog, rel.identifier, rel.options)
+    }
   }
 
   // ─── Argument parsing ──────────────────────────────────────────────────────

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/LanceVectorSearchTableFunction.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/read/LanceVectorSearchTableFunction.scala
@@ -1,0 +1,350 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.FunctionIdentifier
+import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.util.ArrayData
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.{DoubleType, FloatType, IntegerType, LongType}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.ipc.Query
+import org.lance.spark.{LanceDataset, LanceDataSource, LanceSparkReadOptions}
+import org.lance.spark.utils.QueryUtils
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+/**
+ * `lance_vector_search` — table-valued function exposing Lance ANN / kNN pushdown to Spark SQL.
+ *
+ * Usage (positional; first four required):
+ * {{{
+ *   SELECT id, category
+ *   FROM lance_vector_search(
+ *          'lance.db.items',            -- table ref (catalog-qualified id OR filesystem URI)
+ *          'embedding',                 -- vector column
+ *          array(0.1f, 0.2f, ...),      -- query vector (float / double array)
+ *          10                           -- k
+ *          [, 'cosine'                  -- metric: l2 | cosine | dot | hamming
+ *          [, 20                        -- nprobes (IVF)
+ *          [, 1                         -- refine_factor (PQ)
+ *          [, 64                        -- ef (HNSW)
+ *          [, true                      -- use_index (false = brute force)
+ *          ]]]]]
+ *        )
+ *   WHERE category = 'books'
+ *   ORDER BY _distance;                  -- only if column was projected through by the scan
+ * }}}
+ *
+ * Named arguments (Spark 3.5+) are also accepted and recognised by parameter name:
+ *   `table`, `column`, `query`, `k`, `metric`, `nprobes`, `refine_factor`, `ef`, `use_index`.
+ *
+ * The resulting LogicalPlan is a standard Lance DataSource read with the
+ * [[LanceSparkReadOptions.CONFIG_NEAREST]] option populated — so all existing
+ * pushdown, filter, and projection paths apply unchanged.
+ */
+object LanceVectorSearchTableFunction {
+
+  val NAME = "lance_vector_search"
+
+  val IDENTIFIER: FunctionIdentifier = FunctionIdentifier(NAME)
+
+  val INFO: ExpressionInfo = new ExpressionInfo(
+    "org.lance.spark.read.LanceVectorSearchTableFunction",
+    null,
+    NAME,
+    "_FUNC_(table, column, query, k" +
+      "[, metric[, nprobes[, refine_factor[, ef[, use_index]]]]]) - " +
+      "Approximate nearest-neighbour search over a Lance vector column.",
+    "",
+    """
+      |    Examples:
+      |      > SELECT id, _distance FROM _FUNC_('lance.db.items', 'embedding',
+      |          array(0.1f, 0.2f, 0.3f), 10, 'cosine');
+    """.stripMargin,
+    "",
+    "table_funcs",
+    "",
+    "",
+    "built-in")
+
+  val BUILDER: Seq[Expression] => LogicalPlan = (args: Seq[Expression]) => buildPlan(args)
+
+  /**
+   * Core builder. Separated from [[BUILDER]] to make unit testing straightforward.
+   */
+  def buildPlan(args: Seq[Expression]): LogicalPlan = {
+    val parsed = parseArgs(args)
+
+    val query = buildQuery(parsed)
+    val queryJson = QueryUtils.queryToString(query)
+
+    val spark = SparkSession.active
+    val (datasetUri, storageOptions) = resolveDatasetLocation(spark, parsed.table)
+
+    val reader = spark.read.format(LanceDataSource.name)
+    // Apply catalog-derived storage options first so the caller-facing `nearest`
+    // cannot be clobbered by per-table config.
+    storageOptions.foreach { case (k, v) => reader.option(k, v) }
+    reader.option(LanceSparkReadOptions.CONFIG_NEAREST, queryJson)
+
+    reader.load(datasetUri).queryExecution.analyzed
+  }
+
+  // ─── Argument parsing ──────────────────────────────────────────────────────
+
+  private[read] case class ParsedArgs(
+      table: String,
+      column: String,
+      query: Array[Float],
+      k: Int,
+      metric: Option[String],
+      nprobes: Option[Int],
+      refineFactor: Option[Int],
+      ef: Option[Int],
+      useIndex: Option[Boolean])
+
+  /** Test-only hook so unit tests can exercise argument parsing without a SparkSession. */
+  private[read] def parseArgsForTest(args: Seq[Expression]): ParsedArgs = parseArgs(args)
+
+  private def parseArgs(args: Seq[Expression]): ParsedArgs = {
+    val byName = scala.collection.mutable.Map.empty[String, Expression]
+    val positional = scala.collection.mutable.ArrayBuffer.empty[Expression]
+    args.foreach { expr =>
+      NamedArgExtractor.unapply(expr) match {
+        case Some((name, value)) => byName(name.toLowerCase) = value
+        case None => positional += expr
+      }
+    }
+
+    def atName(name: String): Option[Expression] = byName.get(name)
+    def atPos(idx: Int): Option[Expression] =
+      if (idx < positional.length) Some(positional(idx)) else None
+    def pick(name: String, idx: Int): Option[Expression] = atName(name).orElse(atPos(idx))
+
+    val tableExpr = pick("table", 0)
+      .getOrElse(throw missing("table"))
+    val columnExpr = pick("column", 1)
+      .getOrElse(throw missing("column"))
+    val queryExpr = pick("query", 2)
+      .getOrElse(throw missing("query"))
+    val kExpr = pick("k", 3)
+      .getOrElse(throw missing("k"))
+
+    val table = evalString(tableExpr, "table")
+    val column = evalString(columnExpr, "column")
+    val queryVec = evalFloatArray(queryExpr, "query")
+    val k = evalInt(kExpr, "k")
+    require(k > 0, s"lance_vector_search: 'k' must be positive, got $k")
+
+    val metric = pick("metric", 4).map(evalString(_, "metric"))
+    val nprobes = pick("nprobes", 5).map(evalInt(_, "nprobes"))
+    val refineFactor = pick("refine_factor", 6).map(evalInt(_, "refine_factor"))
+    val ef = pick("ef", 7).map(evalInt(_, "ef"))
+    val useIndex = pick("use_index", 8).map(evalBoolean(_, "use_index"))
+
+    ParsedArgs(table, column, queryVec, k, metric, nprobes, refineFactor, ef, useIndex)
+  }
+
+  private def missing(name: String): IllegalArgumentException =
+    new IllegalArgumentException(s"lance_vector_search: missing required argument '$name'")
+
+  private def evalLiteral(expr: Expression, argName: String): Any = {
+    val folded = expr match {
+      case l: Literal => l
+      case other if other.foldable => Literal(other.eval(), other.dataType)
+      case other =>
+        throw new IllegalArgumentException(
+          s"lance_vector_search: argument '$argName' must be a constant expression, got $other")
+    }
+    folded.value
+  }
+
+  private def evalString(expr: Expression, argName: String): String =
+    evalLiteral(expr, argName) match {
+      case null =>
+        throw new IllegalArgumentException(s"lance_vector_search: '$argName' cannot be null")
+      case s: UTF8String => s.toString
+      case s: String => s
+      case other =>
+        throw new IllegalArgumentException(
+          s"lance_vector_search: '$argName' must be a STRING literal, got ${other.getClass.getName}")
+    }
+
+  private def evalInt(expr: Expression, argName: String): Int = evalLiteral(expr, argName) match {
+    case null =>
+      throw new IllegalArgumentException(s"lance_vector_search: '$argName' cannot be null")
+    case i: java.lang.Integer => i.intValue()
+    case i: Int => i
+    case l: java.lang.Long => l.intValue()
+    case other =>
+      throw new IllegalArgumentException(
+        s"lance_vector_search: '$argName' must be an integer, got ${other.getClass.getName}")
+  }
+
+  private def evalBoolean(expr: Expression, argName: String): Boolean =
+    evalLiteral(expr, argName) match {
+      case null =>
+        throw new IllegalArgumentException(s"lance_vector_search: '$argName' cannot be null")
+      case b: java.lang.Boolean => b.booleanValue()
+      case b: Boolean => b
+      case other =>
+        throw new IllegalArgumentException(
+          s"lance_vector_search: '$argName' must be a BOOLEAN, got ${other.getClass.getName}")
+    }
+
+  private def evalFloatArray(expr: Expression, argName: String): Array[Float] = {
+    val value = evalLiteral(expr, argName)
+    value match {
+      case null =>
+        throw new IllegalArgumentException(s"lance_vector_search: '$argName' cannot be null")
+      case arr: ArrayData =>
+        val dt = expr.dataType match {
+          case org.apache.spark.sql.types.ArrayType(elementType, _) => elementType
+          case other =>
+            throw new IllegalArgumentException(
+              s"lance_vector_search: '$argName' must be an ARRAY of numeric values, got $other")
+        }
+        def checkNotNull(i: Int): Unit =
+          if (arr.isNullAt(i)) {
+            throw new IllegalArgumentException(
+              s"lance_vector_search: '$argName' must not contain null elements (index $i)")
+          }
+        dt match {
+          case FloatType =>
+            val out = new Array[Float](arr.numElements())
+            var i = 0
+            while (i < out.length) {
+              checkNotNull(i)
+              out(i) = arr.getFloat(i)
+              i += 1
+            }
+            out
+          case DoubleType =>
+            val out = new Array[Float](arr.numElements())
+            var i = 0
+            while (i < out.length) {
+              checkNotNull(i)
+              out(i) = arr.getDouble(i).toFloat
+              i += 1
+            }
+            out
+          case IntegerType | LongType =>
+            val out = new Array[Float](arr.numElements())
+            var i = 0
+            while (i < out.length) {
+              checkNotNull(i)
+              out(i) = if (dt == IntegerType) arr.getInt(i).toFloat else arr.getLong(i).toFloat
+              i += 1
+            }
+            out
+          case other =>
+            throw new IllegalArgumentException(
+              s"lance_vector_search: '$argName' must be ARRAY<FLOAT|DOUBLE>, " +
+                s"got ARRAY<$other>")
+        }
+      case other =>
+        throw new IllegalArgumentException(
+          s"lance_vector_search: '$argName' must be an ARRAY literal, got ${other.getClass.getName}")
+    }
+  }
+
+  // ─── Query assembly ───────────────────────────────────────────────────────
+
+  private def buildQuery(p: ParsedArgs): Query = {
+    val b = new Query.Builder()
+      .setColumn(p.column)
+      .setKey(p.query)
+      .setK(p.k)
+      .setUseIndex(p.useIndex.getOrElse(true))
+    p.metric.foreach(m => b.setDistanceType(DistanceTypes.parse(m, "lance_vector_search")))
+    p.nprobes.foreach(b.setMinimumNprobes)
+    p.refineFactor.foreach(b.setRefineFactor)
+    p.ef.foreach(b.setEf)
+    b.build()
+  }
+
+  // ─── Table resolution ─────────────────────────────────────────────────────
+
+  /**
+   * Resolves a user-supplied table reference to a Lance dataset URI plus any storage options
+   * inherited from the catalog. Accepts either a catalog-qualified name (e.g. `lance.db.t`) or a
+   * plain filesystem URI. Catalog lookup uses [[SparkSession.table]] and walks the analysed plan
+   * for a [[LanceDataset]].
+   */
+  private def resolveDatasetLocation(
+      spark: SparkSession,
+      tableRef: String): (String, Map[String, String]) = {
+    val trimmed = tableRef.trim
+    // Heuristic: only treat as a filesystem URI if it carries a scheme or an absolute/relative
+    // path prefix. A bare `.lance` suffix is *not* enough — a catalog identifier may legitimately
+    // end in `.lance` (e.g. `cat.db.my.lance`).
+    val looksLikeUri = trimmed.contains("://") || trimmed.startsWith("/") ||
+      trimmed.startsWith("./") || trimmed.startsWith("../")
+    if (looksLikeUri) {
+      return (trimmed, Map.empty)
+    }
+    val plan =
+      try {
+        spark.table(trimmed).queryExecution.analyzed
+      } catch {
+        case NonFatal(e) =>
+          throw new IllegalArgumentException(
+            s"lance_vector_search: could not resolve table '$tableRef' " +
+              "(treat it as a catalog identifier or a Lance URI).",
+            e)
+      }
+    val lanceTable = plan.collectFirst {
+      case rel: DataSourceV2Relation if rel.table.isInstanceOf[LanceDataset] =>
+        rel.table.asInstanceOf[LanceDataset]
+    }.getOrElse(throw new IllegalArgumentException(
+      s"lance_vector_search: table '$tableRef' does not resolve to a Lance dataset."))
+    val readOpts = lanceTable.readOptions()
+    val storage = Option(readOpts.getStorageOptions)
+      .map(_.asScala.toMap)
+      .getOrElse(Map.empty[String, String])
+    (readOpts.getDatasetUri, storage)
+  }
+
+  /**
+   * Extracts a name → expression pair from a [[NamedArgumentExpression]] in Spark 3.5+.
+   * Uses reflection so this file compiles against older Spark versions where the class does not
+   * exist — those versions simply never produce such expressions, so the extractor returns None.
+   */
+  private object NamedArgExtractor {
+    private val clazz: Class[_] =
+      try {
+        Class.forName("org.apache.spark.sql.catalyst.analysis.NamedArgumentExpression")
+      } catch {
+        case _: ClassNotFoundException => null
+      }
+    private val keyMethod: java.lang.reflect.Method =
+      if (clazz == null) null else clazz.getMethod("key")
+    private val valueMethod: java.lang.reflect.Method =
+      if (clazz == null) null else clazz.getMethod("value")
+
+    def unapply(expr: Expression): Option[(String, Expression)] = {
+      if (clazz == null || !clazz.isInstance(expr)) {
+        None
+      } else {
+        Some((
+          keyMethod.invoke(expr).asInstanceOf[String],
+          valueMethod.invoke(expr).asInstanceOf[Expression]))
+      }
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
@@ -75,7 +75,7 @@ public abstract class BaseLanceVectorSearchTest {
   }
 
   @AfterEach
-  public void tearDown() {
+  public void tearDown() throws IOException {
     if (spark != null) {
       spark.close();
       spark = null;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
@@ -13,9 +13,18 @@
  */
 package org.lance.spark.read;
 
+import org.lance.Fragment;
+import org.lance.ipc.ColumnOrdering;
+import org.lance.ipc.Query;
+import org.lance.ipc.ScanOptions;
+import org.lance.spark.LanceConstant;
+
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,13 +32,17 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -53,6 +66,8 @@ public abstract class BaseLanceVectorSearchTest {
 
   @TempDir Path tempDir;
 
+  protected String tableDir;
+
   @BeforeEach
   public void setup() throws IOException {
     Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
@@ -72,6 +87,8 @@ public abstract class BaseLanceVectorSearchTest {
             .getOrCreate();
     this.tableName = "vec_" + UUID.randomUUID().toString().replace("-", "");
     this.fullTable = catalogName + ".default." + this.tableName;
+    this.tableDir =
+        FileSystems.getDefault().getPath(testRoot, this.tableName + ".lance").toString();
   }
 
   @AfterEach
@@ -170,6 +187,207 @@ public abstract class BaseLanceVectorSearchTest {
                             + ", 5)")
                     .collect());
     Assertions.assertNotNull(ex.getMessage());
+  }
+
+  // ─── Tests: _distance virtual column ──────────────────────────────────────
+
+  @Test
+  public void testTvfSchemaSurfacesDistanceColumn() {
+    prepareDataset();
+    StructType schema = tvfSqlAllColumns(10, "l2").schema();
+    StructField distanceField = null;
+    for (StructField f : schema.fields()) {
+      if (LanceConstant.DISTANCE.equals(f.name())) {
+        distanceField = f;
+        break;
+      }
+    }
+    Assertions.assertNotNull(
+        distanceField,
+        "Expected '"
+            + LanceConstant.DISTANCE
+            + "' field in schema, got "
+            + Arrays.toString(schema.fieldNames()));
+    Assertions.assertEquals(DataTypes.FloatType, distanceField.dataType());
+    Assertions.assertFalse(distanceField.nullable(), "_distance should be non-nullable");
+  }
+
+  @Test
+  public void testSelectDistanceReturnsNonNullFloats() {
+    prepareDataset();
+    List<Row> rows =
+        spark
+            .sql(
+                "SELECT id, _distance FROM lance_vector_search('"
+                    + fullTable
+                    + "', 'emb', "
+                    + queryVectorLiteral()
+                    + ", 10, 'l2', 20, 1, 64, false)")
+            .collectAsList();
+    Assertions.assertFalse(rows.isEmpty(), "TVF must return rows");
+    for (Row r : rows) {
+      Assertions.assertFalse(r.isNullAt(1), "_distance must be non-null for row id=" + r.getInt(0));
+      float d = r.getFloat(1);
+      Assertions.assertTrue(
+          Float.isFinite(d) && d >= 0.0f,
+          "_distance must be finite and non-negative (L2), got " + d + " for id=" + r.getInt(0));
+    }
+  }
+
+  @Test
+  public void testOrderByDistanceProducesGlobalTopK() {
+    prepareDataset();
+    int k = 5;
+    List<Row> rows =
+        spark
+            .sql(
+                "SELECT id, _distance FROM lance_vector_search('"
+                    + fullTable
+                    + "', 'emb', "
+                    + queryVectorLiteral()
+                    + ", "
+                    + k
+                    + ", 'l2', 20, 1, 64, false) ORDER BY _distance LIMIT "
+                    + k)
+            .collectAsList();
+    Assertions.assertEquals(k, rows.size(), "Expected " + k + " rows after global top-k");
+    for (int i = 1; i < rows.size(); i++) {
+      float prev = rows.get(i - 1).getFloat(1);
+      float cur = rows.get(i).getFloat(1);
+      Assertions.assertTrue(
+          prev <= cur, "ORDER BY _distance must be ascending; prev=" + prev + " cur=" + cur);
+    }
+    Assertions.assertEquals(
+        plantedRowId(),
+        rows.get(0).getInt(0),
+        "Closest row by _distance should be the planted neighbour");
+  }
+
+  @Test
+  public void testWhereDistanceFilters() {
+    prepareDataset();
+    float threshold = 0.5f;
+    List<Row> rows =
+        spark
+            .sql(
+                "SELECT id, _distance FROM lance_vector_search('"
+                    + fullTable
+                    + "', 'emb', "
+                    + queryVectorLiteral()
+                    + ", 20, 'l2', 20, 1, 64, false) WHERE _distance < "
+                    + threshold)
+            .collectAsList();
+    Assertions.assertFalse(rows.isEmpty(), "At least the planted neighbour must pass threshold");
+    for (Row r : rows) {
+      Assertions.assertTrue(
+          r.getFloat(1) < threshold,
+          "WHERE _distance < " + threshold + " leaked row with d=" + r.getFloat(1));
+    }
+  }
+
+  @Test
+  public void testScalarOnlyProjectionStillWorks() {
+    // Scalar-only projection (no _distance) must not regress with the decorator in place.
+    prepareDataset();
+    Set<Integer> ids = collectIds(runTvfSql(10, "l2"));
+    Assertions.assertTrue(
+        ids.contains(plantedRowId()),
+        "Scalar-only projection must still return planted neighbour, got " + ids);
+  }
+
+  @Test
+  public void testNonNearestReadDoesNotExposeDistance() {
+    // Regression guard: regular reads must not pick up _distance.
+    prepareDataset();
+    Dataset<Row> df = spark.read().format("lance").load(tableDir);
+    Assertions.assertFalse(
+        Arrays.asList(df.schema().fieldNames()).contains(LanceConstant.DISTANCE),
+        "Non-nearest read must not contain _distance; got "
+            + Arrays.toString(df.schema().fieldNames()));
+  }
+
+  /**
+   * Contract test pinning Lance native's current behaviour: attempting to filter on {@code
+   * _distance} at the scanner level raises {@code Column _distance does not exist}. Documents
+   * <em>why</em> {@code LanceScanBuilder#pushFilters} refuses to push filters that reference the
+   * virtual column. If Lance upstream starts accepting {@code _distance} in SQL WHERE clauses this
+   * test will begin to pass without an exception — at which point the guard can be relaxed.
+   */
+  @Test
+  public void testLanceNativeRejectsDistanceInWhereClause() {
+    prepareDataset();
+    runAndAssertDistanceRejected(
+        b -> b.filter(LanceConstant.DISTANCE + " < 0.5"),
+        new Query.Builder()
+            .setColumn("emb")
+            .setKey(queryVector())
+            .setK(5)
+            .setUseIndex(false)
+            .build());
+  }
+
+  /**
+   * Contract test pinning Lance native's current behaviour: attempting to sort by {@code _distance}
+   * at the scanner level raises {@code Column _distance not found}. Same unblock criterion as
+   * {@link #testLanceNativeRejectsDistanceInWhereClause}.
+   */
+  @Test
+  public void testLanceNativeRejectsDistanceInColumnOrderings() {
+    prepareDataset();
+    ColumnOrdering.Builder cob = new ColumnOrdering.Builder();
+    cob.setColumnName(LanceConstant.DISTANCE);
+    cob.setAscending(true);
+    cob.setNullFirst(false);
+    ColumnOrdering ordering = cob.build();
+    runAndAssertDistanceRejected(
+        b -> b.setColumnOrderings(Collections.singletonList(ordering)),
+        new Query.Builder()
+            .setColumn("emb")
+            .setKey(queryVector())
+            .setK(5)
+            .setUseIndex(false)
+            .build());
+  }
+
+  /**
+   * Builds a nearest-scan over fragment 0 with the caller-supplied extra option (filter, ordering,
+   * …), executes it, and asserts that Lance native raises an {@link IllegalArgumentException} whose
+   * message mentions {@code _distance}.
+   */
+  private void runAndAssertDistanceRejected(Consumer<ScanOptions.Builder> extraOption, Query q) {
+    org.lance.Dataset ds = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      Fragment fragment = ds.getFragments().get(0);
+      ScanOptions.Builder b = new ScanOptions.Builder();
+      b.columns(Collections.singletonList("id"));
+      b.nearest(q);
+      b.prefilter(true);
+      extraOption.accept(b);
+      ScanOptions opts = b.build();
+      IllegalArgumentException ex =
+          Assertions.assertThrows(
+              IllegalArgumentException.class,
+              () -> fragment.newScan(opts).scanBatches().loadNextBatch());
+      Assertions.assertTrue(
+          ex.getMessage().contains(LanceConstant.DISTANCE),
+          "Expected Lance error to mention _distance, got: " + ex.getMessage());
+    } finally {
+      ds.close();
+    }
+  }
+
+  /** Like {@link #runTvfSql} but selects all columns so the schema includes {@code _distance}. */
+  private Dataset<Row> tvfSqlAllColumns(int k, String metric) {
+    return spark.sql(
+        "SELECT * FROM lance_vector_search('"
+            + fullTable
+            + "', 'emb', "
+            + queryVectorLiteral()
+            + ", "
+            + k
+            + ", '"
+            + metric
+            + "', 20, 1, 64, false)");
   }
 
   // ─── Helpers ──────────────────────────────────────────────────────────────

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * End-to-end coverage for the {@code lance_vector_search} SQL table-valued function.
+ *
+ * <p>All tests run in brute-force mode ({@code use_index=false}) so this class has no dependency on
+ * the vector-index DDL feature — it exercises the TVF mechanics in isolation: argument parsing,
+ * positional vs. named call sites, error surface, and {@code WHERE} composition.
+ */
+public abstract class BaseLanceVectorSearchTest {
+
+  protected static final int DIM = 16;
+  protected static final int ROWS = 256;
+  protected static final long SEED = 1234567L;
+
+  protected String catalogName = "lance_vec";
+  protected String tableName;
+  protected String fullTable;
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    this.spark =
+        SparkSession.builder()
+            .appName("lance-vector-search-test")
+            .master("local[2]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .getOrCreate();
+    this.tableName = "vec_" + UUID.randomUUID().toString().replace("-", "");
+    this.fullTable = catalogName + ".default." + this.tableName;
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+    }
+  }
+
+  // ─── Tests ────────────────────────────────────────────────────────────────
+
+  @Test
+  public void testTvfBruteForceReturnsPlantedNeighbor() {
+    prepareDataset();
+    Set<Integer> ids = collectIds(runTvfSql(/* k= */ 10, "l2"));
+    Assertions.assertTrue(
+        ids.contains(plantedRowId()),
+        "Planted neighbour id=" + plantedRowId() + " missing from top-k results " + ids);
+  }
+
+  @Test
+  public void testTvfPreFilter() {
+    prepareDataset();
+    Dataset<Row> result =
+        spark.sql(
+            "SELECT id, category FROM lance_vector_search('"
+                + fullTable
+                + "', 'emb', "
+                + queryVectorLiteral()
+                + ", 10, 'l2', 20, 1, 64, false) "
+                + "WHERE category = 'odd'");
+    List<Row> rows = result.collectAsList();
+    Assertions.assertFalse(rows.isEmpty(), "Pre-filter must leave at least one row");
+    for (Row r : rows) {
+      Assertions.assertEquals("odd", r.getString(1));
+    }
+  }
+
+  @Test
+  public void testTvfRejectsNonPositiveK() {
+    prepareDataset();
+    Exception ex =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql(
+                        "SELECT * FROM lance_vector_search('"
+                            + fullTable
+                            + "', 'emb', "
+                            + queryVectorLiteral()
+                            + ", 0)")
+                    .collect());
+    String msg = rootCauseMessage(ex);
+    Assertions.assertTrue(
+        msg.contains("k") && msg.contains("positive"),
+        "Expected complaint about non-positive k, got: " + msg);
+  }
+
+  @Test
+  public void testTvfRejectsUnknownMetric() {
+    prepareDataset();
+    Exception ex =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql(
+                        "SELECT * FROM lance_vector_search('"
+                            + fullTable
+                            + "', 'emb', "
+                            + queryVectorLiteral()
+                            + ", 5, 'manhattan')")
+                    .collect());
+    String msg = rootCauseMessage(ex);
+    Assertions.assertTrue(
+        msg.toLowerCase(Locale.ROOT).contains("metric"),
+        "Expected complaint about unsupported metric, got: " + msg);
+  }
+
+  @Test
+  public void testTvfRejectsNonExistentTable() {
+    Exception ex =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql(
+                        "SELECT * FROM lance_vector_search('"
+                            + catalogName
+                            + ".default.does_not_exist_"
+                            + UUID.randomUUID().toString().replace('-', '_')
+                            + "', 'emb', "
+                            + queryVectorLiteral()
+                            + ", 5)")
+                    .collect());
+    Assertions.assertNotNull(ex.getMessage());
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a table with a 16-dim vector column plus two scalar columns (id, category), inserts
+   * {@link #ROWS} deterministic rows, and "plants" the neighbour closest to {@link #queryVector()}
+   * at {@link #plantedRowId()}. Data is split across two inserts to force at least two fragments.
+   */
+  protected void prepareDataset() {
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT NOT NULL, category STRING, emb ARRAY<FLOAT> NOT NULL) "
+                + "USING lance TBLPROPERTIES ('emb.arrow.fixed-size-list.size' = '%d')",
+            fullTable, DIM));
+    int half = ROWS / 2;
+    insertRange(0, half);
+    insertRange(half, ROWS);
+  }
+
+  private void insertRange(int from, int to) {
+    Random rng = new Random(SEED + from);
+    StringBuilder sql = new StringBuilder();
+    sql.append("INSERT INTO ").append(fullTable).append(" VALUES ");
+    boolean first = true;
+    for (int i = from; i < to; i++) {
+      if (!first) {
+        sql.append(", ");
+      }
+      first = false;
+      String cat = (i % 2 == 0) ? "even" : "odd";
+      sql.append("(")
+          .append(i)
+          .append(", '")
+          .append(cat)
+          .append("', array(")
+          .append(vectorLiteral(i, rng))
+          .append("))");
+    }
+    spark.sql(sql.toString());
+  }
+
+  private String vectorLiteral(int i, Random rng) {
+    float[] query = queryVector();
+    StringBuilder sb = new StringBuilder();
+    for (int d = 0; d < DIM; d++) {
+      if (d > 0) sb.append(", ");
+      float v;
+      if (i == plantedRowId()) {
+        v = query[d] + ((rng.nextFloat() - 0.5f) * 0.001f);
+      } else {
+        v = rng.nextFloat() * 10.0f - 5.0f;
+      }
+      sb.append(Float.toString(v)).append("f");
+    }
+    return sb.toString();
+  }
+
+  protected int plantedRowId() {
+    return 42;
+  }
+
+  protected float[] queryVector() {
+    float[] v = new float[DIM];
+    for (int i = 0; i < DIM; i++) {
+      v[i] = (float) (0.1 * (i + 1));
+    }
+    return v;
+  }
+
+  protected String queryVectorLiteral() {
+    float[] v = queryVector();
+    StringBuilder sb = new StringBuilder();
+    sb.append("array(");
+    for (int i = 0; i < v.length; i++) {
+      if (i > 0) sb.append(", ");
+      sb.append("CAST(").append(v[i]).append(" AS FLOAT)");
+    }
+    sb.append(")");
+    return sb.toString();
+  }
+
+  protected Dataset<Row> runTvfSql(int k, String metric) {
+    return spark.sql(
+        "SELECT id FROM lance_vector_search('"
+            + fullTable
+            + "', 'emb', "
+            + queryVectorLiteral()
+            + ", "
+            + k
+            + ", '"
+            + metric
+            + "', 20, 1, 64, false)");
+  }
+
+  protected Set<Integer> collectIds(Dataset<Row> df) {
+    return df.collectAsList().stream().map(r -> r.getInt(0)).collect(Collectors.toSet());
+  }
+
+  protected static String rootCauseMessage(Throwable t) {
+    Throwable cur = t;
+    while (cur.getCause() != null && cur.getCause() != cur) {
+      cur = cur.getCause();
+    }
+    String msg = cur.getMessage();
+    return msg == null ? cur.getClass().getName() : msg;
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseLanceVectorSearchTest.java
@@ -48,9 +48,11 @@ import java.util.stream.Collectors;
 /**
  * End-to-end coverage for the {@code lance_vector_search} SQL table-valued function.
  *
- * <p>All tests run in brute-force mode ({@code use_index=false}) so this class has no dependency on
- * the vector-index DDL feature — it exercises the TVF mechanics in isolation: argument parsing,
- * positional vs. named call sites, error surface, and {@code WHERE} composition.
+ * <p>Most tests run in brute-force mode ({@code use_index=false}) and exercise the TVF mechanics in
+ * isolation: argument parsing, positional vs. named call sites, error surface, and {@code WHERE}
+ * composition. {@link #testTvfWithIndexAgreesWithBruteForce()} is the one exception — it
+ * additionally requires the vector-index DDL (the {@code ivf_*} method values for {@code ALTER
+ * TABLE … CREATE INDEX}) and verifies the two features compose end-to-end.
  */
 public abstract class BaseLanceVectorSearchTest {
 
@@ -187,6 +189,59 @@ public abstract class BaseLanceVectorSearchTest {
                             + ", 5)")
                     .collect());
     Assertions.assertNotNull(ex.getMessage());
+  }
+
+  // ─── Tests: TVF + vector index integration ────────────────────────────────
+
+  /**
+   * Confirms TVF correctly threads {@code use_index=true} through to the {@code Query.Builder} —
+   * i.e. that the `lance_vector_search` SQL TVF (this PR's feature) and the `ALTER TABLE … CREATE
+   * INDEX … USING ivf_pq` statement (the vector-index PR's feature) compose end-to-end.
+   *
+   * <p>This is the only test in the suite that exercises both halves of the vector-search story
+   * together; the rest of `BaseLanceVectorSearchTest` runs in brute-force mode so the file stays
+   * usable on its own.
+   */
+  @Test
+  public void testTvfWithIndexAgreesWithBruteForce() {
+    prepareDataset();
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX idx_bf USING ivf_pq (emb) "
+                + "WITH (num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2')",
+            fullTable));
+
+    Set<Integer> withIndex = collectIds(runTvfSqlIndexed(/* k= */ 10, "l2"));
+    Set<Integer> bruteForce = collectIds(runTvfSql(/* k= */ 5, "l2"));
+    Assertions.assertTrue(
+        bruteForce.contains(plantedRowId()),
+        "brute-force scan must include the planted neighbour, got " + bruteForce);
+    Assertions.assertTrue(
+        withIndex.contains(plantedRowId()),
+        "indexed scan must include the planted neighbour, got " + withIndex);
+    // Indexed top-10 should subsume a majority of the brute-force top-5 — IVF/PQ is approximate,
+    // so don't demand strict containment.
+    long shared = bruteForce.stream().filter(withIndex::contains).count();
+    Assertions.assertTrue(
+        shared >= (bruteForce.size() + 1) / 2,
+        "Expected indexed top-10 to share a majority of the brute-force top-5; "
+            + "indexed="
+            + withIndex
+            + ", bruteForce="
+            + bruteForce);
+  }
+
+  protected Dataset<Row> runTvfSqlIndexed(int k, String metric) {
+    return spark.sql(
+        "SELECT id FROM lance_vector_search('"
+            + fullTable
+            + "', 'emb', "
+            + queryVectorLiteral()
+            + ", "
+            + k
+            + ", '"
+            + metric
+            + "', 20, 1, 64, true)");
   }
 
   // ─── Tests: _distance virtual column ──────────────────────────────────────

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseLanceVectorIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseLanceVectorIndexTest.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+import org.lance.index.DistanceType;
+import org.lance.index.Index;
+import org.lance.ipc.Query;
+import org.lance.spark.LanceDataSource;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.utils.QueryUtils;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * End-to-end coverage for the {@code ivf_*} vector index DDL.
+ *
+ * <p>The matrix is deliberately narrow — one representative cell per (index × metric × dtype)
+ * combination — because training an IVF/HNSW index is substantially more expensive than a scalar
+ * one and the Spark side of each case is identical. What we really care about is that
+ *
+ * <ul>
+ *   <li>each supported index type builds without error;
+ *   <li>each supported metric is accepted and returns results in the right order;
+ *   <li>each supported vector dtype (float32 / float64 / float16) round-trips through the index;
+ *   <li>asking for a vector index on a non-vector column is rejected with a useful message.
+ * </ul>
+ *
+ * <p>Index correctness is verified through the existing DataFrame API path (the {@code "nearest"}
+ * read option backed by {@code LanceSparkReadOptions#CONFIG_NEAREST}), so this test class has no
+ * dependency on the {@code lance_vector_search} SQL table-valued function.
+ *
+ * <p>Tests that exercise features only available on Spark 4.0+ (e.g. {@code arrow.float16}) call
+ * {@link #assumeArrow18Available()} up front so they are skipped on 3.x without failure.
+ */
+public abstract class BaseLanceVectorIndexTest {
+
+  protected static final int DIM = 16;
+  protected static final int ROWS = 256;
+  protected static final long SEED = 1234567L;
+
+  protected String catalogName = "lance_vec";
+  protected String tableName;
+  protected String fullTable;
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  protected String tableDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    this.spark =
+        SparkSession.builder()
+            .appName("lance-vector-index-test")
+            .master("local[2]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .getOrCreate();
+    this.tableName = "vec_" + UUID.randomUUID().toString().replace("-", "");
+    this.fullTable = catalogName + ".default." + this.tableName;
+    this.tableDir =
+        FileSystems.getDefault().getPath(testRoot, this.tableName + ".lance").toString();
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (spark != null) {
+      spark.close();
+      spark = null;
+    }
+  }
+
+  // ─── Tests: DDL × index type ──────────────────────────────────────────────
+
+  @Test
+  public void testIvfFlatIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex("idx_ivf_flat", "ivf_flat", "num_partitions=4, metric='l2'");
+    assertIndexExists("idx_ivf_flat");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfPqIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_pq", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_ivf_pq");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfHnswPqIndexCosineFloat32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_hnsw_pq",
+        "ivf_hnsw_pq",
+        "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='cosine', "
+            + "m=8, ef_construction=40");
+    assertIndexExists("idx_ivf_hnsw_pq");
+    // Re-search with the 'cosine' metric so the expected neighbour matches the index.
+    assertNearestReturnsPlantedNeighbor("cosine");
+  }
+
+  @Test
+  public void testIvfHnswSqIndexL2Float32() {
+    prepareFloat32Dataset();
+    createVectorIndex(
+        "idx_ivf_hnsw_sq",
+        "ivf_hnsw_sq",
+        "num_partitions=4, num_bits=8, metric='l2', m=8, ef_construction=40");
+    assertIndexExists("idx_ivf_hnsw_sq");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  // ─── Tests: vector dtype ──────────────────────────────────────────────────
+
+  @Test
+  public void testIvfPqOnFloat64Column() {
+    prepareDataset(/* useDouble= */ true, /* useFloat16= */ false);
+    createVectorIndex(
+        "idx_pq_f64", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_pq_f64");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  @Test
+  public void testIvfPqOnFloat16Column() {
+    // float16 via `arrow.float16` metadata requires Arrow 18+ which is bundled with Spark 4.0+.
+    assumeArrow18Available();
+    prepareDataset(/* useDouble= */ false, /* useFloat16= */ true);
+    createVectorIndex(
+        "idx_pq_f16", "ivf_pq", "num_partitions=4, num_sub_vectors=4, num_bits=8, metric='l2'");
+    assertIndexExists("idx_pq_f16");
+    assertVectorSearchReturnsPlantedNeighbor();
+  }
+
+  // ─── Tests: input validation ──────────────────────────────────────────────
+
+  @Test
+  public void testCreateVectorIndexOnScalarColumnFails() {
+    prepareFloat32Dataset();
+    IllegalArgumentException ex =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                spark
+                    .sql(
+                        String.format(
+                            "ALTER TABLE %s CREATE INDEX bad_idx USING ivf_pq (id) "
+                                + "WITH (num_partitions=4)",
+                            fullTable))
+                    .collect());
+    Assertions.assertTrue(
+        ex.getMessage().toLowerCase(Locale.ROOT).contains("vector"),
+        "Error should mention vector requirement, got: " + ex.getMessage());
+  }
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  protected void prepareFloat32Dataset() {
+    prepareDataset(/* useDouble= */ false, /* useFloat16= */ false);
+  }
+
+  /**
+   * Creates a table with a 16-dim vector column plus two scalar columns (id, category), inserts
+   * {@link #ROWS} deterministic rows, and "plants" the neighbour closest to {@link #queryVector()}
+   * at {@link #plantedRowId()}. Data is split across two inserts to force at least two fragments.
+   */
+  protected void prepareDataset(boolean useDouble, boolean useFloat16) {
+    String elementType = useDouble ? "DOUBLE" : "FLOAT";
+    StringBuilder tblProps = new StringBuilder();
+    tblProps.append("'emb.arrow.fixed-size-list.size' = '").append(DIM).append("'");
+    if (useFloat16) {
+      tblProps.append(", 'emb.arrow.float16' = 'true'");
+    }
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT NOT NULL, category STRING, emb ARRAY<%s> NOT NULL) "
+                + "USING lance TBLPROPERTIES (%s)",
+            fullTable, elementType, tblProps));
+
+    int half = ROWS / 2;
+    insertRange(0, half, useDouble);
+    insertRange(half, ROWS, useDouble);
+  }
+
+  private void insertRange(int from, int to, boolean useDouble) {
+    Random rng = new Random(SEED + from);
+    StringBuilder sql = new StringBuilder();
+    sql.append("INSERT INTO ").append(fullTable).append(" VALUES ");
+    boolean first = true;
+    for (int i = from; i < to; i++) {
+      if (!first) {
+        sql.append(", ");
+      }
+      first = false;
+      String cat = (i % 2 == 0) ? "even" : "odd";
+      sql.append("(")
+          .append(i)
+          .append(", '")
+          .append(cat)
+          .append("', array(")
+          .append(vectorLiteral(i, rng, useDouble))
+          .append("))");
+    }
+    spark.sql(sql.toString());
+  }
+
+  /**
+   * Generates a vector for row {@code i}. The row at {@link #plantedRowId()} is made very close to
+   * the query vector so that any correctly-working search must surface it.
+   */
+  private String vectorLiteral(int i, Random rng, boolean useDouble) {
+    float[] query = queryVector();
+    StringBuilder sb = new StringBuilder();
+    for (int d = 0; d < DIM; d++) {
+      if (d > 0) sb.append(", ");
+      float v;
+      if (i == plantedRowId()) {
+        // Same direction as the query, tiny perturbation.
+        v = query[d] + ((rng.nextFloat() - 0.5f) * 0.001f);
+      } else {
+        v = rng.nextFloat() * 10.0f - 5.0f;
+      }
+      if (useDouble) {
+        sb.append(Double.toString(v));
+      } else {
+        sb.append(Float.toString(v)).append("f");
+      }
+    }
+    return sb.toString();
+  }
+
+  protected int plantedRowId() {
+    return 42;
+  }
+
+  protected float[] queryVector() {
+    float[] v = new float[DIM];
+    for (int i = 0; i < DIM; i++) {
+      v[i] = (float) (0.1 * (i + 1));
+    }
+    return v;
+  }
+
+  protected void createVectorIndex(String indexName, String method, String withClause) {
+    Dataset<Row> out =
+        spark.sql(
+            String.format(
+                "ALTER TABLE %s CREATE INDEX %s USING %s (emb) WITH (%s)",
+                fullTable, indexName, method, withClause));
+    Row row = out.collectAsList().get(0);
+    Assertions.assertEquals(indexName, row.getString(1));
+    Assertions.assertTrue(row.getLong(0) >= 1, "Expected at least one fragment indexed");
+  }
+
+  protected void assertIndexExists(String indexName) {
+    org.lance.Dataset ds = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      List<Index> indexes = ds.getIndexes();
+      Set<String> names = indexes.stream().map(Index::name).collect(Collectors.toSet());
+      Assertions.assertTrue(
+          names.contains(indexName), "Expected index '" + indexName + "' in " + names);
+    } finally {
+      ds.close();
+    }
+  }
+
+  protected void assertVectorSearchReturnsPlantedNeighbor() {
+    assertNearestReturnsPlantedNeighbor("l2");
+  }
+
+  /**
+   * Runs a kNN search through the existing DataFrame read path ({@code option("nearest", …)}) and
+   * asserts the planted row appears in the top-k. Intentionally avoids the {@code
+   * lance_vector_search} SQL TVF so this test class stays independent of that PR.
+   */
+  protected void assertNearestReturnsPlantedNeighbor(String metric) {
+    Query query =
+        new Query.Builder()
+            .setColumn("emb")
+            .setKey(queryVector())
+            .setK(10)
+            .setDistanceType(parseDistance(metric))
+            .setUseIndex(true)
+            .build();
+    Dataset<Row> df =
+        spark
+            .read()
+            .format(LanceDataSource.name)
+            .option(LanceSparkReadOptions.CONFIG_NEAREST, QueryUtils.queryToString(query))
+            .option(LanceSparkReadOptions.CONFIG_DATASET_URI, tableDir)
+            .load()
+            .select("id");
+    Set<Integer> ids =
+        df.collectAsList().stream().map(r -> r.getInt(0)).collect(Collectors.toSet());
+    Assertions.assertTrue(
+        ids.contains(plantedRowId()),
+        "Planted neighbour id=" + plantedRowId() + " missing from top-k results " + ids);
+  }
+
+  private static DistanceType parseDistance(String metric) {
+    switch (metric.toLowerCase(Locale.ROOT)) {
+      case "l2":
+        return DistanceType.L2;
+      case "cosine":
+        return DistanceType.Cosine;
+      case "dot":
+        return DistanceType.Dot;
+      case "hamming":
+        return DistanceType.Hamming;
+      default:
+        throw new IllegalArgumentException("Unknown metric: " + metric);
+    }
+  }
+
+  /**
+   * Skips the current test if the Arrow version on the classpath is older than 18 (where the
+   * canonical half-precision float type landed) — i.e. on Spark 3.x. Subclasses may override to
+   * force-enable on newer Spark versions.
+   */
+  protected void assumeArrow18Available() {
+    boolean available;
+    try {
+      Class.forName("org.apache.arrow.vector.Float2Vector");
+      available = true;
+    } catch (ClassNotFoundException e) {
+      available = false;
+    }
+    Assumptions.assumeTrue(available, "Arrow 18+ required for float16 vectors (Spark 4.0+)");
+  }
+}

--- a/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorIndexParamsBuilderTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorIndexParamsBuilderTest.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.apache.spark.sql.execution.datasources.v2.VectorIndexParamsBuilder
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.lance.index.DistanceType
+
+class VectorIndexParamsBuilderTest {
+
+  // ─── DistanceTypes ─────────────────────────────────────────────────────────
+
+  @Test def distanceTypesAcceptsAllAliases(): Unit = {
+    assertEquals(DistanceType.L2, DistanceTypes.parse("l2", "ctx"))
+    assertEquals(DistanceType.L2, DistanceTypes.parse("L2", "ctx"))
+    assertEquals(DistanceType.L2, DistanceTypes.parse("euclidean", "ctx"))
+    assertEquals(DistanceType.Cosine, DistanceTypes.parse("cosine", "ctx"))
+    assertEquals(DistanceType.Cosine, DistanceTypes.parse("Cosine", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("dot", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("inner_product", "ctx"))
+    assertEquals(DistanceType.Dot, DistanceTypes.parse("ip", "ctx"))
+    assertEquals(DistanceType.Hamming, DistanceTypes.parse("hamming", "ctx"))
+  }
+
+  @Test def distanceTypesRejectsUnknown(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => DistanceTypes.parse("manhattan", "myctx"))
+    assertTrue(ex.getMessage.contains("myctx"))
+    assertTrue(ex.getMessage.contains("manhattan"))
+  }
+
+  // ─── VectorIndexParamsBuilder ──────────────────────────────────────────────
+
+  @Test def isVectorMethodRecognisesSupportedKinds(): Unit = {
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_flat"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("IVF_PQ"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_hnsw_pq"))
+    assertTrue(VectorIndexParamsBuilder.isVectorMethod("ivf_hnsw_sq"))
+    assertFalse(VectorIndexParamsBuilder.isVectorMethod("btree"))
+    assertFalse(VectorIndexParamsBuilder.isVectorMethod("fts"))
+  }
+
+  @Test def buildHandlesEmptyArgs(): Unit = {
+    Seq(null.asInstanceOf[String], "", "  ", "{}").foreach { json =>
+      val params = VectorIndexParamsBuilder.build("ivf_flat", json)
+      assertNotNull(params, s"build(ivf_flat, '$json') returned null")
+    }
+  }
+
+  @Test def buildAcceptsMixedNumericTypes(): Unit = {
+    val json =
+      """{"num_partitions": 4, "sample_rate": 256, "num_sub_vectors": 2.0, "num_bits": 8}"""
+    val params = VectorIndexParamsBuilder.build("ivf_pq", json)
+    assertNotNull(params)
+  }
+
+  @Test def buildRejectsNonIntegerForIntArg(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_pq", """{"num_partitions": "four"}"""))
+    assertTrue(ex.getMessage.contains("num_partitions"))
+  }
+
+  @Test def buildRejectsUnknownMethod(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("hnsw", "{}"))
+    assertTrue(ex.getMessage.toLowerCase.contains("unsupported vector index method"))
+  }
+
+  @Test def buildRejectsBadMetric(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_flat", """{"metric": "manhattan"}"""))
+    assertTrue(ex.getMessage.contains("manhattan"))
+  }
+
+  @Test def buildRejectsNonObjectJson(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () => VectorIndexParamsBuilder.build("ivf_flat", "[1, 2, 3]"))
+    assertTrue(ex.getMessage.toLowerCase.contains("json object"))
+  }
+}

--- a/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorSearchArgParsingTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/lance/spark/read/VectorSearchArgParsingTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read
+
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.util.GenericArrayData
+import org.apache.spark.sql.types.{ArrayType, DoubleType, FloatType, IntegerType, LongType}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+class VectorSearchArgParsingTest {
+
+  private def floatArrayLit(vs: Float*): Literal =
+    Literal.create(new GenericArrayData(vs.toArray[Any]), ArrayType(FloatType))
+
+  @Test def parseArgsAcceptsRequiredPositional(): Unit = {
+    val args = Seq(
+      Literal("cat.db.t"),
+      Literal("emb"),
+      floatArrayLit(0.1f, 0.2f, 0.3f),
+      Literal(5))
+    val parsed = LanceVectorSearchTableFunction.parseArgsForTest(args)
+    assertEquals("cat.db.t", parsed.table)
+    assertEquals("emb", parsed.column)
+    assertArrayEquals(Array(0.1f, 0.2f, 0.3f), parsed.query)
+    assertEquals(5, parsed.k)
+    assertTrue(parsed.metric.isEmpty)
+    assertTrue(parsed.useIndex.isEmpty)
+  }
+
+  @Test def parseArgsAcceptsOptionalPositional(): Unit = {
+    val args = Seq(
+      Literal("t"),
+      Literal("c"),
+      floatArrayLit(1.0f),
+      Literal(3),
+      Literal("cosine"),
+      Literal(20),
+      Literal(2),
+      Literal(64),
+      Literal(false))
+    val parsed = LanceVectorSearchTableFunction.parseArgsForTest(args)
+    assertEquals(Some("cosine"), parsed.metric)
+    assertEquals(Some(20), parsed.nprobes)
+    assertEquals(Some(2), parsed.refineFactor)
+    assertEquals(Some(64), parsed.ef)
+    assertEquals(Some(false), parsed.useIndex)
+  }
+
+  @Test def parseArgsConvertsArrayDoubleAndIntQueries(): Unit = {
+    val asDouble = Literal.create(
+      new GenericArrayData(Array[Any](0.1d, 0.2d, 0.3d)),
+      ArrayType(DoubleType))
+    val pd = LanceVectorSearchTableFunction.parseArgsForTest(
+      Seq(Literal("t"), Literal("c"), asDouble, Literal(3)))
+    assertEquals(3, pd.query.length)
+    assertTrue(math.abs(pd.query(0) - 0.1f) < 1e-6f)
+
+    val asInt = Literal.create(
+      new GenericArrayData(Array[Any](1, 2, 3)),
+      ArrayType(IntegerType))
+    val pi = LanceVectorSearchTableFunction.parseArgsForTest(
+      Seq(Literal("t"), Literal("c"), asInt, Literal(3)))
+    assertArrayEquals(Array(1.0f, 2.0f, 3.0f), pi.query)
+
+    val asLong = Literal.create(
+      new GenericArrayData(Array[Any](1L, 2L)),
+      ArrayType(LongType))
+    val pl = LanceVectorSearchTableFunction.parseArgsForTest(
+      Seq(Literal("t"), Literal("c"), asLong, Literal(3)))
+    assertArrayEquals(Array(1.0f, 2.0f), pl.query)
+  }
+
+  @Test def parseArgsRejectsNullElements(): Unit = {
+    val withNull = Literal.create(
+      new GenericArrayData(Array[Any](0.1f, null, 0.3f)),
+      ArrayType(FloatType))
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () =>
+        LanceVectorSearchTableFunction.parseArgsForTest(
+          Seq(Literal("t"), Literal("c"), withNull, Literal(3))))
+    assertTrue(ex.getMessage.contains("null"))
+  }
+
+  @Test def parseArgsRejectsNonPositiveK(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () =>
+        LanceVectorSearchTableFunction.parseArgsForTest(
+          Seq(Literal("t"), Literal("c"), floatArrayLit(1.0f), Literal(0))))
+    assertTrue(ex.getMessage.contains("positive"))
+  }
+
+  @Test def parseArgsReportsMissingArgByName(): Unit = {
+    val ex = assertThrows(
+      classOf[IllegalArgumentException],
+      () =>
+        LanceVectorSearchTableFunction.parseArgsForTest(
+          Seq(Literal("t"), Literal("c"), floatArrayLit(1.0f))))
+    assertTrue(ex.getMessage.contains("'k'"))
+  }
+}


### PR DESCRIPTION
Part of #65 (vector search SQL extension).

This is one of three PRs that supersede #436, splitting it per [reviewer feedback](https://github.com/lance-format/lance-spark/pull/436#pullrequestreview-4133774667).

> **⚠️ Depends on both #449 (vector-index) and #450 (TVF).** Marked as draft until both merge. The diff below currently includes #449's and #450's changes; once both are merged the diff will reduce to just this PR's contents (7 `_distance`-specific files + 1 integration test).

## Summary

Surfaces the virtual `_distance` column produced by Lance vector search in the relation's schema, so references to it in `SELECT`, `ORDER BY`, and `WHERE` resolve during analysis. Also adds the one integration test that exercises **TVF + indexed vector search** end-to-end (the only test that requires both #449 and #450 — the rest of the suites in those PRs cover their halves in isolation).

### Implementation

A thin Table-decorator (`LanceVirtualColumnsTable`) wraps the underlying `LanceDataset` and appends extra `StructField`s to `schema()`. The decorator is applied inside `LanceVectorSearchTableFunction` via a `transformUp` over the analyzed plan — done at the TVF site (rather than in `LanceDataSource.getTable`) because `SupportsCatalogOptions` routes `.load()` through `catalog.loadTable(ident)`, which bypasses `getTable` and never sees the per-read `nearest` option.

### Generalization

The decorator is generalized so future virtual columns (`_score` for FTS, `_rowid`, `_score_explain`, …) can reuse it by passing additional `StructField`s — no per-column decorator class needed. This addresses the reviewer's concern *"There may be more column additions in the future, so maybe it needs to be generalized."*

### Pushdown guards

Filter and top-N pushdown for `_distance` are explicitly blocked in `LanceScanBuilder`, because Lance native currently rejects `_distance` as an unknown column in `WHERE` and column orderings. Two contract tests pin that upstream behaviour at the JNI layer; once Lance starts accepting `_distance` in pushdowns, the tests will fail and signal that the guards can be relaxed.

### Integration test

`testTvfWithIndexAgreesWithBruteForce` creates a vector index via `ALTER TABLE … CREATE INDEX … USING ivf_pq` (#449's feature) then runs `lance_vector_search(... use_index=true)` (#450's feature) and verifies the indexed top-k contains the planted neighbour and overlaps with brute-force. This is the only place the two halves are exercised together.

## Test plan
- [x] `make test SPARK_VERSION=3.5 -Dtest=LanceVectorSearchTest` — 14 integration tests pass (5 from #450 + 1 integration + 8 `_distance` tests)
- [x] `make lint` — checkstyle + spotless clean
- [ ] After #449 and #450 merge: rebase onto main, run `make test-all` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)