### PR TITLE
feat: add distributed zonemap index build

### DIFF
--- a/docker/tests/test_lance_spark.py
+++ b/docker/tests/test_lance_spark.py
@@ -492,7 +492,7 @@ class TestDDLAlterTableProperties:
 
 
 class TestDDLIndex:
-    """Test DDL index operations: CREATE INDEX (BTree, FTS)."""
+    """Test DDL index operations: CREATE INDEX (BTree, ZoneMap, FTS)."""
 
     def test_create_btree_index_on_int(self, spark):
         """Test CREATE INDEX with BTree on integer column."""
@@ -561,6 +561,42 @@ class TestDDLIndex:
             SELECT * FROM default.employees WHERE department = 'Engineering'
         """).collect()
         assert len(query_result) == 3
+
+    def test_create_zonemap_index_on_int(self, spark):
+        """Test CREATE INDEX with ZoneMap on integer column."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING,
+                value DOUBLE
+            )
+        """)
+
+        data = [(i, f"Name{i}", float(i * 10)) for i in range(100)]
+        df = spark.createDataFrame(data, ["id", "name", "value"])
+        df.writeTo("default.test_table").append()
+
+        result = spark.sql("""
+            ALTER TABLE default.test_table
+            CREATE INDEX idx_id_zonemap USING zonemap (id)
+            WITH (rows_per_zone = 8)
+        """).collect()
+
+        assert len(result) == 1
+        assert result[0][1] == "idx_id_zonemap"
+
+        indexes = spark.sql("""
+            SHOW INDEXES IN default.test_table
+        """).collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_id_zonemap"]
+        assert len(zonemap_rows) == 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
+        query_result = spark.sql("""
+            SELECT * FROM default.test_table WHERE id = 50
+        """).collect()
+        assert len(query_result) == 1
+        assert query_result[0].id == 50
 
     def test_create_fts_index(self, spark):
         """Test CREATE INDEX with full-text search (FTS)."""

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -7,7 +7,7 @@ Creates a scalar index on a Lance table to accelerate queries.
 
 ## Overview
 
-The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. Depending on the index method, Lance Spark either uses a fragment-parallel build path or delegates to Lance's built-in single-phase index creation path.
+The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. Depending on the index method, Lance Spark either uses a fragment-parallel build path or a driver-coordinated commit flow after parallel executor builds.
 
 ## Basic Usage
 
@@ -151,12 +151,12 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree` can use fragment-parallel execution, while `zonemap` is built through Lance's single-phase create-index API.
-2.  **Metadata Finalization**: Lance records the new index metadata as part of the index creation flow.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
+2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
 ## Notes and Limitations
 
 - **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
 - **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
-- **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.
+- **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one.

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -7,7 +7,7 @@ Creates a scalar index on a Lance table to accelerate queries.
 
 ## Overview
 
-The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. This operation is performed in a distributed manner, building indexes for each data fragment in parallel.
+The `CREATE INDEX` command builds an index on one or more columns of a Lance table. Indexing can improve the performance of queries that filter on the indexed columns. Depending on the index method, Lance Spark either uses a fragment-parallel build path or delegates to Lance's built-in single-phase index creation path.
 
 ## Basic Usage
 
@@ -24,12 +24,21 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
+| `zonemap` | Lightweight min/max index for fragment pruning on scalar columns.         |
 | `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
 | `fts`   | Full-text search (inverted) index for text search on string columns.        |
 
 ## Options
 
 The `CREATE INDEX` command supports options via the `WITH` clause to control index creation. These options are specific to the chosen index method.
+
+### ZoneMap Options
+
+For the `zonemap` method, the following options are supported:
+
+| Option          | Type | Description                                  |
+|-----------------|------|----------------------------------------------|
+| `rows_per_zone` | Long | The approximate number of rows per zonemap zone. |
 
 ### BTree Options
 
@@ -77,6 +86,15 @@ Create a composite index on multiple columns.
     ALTER TABLE lance.db.logs CREATE INDEX idx_ts_level USING btree (timestamp, level);
     ```
 
+### Lightweight Fragment Pruning
+
+Create a zonemap index when you want lightweight min/max-based fragment pruning:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id);
+    ```
+
 ### Indexing with Options
 
 Create an index and specify the `zone_size` for the B-tree:
@@ -84,6 +102,15 @@ Create an index and specify the `zone_size` for the B-tree:
 === "SQL"
     ```sql
     ALTER TABLE lance.db.users CREATE INDEX idx_id_zoned USING btree (id) WITH (zone_size = 2048);
+    ```
+
+### Zonemap with Options
+
+Create a zonemap index and specify the approximate number of rows per zone:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id) WITH (rows_per_zone = 2048);
     ```
 
 ### Full-Text Search Index
@@ -117,17 +144,18 @@ The `CREATE INDEX` command returns the following information about the operation
 Consider creating an index when:
 
 - You frequently filter a large table on a specific column.
+- You want lightweight fragment pruning based on per-zone min/max statistics.
 - Your queries involve point lookups or small range scans.
 
 ## How It Works
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Distributed Index Building**: For each fragment in the Lance dataset, a separate task is launched to build an index on the specified column(s).
-2.  **Metadata Merging**: Once all per-fragment indexes are built, their metadata is collected and merged.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree` can use fragment-parallel execution, while `zonemap` is built through Lance's single-phase create-index API.
+2.  **Metadata Finalization**: Lance records the new index metadata as part of the index creation flow.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
 ## Notes and Limitations
 
-- **Index Methods**: The `btree` and `fts` methods are supported for scalar index creation.
+- **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -39,6 +39,7 @@ For the `zonemap` method, the following options are supported:
 | Option          | Type | Description                                  |
 |-----------------|------|----------------------------------------------|
 | `rows_per_zone` | Long | The approximate number of rows per zonemap zone. |
+| `num_segments` | Integer | Number of index segments to create. Each segment covers a batch of fragments. Defaults to `min(fragment_count, spark.default.parallelism)`. |
 
 ### BTree Options
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -47,7 +47,7 @@ For the `btree` method, the following options are supported:
 | Option      | Type   | Description                                  |
 |-------------|--------|----------------------------------------------|
 | `zone_size` | Long   | The number of rows per zone in the B-tree index. |
-| `build_mode`| String | Index building mode: `'fragment'` builds BTREE segments in parallel across fragment batches and commits them as one logical index for single-column BTREE builds; `'range'` sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is `'fragment'`.| 
+| `build_mode`| String | Index building mode: `'fragment'` builds indexes in parallel by fragment; `'range'` sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is `'fragment'`.| 
 
 ### FTS Options
 
@@ -151,7 +151,7 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. Single-column fragment-mode `btree` and `zonemap` publish those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. `zonemap` publishes those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -47,7 +47,7 @@ For the `btree` method, the following options are supported:
 | Option      | Type   | Description                                  |
 |-------------|--------|----------------------------------------------|
 | `zone_size` | Long   | The number of rows per zone in the B-tree index. |
-| `build_mode`| String | Index building mode: 'fragment' builds indexes in parallel by fragment; 'range' sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is 'fragment'.|
+| `build_mode`| String | Index building mode: `'fragment'` builds BTREE segments in parallel across fragment batches and commits them as one logical index for single-column BTREE builds; `'range'` sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is `'fragment'`.| 
 
 ### FTS Options
 
@@ -151,7 +151,7 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. Single-column fragment-mode `btree` and `zonemap` publish those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -24,7 +24,7 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
-| `zonemap` | Lightweight min/max index for fragment pruning on scalar columns.         |
+| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
 | `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
 | `fts`   | Full-text search (inverted) index for text search on string columns.        |
 
@@ -158,4 +158,5 @@ The `CREATE INDEX` command operates as follows:
 ## Notes and Limitations
 
 - **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
+- **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.

--- a/docs/src/operations/ddl/show-indexes.md
+++ b/docs/src/operations/ddl/show-indexes.md
@@ -49,7 +49,7 @@ The `SHOW INDEXES` command returns the following columns:
 |-------------------------|---------------|--------------------------------------------------------------------|
 | `name`                  | string        | Logical name of the index.                                         |
 | `fields`                | array<string> | List of column names included in the index.                        |
-| `index_type`            | string        | Human-readable index type (for example `btree`).                   |
+| `index_type`            | string        | Human-readable index type (for example `btree` or `zonemap`).      |
 | `num_indexed_fragments` | long          | Number of fragments fully or partially covered by the index.       |
 | `num_indexed_rows`      | long          | Approximate number of rows covered by the index.                   |
 | `num_unindexed_fragments` | long        | Number of fragments that are not yet indexed.                      |

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -620,7 +620,7 @@ class TestDDLColumnCompression:
 
 
 class TestDDLIndex:
-    """Test DDL index operations: CREATE INDEX (BTree, FTS)."""
+    """Test DDL index operations: CREATE INDEX (BTree, ZoneMap, FTS)."""
 
     def test_create_btree_index_on_int(self, spark):
         """Test CREATE INDEX with BTree on integer column."""
@@ -689,6 +689,42 @@ class TestDDLIndex:
             SELECT * FROM default.employees WHERE department = 'Engineering'
         """).collect()
         assert len(query_result) == 3
