### PR TITLE
fix(spark): gss initiate failed on hms executors; spark.sql.catalog read options not applied

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -59,12 +59,48 @@ public class LanceSparkReadOptions implements Serializable {
   public static final String CONFIG_TOP_N_PUSH_DOWN = "topN_push_down";
 
   public static final String CONFIG_NEAREST = "nearest";
+
+  /**
+   * Whether executors should rebuild the namespace client and re-fetch storage options via {@code
+   * namespace.describeTable()} when opening a dataset for fragment scans.
+   *
+   * <p>When {@code true} (the default), executors reconstruct the namespace client and route the
+   * dataset open through the namespace path. This keeps the Rust-side storage-options provider
+   * attached so that short-lived vended credentials returned by {@code describeTable()} (e.g. STS
+   * tokens from Iceberg REST, Polaris, Unity) can be refreshed mid-scan.
+   *
+   * <p>When {@code false}, executors open the dataset directly by URI using the storage options the
+   * driver already obtained (passed in via {@code initialStorageOptions}). This skips the eager
+   * {@code describeTable()} RPC on every fragment scan, which is required for catalogs whose
+   * backing service authenticates per-call (e.g. Hive Metastore over Kerberos): executors typically
+   * do not have a Kerberos TGT and the call would otherwise fail with {@code GSS initiate failed}.
+   *
+   * <p>Whether disabling this option actually costs anything depends on the namespace impl:
+   *
+   * <ul>
+   *   <li>{@code Hive2Namespace} / {@code Hive3Namespace}: {@code describeTable()} returns only the
+   *       table location, never storage options. The refresh callback is a no-op, so setting this
+   *       option to {@code false} has no downside. The underlying object-store credentials (e.g.
+   *       IAM-role / {@code hive-site.xml} / env-vars on the executor) are rotated by the storage
+   *       client SDK independently of Lance.
+   *   <li>{@code GlueNamespace}: storage options come from a static {@code
+   *       config.getStorageOptions()} and are typically not time-bound; setting {@code false} is
+   *       usually safe unless you rely on LakeFormation-vended temporary credentials.
+   *   <li>{@code IcebergNamespace} (REST), {@code PolarisNamespace}, {@code UnityNamespace}: {@code
+   *       describeTable()} commonly returns vended temporary credentials. Leave this option at the
+   *       default ({@code true}) unless every scan is guaranteed to finish within the credential
+   *       TTL.
+   * </ul>
+   */
+  public static final String CONFIG_EXECUTOR_CREDENTIAL_REFRESH = "executor_credential_refresh";
+
   public static final String LANCE_FILE_SUFFIX = ".lance";
 
   private static final boolean DEFAULT_PUSH_DOWN_FILTERS = true;
   // Changed from 512 to 8192 for better OLAP scan performance (33x improvement)
   private static final int DEFAULT_BATCH_SIZE = 8192;
   private static final boolean DEFAULT_TOP_N_PUSH_DOWN = true;
+  private static final boolean DEFAULT_EXECUTOR_CREDENTIAL_REFRESH = true;
 
   private final String datasetUri;
   private final String dbPath;
@@ -88,6 +124,12 @@ public class LanceSparkReadOptions implements Serializable {
   /** The catalog name for cache isolation when multiple catalogs are configured. */
   private final String catalogName;
 
+  /**
+   * Whether executors should rebuild the namespace client for credential refresh. See {@link
+   * #CONFIG_EXECUTOR_CREDENTIAL_REFRESH} for details.
+   */
+  private final boolean executorCredentialRefresh;
+
   private LanceSparkReadOptions(Builder builder) {
     this.datasetUri = builder.datasetUri;
     String[] paths = extractDbPathAndDatasetName(datasetUri);
@@ -105,6 +147,7 @@ public class LanceSparkReadOptions implements Serializable {
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
     this.catalogName = builder.catalogName;
+    this.executorCredentialRefresh = builder.executorCredentialRefresh;
   }
 
   /** Creates a new builder for LanceSparkReadOptions. */
@@ -239,6 +282,15 @@ public class LanceSparkReadOptions implements Serializable {
     return catalogName;
   }
 
+  /**
+   * Returns whether executors should rebuild the namespace client and route the dataset open
+   * through the namespace path (for credential refresh). See {@link
+   * #CONFIG_EXECUTOR_CREDENTIAL_REFRESH}.
+   */
+  public boolean isExecutorCredentialRefresh() {
+    return executorCredentialRefresh;
+  }
+
   public boolean hasNamespace() {
     return namespace != null && tableId != null;
   }
@@ -275,6 +327,7 @@ public class LanceSparkReadOptions implements Serializable {
         .namespace(this.namespace)
         .tableId(this.tableId)
         .catalogName(this.catalogName)
+        .executorCredentialRefresh(this.executorCredentialRefresh)
         .build();
   }
 
@@ -324,6 +377,7 @@ public class LanceSparkReadOptions implements Serializable {
     return pushDownFilters == that.pushDownFilters
         && batchSize == that.batchSize
         && topNPushDown == that.topNPushDown
+        && executorCredentialRefresh == that.executorCredentialRefresh
         && Objects.equals(nearest, that.nearest)
         && Objects.equals(datasetUri, that.datasetUri)
         && Objects.equals(blockSize, that.blockSize)
@@ -347,7 +401,8 @@ public class LanceSparkReadOptions implements Serializable {
         nearest,
         topNPushDown,
         storageOptions,
-        tableId);
+        tableId,
+        executorCredentialRefresh);
   }
 
   /** Builder for creating LanceSparkReadOptions instances. */
@@ -365,6 +420,7 @@ public class LanceSparkReadOptions implements Serializable {
     private LanceNamespace namespace;
     private List<String> tableId;
     private String catalogName;
+    private boolean executorCredentialRefresh = DEFAULT_EXECUTOR_CREDENTIAL_REFRESH;
 
     private Builder() {}
 
@@ -442,6 +498,11 @@ public class LanceSparkReadOptions implements Serializable {
       return this;
     }
 
+    public Builder executorCredentialRefresh(boolean executorCredentialRefresh) {
+      this.executorCredentialRefresh = executorCredentialRefresh;
+      return this;
+    }
+
     /**
      * Parses options from a map, extracting read-specific settings.
      *
@@ -450,38 +511,17 @@ public class LanceSparkReadOptions implements Serializable {
      */
     public Builder fromOptions(Map<String, String> options) {
       this.storageOptions = new HashMap<>(options);
-      if (options.containsKey(CONFIG_PUSH_DOWN_FILTERS)) {
-        this.pushDownFilters = Boolean.parseBoolean(options.get(CONFIG_PUSH_DOWN_FILTERS));
-      }
-      if (options.containsKey(CONFIG_BLOCK_SIZE)) {
-        this.blockSize = Integer.parseInt(options.get(CONFIG_BLOCK_SIZE));
-      }
-      if (options.containsKey(CONFIG_VERSION)) {
-        this.version = Integer.parseInt(options.get(CONFIG_VERSION));
-      }
-      if (options.containsKey(CONFIG_INDEX_CACHE_SIZE)) {
-        this.indexCacheSize = Integer.parseInt(options.get(CONFIG_INDEX_CACHE_SIZE));
-      }
-      if (options.containsKey(CONFIG_METADATA_CACHE_SIZE)) {
-        this.metadataCacheSize = Integer.parseInt(options.get(CONFIG_METADATA_CACHE_SIZE));
-      }
-      if (options.containsKey(CONFIG_BATCH_SIZE)) {
-        int parsedBatchSize = Integer.parseInt(options.get(CONFIG_BATCH_SIZE));
-        Preconditions.checkArgument(parsedBatchSize > 0, "batch_size must be positive");
-        this.batchSize = parsedBatchSize;
-      }
-      if (options.containsKey(CONFIG_TOP_N_PUSH_DOWN)) {
-        this.topNPushDown = Boolean.parseBoolean(options.get(CONFIG_TOP_N_PUSH_DOWN));
-      }
-      if (options.containsKey(CONFIG_NEAREST)) {
-        String json = options.get(CONFIG_NEAREST);
-        nearest(json);
-      }
+      parseTypedFlags(options);
       return this;
     }
 
     /**
      * Merges catalog config options as defaults (read options override).
+     *
+     * <p>Also promotes recognized typed flags from the catalog config into their corresponding
+     * Builder fields so that catalog-level settings (e.g. {@code spark.sql.catalog.<name>.<key>})
+     * take effect on paths that do not later go through {@link #fromOptions(Map)} — notably SQL DML
+     * (DELETE / UPDATE / MERGE INTO) and plain SELECT without per-read {@code .option(...)}.
      *
      * @param catalogConfig the catalog config
      * @return this builder
@@ -490,8 +530,45 @@ public class LanceSparkReadOptions implements Serializable {
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
-      this.storageOptions = merged;
-      return this;
+      return fromOptions(merged);
+    }
+
+    /**
+     * Applies typed-flag parsing for every known read option present in {@code opts}. Shared by
+     * {@link #fromOptions(Map)} and {@link #withCatalogDefaults(LanceSparkCatalogConfig)} so that
+     * both call sites stay in sync and catalog-level configs reach the typed fields.
+     */
+    private void parseTypedFlags(Map<String, String> opts) {
+      if (opts.containsKey(CONFIG_PUSH_DOWN_FILTERS)) {
+        this.pushDownFilters = Boolean.parseBoolean(opts.get(CONFIG_PUSH_DOWN_FILTERS));
+      }
+      if (opts.containsKey(CONFIG_BLOCK_SIZE)) {
+        this.blockSize = Integer.parseInt(opts.get(CONFIG_BLOCK_SIZE));
+      }
+      if (opts.containsKey(CONFIG_VERSION)) {
+        this.version = Integer.parseInt(opts.get(CONFIG_VERSION));
+      }
+      if (opts.containsKey(CONFIG_INDEX_CACHE_SIZE)) {
+        this.indexCacheSize = Integer.parseInt(opts.get(CONFIG_INDEX_CACHE_SIZE));
+      }
+      if (opts.containsKey(CONFIG_METADATA_CACHE_SIZE)) {
+        this.metadataCacheSize = Integer.parseInt(opts.get(CONFIG_METADATA_CACHE_SIZE));
+      }
+      if (opts.containsKey(CONFIG_BATCH_SIZE)) {
+        int parsedBatchSize = Integer.parseInt(opts.get(CONFIG_BATCH_SIZE));
+        Preconditions.checkArgument(parsedBatchSize > 0, "batch_size must be positive");
+        this.batchSize = parsedBatchSize;
+      }
+      if (opts.containsKey(CONFIG_TOP_N_PUSH_DOWN)) {
+        this.topNPushDown = Boolean.parseBoolean(opts.get(CONFIG_TOP_N_PUSH_DOWN));
+      }
+      if (opts.containsKey(CONFIG_NEAREST)) {
+        nearest(opts.get(CONFIG_NEAREST));
+      }
+      if (opts.containsKey(CONFIG_EXECUTOR_CREDENTIAL_REFRESH)) {
+        this.executorCredentialRefresh =
+            Boolean.parseBoolean(opts.get(CONFIG_EXECUTOR_CREDENTIAL_REFRESH));
+      }
     }
 
     public LanceSparkReadOptions build() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -56,7 +56,18 @@ public class LanceFragmentScanner implements AutoCloseable {
     Dataset dataset = null;
     try {
       LanceSparkReadOptions readOptions = inputPartition.getReadOptions();
-      if (inputPartition.getNamespaceImpl() != null) {
+      // Optionally rebuild the namespace client on the executor so the dataset open routes through
+      // Utils.OpenDatasetBuilder's namespaceClient branch. This preserves the storage options
+      // provider on the Rust side, which refreshes short-lived vended credentials (e.g. STS
+      // tokens) during long-running scans. The price is an eager describeTable() RPC against the
+      // namespace on every fragment open.
+      //
+      // For catalogs whose backing service authenticates per-call (e.g. Hive Metastore over
+      // Kerberos) executors typically lack a TGT and that RPC fails with "GSS initiate failed".
+      // Setting LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH=false makes executors
+      // skip the rebuild and open the dataset by URI using the initialStorageOptions the driver
+      // already obtained, at the cost of losing the Rust-side credential refresh callback.
+      if (inputPartition.getNamespaceImpl() != null && readOptions.isExecutorCredentialRefresh()) {
         if (LanceRuntime.useNamespaceOnWorkers(inputPartition.getNamespaceImpl())) {
           readOptions.setNamespace(
               LanceRuntime.getOrCreateNamespace(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
@@ -23,6 +23,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class LanceSparkReadOptionsSerializationTest {
 
@@ -105,5 +108,122 @@ public class LanceSparkReadOptionsSerializationTest {
     Assertions.assertTrue(
         deserializedOptionsTrue.getNearest().isUseIndex(),
         "useIndex should remain true after serialization/deserialization");
+  }
+
+  @Test
+  public void testExecutorCredentialRefreshDefaultsToTrue() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder().datasetUri("s3://bucket/path").build();
+    Assertions.assertTrue(
+        options.isExecutorCredentialRefresh(),
+        "executor_credential_refresh must default to true to preserve existing behavior");
+  }
+
+  @Test
+  public void testExecutorCredentialRefreshParsedFromOptions() {
+    LanceSparkReadOptions optionsFalse =
+        LanceSparkReadOptions.from(
+            Collections.singletonMap(
+                LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "false"),
+            "s3://bucket/path");
+    Assertions.assertFalse(optionsFalse.isExecutorCredentialRefresh());
+
+    LanceSparkReadOptions optionsTrue =
+        LanceSparkReadOptions.from(
+            Collections.singletonMap(
+                LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "true"),
+            "s3://bucket/path");
+    Assertions.assertTrue(optionsTrue.isExecutorCredentialRefresh());
+  }
+
+  @Test
+  public void testExecutorCredentialRefreshSurvivesSerialization()
+      throws IOException, ClassNotFoundException {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .executorCredentialRefresh(false)
+            .build();
+    Assertions.assertFalse(options.isExecutorCredentialRefresh());
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(options);
+    }
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    LanceSparkReadOptions deserialized;
+    try (ObjectInputStream ois = new ObjectInputStream(bais)) {
+      deserialized = (LanceSparkReadOptions) ois.readObject();
+    }
+
+    Assertions.assertFalse(
+        deserialized.isExecutorCredentialRefresh(),
+        "executor_credential_refresh must survive Java serialization (driver -> executor handoff)");
+  }
+
+  @Test
+  public void testExecutorCredentialRefreshPreservedByWithVersion() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .executorCredentialRefresh(false)
+            .build();
+
+    LanceSparkReadOptions pinned = options.withVersion(7);
+    Assertions.assertFalse(
+        pinned.isExecutorCredentialRefresh(),
+        "withVersion() must propagate the executor_credential_refresh flag");
+  }
+
+  /**
+   * Catalog-level config (set via {@code --conf spark.sql.catalog.<name>.<key>}) is the only route
+   * available to SQL DML (DELETE / UPDATE / MERGE INTO), which has no per-statement {@code
+   * .option(...)} attach point. This test guards the catalog-conf path.
+   */
+  @Test
+  public void testExecutorCredentialRefreshFromCatalogDefaults() {
+    Map<String, String> catalogOpts = new HashMap<>();
+    catalogOpts.put(LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "false");
+    LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOpts);
+
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    Assertions.assertFalse(
+        options.isExecutorCredentialRefresh(),
+        "executor_credential_refresh set at catalog level must land in the typed field "
+            + "so it takes effect for SELECT without .option(...) and for SQL DML");
+  }
+
+  /**
+   * Spark's scan-time options (via {@code spark.read.option(...)}) go through a second {@code
+   * fromOptions(mergedMap)} rebuild in {@code LanceDataset.newScanBuilder}. Per-read settings must
+   * win over catalog-level defaults.
+   */
+  @Test
+  public void testPerReadOptionOverridesCatalogDefaults() {
+    Map<String, String> catalogOpts = new HashMap<>();
+    catalogOpts.put(LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "false");
+    LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOpts);
+
+    // Simulate the rebuild path in LanceDataset.newScanBuilder: the builder starts by applying
+    // the catalog defaults, then fromOptions() replays against the merged (catalog + per-read)
+    // map where the per-read value wins.
+    Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
+    merged.put(LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "true");
+
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .withCatalogDefaults(catalogConfig)
+            .fromOptions(merged)
+            .build();
+
+    Assertions.assertTrue(
+        options.isExecutorCredentialRefresh(),
+        "per-read .option(...) must override the catalog-level default");
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
@@ -13,8 +13,13 @@
  */
 package org.lance.spark.internal;
 
+import org.lance.namespace.LanceNamespace;
 import org.lance.spark.LanceConstant;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.read.LanceInputPartition;
+import org.lance.spark.utils.Optional;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -23,9 +28,14 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LanceFragmentScannerTest {
 
@@ -198,5 +208,78 @@ public class LanceFragmentScannerTest {
     List<String> result = callGetColumnNames(schema);
     List<String> expected = Arrays.asList("id");
     assertEquals(expected, result);
+  }
+
+  /**
+   * Locks down the executor-branch contract for {@code executor_credential_refresh=false}: when an
+   * executor opens a fragment for a namespace-backed table with the flag disabled, {@link
+   * LanceFragmentScanner#create} must <i>not</i> reconstruct the namespace client. Without this
+   * gate, executors of Kerberized HMS catalogs hit {@code GSS initiate failed} because they lack a
+   * TGT for the eager {@code describeTable()} RPC.
+   *
+   * <p>Strategy: hand a real, loadable {@link LanceNamespace} impl to the partition. If the gate
+   * regresses (rebuild not skipped), {@code LanceNamespace.connect} would succeed via {@code
+   * Class.forName}, {@link RecordingNamespace#initialize} would run, and {@code
+   * readOptions.setNamespace(...)} would fire — all observable here. The bogus dataset URI lets the
+   * outer {@code Utils.openDatasetBuilder().build()} call fail predictably, since the gate runs
+   * <i>before</i> the dataset is opened. No real Lance dataset is required.
+   */
+  @Test
+  public void testCreateSkipsNamespaceRebuildWhenExecutorCredentialRefreshDisabled() {
+    RecordingNamespace.INITIALIZE_CALLS.set(0);
+
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri("file:///tmp/__lance_nonexistent_for_executor_gate_test__")
+            .executorCredentialRefresh(false)
+            .build();
+
+    LanceInputPartition partition =
+        new LanceInputPartition(
+            new StructType(),
+            0,
+            null,
+            readOptions,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            "test-scan",
+            Collections.emptyMap(),
+            RecordingNamespace.class.getName(),
+            Collections.emptyMap(),
+            null);
+
+    assertThrows(RuntimeException.class, () -> LanceFragmentScanner.create(0, partition));
+
+    assertNull(
+        readOptions.getNamespace(),
+        "executor_credential_refresh=false must skip namespace rebuild on the executor");
+    assertEquals(
+        0,
+        RecordingNamespace.INITIALIZE_CALLS.get(),
+        "executor_credential_refresh=false must not load or initialize the namespace impl");
+  }
+
+  /**
+   * Public, top-level-by-FQCN, no-arg {@link LanceNamespace} so that {@link
+   * LanceNamespace#connect(String, Map, BufferAllocator)} can resolve it via {@code Class.forName}
+   * if the executor branch is (incorrectly) taken.
+   */
+  public static class RecordingNamespace implements LanceNamespace {
+    static final AtomicInteger INITIALIZE_CALLS = new AtomicInteger();
+
+    public RecordingNamespace() {}
+
+    @Override
+    public void initialize(Map<String, String> properties, BufferAllocator allocator) {
+      INITIALIZE_CALLS.incrementAndGet();
+    }
+
+    @Override
+    public String namespaceId() {
+      return "recording";
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes `org.apache.thrift.transport.TTransportException: GSS initiate failed` thrown on Spark executors when reading Lance tables registered in a Kerberized Hive Metastore (both plain `SELECT` and SQL DML).

This PR does two things:

1. **Stops executors from rebuilding the namespace client unconditionally.** Adds a new read option `executor_credential_refresh` (default `true`, preserving current behavior). When set to `false`, executors skip the eager `namespace.describeTable()` RPC and open the dataset directly by URI using the storage options the driver already obtained.
2. **Makes catalog-level read options actually reach the typed fields.** Catalog-level conf (`--conf spark.sql.catalog.<name>.executor_credential_refresh=false`) is now parsed in `withCatalogDefaults()`, so `spark.sql(...)` queries (including `SELECT` and SQL DML) — which have no `spark.read.option(...)` attach point — pick up the flag the same way as DataFrameReader-based reads.

## Root Cause

Since #353 removed `LanceDatasetCache`, `LanceFragmentScanner.create()` unconditionally rebuilds the `LanceNamespace` client on each Spark executor and binds it back onto `LanceSparkReadOptions`. This forces the dataset open through `Utils.OpenDatasetBuilder`'s `namespaceClient` branch, which in turn calls `OpenDatasetBuilder.buildFromNamespaceClient()` in the Lance Java SDK — and that path issues an eager `namespace.describeTable()` RPC before handing off to Rust.

For catalogs where the backing service authenticates per-call (HMS over Kerberos, some REST catalogs), Spark executors typically do not have a Kerberos TGT — the `--keytab` / `--principal` credentials only reach the driver / ApplicationMaster, while executors run with Hadoop delegation tokens that cannot be used for HMS Thrift SASL. The `describeTable` RPC therefore fails with:

```
org.apache.thrift.transport.TTransportException: GSS initiate failed
  at org.lance.namespace.hive2.Hive2ClientPool.newClient(Hive2ClientPool.java:42)
  at org.lance.namespace.hive2.Hive2Namespace.describeTable(Hive2Namespace.java:285)
  at org.lance.OpenDatasetBuilder.buildFromNamespaceClient(OpenDatasetBuilder.java:205)
  at org.lance.OpenDatasetBuilder.build(OpenDatasetBuilder.java:191)
  at org.lance.spark.utils.Utils$OpenDatasetBuilder.build(Utils.java:140)
  at org.lance.spark.internal.LanceFragmentScanner.create(LanceFragmentScanner.java:67)
```

Driver-side operations (metadata-only queries, count-via-manifest) succeed because the driver has the TGT. The failure only manifests during fragment scans.

## Why the Existing Behavior Exists

Rebuilding the namespace client on the executor is not dead code — it keeps the Rust `LanceNamespaceStorageOptionsProvider` attached so that short-lived vended credentials (STS tokens for S3 / GCS / Azure) returned by `describeTable()` can be refreshed when they expire mid-scan. Simply removing the rebuild would break long-running scans against object stores that use credential vending.

## Fix

### 1. Gate the executor-side rebuild behind a new option

Add a boolean read option `executor_credential_refresh`, defaulting to `true`:

- `true` (default): unchanged — executor rebuilds the namespace client and routes through the `namespaceClient` branch, preserving credential refresh. Safe for all existing users.
- `false`: executor skips the rebuild, reads remain open via URI using the `initialStorageOptions` the driver already obtained from `describeTable()` at scan-plan time.

### 2. Make catalog-level conf actually reach the typed field

Before this PR, `Builder.withCatalogDefaults(catalogConfig)` only merged the storage-options map and never parsed typed flags. As a result, the catalog-conf syntax looked like it should work but silently ignored the flag. This PR extracts a `parseTypedFlags(Map<String, String>)` helper and calls it from both `fromOptions()` and `withCatalogDefaults()`, so every recognized read option (not just `executor_credential_refresh`) now flows from catalog conf into the typed field.

This is what makes the fix usable from SQL DML. Without the `withCatalogDefaults` parse, a user running `DELETE FROM kerberized_hms_lance_table WHERE id = 1` has no way to disable the rebuild — SQL DML has no per-statement `.option(...)` attach point.

### Configuration surfaces after this PR

| Surface | Example | Works? |
|---|---|---|
| Per-read option | `spark.read.option("executor_credential_refresh", "false").table(...)` (DataFrameReader) | Yes (already worked before this PR; not available for `spark.sql("SELECT ...")`) |
| Catalog conf + plain SELECT | `--conf spark.sql.catalog.lance.executor_credential_refresh=false` + `spark.sql("SELECT * FROM lance.db.t")` | Yes (fixed by this PR) |
| Catalog conf + SQL DML | `--conf spark.sql.catalog.lance.executor_credential_refresh=false` + `spark.sql("DELETE FROM lance.db.t WHERE id=1")` | Yes (fixed by this PR) |

Intended usage for HMS + Kerberos deployments:

```
spark-submit ... \
  --keytab /etc/keytabs/my.keytab \
  --principal my/principal@REALM \
  --conf spark.sql.catalog.lance.executor_credential_refresh=false
```

## Per-Namespace Trade-off Analysis

The refresh callback is meaningful only for namespaces that actually return `storage_options` from `describeTable()`. Survey of the impls in `lance-namespace-impls`:

| Namespace                  | `describeTable()` populates `storage_options`? | Cost of `executor_credential_refresh=false`                                     |
|----------------------------|------------------------------------------------|---------------------------------------------------------------------------------|
| `Hive2Namespace`           | No — `setLocation` only                        | **None.** The refresh callback is a no-op for HMS regardless of underlying storage. |
| `Hive3Namespace`           | No — `setLocation` only                        | **None.** Same as Hive2.                                                        |
| `GlueNamespace`            | Static `config.getStorageOptions()`            | Effectively none for plain Glue. Use the default if you rely on LakeFormation vended creds. |
| `IcebergNamespace` (REST)  | Yes — vended creds typical                     | Long scans against vended creds will fail when the credential expires.          |
| `PolarisNamespace`         | Yes — vended creds typical                     | Same as Iceberg REST.                                                           |
| `UnityNamespace`           | Yes — Databricks-vended temp creds             | Same as Iceberg REST.                                                           |

Concretely, for the HMS + S3 case: HMS does **not** vend S3 credentials (`describeTable()` only sets `location`), so the executor's S3 access is governed entirely by the AWS SDK credential chain (instance profile / `hive-site.xml` / env vars / `~/.aws/credentials`) and the AWS SDK handles all STS rotation independently. The Lance refresh callback would have nothing to refresh, so disabling it costs nothing in practice.

## Scope of Change

- `LanceSparkReadOptions.java`:
  - New constant `CONFIG_EXECUTOR_CREDENTIAL_REFRESH`, new field `executorCredentialRefresh` (default `true`), builder / getter / `withVersion` propagation / `equals` / `hashCode`, Javadoc covering per-namespace trade-off.
  - Extracted `Builder.parseTypedFlags(Map<String, String>)` helper from the previously duplicated `fromOptions` body, now called from both `fromOptions()` and `withCatalogDefaults()`. This incidentally also fixes silent ignores of `push_down_filters`, `batch_size`, `topN_push_down`, etc. when set at the catalog level — a pre-existing latent issue uncovered while fixing the primary bug.
- `LanceFragmentScanner.java`: add `&& readOptions.isExecutorCredentialRefresh()` to the existing rebuild `if`, inline comment explaining the trade-off.
- `LanceSparkReadOptionsSerializationTest.java`: six new tests covering default value, map parsing, serialization round-trip, `withVersion` propagation, catalog-defaults path, and per-read override precedence.

No public API signature is changed; no existing behavior is altered for users who do not set the new option.

## Test Plan

New unit tests (all 305 tests in `lance-spark-base_2.12` pass locally):

- `testExecutorCredentialRefreshDefaultsToTrue` — default value preserved.
- `testExecutorCredentialRefreshParsedFromOptions` — flag honored from both `"true"` and `"false"` map entries.
- `testExecutorCredentialRefreshSurvivesSerialization` — flag survives Java serialization (critical: it must reach the executor).
- `testExecutorCredentialRefreshPreservedByWithVersion` — flag propagated by `withVersion()` used during scan-plan version pinning.
- `testExecutorCredentialRefreshFromCatalogDefaults` — new; guards the catalog-conf path used by SQL DML.
- `testPerReadOptionOverridesCatalogDefaults` — new; pins the precedence rule "per-read `.option(...)` wins over catalog default".
- `LanceFragmentScannerTest.java`: one new end-to-end test that locks in the executor-branch contract through `LanceFragmentScanner.create` (per reviewer suggestion).


Integration test (out-of-band, on internal YARN + HMS + Kerberos + HDFS cluster):

1. `spark-submit` with `--keytab` / `--principal`, Kerberized HMS, `SELECT * FROM lance_hms_table` via `lance-namespace-hive2`.
2. **Before fix**: executor task fails with `GSS initiate failed` on `describeTable`. Reproducible across multiple partitions / runs.
3. **After fix** with `--conf spark.sql.catalog.lance.executor_credential_refresh=false`: scan completes, returns expected row count and sample rows.
4. Default path (`true`) with the same fix jar: behavior unchanged.

## Backward Compatibility

Default is `true`, so every existing job behaves identically without touching configs. Only users who explicitly set the new option to `false` opt into the new path.