### PR TITLE
feat: support zonemap indexes in ALTER TABLE CREATE INDEX

### DIFF
--- a/docker/tests/test_lance_spark.py
+++ b/docker/tests/test_lance_spark.py
@@ -492,7 +492,7 @@ class TestDDLAlterTableProperties:
 
 
 class TestDDLIndex:
-    """Test DDL index operations: CREATE INDEX (BTree, FTS)."""
+    """Test DDL index operations: CREATE INDEX (BTree, ZoneMap, FTS)."""
 
     def test_create_btree_index_on_int(self, spark):
         """Test CREATE INDEX with BTree on integer column."""
@@ -561,6 +561,42 @@ class TestDDLIndex:
             SELECT * FROM default.employees WHERE department = 'Engineering'
         """).collect()
         assert len(query_result) == 3
+
+    def test_create_zonemap_index_on_int(self, spark):
+        """Test CREATE INDEX with ZoneMap on integer column."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING,
+                value DOUBLE
+            )
+        """)
+
+        data = [(i, f"Name{i}", float(i * 10)) for i in range(100)]
+        df = spark.createDataFrame(data, ["id", "name", "value"])
+        df.writeTo("default.test_table").append()
+
+        result = spark.sql("""
+            ALTER TABLE default.test_table
+            CREATE INDEX idx_id_zonemap USING zonemap (id)
+            WITH (rows_per_zone = 8)
+        """).collect()
+
+        assert len(result) == 1
+        assert result[0][1] == "idx_id_zonemap"
+
+        indexes = spark.sql("""
+            SHOW INDEXES IN default.test_table
+        """).collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_id_zonemap"]
+        assert len(zonemap_rows) == 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
+        query_result = spark.sql("""
+            SELECT * FROM default.test_table WHERE id = 50
+        """).collect()
+        assert len(query_result) == 1
+        assert query_result[0].id == 50
 
     def test_create_fts_index(self, spark):
         """Test CREATE INDEX with full-text search (FTS)."""

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -7,7 +7,7 @@ Creates a scalar index on a Lance table to accelerate queries.
 
 ## Overview
 
-The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. This operation is performed in a distributed manner, building indexes for each data fragment in parallel.
+The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. Depending on the index method, Lance Spark either uses a fragment-parallel build path or delegates to Lance's built-in single-phase index creation path.
 
 ## Basic Usage
 
@@ -24,12 +24,21 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
+| `zonemap` | Lightweight min/max index for fragment pruning on scalar columns.         |
 | `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
 | `fts`   | Full-text search (inverted) index for text search on string columns.        |
 
 ## Options
 
 The `CREATE INDEX` command supports options via the `WITH` clause to control index creation. These options are specific to the chosen index method.
+
+### ZoneMap Options
+
+For the `zonemap` method, the following options are supported:
+
+| Option          | Type | Description                                  |
+|-----------------|------|----------------------------------------------|
+| `rows_per_zone` | Long | The approximate number of rows per zonemap zone. |
 
 ### BTree Options
 
@@ -77,6 +86,15 @@ Create a composite index on multiple columns.
     ALTER TABLE lance.db.logs CREATE INDEX idx_ts_level USING btree (timestamp, level);
     ```
 
+### Lightweight Fragment Pruning
+
+Create a zonemap index when you want lightweight min/max-based fragment pruning:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id);
+    ```
+
 ### Indexing with Options
 
 Create an index and specify the `zone_size` for the B-tree:
@@ -84,6 +102,15 @@ Create an index and specify the `zone_size` for the B-tree:
 === "SQL"
     ```sql
     ALTER TABLE lance.db.users CREATE INDEX idx_id_zoned USING btree (id) WITH (zone_size = 2048);
+    ```
+
+### Zonemap with Options
+
+Create a zonemap index and specify the approximate number of rows per zone:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id) WITH (rows_per_zone = 2048);
     ```
 
 ### Full-Text Search Index
@@ -117,17 +144,18 @@ The `CREATE INDEX` command returns the following information about the operation
 Consider creating an index when:
 
 - You frequently filter a large table on a specific column.
+- You want lightweight fragment pruning based on per-zone min/max statistics.
 - Your queries involve point lookups or small range scans.
 
 ## How It Works
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Distributed Index Building**: For each fragment in the Lance dataset, a separate task is launched to build an index on the specified column(s).
-2.  **Metadata Merging**: Once all per-fragment indexes are built, their metadata is collected and merged.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree` can use fragment-parallel execution, while `zonemap` is built through Lance's single-phase create-index API.
+2.  **Metadata Finalization**: Lance records the new index metadata as part of the index creation flow.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
 ## Notes and Limitations
 
-- **Index Methods**: The `btree` and `fts` methods are supported for scalar index creation.
+- **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -24,7 +24,7 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
-| `zonemap` | Lightweight min/max index for fragment pruning on scalar columns.         |
+| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
 | `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
 | `fts`   | Full-text search (inverted) index for text search on string columns.        |
 
@@ -158,4 +158,5 @@ The `CREATE INDEX` command operates as follows:
 ## Notes and Limitations
 
 - **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
+- **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.

--- a/docs/src/operations/ddl/show-indexes.md
+++ b/docs/src/operations/ddl/show-indexes.md
@@ -49,7 +49,7 @@ The `SHOW INDEXES` command returns the following columns:
 |-------------------------|---------------|--------------------------------------------------------------------|
 | `name`                  | string        | Logical name of the index.                                         |
 | `fields`                | array<string> | List of column names included in the index.                        |
-| `index_type`            | string        | Human-readable index type (for example `btree`).                   |
+| `index_type`            | string        | Human-readable index type (for example `btree` or `zonemap`).      |
 | `num_indexed_fragments` | long          | Number of fragments fully or partially covered by the index.       |
 | `num_indexed_rows`      | long          | Approximate number of rows covered by the index.                   |
 | `num_unindexed_fragments` | long        | Number of fragments that are not yet indexed.                      |

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -620,7 +620,7 @@ class TestDDLColumnCompression:
 
 
 class TestDDLIndex:
-    """Test DDL index operations: CREATE INDEX (BTree, FTS)."""
+    """Test DDL index operations: CREATE INDEX (BTree, ZoneMap, FTS)."""
 
     def test_create_btree_index_on_int(self, spark):
         """Test CREATE INDEX with BTree on integer column."""
@@ -689,6 +689,42 @@ class TestDDLIndex:
             SELECT * FROM default.employees WHERE department = 'Engineering'
         """).collect()
         assert len(query_result) == 3
