### PR TITLE
test: cover scalar + nested Float16 -> FloatType across complex types

### DIFF
--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -23,7 +23,7 @@ package org.apache.spark.sql.util
  * It has been modified by the Lance developers to fit the needs of the Lance project.
  */
 
-import org.apache.arrow.vector.types.DateUnit
+import org.apache.arrow.vector.types.{DateUnit, FloatingPointPrecision}
 import org.apache.arrow.vector.types.pojo.{Field, FieldType}
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.SparkUnsupportedOperationException
@@ -115,6 +115,115 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     roundtrip(new StructType().add(
       "struct",
       new StructType().add("i", IntegerType).add("arr", ArrayType(IntegerType))))
+  }
+
+  test("float16 widens to FloatType across complex nestings") {
+    // Lance emits half-precision float columns as FloatingPoint(HALF). Spark
+    // has no native float16, so LanceArrowUtils widens to FloatType. The
+    // recursion must also hit every nested occurrence — otherwise the nested
+    // field falls through to Spark's ArrowUtils and raises UNSUPPORTED_ARROWTYPE.
+
+    def halfField(name: String, nullable: Boolean = true): Field = new Field(
+      name,
+      new FieldType(
+        nullable,
+        new ArrowType.FloatingPoint(FloatingPointPrecision.HALF),
+        null,
+        null),
+      java.util.Collections.emptyList())
+
+    // 1. Scalar Float16 at top level.
+    assert(LanceArrowUtils.fromArrowField(halfField("half")) === FloatType)
+
+    // 2. Struct with a Float16 field.
+    val structField = new Field(
+      "s",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(halfField("h")))
+    assert(
+      LanceArrowUtils
+        .fromArrowField(structField)
+        .asInstanceOf[StructType]("h")
+        .dataType === FloatType)
+
+    // 3. Variable-size List<Float16>.
+    val listField = new Field(
+      "lst",
+      new FieldType(true, ArrowType.List.INSTANCE, null, null),
+      java.util.Arrays.asList(halfField("element")))
+    assert(
+      LanceArrowUtils.fromArrowField(listField) ===
+        ArrayType(FloatType, containsNull = true))
+
+    // 4. FixedSizeList<Float16> — the canonical embedding-vector shape.
+    val fixedListField = new Field(
+      "vec",
+      new FieldType(true, new ArrowType.FixedSizeList(8), null, null),
+      java.util.Arrays.asList(halfField("element")))
+    assert(
+      LanceArrowUtils.fromArrowField(fixedListField) ===
+        ArrayType(FloatType, containsNull = true))
+
+    // 5. Map<Utf8, Float16>.
+    val keyField = new Field(
+      "key",
+      new FieldType(false, ArrowType.Utf8.INSTANCE, null, null),
+      java.util.Collections.emptyList())
+    val entriesField = new Field(
+      "entries",
+      new FieldType(false, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(keyField, halfField("value")))
+    val mapField = new Field(
+      "m",
+      new FieldType(true, new ArrowType.Map(false), null, null),
+      java.util.Arrays.asList(entriesField))
+    val mapType = LanceArrowUtils.fromArrowField(mapField).asInstanceOf[MapType]
+    assert(mapType.keyType === StringType)
+    assert(mapType.valueType === FloatType)
+
+    // 6. Struct containing a List<Float16> — list-in-struct.
+    val listInStruct = new Field(
+      "s",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(
+        new Field(
+          "lst",
+          new FieldType(true, ArrowType.List.INSTANCE, null, null),
+          java.util.Arrays.asList(halfField("element")))))
+    val listInStructType =
+      LanceArrowUtils.fromArrowField(listInStruct).asInstanceOf[StructType]
+    assert(
+      listInStructType("lst").dataType ===
+        ArrayType(FloatType, containsNull = true))
+
+    // 7. Deep nesting: Struct > FixedSizeList<Float16> + sibling scalar Float16.
+    val deep = new Field(
+      "wrapper",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(
+        new Field(
+          "vec",
+          new FieldType(true, new ArrowType.FixedSizeList(4), null, null),
+          java.util.Arrays.asList(halfField("element"))),
+        halfField("score")))
+    val deepType = LanceArrowUtils.fromArrowField(deep).asInstanceOf[StructType]
+    assert(
+      deepType("vec").dataType === ArrayType(FloatType, containsNull = true))
+    assert(deepType("score").dataType === FloatType)
+
+    // 8. List<Struct<Float16>> — struct-inside-list with Float16 field.
+    val structWithHalf = new Field(
+      "element",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(halfField("h")))
+    val listOfStruct = new Field(
+      "items",
+      new FieldType(true, ArrowType.List.INSTANCE, null, null),
+      java.util.Arrays.asList(structWithHalf))
+    val listOfStructType =
+      LanceArrowUtils.fromArrowField(listOfStruct).asInstanceOf[ArrayType]
+    val innerStruct = listOfStructType.elementType.asInstanceOf[StructType]
+    assert(innerStruct("h").dataType === FloatType)
   }
 
   test("nested date millisecond types") {


### PR DESCRIPTION
## Summary

Adds a read-path regression test for the Float16 widening added in #378. The existing `SchemaConverterFloat16Test` only covers the write-side metadata path (`ArrayType(FloatType) + arrow.float16=true`); nothing guarded the `LanceArrowUtils.fromArrowField` branches that widen `FloatingPoint(HALF)` to `FloatType`.

This matters because `fromArrowField` handles several nested shapes (Struct / List / FixedSizeList / Map) before its Float16 case (`LanceArrowUtils.scala:135-138`), and the nested handlers recurse back through `fromArrowField`. If any of those branches stop recursing through this function (e.g. a refactor delegates to Spark's stock `ArrowUtils.fromArrowField` directly), the Float16 case silently gets skipped and reads against a half-precision column explode with:

```
[UNSUPPORTED_ARROWTYPE] Unsupported arrow type FloatingPoint(HALF).
```

(This is the user-visible symptom we saw downstream — the fix is already in `821a436`, but no read-path test guarded it.)

New test case `float16 widens to FloatType across complex nestings` asserts every recursion branch:

- scalar `FloatingPoint(HALF)` at top level
- `Struct<Float16>`
- variable-size `List<Float16>`
- `FixedSizeList<Float16>`
- `Map<Utf8, Float16>`
- `Struct<List<Float16>>` (list-in-struct)
- deep `Struct<FixedSizeList<Float16>, Float16>`
- `List<Struct<Float16>>` (struct-in-list)

## Test plan

- [ ] `mvn test -pl lance-spark-base_2.12 -Dtest=LanceArrowUtilsSuite` passes.
- [ ] Temporarily deleting the Float16 case at `LanceArrowUtils.scala:135-138` makes the new test fail with `UNSUPPORTED_ARROWTYPE`, confirming the test actually exercises the widening path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)