### PR TITLE
refactor: refactor the vector data expose to rust side to improve performance and prevent OOM

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
@@ -24,16 +24,13 @@ import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.ipc.ArrowStreamReader;
-import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -119,22 +116,10 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
   private void flushFragment(int fragmentId, FragmentBuffer buffer) {
     try {
       buffer.writer.finish();
-
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      try (ArrowStreamWriter streamWriter = new ArrowStreamWriter(buffer.data, null, out)) {
-        streamWriter.start();
-        streamWriter.writeBatch();
-        streamWriter.end();
-      } catch (IOException e) {
-        throw new RuntimeException("Cannot write schema root", e);
-      }
-
-      byte[] arrowData = out.toByteArray();
-      ByteArrayInputStream in = new ByteArrayInputStream(arrowData);
       BufferAllocator allocator = LanceRuntime.allocator();
 
-      try (ArrowStreamReader reader = new ArrowStreamReader(in, allocator);
-          ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator);
+          ArrowReader reader = new SingleBatchArrowReader(allocator, buffer.data)) {
         Data.exportArrayStream(allocator, reader, stream);
 
         try (Dataset dataset =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SingleBatchArrowReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SingleBatchArrowReader.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+public class SingleBatchArrowReader extends ArrowReader {
+  private final VectorSchemaRoot source;
+  private boolean returned = false;
+
+  public SingleBatchArrowReader(BufferAllocator allocator, VectorSchemaRoot source) {
+    super(allocator);
+    this.source = source;
+  }
+
+  @Override
+  protected Schema readSchema() {
+    return source.getSchema();
+  }
+
+  @Override
+  public boolean loadNextBatch() throws java.io.IOException {
+    if (returned) {
+      return false;
+    }
+
+    super.prepareLoadNextBatch();
+
+    try (ArrowRecordBatch rb = new VectorUnloader(source).getRecordBatch()) {
+      new VectorLoader(getVectorSchemaRoot()).load(rb);
+    }
+
+    returned = true;
+    return true;
+  }
+
+  @Override
+  public long bytesRead() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected void closeReadSource() {}
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SingleBatchArrowReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SingleBatchArrowReader.java
@@ -21,13 +21,23 @@ import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.types.pojo.Schema;
 
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * An ArrowReader implementation that provides a single ArrowRecordBatch from a given
+ * VectorSchemaRoot.
+ *
+ * <p>This reader will return the batch exactly once when {@link #loadNextBatch()} is called, and
+ * subsequent calls will return false indicating no more batches are available.
+ */
 public class SingleBatchArrowReader extends ArrowReader {
   private final VectorSchemaRoot source;
   private boolean returned = false;
 
   public SingleBatchArrowReader(BufferAllocator allocator, VectorSchemaRoot source) {
     super(allocator);
-    this.source = source;
+    this.source = Objects.requireNonNull(source, "source must not be null");
   }
 
   @Override
@@ -36,7 +46,7 @@ public class SingleBatchArrowReader extends ArrowReader {
   }
 
   @Override
-  public boolean loadNextBatch() throws java.io.IOException {
+  public boolean loadNextBatch() throws IOException {
     if (returned) {
       return false;
     }
@@ -53,7 +63,7 @@ public class SingleBatchArrowReader extends ArrowReader {
 
   @Override
   public long bytesRead() {
-    throw new UnsupportedOperationException();
+    return 0;
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -33,10 +33,10 @@ import org.lance.operation.{CreateIndex => AddIndexOperation}
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 import org.lance.spark.arrow.LanceArrowWriter
 import org.lance.spark.utils.{CloseableUtil, Utils}
+import org.lance.spark.write.SingleBatchArrowReader
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.{Collections, Optional, UUID}
-
 import scala.collection.JavaConverters._
 
 /**
@@ -455,24 +455,8 @@ case class RangeBTreeIndexBuilder(
       return Iterator.empty
     }
 
-    // Serialize the arrow stream to byte array
-    val out = new ByteArrayOutputStream()
-    val streamWriter = new ArrowStreamWriter(data, null, out)
-    try {
-      streamWriter.start()
-      streamWriter.writeBatch()
-      streamWriter.end()
-    } finally {
-      CloseableUtil.closeQuietly(streamWriter)
-      CloseableUtil.closeQuietly(data)
-    }
-
-    val arrowData = out.toByteArray()
-    val in = new ByteArrayInputStream(arrowData)
-
-    // Export data to lance
-    val reader = new ArrowStreamReader(in, allocator)
     val stream = ArrowArrayStream.allocateNew(allocator)
+    val reader = new SingleBatchArrowReader(allocator, data)
 
     var dataset: Dataset = null
 
@@ -505,6 +489,7 @@ case class RangeBTreeIndexBuilder(
     } finally {
       CloseableUtil.closeQuietly(stream)
       CloseableUtil.closeQuietly(reader)
+      CloseableUtil.closeQuietly(data)
 
       if (dataset != null) {
         CloseableUtil.closeQuietly(dataset)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -37,6 +37,7 @@ import org.lance.spark.write.SingleBatchArrowReader
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.{Collections, Optional, UUID}
+
 import scala.collection.JavaConverters._
 
 /**

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -15,7 +15,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.arrow.c.{ArrowArrayStream, Data}
 import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.ipc.{ArrowStreamReader, ArrowStreamWriter}
+import org.apache.arrow.vector.ipc.ArrowReader
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.logical.{AddIndexOutputType, LanceNamedArgument}
@@ -35,7 +35,6 @@ import org.lance.spark.arrow.LanceArrowWriter
 import org.lance.spark.utils.{CloseableUtil, Utils}
 import org.lance.spark.write.SingleBatchArrowReader
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.util.{Collections, Optional, UUID}
 
 import scala.collection.JavaConverters._
@@ -456,12 +455,14 @@ case class RangeBTreeIndexBuilder(
       return Iterator.empty
     }
 
-    val stream = ArrowArrayStream.allocateNew(allocator)
-    val reader = new SingleBatchArrowReader(allocator, data)
-
+    var stream: ArrowArrayStream = null
+    var reader: ArrowReader = null
     var dataset: Dataset = null
 
     try {
+      stream = ArrowArrayStream.allocateNew(allocator)
+      reader = new SingleBatchArrowReader(allocator, data)
+
       dataset = Utils.openDatasetBuilder(
         decode[LanceSparkReadOptions](encodedReadOptions))
         .initialStorageOptions(initialStorageOptions.map(_.asJava).orNull)
@@ -491,10 +492,7 @@ case class RangeBTreeIndexBuilder(
       CloseableUtil.closeQuietly(stream)
       CloseableUtil.closeQuietly(reader)
       CloseableUtil.closeQuietly(data)
-
-      if (dataset != null) {
-        CloseableUtil.closeQuietly(dataset)
-      }
+      CloseableUtil.closeQuietly(dataset)
     }
 
     Iterator.empty

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SingleBatchArrowReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SingleBatchArrowReaderTest.java
@@ -77,7 +77,6 @@ public class SingleBatchArrowReaderTest {
         SingleBatchArrowReader reader = new SingleBatchArrowReader(allocator, source);
         ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
 
-      // 导出到ArrowArrayStream
       Data.exportArrayStream(allocator, reader, stream);
 
       try (ArrowReader exportedReader = Data.importArrayStream(allocator, stream)) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SingleBatchArrowReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SingleBatchArrowReaderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SingleBatchArrowReaderTest {
+
+  private VectorSchemaRoot createIntRoot(BufferAllocator allocator, int rowCount) {
+    Field field =
+        new Field(
+            "column",
+            FieldType.nullable(org.apache.arrow.vector.types.Types.MinorType.INT.getType()),
+            null);
+    Schema schema = new Schema(Collections.singletonList(field));
+
+    VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator);
+    IntVector vector = (IntVector) root.getVector("column");
+    vector.allocateNew(rowCount);
+    for (int i = 0; i < rowCount; i++) {
+      vector.set(i, i + 1);
+    }
+    vector.setValueCount(rowCount);
+    root.setRowCount(rowCount);
+    return root;
+  }
+
+  @Test
+  public void testLoadNextBatch() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot source = createIntRoot(allocator, 3);
+        SingleBatchArrowReader reader = new SingleBatchArrowReader(allocator, source)) {
+      assertTrue(reader.loadNextBatch());
+
+      VectorSchemaRoot out = reader.getVectorSchemaRoot();
+      assertEquals(source.getSchema(), out.getSchema());
+      assertEquals(3, out.getRowCount());
+      for (int i = 0; i < 3; i++) {
+        assertEquals(i + 1, out.getVector("column").getObject(i));
+      }
+
+      assertFalse(reader.loadNextBatch());
+    }
+  }
+
+  @Test
+  public void testExportToArrowArrayStream() throws Exception {
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot source = createIntRoot(allocator, 5);
+        SingleBatchArrowReader reader = new SingleBatchArrowReader(allocator, source);
+        ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+
+      // 导出到ArrowArrayStream
+      Data.exportArrayStream(allocator, reader, stream);
+
+      try (ArrowReader exportedReader = Data.importArrayStream(allocator, stream)) {
+        assertTrue(exportedReader.loadNextBatch());
+        VectorSchemaRoot exportedRoot = exportedReader.getVectorSchemaRoot();
+
+        assertEquals(5, exportedRoot.getRowCount());
+
+        IntVector exportedVector = (IntVector) exportedRoot.getVector("column");
+        for (int i = 0; i < 5; i++) {
+          assertEquals(i + 1, exportedVector.getObject(i));
+        }
+
+        assertFalse(exportedReader.loadNextBatch());
+      }
+
+      assertFalse(reader.loadNextBatch());
+    }
+  }
+}


### PR DESCRIPTION
# Background

Currently the vector data collecting from spark writer firstly are serialized to byte[] and then exported to rust-side. This will involve two problems:

* OOM: If the data is two large and byte[Integer.MAX] can't wrap it, OOM will occur.
* Performance: The serialization will increase the overload.

# How to fix it

We use a SingleBatchArrowReader which extends ArrowReader to wrap the vector data. And  use `Data.exportArrayStream(BufferAllocator allocator, ArrowReader reader, ArrowArrayStream out)` to export the data to rust-side.