+
+    def test_create_zonemap_index_on_int(self, spark):
+        """Test CREATE INDEX with ZoneMap on integer column."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING,
+                value DOUBLE
+            )
+        """)
+
+        data = [(i, f"Name{i}", float(i * 10)) for i in range(100)]
+        df = spark.createDataFrame(data, ["id", "name", "value"])
+        df.writeTo("default.test_table").append()
+
+        result = spark.sql("""
+            ALTER TABLE default.test_table
+            CREATE INDEX idx_id_zonemap USING zonemap (id)
+            WITH (rows_per_zone = 8)
+        """).collect()
+
+        assert len(result) == 1
+        assert result[0][1] == "idx_id_zonemap"
+
+        indexes = spark.sql("""
+            SHOW INDEXES IN default.test_table
+        """).collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_id_zonemap"]
+        assert len(zonemap_rows) == 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
+        query_result = spark.sql("""
+            SELECT * FROM default.test_table WHERE id = 50
+        """).collect()
+        assert len(query_result) == 1
+        assert query_result[0].id == 50
 
     def test_create_fts_index(self, spark):
         """Test CREATE INDEX with full-text search (FTS)."""

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -16,7 +16,8 @@ package org.lance.spark.read;
 import org.lance.Dataset;
 import org.lance.Fragment;
 import org.lance.ManifestSummary;
-import org.lance.index.IndexDescription;
+import org.lance.index.Index;
+import org.lance.index.IndexType;
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
 import org.lance.schema.LanceField;
@@ -382,9 +383,9 @@ public class LanceScanBuilder
         fieldIdToName.put(field.getId(), field.getName());
       }
 
