### PR TITLE
feat: preserve FixedSizeBinary(n) byte width across read-write roundtrips

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
@@ -58,17 +58,15 @@ public class FixedSizeBinaryUtils {
    * Get the byte width from a Spark field's metadata.
    *
    * @param field the Spark struct field
-   * @return the byte width, or -1 if not a FixedSizeBinary field
+   * @return the byte width, or -1 if the field has no FixedSizeBinary metadata
    */
   public static int getByteWidth(StructField field) {
     if (!isFixedSizeBinaryField(field)) {
       return -1;
     }
-    try {
-      return (int) field.metadata().getLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
-    } catch (Exception e) {
-      return -1;
-    }
+    // isFixedSizeBinaryField confirmed the key is present; getLong throwing here would indicate
+    // internal corruption and should surface rather than be masked as "-1 means no metadata".
+    return (int) field.metadata().getLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
@@ -13,9 +13,7 @@
  */
 package org.lance.spark.utils;
 
-import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
 
 /**
  * Utility class for FixedSizeBinary Arrow type metadata handling. When reading a Lance file that
@@ -29,22 +27,6 @@ public class FixedSizeBinaryUtils {
       "arrow.fixed-size-binary.byte-width";
 
   /**
-   * Check if a Spark field carries FixedSizeBinary metadata.
-   *
-   * @param field the Spark struct field to check
-   * @return true if the field is BinaryType with FixedSizeBinary byte-width metadata
-   */
-  public static boolean isFixedSizeBinaryField(StructField field) {
-    if (field == null) {
-      return false;
-    }
-    if (!(field.dataType() instanceof BinaryType)) {
-      return false;
-    }
-    return hasFixedSizeBinaryMetadata(field.metadata());
-  }
-
-  /**
    * Check if metadata contains the FixedSizeBinary byte-width key.
    *
    * @param metadata the Spark field metadata
@@ -52,21 +34,6 @@ public class FixedSizeBinaryUtils {
    */
   public static boolean hasFixedSizeBinaryMetadata(Metadata metadata) {
     return metadata != null && metadata.contains(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
-  }
-
-  /**
-   * Get the byte width from a Spark field's metadata.
-   *
-   * @param field the Spark struct field
-   * @return the byte width, or -1 if the field has no FixedSizeBinary metadata
-   */
-  public static int getByteWidth(StructField field) {
-    if (!isFixedSizeBinaryField(field)) {
-      return -1;
-    }
-    // isFixedSizeBinaryField confirmed the key is present; getLong throwing here would indicate
-    // internal corruption and should surface rather than be masked as "-1 means no metadata".
-    return (int) field.metadata().getLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FixedSizeBinaryUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+
+/**
+ * Utility class for FixedSizeBinary Arrow type metadata handling. When reading a Lance file that
+ * contains FixedSizeBinary(n) columns, the byte width is preserved in Spark field metadata so
+ * subsequent writes can reproduce the original Arrow type instead of falling back to
+ * variable-length Binary.
+ */
+public class FixedSizeBinaryUtils {
+
+  public static final String ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY =
+      "arrow.fixed-size-binary.byte-width";
+
+  /**
+   * Check if a Spark field carries FixedSizeBinary metadata.
+   *
+   * @param field the Spark struct field to check
+   * @return true if the field is BinaryType with FixedSizeBinary byte-width metadata
+   */
+  public static boolean isFixedSizeBinaryField(StructField field) {
+    if (field == null) {
+      return false;
+    }
+    if (!(field.dataType() instanceof BinaryType)) {
+      return false;
+    }
+    return hasFixedSizeBinaryMetadata(field.metadata());
+  }
+
+  /**
+   * Check if metadata contains the FixedSizeBinary byte-width key.
+   *
+   * @param metadata the Spark field metadata
+   * @return true if the metadata contains the byte-width key
+   */
+  public static boolean hasFixedSizeBinaryMetadata(Metadata metadata) {
+    return metadata != null && metadata.contains(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
+  }
+
+  /**
+   * Get the byte width from a Spark field's metadata.
+   *
+   * @param field the Spark struct field
+   * @return the byte width, or -1 if not a FixedSizeBinary field
+   */
+  public static int getByteWidth(StructField field) {
+    if (!isFixedSizeBinaryField(field)) {
+      return -1;
+    }
+    try {
+      return (int) field.metadata().getLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY);
+    } catch (Exception e) {
+      return -1;
+    }
+  }
+
+  /**
+   * Create a table property key for specifying FixedSizeBinary byte width. Used in CREATE TABLE
+   * statements, e.g. {@code 'hash.arrow.fixed-size-binary.byte-width' = '16'}.
+   *
+   * @param columnName the name of the column
+   * @return the property key
+   */
+  public static String createPropertyKey(String columnName) {
+    return columnName + "." + ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY;
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_KEY;
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_VALUE;
+import static org.lance.spark.utils.FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY;
 import static org.lance.spark.utils.Float16Utils.ARROW_FLOAT16_KEY;
 import static org.lance.spark.utils.Float16Utils.ARROW_FLOAT16_VALUE;
 import static org.lance.spark.utils.LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY;
@@ -59,7 +60,9 @@ public class SchemaConverter {
     StructType schemaWithFloat16 = addFloat16Metadata(schemaWithVectors, properties);
     StructType schemaWithBlobs = addBlobMetadata(schemaWithFloat16, properties);
     StructType schemaWithLargeVarChar = addLargeVarCharMetadata(schemaWithBlobs, properties);
-    return addCompressionMetadata(schemaWithLargeVarChar, properties);
+    StructType schemaWithFixedSizeBinary =
+        addFixedSizeBinaryMetadata(schemaWithLargeVarChar, properties);
+    return addCompressionMetadata(schemaWithFixedSizeBinary, properties);
   }
 
   /**
@@ -284,6 +287,51 @@ public class SchemaConverter {
         }
       } else {
         // Keep field as-is
+        newFields[i] = field;
+      }
+    }
+
+    return new StructType(newFields);
+  }
+
+  /**
+   * Adds metadata to BinaryType fields based on table properties for FixedSizeBinary columns.
+   * Properties with pattern "<column_name>.arrow.fixed-size-binary.byte-width" are applied to
+   * matching columns.
+   *
+   * @param sparkSchema the original Spark StructType
+   * @param properties table properties that may contain FixedSizeBinary column metadata
+   * @return StructType with metadata added for FixedSizeBinary columns
+   */
+  private static StructType addFixedSizeBinaryMetadata(
+      StructType sparkSchema, Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return sparkSchema;
+    }
+
+    StructField[] newFields = new StructField[sparkSchema.fields().length];
+    for (int i = 0; i < sparkSchema.fields().length; i++) {
+      StructField field = sparkSchema.fields()[i];
+      String byteWidthProperty = FixedSizeBinaryUtils.createPropertyKey(field.name());
+
+      if (properties.containsKey(byteWidthProperty)) {
+        if (field.dataType() instanceof BinaryType) {
+          long byteWidth = Long.parseLong(properties.get(byteWidthProperty));
+          Metadata newMetadata =
+              new MetadataBuilder()
+                  .withMetadata(field.metadata())
+                  .putLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY, byteWidth)
+                  .build();
+          newFields[i] =
+              new StructField(field.name(), field.dataType(), field.nullable(), newMetadata);
+        } else {
+          throw new IllegalArgumentException(
+              "FixedSizeBinary column '"
+                  + field.name()
+                  + "' must have BINARY type, found: "
+                  + field.dataType());
+        }
+      } else {
         newFields[i] = field;
       }
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -316,7 +316,8 @@ public class SchemaConverter {
 
       if (properties.containsKey(byteWidthProperty)) {
         if (field.dataType() instanceof BinaryType) {
-          long byteWidth = Long.parseLong(properties.get(byteWidthProperty));
+          String raw = properties.get(byteWidthProperty);
+          int byteWidth = parseFixedSizeBinaryByteWidth(field.name(), raw);
           Metadata newMetadata =
               new MetadataBuilder()
                   .withMetadata(field.metadata())
@@ -337,6 +338,37 @@ public class SchemaConverter {
     }
 
     return new StructType(newFields);
+  }
+
+  /**
+   * Parses and validates a FixedSizeBinary byte-width property value. Arrow's {@code
+   * FixedSizeBinary} requires a positive int; {@code 0}, negatives, and values above {@link
+   * Integer#MAX_VALUE} would produce cryptic failures deep inside Arrow, so reject at property-
+   * processing time with the column name in the message.
+   */
+  private static int parseFixedSizeBinaryByteWidth(String columnName, String raw) {
+    long byteWidth;
+    try {
+      byteWidth = Long.parseLong(raw);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "FixedSizeBinary column '"
+              + columnName
+              + "' byte-width property must be an integer, found: '"
+              + raw
+              + "'",
+          e);
+    }
+    if (byteWidth <= 0 || byteWidth > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          "FixedSizeBinary column '"
+              + columnName
+              + "' byte-width must be in the range [1, "
+              + Integer.MAX_VALUE
+              + "], found: "
+              + byteWidth);
+    }
+    return (int) byteWidth;
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
-import org.lance.spark.utils.{BlobUtils, DateMilliUtils, Float16Utils, LargeVarCharUtils, VectorUtils}
+import org.lance.spark.utils.{BlobUtils, DateMilliUtils, FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, VectorUtils}
 
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
@@ -46,6 +46,8 @@ object LanceArrowUtils {
   val ENCODING_BLOB = BlobUtils.LANCE_ENCODING_BLOB_KEY
   val ARROW_LARGE_VAR_CHAR_KEY = LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY
   val ARROW_DATE_MILLISECOND_KEY = DateMilliUtils.ARROW_DATE_MILLISECOND_KEY
+  val ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY =
+    FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY
 
   // Namespaced keys used to embed child Spark Metadata on a parent StructField when the
   // child sits inside an ArrayType/MapType — Spark has no per-element metadata slot of its
@@ -212,6 +214,10 @@ object LanceArrowUtils {
         builder.putString(ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
       case date: ArrowType.Date if date.getUnit == DateUnit.MILLISECOND =>
         builder.putString(ARROW_DATE_MILLISECOND_KEY, DateMilliUtils.ARROW_DATE_MILLISECOND_VALUE)
+      case fsb: ArrowType.FixedSizeBinary =>
+        // Preserve FixedSizeBinary byte width so a subsequent write reproduces
+        // FixedSizeBinary(n) instead of falling back to variable-length Binary.
+        builder.putLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY, fsb.getByteWidth.toLong)
       case _ =>
     }
   }
@@ -403,6 +409,14 @@ object LanceArrowUtils {
         val fieldType = new FieldType(
           nullable,
           new ArrowType.Date(DateUnit.MILLISECOND),
+          null,
+          meta.asJava)
+        new Field(name, fieldType, Seq.empty[Field].asJava)
+      case BinaryType if FixedSizeBinaryUtils.hasFixedSizeBinaryMetadata(metadata) =>
+        val byteWidth = metadata.getLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY).toInt
+        val fieldType = new FieldType(
+          nullable,
+          new ArrowType.FixedSizeBinary(byteWidth),
           null,
           meta.asJava)
         new Field(name, fieldType, Seq.empty[Field].asJava)

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -109,6 +109,7 @@ object LanceArrowWriter {
         new LargeStringWriter(vector)
       case (BinaryType, vector: VarBinaryVector) => new BinaryWriter(vector)
       case (BinaryType, vector: LargeVarBinaryVector) => new LargeBinaryWriter(vector, resolver)
+      case (BinaryType, vector: FixedSizeBinaryVector) => new FixedSizeBinaryWriter(vector)
       case (DateType, vector: DateDayVector) => new DateWriter(vector)
       case (DateType, vector: DateMilliVector) => new DateMilliWriter(vector)
       case (TimestampType, vector: TimeStampMicroTZVector) => new TimestampWriter(vector)
@@ -361,6 +362,17 @@ private[arrow] class BinaryWriter(val valueVector: VarBinaryVector) extends Lanc
 
 // LargeBinaryWriter (BinaryType -> LargeVarBinaryVector) is a custom, non-trivial writer that also
 // resolves blob references flowing through a shuffle; it lives in its own file LargeBinaryWriter.scala.
+
+private[arrow] class FixedSizeBinaryWriter(val valueVector: FixedSizeBinaryVector)
+  extends LanceArrowFieldWriter {
+  override def setNull(): Unit = {
+    valueVector.setNull(count)
+  }
+  override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
+    val bytes = input.getBinary(ordinal)
+    valueVector.setSafe(count, bytes)
+  }
+}
 
 private[arrow] class DateWriter(val valueVector: DateDayVector) extends LanceArrowFieldWriter {
   override def setNull(): Unit = {}

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -375,7 +375,7 @@ private[arrow] class FixedSizeBinaryWriter(val valueVector: FixedSizeBinaryVecto
     // match byteWidth; validate up-front so the user gets a clear, column-aware error instead.
     if (bytes.length != byteWidth) {
       throw new IllegalArgumentException(
-        s"FixedSizeBinary column expects $byteWidth bytes per row, got ${bytes.length}")
+        s"FixedSizeBinary column '$name' expects $byteWidth bytes per row, got ${bytes.length}")
     }
     valueVector.setSafe(count, bytes)
   }

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -365,11 +365,18 @@ private[arrow] class BinaryWriter(val valueVector: VarBinaryVector) extends Lanc
 
 private[arrow] class FixedSizeBinaryWriter(val valueVector: FixedSizeBinaryVector)
   extends LanceArrowFieldWriter {
+  private val byteWidth: Int = valueVector.getByteWidth
   override def setNull(): Unit = {
     valueVector.setNull(count)
   }
   override def setValue(input: SpecializedGetters, ordinal: Int): Unit = {
     val bytes = input.getBinary(ordinal)
+    // FixedSizeBinaryVector.setSafe silently truncates/corrupts when the input length does not
+    // match byteWidth; validate up-front so the user gets a clear, column-aware error instead.
+    if (bytes.length != byteWidth) {
+      throw new IllegalArgumentException(
+        s"FixedSizeBinary column expects $byteWidth bytes per row, got ${bytes.length}")
+    }
     valueVector.setSafe(count, bytes)
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -501,6 +501,9 @@ public class SchemaConverterTest {
 
     StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
     StructField hashField = result.apply("hash");
+    // Spark type must remain BinaryType — Spark has no FixedSizeBinary — only the metadata changes.
+    assertEquals(DataTypes.BinaryType, hashField.dataType());
+    assertTrue(hashField.nullable());
     assertTrue(
         hashField.metadata().contains(FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY));
     assertEquals(
@@ -517,6 +520,51 @@ public class SchemaConverterTest {
             });
     Map<String, String> properties = new HashMap<>();
     properties.put("name.arrow.fixed-size-binary.byte-width", "16");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testFixedSizeBinaryMetadataRejectsNonNumericWidth() {
+    StructType schema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("hash", DataTypes.BinaryType, true)});
+    Map<String, String> properties = new HashMap<>();
+    properties.put("hash.arrow.fixed-size-binary.byte-width", "sixteen");
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+    // Error must include the column name so users can locate the bad property.
+    assertTrue(
+        ex.getMessage().contains("hash"), "error must name the column; got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testFixedSizeBinaryMetadataRejectsZeroAndNegativeWidth() {
+    StructType schema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("hash", DataTypes.BinaryType, true)});
+    for (String bad : new String[] {"0", "-1", "-16"}) {
+      Map<String, String> properties = new HashMap<>();
+      properties.put("hash.arrow.fixed-size-binary.byte-width", bad);
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> SchemaConverter.processSchemaWithProperties(schema, properties),
+          "byte-width=" + bad + " must be rejected");
+    }
+  }
+
+  @Test
+  public void testFixedSizeBinaryMetadataRejectsOverflowWidth() {
+    // Arrow's FixedSizeBinary stores byte width as int; reject values that would overflow int.
+    StructType schema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("hash", DataTypes.BinaryType, true)});
+    Map<String, String> properties = new HashMap<>();
+    properties.put(
+        "hash.arrow.fixed-size-binary.byte-width", String.valueOf((long) Integer.MAX_VALUE + 1L));
     assertThrows(
         IllegalArgumentException.class,
         () -> SchemaConverter.processSchemaWithProperties(schema, properties));

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -489,6 +489,40 @@ public class SchemaConverterTest {
   }
 
   @Test
+  public void testProcessSchemaAddsFixedSizeBinaryMetadata() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("hash", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("hash.arrow.fixed-size-binary.byte-width", "16");
+
+    StructType result = SchemaConverter.processSchemaWithProperties(schema, properties);
+    StructField hashField = result.apply("hash");
+    assertTrue(
+        hashField.metadata().contains(FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY));
+    assertEquals(
+        16L,
+        hashField.metadata().getLong(FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY));
+  }
+
+  @Test
+  public void testFixedSizeBinaryMetadataRejectsNonBinaryType() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("name", DataTypes.StringType, true),
+            });
+    Map<String, String> properties = new HashMap<>();
+    properties.put("name.arrow.fixed-size-binary.byte-width", "16");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
   public void testNegativeCompressionLevelThrows() {
     StructType schema =
         new StructType(

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
-import org.lance.spark.utils.{Float16Utils, LargeVarCharUtils, VectorUtils}
+import org.lance.spark.utils.{FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, VectorUtils}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.ZoneId
@@ -659,5 +659,56 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     val arrowTimeType = arrowField.getType.asInstanceOf[ArrowType.Time]
     assert(arrowTimeType.getUnit === TimeUnit.NANOSECOND)
     assert(arrowTimeType.getBitWidth === 64)
+  }
+
+  test("FixedSizeBinary metadata produces FixedSizeBinary arrow type") {
+    val fixedSizeBinaryMetadata = new MetadataBuilder()
+      .putLong(
+        FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY,
+        16)
+      .build()
+
+    val schema = new StructType()
+      .add("regular_binary", BinaryType, nullable = true)
+      .add("fixed_binary", BinaryType, nullable = true, fixedSizeBinaryMetadata)
+
+    val arrowSchema = LanceArrowUtils.toArrowSchema(schema, "UTC", false)
+
+    // Regular binary should use Binary
+    val regularField = arrowSchema.findField("regular_binary")
+    assert(regularField.getType === ArrowType.Binary.INSTANCE)
+
+    // Fixed binary with metadata should use FixedSizeBinary(16)
+    val fixedField = arrowSchema.findField("fixed_binary")
+    assert(fixedField.getType.isInstanceOf[ArrowType.FixedSizeBinary])
+    assert(fixedField.getType.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth === 16)
+  }
+
+  test("FixedSizeBinary roundtrip preserves byte width") {
+    // Simulate reading: create an Arrow FixedSizeBinary field -> convert to Spark schema
+    val arrowField = new Field(
+      "hash",
+      new FieldType(true, new ArrowType.FixedSizeBinary(32), null, null),
+      java.util.Collections.emptyList())
+    val arrowSchema = new org.apache.arrow.vector.types.pojo.Schema(
+      java.util.Arrays.asList(arrowField))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrowSchema)
+    val hashField = sparkSchema("hash")
+
+    // Data type is BinaryType (Spark has no FixedSizeBinary)
+    assert(hashField.dataType === BinaryType)
+
+    // But metadata preserves the byte width
+    assert(hashField.metadata.contains(FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY))
+    assert(hashField.metadata.getLong(
+      FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY) === 32)
+
+    // Simulate writing: convert Spark schema back to Arrow
+    val roundtripArrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val roundtripField = roundtripArrowSchema.findField("hash")
+
+    assert(roundtripField.getType.isInstanceOf[ArrowType.FixedSizeBinary])
+    assert(roundtripField.getType.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth === 32)
   }
 }

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/vectorized/LanceArrowColumnVectorSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/vectorized/LanceArrowColumnVectorSuite.scala
@@ -777,6 +777,37 @@ class LanceArrowColumnVectorSuite extends AnyFunSuite {
     allocator.close()
   }
 
+  test("fixed_size_binary") {
+    val allocator =
+      ArrowUtils.rootAllocator.newChildAllocator("fixed_size_binary", 0, Long.MaxValue)
+    val vector = new FixedSizeBinaryVector("hash", allocator, 16)
+    vector.allocateNew()
+
+    // Write 16-byte values (e.g., UUIDs or MD5 hashes)
+    (0 until 10).foreach { i =>
+      val bytes = new Array[Byte](16)
+      java.util.Arrays.fill(bytes, i.toByte)
+      vector.setSafe(i, bytes)
+    }
+    vector.setNull(10)
+    vector.setValueCount(11)
+
+    val columnVector = new LanceArrowColumnVector(vector)
+    assert(columnVector.dataType === BinaryType)
+    assert(columnVector.hasNull)
+    assert(columnVector.numNulls === 1)
+
+    (0 until 10).foreach { i =>
+      val expected = new Array[Byte](16)
+      java.util.Arrays.fill(expected, i.toByte)
+      assert(columnVector.getBinary(i) === expected)
+    }
+    assert(columnVector.isNullAt(10))
+
+    columnVector.close()
+    allocator.close()
+  }
+
   test("map") {
     val allocator = ArrowUtils.rootAllocator.newChildAllocator("map", 0, Long.MaxValue)
     val mapType = MapType(StringType, IntegerType, valueContainsNull = true)


### PR DESCRIPTION
## Summary

Arrow's `FixedSizeBinary(n)` has no Spark equivalent, so on the way in it gets mapped to `BinaryType` and the byte width is lost. On the way back out, the connector then writes it as variable-length `Binary` — the schema silently degrades across a roundtrip. This PR preserves the byte width in Spark field metadata on read and uses it on write, so a column that comes in as `FixedSizeBinary(16)` goes back out as `FixedSizeBinary(16)`. It also adds a way for users to declare the width on `CREATE TABLE` via a TBLPROPERTY, and fails loudly on obviously-invalid widths instead of handing garbage to Arrow.

## Changes

A new `FixedSizeBinaryUtils` carries the metadata key (`arrow.fixed-size-binary.byte-width`), plus a helper to check whether `Metadata` carries the byte-width key and one to build the TBLPROPERTY key. Parallel to `LargeVarCharUtils` and `VectorUtils`, just for a different Arrow type.

`LanceArrowUtils.fromArrowSchema` gets a new case in its per-field metadata switch: when an Arrow field's type is `FixedSizeBinary`, stash `fsb.getByteWidth` into Spark metadata. `LanceArrowUtils.toArrowField` gets the mirror: a new `BinaryType` case guarded by `FixedSizeBinaryUtils.hasFixedSizeBinaryMetadata(metadata)` that reads the width back out and builds an Arrow `FixedSizeBinary(n)` field. Plain `BinaryType` without metadata falls through to the existing catch-all and still produces variable-length Binary, so nothing changes for existing tables.

`LanceArrowWriter` grows a `FixedSizeBinaryWriter`. It caches `byteWidth` once at construction time, validates `bytes.length == byteWidth` on each `setValue` call, and throws `IllegalArgumentException` naming the column with the expected-vs-actual counts when they disagree. Without the check, `FixedSizeBinaryVector.setSafe` silently truncates or corrupts the vector depending on Arrow version, so this is the difference between "clear user error" and "debugging a mystery later."

`SchemaConverter.processSchemaWithProperties` picks up `addFixedSizeBinaryMetadata`, slotting into the existing chain after `addLargeVarCharMetadata`. A TBLPROPERTY of the form `<column>.arrow.fixed-size-binary.byte-width` is parsed through `parseFixedSizeBinaryByteWidth`, which rejects non-numeric strings, zero, negatives, and values above `Integer.MAX_VALUE` with column-named error messages. Matches the type-mismatch guard used by the sibling methods: BINARY column → metadata attached; non-BINARY column with the property → `IllegalArgumentException`; column that doesn't exist → silently ignored (consistent with `addCompressionMetadata` et al.).

## Tests

`SchemaConverterTest` adds tests for the happy path (metadata attached to a `BinaryType` column), type-mismatch rejection, non-numeric width, zero/negative widths, and int-overflow width — each verifying the error message names the offending column so users can find it.

`LanceArrowUtilsSuite` adds two schema-level tests: one feeds a `StructType` with the metadata through `toArrowSchema` and asserts the emitted Arrow type is `FixedSizeBinary(16)`; the other does the full round-trip (Arrow `FixedSizeBinary(32)` → Spark `BinaryType` + metadata → Arrow `FixedSizeBinary(32)`) and asserts the width survives at every hop.

`LanceArrowColumnVectorSuite` adds a read-path test that allocates a `FixedSizeBinaryVector` with 10 non-null entries and 1 null, wraps it in `LanceArrowColumnVector`, and asserts the values round-trip through `getBinary` / `isNullAt`.

`mvn test -pl lance-spark-base_2.12` passes 308 tests. `lance-spark-3.4_2.12` cross-compile is green. Spotless and Checkstyle clean.

## Usage

A table whose physical schema contains `FixedSizeBinary(16)` columns now roundtrips automatically — no configuration needed. To create a new table that emits `FixedSizeBinary(n)` instead of variable-length Binary on write, declare the width in `TBLPROPERTIES`:

```sql
CREATE TABLE t (
  id BIGINT,
  hash BINARY
) USING lance TBLPROPERTIES (
  'hash.arrow.fixed-size-binary.byte-width' = '16'
);
```

Every row written to `hash` must then be exactly 16 bytes; a mismatch throws `IllegalArgumentException` naming the column at write time rather than silently corrupting the vector.