+
+    def test_create_zonemap_index_on_int(self, spark):
+        """Test CREATE INDEX with ZoneMap on integer column."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING,
+                value DOUBLE
+            )
+        """)
+
+        data = [(i, f"Name{i}", float(i * 10)) for i in range(100)]
+        df = spark.createDataFrame(data, ["id", "name", "value"])
+        df.writeTo("default.test_table").append()
+
+        result = spark.sql("""
+            ALTER TABLE default.test_table
+            CREATE INDEX idx_id_zonemap USING zonemap (id)
+            WITH (rows_per_zone = 8)
+        """).collect()
+
+        assert len(result) == 1
+        assert result[0][1] == "idx_id_zonemap"
+
+        indexes = spark.sql("""
+            SHOW INDEXES IN default.test_table
+        """).collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_id_zonemap"]
+        assert len(zonemap_rows) == 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
+        query_result = spark.sql("""
+            SELECT * FROM default.test_table WHERE id = 50
+        """).collect()
+        assert len(query_result) == 1
+        assert query_result[0].id == 50
 
     def test_create_fts_index(self, spark):
         """Test CREATE INDEX with full-text search (FTS)."""

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -87,6 +87,7 @@ public class LanceFragmentScanner implements AutoCloseable {
       if (inputPartition.getWhereCondition().isPresent()) {
         scanOptions.filter(inputPartition.getWhereCondition().get());
       }
+      scanOptions.useScalarIndex(inputPartition.isUseScalarIndex());
       scanOptions.batchSize(readOptions.getBatchSize());
       if (readOptions.getNearest() != null) {
         scanOptions.nearest(readOptions.getNearest());

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -77,6 +77,7 @@ public class LanceCountStarPartitionReader implements PartitionReader<ColumnarBa
       if (inputPartition.getWhereCondition().isPresent()) {
         scanOptionsBuilder.filter(inputPartition.getWhereCondition().get());
       }
+      scanOptionsBuilder.useScalarIndex(inputPartition.isUseScalarIndex());
       scanOptionsBuilder.withRowId(true);
       scanOptionsBuilder.columns(Lists.newArrayList());
       scanOptionsBuilder.fragmentIds(fragmentIds);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceInputPartition.java
@@ -38,6 +38,7 @@ public class LanceInputPartition implements HasPartitionKey {
   private final Optional<List<ColumnOrdering>> topNSortOrders;
   private final Optional<Aggregation> pushedAggregation;
   private final String scanId;
+  private final boolean useScalarIndex;
 
   /**
    * Initial storage options fetched from namespace.describeTable() on the driver. These are passed
@@ -69,6 +70,7 @@ public class LanceInputPartition implements HasPartitionKey {
       Optional<List<ColumnOrdering>> topNSortOrders,
       Optional<Aggregation> pushedAggregation,
       String scanId,
+      boolean useScalarIndex,
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
@@ -83,6 +85,7 @@ public class LanceInputPartition implements HasPartitionKey {
     this.topNSortOrders = topNSortOrders;
     this.pushedAggregation = pushedAggregation;
     this.scanId = scanId;
+    this.useScalarIndex = useScalarIndex;
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
@@ -127,6 +130,10 @@ public class LanceInputPartition implements HasPartitionKey {
 
   public String getScanId() {
     return scanId;
+  }
+
+  public boolean isUseScalarIndex() {
+    return useScalarIndex;
   }
 
   public Map<String, String> getInitialStorageOptions() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -107,6 +107,7 @@ public class LanceScan
   private final String namespaceImpl;
 
   private final java.util.Map<String, String> namespaceProperties;
+  private final boolean useScalarIndex;
 
   public LanceScan(
       StructType schema,
@@ -121,6 +122,7 @@ public class LanceScan
       java.util.Map<String, List<ZoneStats>> zonemapStats,
       Set<Integer> survivingFragmentIds,
       ZonemapFragmentPruner.PartitionInfo partitionInfo,
+      boolean useScalarIndex,
       java.util.Map<String, String> initialStorageOptions,
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties) {
@@ -137,6 +139,7 @@ public class LanceScan
     this.zonemapStats = zonemapStats != null ? zonemapStats : Collections.emptyMap();
     this.cachedSurvivingFragmentIds = survivingFragmentIds;
     this.partitionInfo = partitionInfo;
+    this.useScalarIndex = useScalarIndex;
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
@@ -191,6 +194,7 @@ public class LanceScan
                       topNSortOrders,
                       pushedAggregation,
                       scanId,
+                      useScalarIndex,
                       initialStorageOptions,
                       namespaceImpl,
                       namespaceProperties,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -16,7 +16,8 @@ package org.lance.spark.read;
 import org.lance.Dataset;
 import org.lance.Fragment;
 import org.lance.ManifestSummary;
-import org.lance.index.IndexDescription;
+import org.lance.index.Index;
+import org.lance.index.IndexType;
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
 import org.lance.schema.LanceField;
@@ -381,9 +382,9 @@ public class LanceScanBuilder
         fieldIdToName.put(field.getId(), field.getName());
       }
 
-      for (IndexDescription idx : dataset.describeIndices()) {
-        if ("ZONEMAP".equalsIgnoreCase(idx.getIndexType())) {
-          for (int fieldId : idx.getFieldIds()) {
+      for (Index idx : dataset.getIndexes()) {
+        if (idx.indexType() == IndexType.ZONEMAP) {
+          for (int fieldId : idx.fields()) {
             String name = fieldIdToName.get(fieldId);
             if (name != null) {
               columns.add(name);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -49,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,6 +72,7 @@ public class LanceScanBuilder
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
+  private boolean forcePostScanFiltering = false;
   private Optional<Integer> limit = Optional.empty();
   private Optional<Integer> offset = Optional.empty();
   private Optional<List<ColumnOrdering>> topNSortOrders = Optional.empty();
@@ -213,7 +215,11 @@ public class LanceScanBuilder
     // Close the lazily opened dataset - it's no longer needed after build
     closeLazyDataset();
 
-    Optional<String> whereCondition = FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters);
+    Optional<String> whereCondition =
+        forcePostScanFiltering
+            ? Optional.empty()
+            : FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters);
+    boolean useScalarIndex = zonemapStats.isEmpty();
     return new LanceScan(
         schema,
         readOptions,
@@ -227,6 +233,7 @@ public class LanceScanBuilder
         zonemapStats,
         survivingFragmentIds,
         partitionInfo,
+        useScalarIndex,
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties);
@@ -244,7 +251,14 @@ public class LanceScanBuilder
     }
     Filter[][] processFilters = FilterPushDown.processFilters(filters);
     pushedFilters = processFilters[0];
-    return processFilters[1];
+    forcePostScanFiltering = shouldForcePostScanFiltering(pushedFilters);
+    if (!forcePostScanFiltering) {
+      return processFilters[1];
+    }
+    LOG.info(
+        "Using Spark post-scan filtering for segmented zonemap query on dataset {}",
+        readOptions.getDatasetUri());
+    return concatFilters(processFilters[0], processFilters[1]);
   }
 
   @Override
@@ -304,6 +318,9 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushAggregation(Aggregation aggregation) {
+    if (forcePostScanFiltering && pushedFilters.length > 0) {
+      return false;
+    }
     AggregateFunc[] funcs = aggregation.aggregateExpressions();
     if (aggregation.groupByExpressions().length > 0) {
       return false;
@@ -406,5 +423,53 @@ public class LanceScanBuilder
       }
     }
     return columns;
+  }
+
+  /**
+   * Segmented zonemap indexes are currently used safely for fragment pruning, but scan-time filter
+   * pushdown still needs a Spark-side fallback until Lance-core query execution fully handles that
+   * layout.
+   */
+  private boolean shouldForcePostScanFiltering(Filter[] acceptedFilters) {
+    if (acceptedFilters.length == 0) {
+      return false;
+    }
+
+    Set<String> referencedColumns = extractReferencedColumns(acceptedFilters);
+    if (referencedColumns.isEmpty()) {
+      return false;
+    }
+
+    Dataset dataset = getOrOpenDataset();
+    Map<Integer, String> fieldIdToName = new HashMap<>();
+    for (LanceField field : dataset.getLanceSchema().fields()) {
+      fieldIdToName.put(field.getId(), field.getName());
+    }
+
+    Map<String, Integer> segmentedZonemapCounts = new HashMap<>();
+    for (Index idx : dataset.getIndexes()) {
+      if (idx.indexType() != IndexType.ZONEMAP || idx.fields().size() != 1) {
+        continue;
+      }
+      if (!idx.fragments().isPresent() || idx.fragments().get().size() != 1) {
+        continue;
+      }
+
+      String columnName = fieldIdToName.get(idx.fields().get(0));
+      if (columnName == null || !referencedColumns.contains(columnName)) {
+        continue;
+      }
+
+      String key = idx.name() + ":" + columnName;
+      segmentedZonemapCounts.merge(key, 1, Integer::sum);
+    }
+
+    return segmentedZonemapCounts.values().stream().anyMatch(count -> count > 1);
+  }
+
+  private static Filter[] concatFilters(Filter[] first, Filter[] second) {
+    Filter[] combined = Arrays.copyOf(first, first.length + second.length);
+    System.arraycopy(second, 0, combined, first.length, second.length);
+    return combined;
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -33,9 +33,9 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -267,7 +267,9 @@ public final class ZonemapFragmentPruner {
     if (value instanceof BigInteger) {
       return new BigDecimal((BigInteger) value);
     }
-    if (value instanceof Byte || value instanceof Short || value instanceof Integer
+    if (value instanceof Byte
+        || value instanceof Short
+        || value instanceof Integer
         || value instanceof Long) {
       return BigDecimal.valueOf(value.longValue());
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -33,6 +33,8 @@ import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
@@ -159,7 +161,6 @@ public final class ZonemapFragmentPruner {
     return Optional.empty();
   }
 
-  @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeComparison(
       String column,
       Object value,
@@ -171,17 +172,9 @@ public final class ZonemapFragmentPruner {
       return Optional.empty();
     }
 
-    Comparable<Object> target;
-    try {
-      target = (Comparable<Object>) value;
-    } catch (ClassCastException e) {
-      LOG.warn("Cannot cast filter value {} to Comparable for zonemap pruning", value);
-      return Optional.empty();
-    }
-
     Set<Integer> matchingFragments = new HashSet<>();
     for (ZoneStats zone : stats) {
-      if (zoneMatchesComparison(zone, target, type)) {
+      if (zoneMatchesComparison(zone, value, type)) {
         matchingFragments.add(zone.getFragmentId());
       }
     }
@@ -189,12 +182,10 @@ public final class ZonemapFragmentPruner {
     return Optional.of(matchingFragments);
   }
 
-  @SuppressWarnings("unchecked")
-  private static boolean zoneMatchesComparison(
-      ZoneStats zone, Comparable<Object> target, ComparisonType type) {
+  private static boolean zoneMatchesComparison(ZoneStats zone, Object target, ComparisonType type) {
 
-    Comparable<Object> min = (Comparable<Object>) zone.getMin();
-    Comparable<Object> max = (Comparable<Object>) zone.getMax();
+    Object min = zone.getMin();
+    Object max = zone.getMax();
 
     // If min or max is null, the zone contains only nulls for the indexed range;
     // non-null comparisons cannot match.
@@ -206,27 +197,26 @@ public final class ZonemapFragmentPruner {
       switch (type) {
         case EQUALS:
           // target ∈ [min, max]
-          return target.compareTo(min) >= 0 && target.compareTo(max) <= 0;
+          return compareValues(target, min) >= 0 && compareValues(target, max) <= 0;
         case LESS_THAN:
           // ∃ row < target  ⟺  zone.min < target
-          return min.compareTo(target) < 0;
+          return compareValues(min, target) < 0;
         case LESS_THAN_OR_EQUAL:
-          return min.compareTo(target) <= 0;
+          return compareValues(min, target) <= 0;
         case GREATER_THAN:
-          return max.compareTo(target) > 0;
+          return compareValues(max, target) > 0;
         case GREATER_THAN_OR_EQUAL:
-          return max.compareTo(target) >= 0;
+          return compareValues(max, target) >= 0;
         default:
           return true; // conservative
       }
-    } catch (ClassCastException e) {
+    } catch (ClassCastException | IllegalArgumentException e) {
       // Type mismatch between filter value and zone stats — be conservative
       LOG.warn("Type mismatch in zonemap comparison, skipping pruning for zone", e);
       return true;
     }
   }
 
-  @SuppressWarnings("unchecked")
   private static Optional<Set<Integer>> analyzeIn(
       String column, Object[] values, Map<String, List<ZoneStats>> statsByColumn) {
 
@@ -244,14 +234,7 @@ public final class ZonemapFragmentPruner {
             break;
           }
         } else {
-          try {
-            Comparable<Object> target = (Comparable<Object>) value;
-            if (zoneMatchesComparison(zone, target, ComparisonType.EQUALS)) {
-              matchingFragments.add(zone.getFragmentId());
-              break;
-            }
-          } catch (ClassCastException e) {
-            // Non-comparable value, conservatively include
+          if (zoneMatchesComparison(zone, value, ComparisonType.EQUALS)) {
             matchingFragments.add(zone.getFragmentId());
             break;
           }
@@ -260,6 +243,42 @@ public final class ZonemapFragmentPruner {
     }
 
     return Optional.of(matchingFragments);
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static int compareValues(Object left, Object right) {
+    if (left instanceof Number && right instanceof Number) {
+      return compareNumbers((Number) left, (Number) right);
+    }
+    if (isStringLike(left) && isStringLike(right)) {
+      return left.toString().compareTo(right.toString());
+    }
+    return ((Comparable) left).compareTo(right);
+  }
+
+  private static int compareNumbers(Number left, Number right) {
+    return toBigDecimal(left).compareTo(toBigDecimal(right));
+  }
+
+  private static BigDecimal toBigDecimal(Number value) {
+    if (value instanceof BigDecimal) {
+      return (BigDecimal) value;
+    }
+    if (value instanceof BigInteger) {
+      return new BigDecimal((BigInteger) value);
+    }
+    if (value instanceof Byte || value instanceof Short || value instanceof Integer
+        || value instanceof Long) {
+      return BigDecimal.valueOf(value.longValue());
+    }
+    if (value instanceof Float || value instanceof Double) {
+      return BigDecimal.valueOf(value.doubleValue());
+    }
+    return new BigDecimal(value.toString());
+  }
+
+  private static boolean isStringLike(Object value) {
+    return value instanceof CharSequence || value instanceof UTF8String;
   }
 
   private static Optional<Set<Integer>> analyzeIsNull(

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -92,6 +92,12 @@ case class AddIndexExec(
     val btreeBuildMode = IndexUtils.btreeBuildMode(indexType, args)
     val useLogicalSegmentCommit = IndexUtils.useLogicalSegmentCommit(indexType)
 
+    val numSegmentsOpt = args.find(_.name == "num_segments")
+    if (numSegmentsOpt.isDefined && !useLogicalSegmentCommit) {
+      throw new IllegalArgumentException(
+        "num_segments option is only supported for index types that use segmented builds (e.g., zonemap)")
+    }
+
     // Create distributed index job and run it
     val createdSegments = createIndexJob(
       lanceDataset,
@@ -317,8 +323,9 @@ class FragmentBasedIndexJob(
     val encodedReadOptions = encode(readOptions)
     val columns = addIndexExec.columns.toList
     val argsJson = IndexUtils.toJson(addIndexExec.args)
+    val numSegments = addIndexExec.args.find(_.name == "num_segments").map(_.value.asInstanceOf[Number].intValue())
     val fragmentBatches = if (groupFragmentsIntoSegments) {
-      batchFragments(fragmentIds)
+      batchFragments(fragmentIds, numSegments)
     } else {
       fragmentIds.map(fid => List(fid))
     }
@@ -346,9 +353,11 @@ class FragmentBasedIndexJob(
       .toSeq
   }
 
-  private def batchFragments(fragmentIds: List[Integer]): Seq[List[Integer]] = {
-    val targetTasks =
-      math.max(1, math.min(fragmentIds.size, addIndexExec.session.sparkContext.defaultParallelism))
+  private def batchFragments(fragmentIds: List[Integer], numSegments: Option[Int] = None): Seq[List[Integer]] = {
+    val targetTasks = numSegments match {
+      case Some(n) => math.max(1, math.min(fragmentIds.size, n))
+      case None => math.max(1, math.min(fragmentIds.size, addIndexExec.session.sparkContext.defaultParallelism))
+    }
     val batchSize = math.ceil(fragmentIds.size.toDouble / targetTasks.toDouble).toInt
     fragmentIds.grouped(batchSize).map(_.toList).toSeq
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -44,8 +44,8 @@ import scala.collection.JavaConverters._
  *
  * <ul>
  * <li>For BTREE index, range mode redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
- * <li>For single-column BTREE fragment mode and zonemap, it builds uncommitted index segments in parallel and commits the logical index on the driver.
- * <li>For other fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
+ * <li>For zonemap index, it builds uncommitted index segments in parallel and commits the logical index on the driver.
+ * <li>For fragment-trainable scalar index types (BTREE fragment mode, FTS, etc.), it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
  * </ul>
  */
 case class AddIndexExec(
@@ -90,8 +90,7 @@ case class AddIndexExec(
     }
 
     val btreeBuildMode = IndexUtils.btreeBuildMode(indexType, args)
-    val useLogicalSegmentCommit =
-      IndexUtils.useLogicalSegmentCommit(indexType, columns, btreeBuildMode)
+    val useLogicalSegmentCommit = IndexUtils.useLogicalSegmentCommit(indexType)
 
     // Create distributed index job and run it
     val createdSegments = createIndexJob(
@@ -633,15 +632,8 @@ object IndexUtils {
     }
   }
 
-  def useLogicalSegmentCommit(
-      indexType: IndexType,
-      columns: Seq[String],
-      btreeBuildMode: Option[String]): Boolean = {
-    indexType match {
-      case IndexType.ZONEMAP => true
-      case IndexType.BTREE => btreeBuildMode != Some("range") && columns.size == 1
-      case _ => false
-    }
+  def useLogicalSegmentCommit(indexType: IndexType): Boolean = {
+    indexType == IndexType.ZONEMAP
   }
 
   def toJson(args: Seq[LanceNamedArgument]): String = {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -43,9 +43,9 @@ import scala.collection.JavaConverters._
  * Physical execution of CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
  *
  * <ul>
- * <li>For BTREE index, it uses a range-based approach that redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
- * <li>For fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
- * <li>For zonemap index, it builds one uncommitted segment per fragment in parallel and commits the logical index on the driver.
+ * <li>For BTREE index, range mode redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
+ * <li>For single-column BTREE fragment mode and zonemap, it builds uncommitted index segments in parallel and commits the logical index on the driver.
+ * <li>For other fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
  * </ul>
  */
 case class AddIndexExec(
@@ -89,10 +89,21 @@ case class AddIndexExec(
         "Zonemap index currently supports a single column only")
     }
 
-    // Create distributed index job and run it
-    val createdSegments = createIndexJob(lanceDataset, readOptions, indexType, uuid.toString, fragmentIds).run()
+    val btreeBuildMode = IndexUtils.btreeBuildMode(indexType, args)
+    val useLogicalSegmentCommit =
+      IndexUtils.useLogicalSegmentCommit(indexType, columns, btreeBuildMode)
 
-    if (indexType == IndexType.ZONEMAP) {
+    // Create distributed index job and run it
+    val createdSegments = createIndexJob(
+      lanceDataset,
+      readOptions,
+      indexType,
+      uuid.toString,
+      fragmentIds,
+      btreeBuildMode,
+      useLogicalSegmentCommit).run()
+
+    if (useLogicalSegmentCommit) {
       commitIndexSegments(readOptions, columns.head, createdSegments)
       return Seq(new GenericInternalRow(Array[Any](
         fragmentIds.size.toLong,
@@ -162,7 +173,10 @@ case class AddIndexExec(
         .toList
 
       val committedSegments =
-        dataset.commitExistingIndexSegments(indexName, column, segments.toList.asJava).asScala.toList
+        dataset.commitExistingIndexSegments(
+          indexName,
+          column,
+          segments.toList.asJava).asScala.toList
 
       if (existingIndices.nonEmpty) {
         val committedUuids = committedSegments.map(_.uuid()).toSet
@@ -205,7 +219,9 @@ case class AddIndexExec(
       readOptions: LanceSparkReadOptions,
       indexType: IndexType,
       uuid: String,
-      fragmentIds: List[Integer]): IndexJob = {
+      fragmentIds: List[Integer],
+      btreeBuildMode: Option[String],
+      useLogicalSegmentCommit: Boolean): IndexJob = {
     // Get namespace info from catalog if available (for credential vending on workers)
     val (nsImpl, nsProps, tableId, initialStorageOpts): (
         Option[String],
@@ -223,8 +239,7 @@ case class AddIndexExec(
 
     indexType match {
       case IndexType.BTREE =>
-        val mode = args.find(_.name == "build_mode").map(_.value.asInstanceOf[String])
-        mode match {
+        btreeBuildMode match {
           case Some("range") =>
             return new RangeBasedBTreeIndexJob(
               this,
@@ -239,8 +254,9 @@ case class AddIndexExec(
             new FragmentBasedIndexJob(
               this,
               readOptions,
-              Some(uuid),
+              if (useLogicalSegmentCommit) None else Some(uuid),
               fragmentIds,
+              useLogicalSegmentCommit,
               nsImpl,
               nsProps,
               tableId,
@@ -257,6 +273,7 @@ case class AddIndexExec(
           readOptions,
           if (indexType == IndexType.ZONEMAP) None else Some(uuid),
           fragmentIds,
+          indexType == IndexType.ZONEMAP,
           nsImpl,
           nsProps,
           tableId,
@@ -291,6 +308,7 @@ class FragmentBasedIndexJob(
     readOptions: LanceSparkReadOptions,
     indexUuid: Option[String],
     fragmentIds: List[Integer],
+    groupFragmentsIntoSegments: Boolean,
     nsImpl: Option[String],
     nsProps: Option[Map[String, String]],
     tableId: Option[List[String]],
@@ -300,7 +318,7 @@ class FragmentBasedIndexJob(
     val encodedReadOptions = encode(readOptions)
     val columns = addIndexExec.columns.toList
     val argsJson = IndexUtils.toJson(addIndexExec.args)
-    val fragmentBatches = if (IndexUtils.buildIndexType(addIndexExec.method) == IndexType.ZONEMAP) {
+    val fragmentBatches = if (groupFragmentsIntoSegments) {
       batchFragments(fragmentIds)
     } else {
       fragmentIds.map(fid => List(fid))
@@ -330,7 +348,8 @@ class FragmentBasedIndexJob(
   }
 
   private def batchFragments(fragmentIds: List[Integer]): Seq[List[Integer]] = {
-    val targetTasks = math.max(1, math.min(fragmentIds.size, addIndexExec.session.sparkContext.defaultParallelism))
+    val targetTasks =
+      math.max(1, math.min(fragmentIds.size, addIndexExec.session.sparkContext.defaultParallelism))
     val batchSize = math.ceil(fragmentIds.size.toDouble / targetTasks.toDouble).toInt
     fragmentIds.grouped(batchSize).map(_.toList).toSeq
   }
@@ -368,6 +387,7 @@ case class FragmentIndexTask(
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
     val indexType = IndexUtils.buildIndexType(method)
+    val publishAsLogicalSegment = indexUuid.isEmpty
     val params = IndexParams.builder()
       .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
       .build()
@@ -375,7 +395,7 @@ case class FragmentIndexTask(
     val indexOptions = IndexOptions
       .builder(java.util.Arrays.asList(columns: _*), indexType, params)
       .withFragmentIds(fragmentIds.asJava)
-    if (indexType == IndexType.ZONEMAP) {
+    if (publishAsLogicalSegment) {
       indexOptions.replace(false)
     } else {
       indexOptions
@@ -595,6 +615,32 @@ object IndexUtils {
       case "zonemap" => IndexType.ZONEMAP
       case "fts" => IndexType.INVERTED
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
+    }
+  }
+
+  def btreeBuildMode(indexType: IndexType, args: Seq[LanceNamedArgument]): Option[String] = {
+    if (indexType != IndexType.BTREE) {
+      None
+    } else {
+      val buildMode = args.find(_.name == "build_mode").map(_.value.asInstanceOf[String])
+      buildMode match {
+        case Some("fragment") | Some("range") | None =>
+          buildMode
+        case Some(unknown) =>
+          throw new IllegalArgumentException(
+            s"Unrecognized build_mode: '$unknown'. Supported values are 'fragment' and 'range'.")
+      }
+    }
+  }
+
+  def useLogicalSegmentCommit(
+      indexType: IndexType,
+      columns: Seq[String],
+      btreeBuildMode: Option[String]): Boolean = {
+    indexType match {
+      case IndexType.ZONEMAP => true
+      case IndexType.BTREE => btreeBuildMode != Some("range") && columns.size == 1
+      case _ => false
     }
   }
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -85,6 +85,10 @@ case class AddIndexExec(
     val indexType = IndexUtils.buildIndexType(method)
 
     if (indexType == IndexType.ZONEMAP) {
+      if (columns.size != 1) {
+        throw new UnsupportedOperationException(
+          "Zonemap index currently supports a single column only")
+      }
       createDirectScalarIndex(readOptions, indexType)
       return Seq(new GenericInternalRow(Array[Any](
         fragmentIds.size.toLong,

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -40,12 +40,12 @@ import java.util.{Collections, Optional, UUID}
 import scala.collection.JavaConverters._
 
 /**
- * Physical execution of distributed CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
+ * Physical execution of CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
  *
  * <ul>
  * <li>For BTREE index, it uses a range-based approach that redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
- * <li>For other index types, it processes each fragment independently in parallel, merges index metadata
- * and commits an index-creation transaction.
+ * <li>For fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
+ * <li>For zonemap index, it delegates to the underlying Lance single-phase index creation path because zonemap does not support fragment training.
  * </ul>
  */
 case class AddIndexExec(
@@ -83,6 +83,13 @@ case class AddIndexExec(
 
     val uuid = UUID.randomUUID()
     val indexType = IndexUtils.buildIndexType(method)
+
+    if (indexType == IndexType.ZONEMAP) {
+      createDirectScalarIndex(readOptions, indexType)
+      return Seq(new GenericInternalRow(Array[Any](
+        fragmentIds.size.toLong,
+        UTF8String.fromString(indexName))))
+    }
 
     // Create distributed index job and run it
     createIndexJob(lanceDataset, readOptions, uuid.toString, fragmentIds).run()
@@ -137,6 +144,28 @@ case class AddIndexExec(
     Seq(new GenericInternalRow(Array[Any](
       fragmentIds.size.toLong,
       UTF8String.fromString(indexName))))
+  }
+
+  private def createDirectScalarIndex(
+      readOptions: LanceSparkReadOptions,
+      indexType: IndexType): Unit = {
+    val argsJson = IndexUtils.toJson(args)
+    val params = IndexParams.builder()
+      .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
+      .build()
+
+    val indexOptions = IndexOptions
+      .builder(columns.asJava, indexType, params)
+      .replace(true)
+      .withIndexName(indexName)
+      .build()
+
+    val dataset = Utils.openDatasetBuilder(readOptions).build()
+    try {
+      dataset.createIndex(indexOptions)
+    } finally {
+      dataset.close()
+    }
   }
 
   private def createIndexJob(
@@ -514,6 +543,7 @@ object IndexUtils {
   def buildIndexType(method: String): IndexType = {
     method match {
       case "btree" => IndexType.BTREE
+      case "zonemap" => IndexType.ZONEMAP
       case "fts" => IndexType.INVERTED
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -45,7 +45,7 @@ import scala.collection.JavaConverters._
  * <ul>
  * <li>For BTREE index, it uses a range-based approach that redistributes and sorts data across partitions, creates indexes for each range in parallel, and finally merges them into a global index structure.
  * <li>For fragment-trainable scalar index types, it processes each fragment independently in parallel, merges index metadata and commits an index-creation transaction.
- * <li>For zonemap index, it delegates to the underlying Lance single-phase index creation path because zonemap does not support fragment training.
+ * <li>For zonemap index, it builds one uncommitted segment per fragment in parallel and commits the logical index on the driver.
  * </ul>
  */
 case class AddIndexExec(
@@ -84,19 +84,20 @@ case class AddIndexExec(
     val uuid = UUID.randomUUID()
     val indexType = IndexUtils.buildIndexType(method)
 
+    if (indexType == IndexType.ZONEMAP && columns.size != 1) {
+      throw new UnsupportedOperationException(
+        "Zonemap index currently supports a single column only")
+    }
+
+    // Create distributed index job and run it
+    val createdSegments = createIndexJob(lanceDataset, readOptions, indexType, uuid.toString, fragmentIds).run()
+
     if (indexType == IndexType.ZONEMAP) {
-      if (columns.size != 1) {
-        throw new UnsupportedOperationException(
-          "Zonemap index currently supports a single column only")
-      }
-      createDirectScalarIndex(readOptions, indexType)
+      commitIndexSegments(readOptions, columns.head, createdSegments)
       return Seq(new GenericInternalRow(Array[Any](
         fragmentIds.size.toLong,
         UTF8String.fromString(indexName))))
     }
-
-    // Create distributed index job and run it
-    createIndexJob(lanceDataset, readOptions, uuid.toString, fragmentIds).run()
 
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
@@ -150,23 +151,50 @@ case class AddIndexExec(
       UTF8String.fromString(indexName))))
   }
 
-  private def createDirectScalarIndex(
+  private def commitIndexSegments(
       readOptions: LanceSparkReadOptions,
-      indexType: IndexType): Unit = {
-    val argsJson = IndexUtils.toJson(args)
-    val params = IndexParams.builder()
-      .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
-      .build()
-
-    val indexOptions = IndexOptions
-      .builder(columns.asJava, indexType, params)
-      .replace(true)
-      .withIndexName(indexName)
-      .build()
-
+      column: String,
+      segments: Seq[Index]): Unit = {
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
-      dataset.createIndex(indexOptions)
+      val existingIndices = dataset.getIndexes.asScala
+        .filter(_.name() == indexName)
+        .toList
+
+      val committedSegments =
+        dataset.commitExistingIndexSegments(indexName, column, segments.toList.asJava).asScala.toList
+
+      if (existingIndices.nonEmpty) {
+        val committedUuids = committedSegments.map(_.uuid()).toSet
+        val refreshedDataset = Utils.openDatasetBuilder(readOptions).build()
+        try {
+          val removedIndices = refreshedDataset.getIndexes.asScala
+            .filter(index => index.name() == indexName && !committedUuids.contains(index.uuid()))
+            .toList
+            .asJava
+
+          if (!removedIndices.isEmpty) {
+            val op = AddIndexOperation.builder()
+              .withNewIndices(Collections.emptyList())
+              .withRemovedIndices(removedIndices)
+              .build()
+            val txn = new Transaction.Builder()
+              .readVersion(refreshedDataset.version())
+              .operation(op)
+              .build()
+            try {
+              val newDataset = new CommitBuilder(refreshedDataset)
+                .writeParams(readOptions.getStorageOptions)
+                .execute(txn)
+              newDataset.close()
+            } finally {
+              txn.close()
+            }
+          }
+        } finally {
+          refreshedDataset.close()
+        }
+      }
     } finally {
       dataset.close()
     }
@@ -175,6 +203,7 @@ case class AddIndexExec(
   private def createIndexJob(
       lanceDataset: LanceDataset,
       readOptions: LanceSparkReadOptions,
+      indexType: IndexType,
       uuid: String,
       fragmentIds: List[Integer]): IndexJob = {
     // Get namespace info from catalog if available (for credential vending on workers)
@@ -192,7 +221,7 @@ case class AddIndexExec(
       case _ => (None, None, None, None)
     }
 
-    IndexUtils.buildIndexType(method) match {
+    indexType match {
       case IndexType.BTREE =>
         val mode = args.find(_.name == "build_mode").map(_.value.asInstanceOf[String])
         mode match {
@@ -210,7 +239,7 @@ case class AddIndexExec(
             new FragmentBasedIndexJob(
               this,
               readOptions,
-              uuid,
+              Some(uuid),
               fragmentIds,
               nsImpl,
               nsProps,
@@ -226,7 +255,7 @@ case class AddIndexExec(
         new FragmentBasedIndexJob(
           this,
           readOptions,
-          uuid,
+          if (indexType == IndexType.ZONEMAP) None else Some(uuid),
           fragmentIds,
           nsImpl,
           nsProps,
@@ -240,7 +269,7 @@ case class AddIndexExec(
  * Interface for index job to implement different indexing strategies.
  */
 trait IndexJob extends Serializable {
-  def run(): Unit
+  def run(): Seq[Index]
 }
 
 /**
@@ -260,28 +289,32 @@ trait IndexJob extends Serializable {
 class FragmentBasedIndexJob(
     addIndexExec: AddIndexExec,
     readOptions: LanceSparkReadOptions,
-    uuid: String,
+    indexUuid: Option[String],
     fragmentIds: List[Integer],
     nsImpl: Option[String],
     nsProps: Option[Map[String, String]],
     tableId: Option[List[String]],
     initialStorageOpts: Option[Map[String, String]]) extends IndexJob {
 
-  override def run(): Unit = {
+  override def run(): Seq[Index] = {
     val encodedReadOptions = encode(readOptions)
     val columns = addIndexExec.columns.toList
     val argsJson = IndexUtils.toJson(addIndexExec.args)
+    val fragmentBatches = if (IndexUtils.buildIndexType(addIndexExec.method) == IndexType.ZONEMAP) {
+      batchFragments(fragmentIds)
+    } else {
+      fragmentIds.map(fid => List(fid))
+    }
 
-    // Build per-fragment tasks
-    val tasks = fragmentIds.map { fid =>
+    val tasks = fragmentBatches.map { batch =>
       FragmentIndexTask(
         encodedReadOptions,
         columns,
         addIndexExec.method,
         argsJson,
         addIndexExec.indexName,
-        uuid,
-        fid,
+        indexUuid,
+        batch,
         nsImpl,
         nsProps,
         tableId,
@@ -292,6 +325,14 @@ class FragmentBasedIndexJob(
       .parallelize(tasks, tasks.size)
       .map(t => t.execute())
       .collect()
+      .map(decode[Index])
+      .toSeq
+  }
+
+  private def batchFragments(fragmentIds: List[Integer]): Seq[List[Integer]] = {
+    val targetTasks = math.max(1, math.min(fragmentIds.size, addIndexExec.session.sparkContext.defaultParallelism))
+    val batchSize = math.ceil(fragmentIds.size.toDouble / targetTasks.toDouble).toInt
+    fragmentIds.grouped(batchSize).map(_.toList).toSeq
   }
 }
 
@@ -305,7 +346,7 @@ class FragmentBasedIndexJob(
  * @param argsJson              JSON string containing index parameters
  * @param indexName             Name of the index being created
  * @param uuid                  Unique identifier for this index operation
- * @param fragmentId            ID of the fragment to create index on
+ * @param fragmentIds           IDs of the fragments to create index on
  * @param namespaceImpl         Implementation class for namespace operations
  * @param namespaceProperties   Properties of the namespace
  * @param tableId               Identifier for the table within the namespace
@@ -317,8 +358,8 @@ case class FragmentIndexTask(
     method: String,
     argsJson: String,
     indexName: String,
-    uuid: String,
-    fragmentId: Int,
+    indexUuid: Option[String],
+    fragmentIds: List[Integer],
     namespaceImpl: Option[String],
     namespaceProperties: Option[Map[String, String]],
     tableId: Option[List[String]],
@@ -333,23 +374,25 @@ case class FragmentIndexTask(
 
     val indexOptions = IndexOptions
       .builder(java.util.Arrays.asList(columns: _*), indexType, params)
-      .replace(true)
-      .withIndexName(indexName)
-      .withIndexUUID(uuid)
-      .withFragmentIds(Collections.singletonList(fragmentId))
-      .build()
+      .withFragmentIds(fragmentIds.asJava)
+    if (indexType == IndexType.ZONEMAP) {
+      indexOptions.replace(false)
+    } else {
+      indexOptions
+        .replace(true)
+        .withIndexName(indexName)
+      indexUuid.foreach(indexOptions.withIndexUUID)
+    }
 
     val dataset = Utils.openDatasetBuilder(readOptions)
       .initialStorageOptions(initialStorageOptions.map(_.asJava).orNull)
       .build()
 
     try {
-      dataset.createIndex(indexOptions)
+      encode(dataset.createIndex(indexOptions.build()))
     } finally {
       dataset.close()
     }
-
-    encode("OK")
   }
 }
 
@@ -377,7 +420,7 @@ class RangeBasedBTreeIndexJob(
 
   private val VALUE_COLUMN_NAME = "value"
 
-  override def run(): Unit = {
+  override def run(): Seq[Index] = {
     if (addIndexExec.columns.size != 1) {
       throw new UnsupportedOperationException(
         "Range-based BTree index currently supports a single column only")
@@ -426,6 +469,8 @@ class RangeBasedBTreeIndexJob(
     rangeDf.queryExecution.toRdd.mapPartitionsWithIndex { case (rangeId, rowsIter) =>
       indexBuilder.buildForRange(rangeId, rowsIter)
     }.collect()
+
+    Seq.empty
   }
 
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
@@ -23,6 +23,7 @@ import org.apache.spark.sql.types.StructType;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class TestUtils {
@@ -88,9 +89,10 @@ public class TestUtils {
               Optional.empty() /* topNSortOrders */,
               Optional.empty() /* pushedAggregation */,
               "test" /* scanId */,
-              null /* initialStorageOptions */,
+              true /* useScalarIndex */,
+              Collections.emptyMap() /* initialStorageOptions */,
               null /* namespaceImpl */,
-              null /* namespaceProperties */,
+              Collections.emptyMap() /* namespaceProperties */,
               null /* partitionKeyRow */);
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
@@ -43,9 +43,10 @@ public class LanceColumnarPartitionReaderTest {
             Optional.empty() /* topNSortOrders */,
             Optional.empty() /* pushedAggregation */,
             "test" /* scanId */,
-            null /* initialStorageOptions */,
+            true /* useScalarIndex */,
+            Collections.emptyMap() /* initialStorageOptions */,
             null /* namespaceImpl */,
-            null /* namespaceProperties */,
+            Collections.emptyMap() /* namespaceProperties */,
             null /* partitionKeyRow */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;
@@ -86,9 +87,10 @@ public class LanceColumnarPartitionReaderTest {
             Optional.empty() /* topNSortOrders */,
             Optional.empty() /* pushedAggregation */,
             "testOffsetAndLimit" /* scanId */,
-            null /* initialStorageOptions */,
+            true /* useScalarIndex */,
+            Collections.emptyMap() /* initialStorageOptions */,
             null /* namespaceImpl */,
-            null /* namespaceProperties */,
+            Collections.emptyMap() /* namespaceProperties */,
             null /* partitionKeyRow */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;
@@ -131,9 +133,10 @@ public class LanceColumnarPartitionReaderTest {
             Optional.of(Collections.singletonList(builder.build())) /* topNSortOrders */,
             Optional.empty() /* pushedAggregation */,
             "testTopN" /* scanId */,
-            null /* initialStorageOptions */,
+            true /* useScalarIndex */,
+            Collections.emptyMap() /* initialStorageOptions */,
             null /* namespaceImpl */,
-            null /* namespaceProperties */,
+            Collections.emptyMap() /* namespaceProperties */,
             null /* partitionKeyRow */);
     try (LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition)) {
       List<List<Long>> expectedValues = TestUtils.TestTable1Config.expectedValues;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceCountStarPartitionReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceCountStarPartitionReaderTest.java
@@ -25,6 +25,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,9 +50,10 @@ public class LanceCountStarPartitionReaderTest {
             Optional.empty(),
             Optional.of(countStarAgg),
             "testCountStarMemoryLeak",
+            true,
+            Collections.emptyMap(),
             null,
-            null,
-            null,
+            Collections.emptyMap(),
             null);
 
     LanceCountStarPartitionReader reader = new LanceCountStarPartitionReader(partition);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceDatasetReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceDatasetReadTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -125,9 +126,10 @@ public class LanceDatasetReadTest {
                 Optional.empty() /* topNSortOrders */,
                 Optional.empty() /* pushedAggregation */,
                 "validateFragment" /* scanId */,
-                null /* initialStorageOptions */,
+                true /* useScalarIndex */,
+                Collections.emptyMap() /* initialStorageOptions */,
                 null /* namespaceImpl */,
-                null /* namespaceProperties */,
+                Collections.emptyMap() /* namespaceProperties */,
                 null /* partitionKeyRow */))) {
       try (ArrowReader reader = scanner.getArrowReader()) {
         VectorSchemaRoot root = reader.getVectorSchemaRoot();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -215,6 +215,7 @@ public class LanceScanTest {
             Collections.emptyMap(),
             null,
             partInfo,
+            true,
             Collections.emptyMap(),
             null,
             Collections.emptyMap());

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -76,6 +76,16 @@ public class ZonemapFragmentPrunerTest {
   }
 
   @Test
+  public void testEqualToMatchesOneFragmentWithIntegerFilterValue() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Filter[] filters = new Filter[] {new EqualTo("x", 150)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1), result.get());
+  }
+
+  @Test
   public void testEqualToMatchesNoFragment() {
     Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
     Filter[] filters = new Filter[] {new EqualTo("x", 500L)};

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -336,6 +336,53 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateZonemapIndexWithNumSegments() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index test_index_zonemap_segments using zonemap (id) with (num_segments = 3)",
+                fullTable));
+
+    Row row = result.collectAsList().get(0);
+    long fragmentsIndexed = row.getLong(0);
+    String indexName = row.getString(1);
+
+    Assertions.assertTrue(fragmentsIndexed >= 2, "Expected at least 2 fragments to be indexed");
+    Assertions.assertEquals("test_index_zonemap_segments", indexName);
+
+    // Verify the number of segments matches the requested num_segments
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      int fragmentCount = lanceDataset.getFragments().size();
+      int expectedSegmentCount = Math.min(fragmentCount, 3);
+      List<Index> segments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "test_index_zonemap_segments".equals(index.name()))
+              .collect(Collectors.toList());
+
+      Assertions.assertEquals(
+          expectedSegmentCount,
+          segments.size(),
+          "Expected num_segments=3 to produce exactly 3 segments (or fewer if fragment count < 3)");
+
+      int coveredFragments =
+          segments.stream()
+              .map(index -> index.fragments().orElse(Collections.emptyList()).size())
+              .mapToInt(Integer::intValue)
+              .sum();
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments,
+          "Expected committed segments to cover all fragments exactly once");
+    } finally {
+      lanceDataset.close();
+    }
+  }
+
+
+  @Test
   public void testCreateBTreeIndexWithRangeMode() {
     prepareDataset();
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -131,6 +131,7 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index");
+    assertSegmentedIndexCoverage("test_index");
   }
 
   @Test
@@ -152,6 +153,7 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index_repeat");
+    assertSegmentedIndexCoverage("test_index_repeat");
 
     Dataset<Row> result2 =
         spark.sql(
@@ -168,6 +170,7 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index_repeat");
+    assertSegmentedIndexCoverage("test_index_repeat");
   }
 
   @Test
@@ -227,8 +230,7 @@ public abstract class BaseAddIndexTest {
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
     try {
       int fragmentCount = lanceDataset.getFragments().size();
-      int expectedSegmentCount =
-          Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
+      int expectedSegmentCount = Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
       List<Index> zonemapSegments =
           lanceDataset.getIndexes().stream()
               .filter(index -> "test_index_zonemap".equals(index.name()))
@@ -245,11 +247,13 @@ public abstract class BaseAddIndexTest {
           "Expected distributed zonemap build to batch fragments into bounded segment count");
       Assertions.assertTrue(
           zonemapSegments.stream()
-              .allMatch(index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
+              .allMatch(
+                  index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
           "Expected each zonemap segment to cover at least one fragment");
       Assertions.assertTrue(
           zonemapSegments.stream()
-              .anyMatch(index -> index.fragments().isPresent() && index.fragments().get().size() > 1),
+              .anyMatch(
+                  index -> index.fragments().isPresent() && index.fragments().get().size() > 1),
           "Expected zonemap batching to create at least one multi-fragment segment");
       Assertions.assertEquals(
           fragmentCount,
@@ -305,8 +309,7 @@ public abstract class BaseAddIndexTest {
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
     try {
       int fragmentCount = lanceDataset.getFragments().size();
-      int expectedSegmentCount =
-          Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
+      int expectedSegmentCount = Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
       List<Index> zonemapSegments =
           lanceDataset.getIndexes().stream()
               .filter(index -> "test_index_zonemap_repeat".equals(index.name()))
@@ -323,7 +326,8 @@ public abstract class BaseAddIndexTest {
           "Expected recreated zonemap index to replace existing batched segments instead of duplicating them");
       Assertions.assertTrue(
           zonemapSegments.stream()
-              .allMatch(index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
+              .allMatch(
+                  index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
           "Expected recreated zonemap segments to keep non-empty fragment coverage");
       Assertions.assertEquals(
           fragmentCount,
@@ -383,6 +387,13 @@ public abstract class BaseAddIndexTest {
     Assertions.assertEquals("test_index_btree_fragment", indexName);
 
     checkIndex("test_index_btree_fragment");
+    assertSegmentedIndexCoverage("test_index_btree_fragment");
+
+    Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
+    Assertions.assertEquals(1L, query.count());
+    Row r = query.collectAsList().get(0);
+    Assertions.assertEquals(15, r.getInt(0));
+    Assertions.assertEquals("text_15", r.getString(1));
   }
 
   @Test
@@ -634,6 +645,46 @@ public abstract class BaseAddIndexTest {
       Assertions.assertTrue(indexList.size() >= 1);
       Set<String> indexNames = indexList.stream().map(Index::name).collect(Collectors.toSet());
       Assertions.assertTrue(indexNames.contains(indexName));
+    } finally {
+      lanceDataset.close();
+    }
+  }
+
+  private void assertSegmentedIndexCoverage(String indexName) {
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      int fragmentCount = lanceDataset.getFragments().size();
+      int expectedSegmentCount = Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
+      List<Index> segments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> indexName.equals(index.name()))
+              .collect(Collectors.toList());
+      int coveredFragments =
+          segments.stream()
+              .map(index -> index.fragments().orElse(Collections.emptyList()).size())
+              .mapToInt(Integer::intValue)
+              .sum();
+
+      Assertions.assertEquals(
+          expectedSegmentCount,
+          segments.size(),
+          "Expected segmented index build to batch fragments into bounded segment count");
+      Assertions.assertTrue(
+          segments.stream()
+              .allMatch(
+                  index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
+          "Expected each index segment to cover at least one fragment");
+      if (fragmentCount > expectedSegmentCount) {
+        Assertions.assertTrue(
+            segments.stream()
+                .anyMatch(
+                    index -> index.fragments().isPresent() && index.fragments().get().size() > 1),
+            "Expected batched segment build to create at least one multi-fragment segment");
+      }
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments,
+          "Expected committed segments to cover all fragments exactly once");
     } finally {
       lanceDataset.close();
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -243,6 +243,25 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateMultiColumnZonemapIndexThrowsHelpfulError() {
+    prepareDataset();
+
+    UnsupportedOperationException exception =
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                spark.sql(
+                    String.format(
+                        "alter table %s create index test_index_zonemap_multi using zonemap (id, text) with (rows_per_zone=4)",
+                        fullTable)));
+
+    Assertions.assertTrue(
+        exception.getMessage().contains("single column"),
+        "Expected multi-column zonemap error to mention single-column support, got: "
+            + exception.getMessage());
+  }
+
+  @Test
   public void testCreateBTreeIndexWithRangeMode() {
     prepareDataset();
 
@@ -497,6 +516,10 @@ public abstract class BaseAddIndexTest {
   }
 
   private void assertZonemapFilterPrunesFragments(int targetId) {
+    assertZonemapFilterPrunesFragments(new EqualTo("id", targetId), String.format("id=%d", targetId));
+  }
+
+  private void assertZonemapFilterPrunesFragments(Filter filter, String description) {
     LanceSparkReadOptions readOptions = LanceSparkReadOptions.from(tableDir);
 
     LanceScanBuilder unfilteredBuilder =
@@ -519,14 +542,14 @@ public abstract class BaseAddIndexTest {
             null,
             Collections.emptyMap(),
             Collections.emptyMap());
-    filteredBuilder.pushFilters(new Filter[] {new EqualTo("id", targetId)});
+    filteredBuilder.pushFilters(new Filter[] {filter});
     int filteredPartitions = ((LanceScan) filteredBuilder.build()).planInputPartitions().length;
 
     Assertions.assertTrue(
         filteredPartitions < unfilteredPartitions,
         String.format(
-            "Expected zonemap pruning to reduce planned partitions for id=%d (before=%d, after=%d)",
-            targetId, unfilteredPartitions, filteredPartitions));
+            "Expected zonemap pruning to reduce planned partitions for %s (before=%d, after=%d)",
+            description, unfilteredPartitions, filteredPartitions));
   }
 
   private void checkIndex(String indexName) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -131,7 +131,6 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index");
-    assertSegmentedIndexCoverage("test_index");
   }
 
   @Test
@@ -153,7 +152,6 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index_repeat");
-    assertSegmentedIndexCoverage("test_index_repeat");
 
     Dataset<Row> result2 =
         spark.sql(
@@ -170,7 +168,6 @@ public abstract class BaseAddIndexTest {
 
     // Check index is created successfully
     checkIndex("test_index_repeat");
-    assertSegmentedIndexCoverage("test_index_repeat");
   }
 
   @Test
@@ -387,7 +384,6 @@ public abstract class BaseAddIndexTest {
     Assertions.assertEquals("test_index_btree_fragment", indexName);
 
     checkIndex("test_index_btree_fragment");
-    assertSegmentedIndexCoverage("test_index_btree_fragment");
 
     Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
     Assertions.assertEquals(1L, query.count());

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -14,10 +14,15 @@
 package org.lance.spark.update;
 
 import org.lance.index.Index;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.read.LanceScan;
+import org.lance.spark.read.LanceScanBuilder;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.sources.EqualTo;
+import org.apache.spark.sql.sources.Filter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +33,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -188,6 +194,47 @@ public abstract class BaseAddIndexTest {
     checkIndex("test_index_btree_param");
 
     // Verify query using the indexed field with zone_size parameter
+    Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
+    Assertions.assertEquals(1L, query.count());
+    Row r = query.collectAsList().get(0);
+    Assertions.assertEquals(15, r.getInt(0));
+    Assertions.assertEquals("text_15", r.getString(1));
+  }
+
+  @Test
+  public void testCreateZonemapIndexWithRowsPerZone() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index test_index_zonemap using zonemap (id) with (rows_per_zone=4)",
+                fullTable));
+
+    Assertions.assertEquals(
+        "StructType(StructField(fragments_indexed,LongType,true),StructField(index_name,StringType,true))",
+        result.schema().toString());
+
+    Row row = result.collectAsList().get(0);
+    long fragmentsIndexed = row.getLong(0);
+    String indexName = row.getString(1);
+
+    Assertions.assertTrue(fragmentsIndexed >= 2, "Expected at least 2 fragments to be indexed");
+    Assertions.assertEquals("test_index_zonemap", indexName);
+
+    checkIndex("test_index_zonemap");
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      Assertions.assertFalse(
+          lanceDataset.getZonemapStats("id").isEmpty(),
+          "Expected zonemap stats for indexed column");
+    } finally {
+      lanceDataset.close();
+    }
+
+    assertZonemapFilterPrunesFragments(15);
+
     Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
     Assertions.assertEquals(1L, query.count());
     Row r = query.collectAsList().get(0);
@@ -447,6 +494,39 @@ public abstract class BaseAddIndexTest {
     // Verify query still works
     Dataset<Row> query = spark.sql(String.format("select * from %s where id=5", fullTable));
     Assertions.assertEquals(1L, query.count());
+  }
+
+  private void assertZonemapFilterPrunesFragments(int targetId) {
+    LanceSparkReadOptions readOptions = LanceSparkReadOptions.from(tableDir);
+
+    LanceScanBuilder unfilteredBuilder =
+        new LanceScanBuilder(
+            spark.table(fullTable).schema(),
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    int unfilteredPartitions = ((LanceScan) unfilteredBuilder.build()).planInputPartitions().length;
+    Assertions.assertTrue(
+        unfilteredPartitions >= 2, "Expected multiple partitions for zonemap pruning test");
+
+    LanceScanBuilder filteredBuilder =
+        new LanceScanBuilder(
+            spark.table(fullTable).schema(),
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            Collections.emptyMap());
+    filteredBuilder.pushFilters(new Filter[] {new EqualTo("id", targetId)});
+    int filteredPartitions = ((LanceScan) filteredBuilder.build()).planInputPartitions().length;
+
+    Assertions.assertTrue(
+        filteredPartitions < unfilteredPartitions,
+        String.format(
+            "Expected zonemap pruning to reduce planned partitions for id=%d (before=%d, after=%d)",
+            targetId, unfilteredPartitions, filteredPartitions));
   }
 
   private void checkIndex(String indexName) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -516,7 +516,8 @@ public abstract class BaseAddIndexTest {
   }
 
   private void assertZonemapFilterPrunesFragments(int targetId) {
-    assertZonemapFilterPrunesFragments(new EqualTo("id", targetId), String.format("id=%d", targetId));
+    assertZonemapFilterPrunesFragments(
+        new EqualTo("id", targetId), String.format("id=%d", targetId));
   }
 
   private void assertZonemapFilterPrunesFragments(Filter filter, String description) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -226,6 +226,35 @@ public abstract class BaseAddIndexTest {
 
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
     try {
+      int fragmentCount = lanceDataset.getFragments().size();
+      int expectedSegmentCount =
+          Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
+      List<Index> zonemapSegments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "test_index_zonemap".equals(index.name()))
+              .collect(Collectors.toList());
+      int coveredFragments =
+          zonemapSegments.stream()
+              .map(index -> index.fragments().orElse(Collections.emptyList()).size())
+              .mapToInt(Integer::intValue)
+              .sum();
+
+      Assertions.assertEquals(
+          expectedSegmentCount,
+          zonemapSegments.size(),
+          "Expected distributed zonemap build to batch fragments into bounded segment count");
+      Assertions.assertTrue(
+          zonemapSegments.stream()
+              .allMatch(index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
+          "Expected each zonemap segment to cover at least one fragment");
+      Assertions.assertTrue(
+          zonemapSegments.stream()
+              .anyMatch(index -> index.fragments().isPresent() && index.fragments().get().size() > 1),
+          "Expected zonemap batching to create at least one multi-fragment segment");
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments,
+          "Expected zonemap segments to cover all fragments exactly once");
       Assertions.assertFalse(
           lanceDataset.getZonemapStats("id").isEmpty(),
           "Expected zonemap stats for indexed column");
@@ -259,6 +288,50 @@ public abstract class BaseAddIndexTest {
         exception.getMessage().contains("single column"),
         "Expected multi-column zonemap error to mention single-column support, got: "
             + exception.getMessage());
+  }
+
+  @Test
+  public void testRepeatedCreateZonemapIndexReplacesExistingSegments() {
+    prepareDataset();
+
+    String sql =
+        String.format(
+            "alter table %s create index test_index_zonemap_repeat using zonemap (id) with (rows_per_zone=4)",
+            fullTable);
+
+    spark.sql(sql);
+    spark.sql(sql);
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      int fragmentCount = lanceDataset.getFragments().size();
+      int expectedSegmentCount =
+          Math.min(fragmentCount, spark.sparkContext().defaultParallelism());
+      List<Index> zonemapSegments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "test_index_zonemap_repeat".equals(index.name()))
+              .collect(Collectors.toList());
+      int coveredFragments =
+          zonemapSegments.stream()
+              .map(index -> index.fragments().orElse(Collections.emptyList()).size())
+              .mapToInt(Integer::intValue)
+              .sum();
+
+      Assertions.assertEquals(
+          expectedSegmentCount,
+          zonemapSegments.size(),
+          "Expected recreated zonemap index to replace existing batched segments instead of duplicating them");
+      Assertions.assertTrue(
+          zonemapSegments.stream()
+              .allMatch(index -> index.fragments().isPresent() && !index.fragments().get().isEmpty()),
+          "Expected recreated zonemap segments to keep non-empty fragment coverage");
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments,
+          "Expected recreated zonemap segments to cover all fragments exactly once");
+    } finally {
+      lanceDataset.close();
+    }
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -131,4 +131,30 @@ public abstract class BaseShowIndexesTest {
     long numIndexedRows = row.getLong(4);
     Assertions.assertTrue(numIndexedRows >= 1L, "num_indexed_rows should be at least 1");
   }
+
+  @Test
+  public void testShowZonemapIndexes() {
+    prepareDataset();
+
+    spark.sql(
+        String.format(
+            "alter table %s create index test_zonemap using zonemap (id) with (rows_per_zone=4)",
+            fullTable));
+
+    Dataset<Row> result = spark.sql(String.format("show indexes from %s", fullTable));
+    List<Row> rows = result.collectAsList();
+
+    Row row =
+        rows.stream()
+            .filter(r -> "test_zonemap".equals(r.getString(0)))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Expected SHOW INDEXES to include test_zonemap"));
+
+    @SuppressWarnings("unchecked")
+    List<String> fieldNames = row.getList(1);
+    Assertions.assertTrue(fieldNames.contains("id"), "fields should contain column name 'id'");
+    Assertions.assertEquals("zonemap", row.getString(2));
+    Assertions.assertTrue(row.getLong(3) >= 1L, "num_indexed_fragments should be at least 1");
+    Assertions.assertTrue(row.getLong(4) >= 1L, "num_indexed_rows should be at least 1");
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.3</lance-spark.version>
-        <lance.version>6.0.0-beta.2</lance.version>
+        <lance.version>6.0.0-beta.3</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary

This PR adds a distributed zonemap index build path for  in .

It keeps the SQL surface unchanged, but changes the execution strategy from the driver-only/single-process flow to Spark-side fragment processing and logical segment commit.

This is intended as the distributed alternative to #466, which stays open as the simpler single-process solution.

## What Changed

- build zonemap index segments on Spark tasks and commit them through 
- support Spark-side zonemap pruning for segmented zonemap indices
- batch multiple fragments into a single zonemap segment so task and segment counts stay bounded
- keep zonemap restricted to single-column indexing
- update docs and tests for distributed zonemap behavior

## Validation

Tested with Spark 4.0 / Scala 2.13:

[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-3.5_2.12:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 73, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-3.4_2.12:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 76, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-3.5_2.13:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 77, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-3.4_2.13:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 78, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-4.0_2.13:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 79, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.lance:lance-spark-bundle-4.1_2.13:jar:0.4.0-beta.3
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 79, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] lance-spark-root                                                   [pom]
[INFO] lance-spark-base_2.13                                              [jar]
[INFO] lance-spark-4.0_2.13                                               [jar]
[INFO] 
[INFO] ---------------------< org.lance:lance-spark-root >---------------------
[INFO] Building lance-spark-root 0.4.0-beta.3                             [1/3]
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- checkstyle:3.3.1:check (validate) @ lance-spark-root ---
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- spotless:2.43.0:apply (spotless-check) @ lance-spark-root ---
[INFO] 
[INFO] ------------------< org.lance:lance-spark-base_2.13 >-------------------
[INFO] Building lance-spark-base_2.13 0.4.0-beta.3                        [2/3]
[INFO]   from lance-spark-base_2.13/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] 2 problems were encountered while building the effective model for org.apache.yetus:audience-annotations:jar:0.5.0 during dependency collection step for project (use -X to see details)
[INFO] 
[INFO] --- checkstyle:3.3.1:check (validate) @ lance-spark-base_2.13 ---
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- spotless:2.43.0:apply (spotless-check) @ lance-spark-base_2.13 ---
[INFO] 
[INFO] --- build-helper:3.2.0:add-source (add-java-source) @ lance-spark-base_2.13 ---
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-base_2.12/src/main/java added.
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ lance-spark-base_2.13 ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /home/beinanwang/o/lance-spark/lance-spark-base_2.13/src/main/resources
[INFO] 
[INFO] --- scala:4.9.10:add-source (scala-compile-first) @ lance-spark-base_2.13 ---
[INFO] 
[INFO] --- scala:4.9.10:compile (scala-compile-first) @ lance-spark-base_2.13 ---
[INFO] Compiler bridge file: /home/beinanwang/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.12.0-bin_2.13.16__65.0-1.12.0_20260104T231500.jar
[INFO] compile in 2.3 s
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ lance-spark-base_2.13 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- compiler:3.8.1:compile (default) @ lance-spark-base_2.13 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ lance-spark-base_2.13 ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 70 resources
[INFO] 
[INFO] --- scala:4.9.10:testCompile (scala-test-compile) @ lance-spark-base_2.13 ---
[INFO] Compiler bridge file: /home/beinanwang/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.12.0-bin_2.13.16__65.0-1.12.0_20260104T231500.jar
[INFO] compile in 0.1 s
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ lance-spark-base_2.13 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ lance-spark-base_2.13 ---
[INFO] 
[INFO] -------------------< org.lance:lance-spark-4.0_2.13 >-------------------
[INFO] Building lance-spark-4.0_2.13 0.4.0-beta.3                         [3/3]
[INFO]   from lance-spark-4.0_2.13/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- checkstyle:3.3.1:check (validate) @ lance-spark-4.0_2.13 ---
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Starting audit...
Audit done.
[INFO] You have 0 Checkstyle violations.
[INFO] 
[INFO] --- spotless:2.43.0:apply (spotless-check) @ lance-spark-4.0_2.13 ---
[INFO] Spotless.Java is keeping 1 files clean - 0 were changed to be clean, 0 were already clean, 1 were skipped because caching determined they were already clean
[INFO] Spotless.Scala is keeping 3 files clean - 0 were changed to be clean, 0 were already clean, 3 were skipped because caching determined they were already clean
[INFO] 
[INFO] --- antlr4:4.13.1:antlr4 (default) @ lance-spark-4.0_2.13 ---
[INFO] No grammars to process
[INFO] ANTLR 4: Processing source directory /home/beinanwang/o/lance-spark/lance-spark-base_2.12/src/main/antlr4
[INFO] 
[INFO] --- build-helper:3.2.0:add-source (add-java-source) @ lance-spark-4.0_2.13 ---
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-base_2.12/src/main/java added.
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-3.5_2.12/src/main/java added.
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-4.0_2.13/src/main/java added.
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-4.0_2.13/src/main/scala added.
[INFO] Source directory: /home/beinanwang/o/lance-spark/lance-spark-4.0_2.13/target/generated-sources/antlr4 added.
[INFO] 
[INFO] --- resources:3.0.2:resources (default-resources) @ lance-spark-4.0_2.13 ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
[INFO] 
[INFO] --- scala:4.9.10:compile (scala-compile-first) @ lance-spark-4.0_2.13 ---
[INFO] Compiler bridge file: /home/beinanwang/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.12.0-bin_2.13.16__65.0-1.12.0_20260104T231500.jar
[INFO] compile in 0.4 s
[INFO] 
[INFO] --- compiler:3.8.1:compile (default-compile) @ lance-spark-4.0_2.13 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- build-helper:3.2.0:add-test-source (add-java-test-source) @ lance-spark-4.0_2.13 ---
[INFO] Test Source directory: /home/beinanwang/o/lance-spark/lance-spark-base_2.12/src/test/java added.
[INFO] Test Source directory: /home/beinanwang/o/lance-spark/lance-spark-3.5_2.12/src/test/java added.
[INFO] Test Source directory: /home/beinanwang/o/lance-spark/lance-spark-4.0_2.13/src/test/java added.
[INFO] 
[INFO] --- resources:3.0.2:testResources (default-testResources) @ lance-spark-4.0_2.13 ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 70 resources
[INFO] 
[INFO] --- scala:4.9.10:testCompile (scala-test-compile) @ lance-spark-4.0_2.13 ---
[INFO] Compiler bridge file: /home/beinanwang/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.12.0-bin_2.13.16__65.0-1.12.0_20260104T231500.jar
[INFO] compile in 0.1 s
[INFO] 
[INFO] --- compiler:3.8.1:testCompile (default-testCompile) @ lance-spark-4.0_2.13 ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- surefire:3.2.5:test (default-test) @ lance-spark-4.0_2.13 ---
[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.lance.spark.update.CreateIndexStandardSyntaxTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 9.235 s -- in org.lance.spark.update.CreateIndexStandardSyntaxTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for lance-spark-root 0.4.0-beta.3:
[INFO] 
[INFO] lance-spark-root ................................... SUCCESS [  1.645 s]
[INFO] lance-spark-base_2.13 .............................. SUCCESS [  4.527 s]
[INFO] lance-spark-4.0_2.13 ............................... SUCCESS [ 12.492 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.830 s
[INFO] Finished at: 2026-04-23T01:00:54Z
[INFO] ------------------------------------------------------------------------

## Notes

- This branch depends on the corresponding  core segmented zonemap work already proposed in lance-format/lance#6593.
- The distributed implementation now batches fragment IDs per task instead of forcing one task and one segment per fragment.
- PR #466 can remain as the single-process option for comparison / fallback while this distributed path is reviewed.