-      for (IndexDescription idx : dataset.describeIndices()) {
-        if ("ZONEMAP".equalsIgnoreCase(idx.getIndexType())) {
-          for (int fieldId : idx.getFieldIds()) {
+      for (Index idx : dataset.getIndexes()) {
+        if (idx.indexType() == IndexType.ZONEMAP) {
+          for (int fieldId : idx.fields()) {
             String name = fieldIdToName.get(fieldId);
             if (name != null) {
               columns.add(name);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -33,9 +33,9 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -267,7 +267,9 @@ public final class ZonemapFragmentPruner {
     if (value instanceof BigInteger) {
       return new BigDecimal((BigInteger) value);
     }
-    if (value instanceof Byte || value instanceof Short || value instanceof Integer
+    if (value instanceof Byte
+        || value instanceof Short
+        || value instanceof Integer
         || value instanceof Long) {
       return BigDecimal.valueOf(value.longValue());
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -33,6 +33,8 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -159,7 +161,6 @@ public final class ZonemapFragmentPruner {
     return Optional.empty();
   }
 
-  @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeComparison(
       String column,
       Object value,
@@ -171,17 +172,9 @@ public final class ZonemapFragmentPruner {
       return Optional.empty();
     }
 
-    Comparable<Object> target;
-    try {
-      target = (Comparable<Object>) value;
-    } catch (ClassCastException e) {
-      LOG.warn("Cannot cast filter value {} to Comparable for zonemap pruning", value);
-      return Optional.empty();
-    }
-
     Set<Integer> matchingFragments = new HashSet<>();
     for (ZoneStats zone : stats) {
-      if (zoneMatchesComparison(zone, target, type)) {
+      if (zoneMatchesComparison(zone, value, type)) {
         matchingFragments.add(zone.getFragmentId());
       }
     }
@@ -189,12 +182,10 @@ public final class ZonemapFragmentPruner {
     return Optional.of(matchingFragments);
   }
 
-  @SuppressWarnings("unchecked")
-  private static boolean zoneMatchesComparison(
-      ZoneStats zone, Comparable<Object> target, ComparisonType type) {
+  private static boolean zoneMatchesComparison(ZoneStats zone, Object target, ComparisonType type) {
 
-    Comparable<Object> min = (Comparable<Object>) zone.getMin();
-    Comparable<Object> max = (Comparable<Object>) zone.getMax();
+    Object min = zone.getMin();
+    Object max = zone.getMax();
 
     // If min or max is null, the zone contains only nulls for the indexed range;
     // non-null comparisons cannot match.
@@ -206,27 +197,26 @@ public final class ZonemapFragmentPruner {
       switch (type) {
         case EQUALS:
           // target ∈ [min, max]
-          return target.compareTo(min) >= 0 && target.compareTo(max) <= 0;
+          return compareValues(target, min) >= 0 && compareValues(target, max) <= 0;
         case LESS_THAN:
           // ∃ row < target  ⟺  zone.min < target
-          return min.compareTo(target) < 0;
+          return compareValues(min, target) < 0;
         case LESS_THAN_OR_EQUAL:
-          return min.compareTo(target) <= 0;
+          return compareValues(min, target) <= 0;
         case GREATER_THAN:
-          return max.compareTo(target) > 0;
+          return compareValues(max, target) > 0;
         case GREATER_THAN_OR_EQUAL:
-          return max.compareTo(target) >= 0;
+          return compareValues(max, target) >= 0;
         default:
           return true; // conservative
       }
-    } catch (ClassCastException e) {
+    } catch (ClassCastException | IllegalArgumentException e) {
       // Type mismatch between filter value and zone stats — be conservative
       LOG.warn("Type mismatch in zonemap comparison, skipping pruning for zone", e);
       return true;
     }
   }
 
-  @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeIn(
       String column, Object[] values, Map<String, List<ZoneStats>> statsByColumn) {
 
@@ -244,14 +234,7 @@ public final class ZonemapFragmentPruner {
             break;
           }
         } else {
-          try {
-            Comparable<Object> target = (Comparable<Object>) value;
-            if (zoneMatchesComparison(zone, target, ComparisonType.EQUALS)) {
-              matchingFragments.add(zone.getFragmentId());
-              break;
-            }
-          } catch (ClassCastException e) {
-            // Non-comparable value, conservatively include
+          if (zoneMatchesComparison(zone, value, ComparisonType.EQUALS)) {
             matchingFragments.add(zone.getFragmentId());
             break;
           }
@@ -260,6 +243,42 @@ public final class ZonemapFragmentPruner {
     }
 
     return Optional.of(matchingFragments);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static int compareValues(Object left, Object right) {
+    if (left instanceof Number && right instanceof Number) {
+      return compareNumbers((Number) left, (Number) right);
+    }
+    if (isStringLike(left) && isStringLike(right)) {
+      return left.toString().compareTo(right.toString());
+    }
+    return ((Comparable) left).compareTo(right);
+  }
+
+  private static int compareNumbers(Number left, Number right) {
+    return toBigDecimal(left).compareTo(toBigDecimal(right));
+  }
+
+  private static BigDecimal toBigDecimal(Number value) {
+    if (value instanceof BigDecimal) {
+      return (BigDecimal) value;
+    }
+    if (value instanceof BigInteger) {
+      return new BigDecimal((BigInteger) value);
+    }
+    if (value instanceof Byte || value instanceof Short || value instanceof Integer
+        || value instanceof Long) {
+      return BigDecimal.valueOf(value.longValue());
+    }
+    if (value instanceof Float || value instanceof Double) {
+      return BigDecimal.valueOf(value.doubleValue());
+    }
+    return new BigDecimal(value.toString());
+  }
+
+  private static boolean isStringLike(Object value) {
+    return value instanceof CharSequence || value instanceof UTF8String;
   }
 
   private static Optional<Set<Integer>> analyzeIsNull(

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -40,12 +40,12 @@ import java.util.{Collections, Optional, UUID}
 import scala.collection.JavaConverters._
 
 /**
- * Physical execution of distributed CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
+ * Physical execution of CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
  *
  * <ul>
  * <li>For BTREE index, it uses a range-based approach that redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
- * <li>For other index types, it processes each fragment independently in parallel, merges index metadata
- * and commits an index-creation transaction.
+ * <li>For fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
+ * <li>For zonemap index, it delegates to the underlying Lance single-phase index creation path because zonemap does not support fragment training.
  * </ul>
  */
 case class AddIndexExec(
@@ -83,6 +83,13 @@ case class AddIndexExec(
 
     val uuid = UUID.randomUUID()
     val indexType = IndexUtils.buildIndexType(method)
+
+    if (indexType == IndexType.ZONEMAP) {
+      createDirectScalarIndex(readOptions, indexType)
+      return Seq(new GenericInternalRow(Array[Any](
+        fragmentIds.size.toLong,
+        UTF8String.fromString(indexName))))
+    }
 
     // Create distributed index job and run it
     createIndexJob(lanceDataset, readOptions, uuid.toString, fragmentIds).run()
@@ -137,6 +144,28 @@ case class AddIndexExec(
     Seq(new GenericInternalRow(Array[Any](
       fragmentIds.size.toLong,
       UTF8String.fromString(indexName))))
+  }
+
+  private def createDirectScalarIndex(
+      readOptions: LanceSparkReadOptions,
+      indexType: IndexType): Unit = {
+    val argsJson = IndexUtils.toJson(args)
+    val params = IndexParams.builder()
+      .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
+      .build()
+
+    val indexOptions = IndexOptions
+      .builder(columns.asJava, indexType, params)
+      .replace(true)
+      .withIndexName(indexName)
+      .build()
+
+    val dataset = Utils.openDatasetBuilder(readOptions).build()
+    try {
+      dataset.createIndex(indexOptions)
+    } finally {
+      dataset.close()
+    }
   }
 
   private def createIndexJob(
@@ -530,6 +559,7 @@ object IndexUtils {
   def buildIndexType(method: String): IndexType = {
     method match {
       case "btree" => IndexType.BTREE
+      case "zonemap" => IndexType.ZONEMAP
       case "fts" => IndexType.INVERTED
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -85,6 +85,10 @@ case class AddIndexExec(
     val indexType = IndexUtils.buildIndexType(method)
 
     if (indexType == IndexType.ZONEMAP) {
+      if (columns.size != 1) {
+        throw new UnsupportedOperationException(
+          "Zonemap index currently supports a single column only")
+      }
       createDirectScalarIndex(readOptions, indexType)
       return Seq(new GenericInternalRow(Array[Any](
         fragmentIds.size.toLong,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -76,6 +76,16 @@ public class ZonemapFragmentPrunerTest {
   }
 
   @Test
+  public void testEqualToMatchesOneFragmentWithIntegerFilterValue() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Filter[] filters = new Filter[] {new EqualTo("x", 150)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1), result.get());
+  }
+
+  @Test
   public void testEqualToMatchesNoFragment() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     Filter[] filters = new Filter[] {new EqualTo("x", 500L)};

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -243,6 +243,25 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateMultiColumnZonemapIndexThrowsHelpfulError() {
+    prepareDataset();
+
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                spark.sql(
+                    String.format(
+                        "alter table %s create index test_index_zonemap_multi using zonemap (id, text) with (rows_per_zone=4)",
+                        fullTable)));
+
+    Assertions.assertTrue(
+        exception.getMessage().contains("single column"),
+        "Expected multi-column zonemap error to mention single-column support, got: "
+            + exception.getMessage());
+  }
+
+  @Test
   public void testCreateBTreeIndexWithRangeMode() {
     prepareDataset();
 
@@ -497,6 +516,10 @@ public abstract class BaseAddIndexTest {
   }
 
   private void assertZonemapFilterPrunesFragments(int targetId) {
+    assertZonemapFilterPrunesFragments(new EqualTo("id", targetId), String.format("id=%d", targetId));
+  }
+
+  private void assertZonemapFilterPrunesFragments(Filter filter, String description) {
     LanceSparkReadOptions readOptions = LanceSparkReadOptions.from(tableDir);
 
     LanceScanBuilder unfilteredBuilder =
@@ -519,14 +542,14 @@ public abstract class BaseAddIndexTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    filteredBuilder.pushFilters(new Filter[] {new EqualTo("id", targetId)});
+    filteredBuilder.pushFilters(new Filter[] {filter});
     int filteredPartitions = ((LanceScan) filteredBuilder.build()).planInputPartitions().length;
 
     Assertions.assertTrue(
         filteredPartitions < unfilteredPartitions,
         String.format(
-            "Expected zonemap pruning to reduce planned partitions for id=%d (before=%d, after=%d)",
-            targetId, unfilteredPartitions, filteredPartitions));
+            "Expected zonemap pruning to reduce planned partitions for %s (before=%d, after=%d)",
+            description, unfilteredPartitions, filteredPartitions));
   }
 
   private void checkIndex(String indexName) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -14,10 +14,15 @@
 package org.lance.spark.update;
 
 import org.lance.index.Index;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.read.LanceScan;
+import org.lance.spark.read.LanceScanBuilder;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.Filter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -188,6 +194,47 @@ public abstract class BaseAddIndexTest {
     checkIndex("test_index_btree_param");
 
     // Verify query using the indexed field with zone_size parameter
+    Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
+    Assertions.assertEquals(1L, query.count());
+    Row r = query.collectAsList().get(0);
+    Assertions.assertEquals(15, r.getInt(0));
+    Assertions.assertEquals("text_15", r.getString(1));
+  }
+
+  @Test
+  public void testCreateZonemapIndexWithRowsPerZone() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index test_index_zonemap using zonemap (id) with (rows_per_zone=4)",
+                fullTable));
+
+    Assertions.assertEquals(
+        "StructType(StructField(fragments_indexed,LongType,true),StructField(index_name,StringType,true))",
+        result.schema().toString());
+
+    Row row = result.collectAsList().get(0);
+    long fragmentsIndexed = row.getLong(0);
+    String indexName = row.getString(1);
+
+    Assertions.assertTrue(fragmentsIndexed >= 2, "Expected at least 2 fragments to be indexed");
+    Assertions.assertEquals("test_index_zonemap", indexName);
+
+    checkIndex("test_index_zonemap");
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      Assertions.assertFalse(
+          lanceDataset.getZonemapStats("id").isEmpty(),
+          "Expected zonemap stats for indexed column");
+    } finally {
+      lanceDataset.close();
+    }
+
+    assertZonemapFilterPrunesFragments(15);
+
     Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
     Assertions.assertEquals(1L, query.count());
     Row r = query.collectAsList().get(0);
@@ -447,6 +494,39 @@ public abstract class BaseAddIndexTest {
     // Verify query still works
     Dataset<Row> query = spark.sql(String.format("select * from %s where id=5", fullTable));
     Assertions.assertEquals(1L, query.count());
+  }
+
+  private void assertZonemapFilterPrunesFragments(int targetId) {
+    LanceSparkReadOptions readOptions = LanceSparkReadOptions.from(tableDir);
+
+    LanceScanBuilder unfilteredBuilder =
+        new LanceScanBuilder(
+            spark.table(fullTable).schema(),
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    int unfilteredPartitions = ((LanceScan) unfilteredBuilder.build()).planInputPartitions().length;
+    Assertions.assertTrue(
+        unfilteredPartitions >= 2, "Expected multiple partitions for zonemap pruning test");
+
+    LanceScanBuilder filteredBuilder =
+        new LanceScanBuilder(
+            spark.table(fullTable).schema(),
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    filteredBuilder.pushFilters(new Filter[] {new EqualTo("id", targetId)});
+    int filteredPartitions = ((LanceScan) filteredBuilder.build()).planInputPartitions().length;
+
+    Assertions.assertTrue(
+        filteredPartitions < unfilteredPartitions,
+        String.format(
+            "Expected zonemap pruning to reduce planned partitions for id=%d (before=%d, after=%d)",
+            targetId, unfilteredPartitions, filteredPartitions));
   }
 
   private void checkIndex(String indexName) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -516,7 +516,8 @@ public abstract class BaseAddIndexTest {
   }
 
   private void assertZonemapFilterPrunesFragments(int targetId) {
-    assertZonemapFilterPrunesFragments(new EqualTo("id", targetId), String.format("id=%d", targetId));
+    assertZonemapFilterPrunesFragments(
+        new EqualTo("id", targetId), String.format("id=%d", targetId));
   }
 
   private void assertZonemapFilterPrunesFragments(Filter filter, String description) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -131,4 +131,30 @@ public abstract class BaseShowIndexesTest {
     long numIndexedRows = row.getLong(4);
     Assertions.assertTrue(numIndexedRows >= 1L, "num_indexed_rows should be at least 1");
   }
+
+  @Test
+  public void testShowZonemapIndexes() {
+    prepareDataset();
+
+    spark.sql(
+        String.format(
+            "alter table %s create index test_zonemap using zonemap (id) with (rows_per_zone=4)",
+            fullTable));
+
+    Dataset<Row> result = spark.sql(String.format("show indexes from %s", fullTable));
+    List<Row> rows = result.collectAsList();
+
+    Row row =
+        rows.stream()
+            .filter(r -> "test_zonemap".equals(r.getString(0)))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected SHOW INDEXES to include test_zonemap"));
+
+    @SuppressWarnings("unchecked")
+    List<String> fieldNames = row.getList(1);
+    Assertions.assertTrue(fieldNames.contains("id"), "fields should contain column name 'id'");
+    Assertions.assertEquals("zonemap", row.getString(2));
+    Assertions.assertTrue(row.getLong(3) >= 1L, "num_indexed_fragments should be at least 1");
+    Assertions.assertTrue(row.getLong(4) >= 1L, "num_indexed_rows should be at least 1");
+  }
 }


### PR DESCRIPTION
## Summary
- add single-column zonemap support for `ALTER TABLE ... CREATE INDEX` via Lance direct `createIndex` instead of fragment training
- surface zonemap indexes in `SHOW INDEXES` and scan planning, and fix numeric zonemap pruning across mixed numeric types
- clarify and test that multi-column zonemap is not yet supported, with a clearer Spark-side error and updated docs

## Testing
- `./mvnw -pl lance-spark-4.0_2.13,lance-spark-4.1_2.13 -Dtest=AddIndexTest,ShowIndexesTest,ZonemapFragmentPrunerTest,CreateIndexStandardSyntaxTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl lance-spark-4.0_2.13,lance-spark-4.1_2.13 -Dtest=AddIndexTest,ShowIndexesTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Notes
- generic Spark `CREATE INDEX` syntax accepts a column list, but current Lance core rejects multi-column zonemap creation with `LanceError(Index): Only support building index on 1 column at the moment`
- Spark now fails earlier with `Zonemap index currently supports a single column only`
- Python integration tests were updated but not run locally because this environment does not have `pytest` or the expected `/home/lance/data` fixture path