### PR TITLE
fix: apply per-column compression metadata on direct-path writes

### DIFF
--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/CompressionRoundtripTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/CompressionRoundtripTest.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+/** Concrete implementation of BaseCompressionRoundtripTest for Spark 3.4. */
+public class CompressionRoundtripTest extends BaseCompressionRoundtripTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/CompressionRoundtripTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/CompressionRoundtripTest.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+/** Concrete implementation of BaseCompressionRoundtripTest for Spark 3.5. */
+public class CompressionRoundtripTest extends BaseCompressionRoundtripTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -15,6 +15,7 @@ package org.lance.spark;
 
 import org.lance.spark.read.LanceScanBuilder;
 import org.lance.spark.utils.BlobUtils;
+import org.lance.spark.utils.SchemaConverter;
 import org.lance.spark.write.AddColumnsBackfillWrite;
 import org.lance.spark.write.SparkWrite;
 import org.lance.spark.write.StagedCommit;
@@ -326,6 +327,13 @@ public class LanceDataset
     }
     LanceSparkWriteOptions writeOptions = writeOptionsBuilder.build();
 
+    // Apply encoding metadata from write options to the schema. This handles the case
+    // where compression options are passed via .option() on df.write().format("lance").save(path),
+    // since Spark's DataFrameWriter passes properties=Map.empty to createTable for the
+    // SupportsCatalogOptions path, causing compression metadata to be lost at table creation time.
+    StructType effectiveSchema =
+        SchemaConverter.processSchemaWithProperties(sparkSchema, mergedOptions);
+
     List<String> backfillColumns =
         Arrays.stream(
                 sparkWriteOptions.getOrDefault(LanceConstant.BACKFILL_COLUMNS_KEY, "").split(","))
@@ -334,7 +342,7 @@ public class LanceDataset
             .collect(Collectors.toList());
     if (!backfillColumns.isEmpty()) {
       return new AddColumnsBackfillWrite.AddColumnsWriteBuilder(
-          sparkSchema,
+          effectiveSchema,
           writeOptions,
           backfillColumns,
           initialStorageOptions,
@@ -351,7 +359,7 @@ public class LanceDataset
             .collect(Collectors.toList());
     if (!updateColumns.isEmpty()) {
       return new UpdateColumnsBackfillWrite.UpdateColumnsWriteBuilder(
-          sparkSchema,
+          effectiveSchema,
           writeOptions,
           updateColumns,
           initialStorageOptions,
@@ -362,7 +370,7 @@ public class LanceDataset
 
     SparkWrite.SparkWriteBuilder builder =
         new SparkWrite.SparkWriteBuilder(
-            sparkSchema,
+            effectiveSchema,
             writeOptions,
             initialStorageOptions,
             namespaceImpl,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseCompressionRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseCompressionRoundtripTest.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.LanceFileCompressionReader;
+import org.lance.spark.utils.LanceFileCompressionReader.CompressionScheme;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * E2E roundtrip tests for per-column compression via TBLPROPERTIES.
+ *
+ * <p>Verifies that data written with {@code <col>.lance.compression} TBLPROPERTIES (lz4, zstd,
+ * none) can be read back with identical values, AND that the on-disk Lance files actually use the
+ * requested compression codec. The latter is verified by parsing the Lance v2 file footer and
+ * column metadata protobuf to extract BufferCompression.scheme from the encoding tree.
+ *
+ * <p>Tests use {@code file_format_version = '2.2'} to enable block-level compression, which has no
+ * minimum buffer size threshold (unlike miniblock compression in V2.1 which requires buffers &ge; 4
+ * KB). Tests also generate enough data (10K+ rows with long strings) to ensure the compressed
+ * output is smaller than the original, avoiding the compression effectiveness fallback.
+ *
+ * <p>The tests exercise both the SQL TBLPROPERTIES path and the DataFrame {@code tableProperty()}
+ * API.
+ */
+public abstract class BaseCompressionRoundtripTest {
+  private SparkSession spark;
+  private static final String CATALOG_NAME = "lance_compression";
+
+  @TempDir protected Path tempDir;
+
+  @BeforeEach
+  void setup() {
+    spark =
+        SparkSession.builder()
+            .appName("compression-roundtrip-test")
+            .master("local[*]")
+            .config(
+                "spark.sql.catalog." + CATALOG_NAME, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".impl", "dir")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".root", tempDir.toString())
+            .getOrCreate();
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS " + CATALOG_NAME + ".default");
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  private String fullTableName(String table) {
+    return CATALOG_NAME + ".default." + table;
+  }
+
+  /**
+   * Number of rows to generate for compression tests. Must be large enough to produce data that
+   * exceeds compression thresholds and compresses effectively.
+   */
+  private static final int SAMPLE_ROW_COUNT = 10_000;
+
+  private List<Row> sampleRows() {
+    List<Row> rows = new ArrayList<>(SAMPLE_ROW_COUNT);
+    for (int i = 0; i < SAMPLE_ROW_COUNT; i++) {
+      String name = (i % 7 == 0) ? null : "name_padding_string_value_" + i + "_extra_content";
+      Long value = (i % 11 == 0) ? null : (long) (i * 100);
+      rows.add(RowFactory.create(i, name, value));
+    }
+    return rows;
+  }
+
+  private StructType sampleSchema() {
+    return new StructType()
+        .add("id", DataTypes.IntegerType, false)
+        .add("name", DataTypes.StringType, true)
+        .add("value", DataTypes.LongType, true);
+  }
+
+  private void assertDataIntegrity(String tableName, int expectedRowCount) {
+    // Count client-side via collectAsList().size() rather than SELECT count(*) to sidestep a
+    // Spark 3.5 binary-compat bug: single-table COUNT(*) goes through the V2 pushed-aggregation
+    // path which instantiates the old 2-arg Sum(Expression, Enumeration$Value) constructor that
+    // was removed in some 3.5.x patch releases, causing NoSuchMethodError at test time. Pattern
+    // re-used from the DFP integration-test suite.
+    int rowCount = spark.sql("SELECT * FROM " + fullTableName(tableName)).collectAsList().size();
+    assertEquals(expectedRowCount, rowCount, "Row count mismatch");
+  }
+
+  /**
+   * Asserts that the specified columns in the on-disk Lance files use the expected compression
+   * scheme. Columns are identified by their zero-based index in the schema.
+   *
+   * @param tableName table name (used to locate the .lance dataset directory)
+   * @param expectedByColumn map from column index to expected compression scheme
+   */
+  private void assertColumnCompression(
+      String tableName, Map<Integer, CompressionScheme> expectedByColumn) throws IOException {
+    List<Path> dataFiles = LanceFileCompressionReader.findDataFilesForTable(tempDir, tableName);
+    assertFalse(dataFiles.isEmpty(), "No .lance data files found for table " + tableName);
+
+    for (Path file : dataFiles) {
+      List<Set<CompressionScheme>> columnSchemes =
+          LanceFileCompressionReader.readColumnCompressions(file);
+
+      for (Map.Entry<Integer, CompressionScheme> entry : expectedByColumn.entrySet()) {
+        int colIdx = entry.getKey();
+        CompressionScheme expected = entry.getValue();
+
+        assertTrue(
+            colIdx < columnSchemes.size(),
+            "Column index "
+                + colIdx
+                + " out of range (file has "
+                + columnSchemes.size()
+                + " columns)");
+
+        Set<CompressionScheme> actual = columnSchemes.get(colIdx);
+        if (expected == CompressionScheme.UNSPECIFIED) {
+          // "none" compression: should not contain LZ4 or ZSTD
+          assertFalse(
+              actual.contains(CompressionScheme.LZ4),
+              "Column " + colIdx + " should not use LZ4 but found: " + actual);
+          assertFalse(
+              actual.contains(CompressionScheme.ZSTD),
+              "Column " + colIdx + " should not use ZSTD but found: " + actual);
+        } else {
+          assertTrue(
+              actual.contains(expected),
+              "Column "
+                  + colIdx
+                  + " expected "
+                  + expected
+                  + " but found: "
+                  + actual
+                  + " in file "
+                  + file);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testLz4CompressionWithSqlTblProperties() throws Exception {
+    String tableName = "comp_lz4_sql_" + System.currentTimeMillis();
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fullTableName(tableName)
+            + " (id INT NOT NULL, name STRING, value BIGINT)"
+            + " USING lance"
+            + " TBLPROPERTIES ("
+            + "'file_format_version' = '2.2',"
+            + "'name.lance.compression' = 'lz4',"
+            + "'value.lance.compression' = 'lz4'"
+            + ")");
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.writeTo(fullTableName(tableName)).append();
+
+    assertDataIntegrity(tableName, data.size());
+    // schema: id(0), name(1), value(2) — verify name and value use LZ4
+    assertColumnCompression(tableName, Map.of(1, CompressionScheme.LZ4, 2, CompressionScheme.LZ4));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testZstdCompressionWithSqlTblProperties() throws Exception {
+    String tableName = "comp_zstd_sql_" + System.currentTimeMillis();
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fullTableName(tableName)
+            + " (id INT NOT NULL, name STRING, value BIGINT)"
+            + " USING lance"
+            + " TBLPROPERTIES ("
+            + "'file_format_version' = '2.2',"
+            + "'name.lance.compression' = 'zstd',"
+            + "'value.lance.compression' = 'zstd'"
+            + ")");
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.writeTo(fullTableName(tableName)).append();
+
+    assertDataIntegrity(tableName, data.size());
+    assertColumnCompression(
+        tableName, Map.of(1, CompressionScheme.ZSTD, 2, CompressionScheme.ZSTD));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testNoneCompressionWithSqlTblProperties() throws Exception {
+    String tableName = "comp_none_sql_" + System.currentTimeMillis();
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fullTableName(tableName)
+            + " (id INT NOT NULL, name STRING, value BIGINT)"
+            + " USING lance"
+            + " TBLPROPERTIES ("
+            + "'file_format_version' = '2.2',"
+            + "'name.lance.compression' = 'none',"
+            + "'value.lance.compression' = 'none'"
+            + ")");
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.writeTo(fullTableName(tableName)).append();
+
+    assertDataIntegrity(tableName, data.size());
+    assertColumnCompression(
+        tableName, Map.of(1, CompressionScheme.UNSPECIFIED, 2, CompressionScheme.UNSPECIFIED));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testMixedCompressionPerColumn() throws Exception {
+    String tableName = "comp_mixed_" + System.currentTimeMillis();
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fullTableName(tableName)
+            + " (id INT NOT NULL, name STRING, value BIGINT)"
+            + " USING lance"
+            + " TBLPROPERTIES ("
+            + "'file_format_version' = '2.2',"
+            + "'name.lance.compression' = 'lz4',"
+            + "'value.lance.compression' = 'zstd'"
+            + ")");
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.writeTo(fullTableName(tableName)).append();
+
+    assertDataIntegrity(tableName, data.size());
+    assertColumnCompression(tableName, Map.of(1, CompressionScheme.LZ4, 2, CompressionScheme.ZSTD));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testCompressionWithDataFrameTablePropertyApi() throws Exception {
+    String tableName = "comp_df_api_" + System.currentTimeMillis();
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.writeTo(fullTableName(tableName))
+        .tableProperty("file_format_version", "2.2")
+        .tableProperty("name.lance.compression", "lz4")
+        .tableProperty("value.lance.compression", "zstd")
+        .createOrReplace();
+
+    assertDataIntegrity(tableName, data.size());
+    assertColumnCompression(tableName, Map.of(1, CompressionScheme.LZ4, 2, CompressionScheme.ZSTD));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testCompressionWithMultipleAppends() throws Exception {
+    String tableName = "comp_multi_append_" + System.currentTimeMillis();
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fullTableName(tableName)
+            + " (id INT NOT NULL, name STRING, value BIGINT)"
+            + " USING lance"
+            + " TBLPROPERTIES ("
+            + "'file_format_version' = '2.2',"
+            + "'name.lance.compression' = 'zstd',"
+            + "'value.lance.compression' = 'lz4'"
+            + ")");
+
+    // First append
+    List<Row> batch1 = sampleRows();
+    spark.createDataFrame(batch1, sampleSchema()).writeTo(fullTableName(tableName)).append();
+
+    // Second append
+    List<Row> batch2 = sampleRows();
+    spark.createDataFrame(batch2, sampleSchema()).writeTo(fullTableName(tableName)).append();
+
+    // Verify all data
+    assertDataIntegrity(tableName, batch1.size() + batch2.size());
+
+    // Verify compression on all data files
+    assertColumnCompression(tableName, Map.of(1, CompressionScheme.ZSTD, 2, CompressionScheme.LZ4));
+
+    spark.sql("DROP TABLE IF EXISTS " + fullTableName(tableName));
+  }
+
+  @Test
+  public void testCompressionWithDirectPathWrite() throws Exception {
+    // Direct path write: df.write().format("lance").option(...).save(path)
+    // This exercises the SupportsCatalogOptions path where Spark's DataFrameWriter
+    // passes properties=Map.empty to createTable, so compression options passed via
+    // .option() must be applied in newWriteBuilder() instead.
+    String tableName = "comp_direct_path_" + System.currentTimeMillis();
+    String tablePath = tempDir.resolve(tableName).toString();
+
+    List<Row> data = sampleRows();
+    Dataset<Row> df = spark.createDataFrame(data, sampleSchema());
+    df.write()
+        .format("lance")
+        .option("file_format_version", "2.2")
+        .option("name.lance.compression", "lz4")
+        .option("value.lance.compression", "zstd")
+        .save(tablePath);
+
+    // Verify data integrity by reading back. Use collectAsList().size() instead of Dataset.count()
+    // for the same Spark 3.5 Sum-binary-compat reason documented in assertDataIntegrity().
+    int count = spark.read().format("lance").load(tablePath).collectAsList().size();
+    assertEquals(data.size(), count, "Row count mismatch for direct path write");
+
+    // Verify compression on disk — locate the .lance dataset directory
+    List<Path> dataFiles = LanceFileCompressionReader.findDataFiles(Path.of(tablePath));
+    assertFalse(dataFiles.isEmpty(), "No .lance data files found for direct path write");
+
+    for (Path file : dataFiles) {
+      List<Set<CompressionScheme>> columnSchemes =
+          LanceFileCompressionReader.readColumnCompressions(file);
+      // schema: id(0), name(1), value(2)
+      assertTrue(
+          columnSchemes.get(1).contains(CompressionScheme.LZ4),
+          "Column 1 (name) expected LZ4 but found: " + columnSchemes.get(1) + " in " + file);
+      assertTrue(
+          columnSchemes.get(2).contains(CompressionScheme.ZSTD),
+          "Column 2 (value) expected ZSTD but found: " + columnSchemes.get(2) + " in " + file);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LanceFileCompressionReader.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/LanceFileCompressionReader.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Reads Lance v2 file footer and column metadata to extract the compression schemes actually
+ * applied to each column.
+ *
+ * <p>This is a test-only utility for verifying that TBLPROPERTIES compression settings are
+ * propagated through the write path into the on-disk Lance file format. It parses the binary
+ * protobuf encoding tree without requiring the protobuf-java runtime by implementing minimal varint
+ * and tag-length-value parsing.
+ *
+ * <h3>Lance v2 file layout (from EOF):</h3>
+ *
+ * <pre>
+ * [Footer - 40 bytes at EOF]
+ *   u64: column_meta_start
+ *   u64: column_meta_offsets_start  (CMO table)
+ *   u64: global_buff_offsets_start  (GBO table)
+ *   u32: num_global_buffers
+ *   u32: num_columns
+ *   u16: major_version
+ *   u16: minor_version
+ *   "LANC" (4 bytes magic)
+ * </pre>
+ *
+ * <p>The CMO table contains {@code num_columns} entries of 16 bytes each (u64 offset, u64 length),
+ * pointing to protobuf-encoded {@code ColumnMetadata} messages.
+ */
+public final class LanceFileCompressionReader {
+
+  /** Compression schemes defined in Lance's encodings_v2_1.proto. */
+  public enum CompressionScheme {
+    UNSPECIFIED,
+    LZ4,
+    ZSTD;
+
+    static CompressionScheme fromProtoValue(int value) {
+      switch (value) {
+        case 1:
+          return LZ4;
+        case 2:
+          return ZSTD;
+        default:
+          return UNSPECIFIED;
+      }
+    }
+  }
+
+  private static final byte[] MAGIC = {0x4C, 0x41, 0x4E, 0x43}; // "LANC"
+  private static final int FOOTER_LEN = 40;
+
+  /** Protobuf wire types. */
+  private static final int WIRE_VARINT = 0;
+
+  private static final int WIRE_FIXED64 = 1;
+  private static final int WIRE_LENGTH_DELIMITED = 2;
+  private static final int WIRE_FIXED32 = 5;
+
+  private LanceFileCompressionReader() {}
+
+  /**
+   * Reads compression schemes for all columns in a single Lance data file.
+   *
+   * @param lanceFile path to a .lance data file
+   * @return list of sets, one per column; each set contains the distinct compression schemes found
+   *     in that column's page encodings
+   */
+  public static List<Set<CompressionScheme>> readColumnCompressions(Path lanceFile)
+      throws IOException {
+    try (RandomAccessFile raf = new RandomAccessFile(lanceFile.toFile(), "r")) {
+      long fileLen = raf.length();
+      if (fileLen < FOOTER_LEN) {
+        throw new IOException("File too small to contain a Lance footer: " + fileLen);
+      }
+
+      // Read 40-byte footer
+      raf.seek(fileLen - FOOTER_LEN);
+      byte[] footer = new byte[FOOTER_LEN];
+      raf.readFully(footer);
+
+      // Verify magic
+      for (int i = 0; i < 4; i++) {
+        if (footer[36 + i] != MAGIC[i]) {
+          throw new IOException("Not a Lance file (bad magic)");
+        }
+      }
+
+      ByteBuffer fb = ByteBuffer.wrap(footer).order(ByteOrder.LITTLE_ENDIAN);
+      long cmoStart = fb.getLong(8); // column_meta_offsets_start
+      int numColumns = fb.getInt(28);
+
+      // Read CMO table: num_columns * 16 bytes
+      raf.seek(cmoStart);
+      byte[] cmoTable = new byte[numColumns * 16];
+      raf.readFully(cmoTable);
+      ByteBuffer cmoBuf = ByteBuffer.wrap(cmoTable).order(ByteOrder.LITTLE_ENDIAN);
+
+      List<Set<CompressionScheme>> result = new ArrayList<>(numColumns);
+
+      for (int col = 0; col < numColumns; col++) {
+        long pos = cmoBuf.getLong(col * 16);
+        long len = cmoBuf.getLong(col * 16 + 8);
+
+        raf.seek(pos);
+        byte[] colMeta = new byte[(int) len];
+        raf.readFully(colMeta);
+
+        result.add(extractCompressionSchemes(colMeta));
+      }
+
+      return result;
+    }
+  }
+
+  /**
+   * Finds all Lance data files (*.lance regular files) under the given dataset directory.
+   *
+   * @param datasetDir the .lance dataset root (e.g., {@code /tmp/table_name.lance})
+   * @return list of paths to individual data files
+   */
+  public static List<Path> findDataFiles(Path datasetDir) throws IOException {
+    Path dataDir = datasetDir.resolve("data");
+    if (!Files.isDirectory(dataDir)) {
+      return Collections.emptyList();
+    }
+
+    List<Path> files = new ArrayList<>();
+    Files.walkFileTree(
+        dataDir,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+            if (file.getFileName().toString().endsWith(".lance")) {
+              files.add(file);
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        });
+    return files;
+  }
+
+  /**
+   * Searches recursively under {@code root} for a Lance dataset directory that belongs to the given
+   * table and returns the Lance data files within it.
+   *
+   * <p>Handles two naming conventions used by the DirectoryNamespace:
+   *
+   * <ul>
+   *   <li>Root namespace with dir_listing: {@code {tableName}.lance}
+   *   <li>Manifest mode with child namespace: {@code {8hex}_{namespace}${tableName}} (e.g., {@code
+   *       a1b2c3d4_default$my_table})
+   * </ul>
+   *
+   * A directory is considered a Lance dataset if it contains a {@code data/} subdirectory.
+   *
+   * @param root the search root (e.g., the catalog root or temp directory)
+   * @param tableName the table name (without the .lance suffix)
+   * @return list of paths to individual data files
+   */
+  public static List<Path> findDataFilesForTable(Path root, String tableName) throws IOException {
+    String dirListingName = tableName + ".lance";
+    String manifestSuffix = "$" + tableName;
+    List<Path> datasetDirs = new ArrayList<>();
+
+    Files.walkFileTree(
+        root,
+        new SimpleFileVisitor<Path>() {
+          @Override
+          public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+            if (dir.getFileName() == null) {
+              return FileVisitResult.CONTINUE;
+            }
+            String name = dir.getFileName().toString();
+            if (name.equals(dirListingName) || name.endsWith(manifestSuffix)) {
+              // Verify it looks like a Lance dataset (has a data/ subdirectory)
+              if (Files.isDirectory(dir.resolve("data"))) {
+                datasetDirs.add(dir);
+                return FileVisitResult.SKIP_SUBTREE;
+              }
+            }
+            return FileVisitResult.CONTINUE;
+          }
+        });
+
+    List<Path> allFiles = new ArrayList<>();
+    for (Path dsDir : datasetDirs) {
+      allFiles.addAll(findDataFiles(dsDir));
+    }
+    return allFiles;
+  }
+
+  // --------------- Protobuf parsing internals ---------------
+
+  /**
+   * Extracts compression schemes from a serialized ColumnMetadata protobuf.
+   *
+   * <p>Rather than navigating the exact protobuf field hierarchy (which is fragile across schema
+   * versions), this method recursively scans all nested messages within the ColumnMetadata looking
+   * for BufferCompression messages. A BufferCompression is identified by its structure: a small
+   * message (≤12 bytes) containing only varint fields, with field 1 having value 0 (UNSPECIFIED), 1
+   * (LZ4), or 2 (ZSTD).
+   */
+  static Set<CompressionScheme> extractCompressionSchemes(byte[] columnMetadata) {
+    Set<CompressionScheme> schemes = EnumSet.noneOf(CompressionScheme.class);
+    scanForBufferCompression(columnMetadata, schemes);
+    return schemes;
+  }
+
+  /**
+   * Recursively scans protobuf bytes for BufferCompression messages.
+   *
+   * <p>Descends into all length-delimited fields (which may be nested protobuf messages), and at
+   * each level attempts to identify BufferCompression messages by their structure. Parsing errors
+   * at any nesting level are caught and silently ignored, since length-delimited fields may also be
+   * raw bytes or packed repeated fields rather than sub-messages.
+   */
+  private static void scanForBufferCompression(byte[] bytes, Set<CompressionScheme> schemes) {
+    int[] pos = {0};
+    try {
+      while (pos[0] < bytes.length) {
+        int tag = readVarint32(bytes, pos);
+        int wireType = tag & 0x7;
+
+        if (wireType == WIRE_LENGTH_DELIMITED) {
+          byte[] inner = readLengthDelimited(bytes, pos);
+          // Try to parse as BufferCompression first
+          CompressionScheme scheme = tryParseBufferCompression(inner);
+          if (scheme != null) {
+            schemes.add(scheme);
+          }
+          // Always recurse into sub-messages to find deeper BufferCompression instances
+          scanForBufferCompression(inner, schemes);
+        } else if (wireType == WIRE_VARINT) {
+          readVarint64(bytes, pos);
+        } else if (wireType == WIRE_FIXED64) {
+          pos[0] += 8;
+        } else if (wireType == WIRE_FIXED32) {
+          pos[0] += 4;
+        } else {
+          // Unknown wire type (e.g. deprecated groups) — stop parsing this message
+          break;
+        }
+      }
+    } catch (Exception e) {
+      // Parsing error (truncated data, invalid varint, etc.) — return what we found so far
+    }
+  }
+
+  /**
+   * Attempts to parse a byte array as a BufferCompression protobuf message.
+   *
+   * <p>BufferCompression has: scheme (field 1, varint) and optional level (field 2, varint). If the
+   * bytes match this structure and field 1 has value 0, 1, or 2, we treat it as a valid
+   * BufferCompression.
+   *
+   * @return the compression scheme if parsing succeeds, null otherwise
+   */
+  private static CompressionScheme tryParseBufferCompression(byte[] bytes) {
+    if (bytes.length == 0 || bytes.length > 12) {
+      return null;
+    }
+    int[] pos = {0};
+    CompressionScheme found = null;
+    try {
+      while (pos[0] < bytes.length) {
+        int tag = readVarint32(bytes, pos);
+        int fieldNum = tag >>> 3;
+        int wireType = tag & 0x7;
+
+        if (wireType != WIRE_VARINT) {
+          return null; // BufferCompression only has varint fields
+        }
+
+        long value = readVarint64(bytes, pos);
+
+        if (fieldNum == 1 && value >= 0 && value <= 2) {
+          found = CompressionScheme.fromProtoValue((int) value);
+        } else if (fieldNum == 2) {
+          // level field — valid, continue
+        } else {
+          return null; // unexpected field
+        }
+      }
+    } catch (Exception e) {
+      return null;
+    }
+    return found;
+  }
+
+  // --------------- Low-level protobuf wire format helpers ---------------
+
+  private static int readVarint32(byte[] data, int[] pos) {
+    return (int) readVarint64(data, pos);
+  }
+
+  private static long readVarint64(byte[] data, int[] pos) {
+    long result = 0;
+    int shift = 0;
+    while (pos[0] < data.length) {
+      byte b = data[pos[0]++];
+      result |= (long) (b & 0x7F) << shift;
+      if ((b & 0x80) == 0) {
+        return result;
+      }
+      shift += 7;
+      if (shift >= 64) {
+        throw new IllegalStateException("Varint too long");
+      }
+    }
+    throw new IllegalStateException("Truncated varint");
+  }
+
+  private static byte[] readLengthDelimited(byte[] data, int[] pos) {
+    int len = readVarint32(data, pos);
+    if (len < 0 || pos[0] + len > data.length) {
+      throw new IllegalStateException("Invalid length-delimited field: len=" + len);
+    }
+    byte[] result = new byte[len];
+    System.arraycopy(data, pos[0], result, 0, len);
+    pos[0] += len;
+    return result;
+  }
+
+  private static void skipField(byte[] data, int[] pos, int wireType) {
+    switch (wireType) {
+      case WIRE_VARINT:
+        readVarint64(data, pos);
+        break;
+      case WIRE_FIXED64:
+        pos[0] += 8;
+        break;
+      case WIRE_LENGTH_DELIMITED:
+        int len = readVarint32(data, pos);
+        pos[0] += len;
+        break;
+      case WIRE_FIXED32:
+        pos[0] += 4;
+        break;
+      default:
+        throw new IllegalStateException("Unknown wire type: " + wireType);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

When users write via `df.write().format("lance").option("<col>.lance.compression", "lz4").save(path)`, the compression setting is silently dropped. Spark's `DataFrameWriter` routes this path through `SupportsCatalogOptions.createTable` with `properties=Map.empty`, so the per-column compression metadata never reaches the Arrow schema at table-creation time.

Fix this in `LanceDataset.newWriteBuilder` by running `SchemaConverter.processSchemaWithProperties` against the merged write options, so the `lance-encoding:compression` field metadata is applied before handing off to the write builder. The TBLPROPERTIES and `writeTo().tableProperty()` paths already worked correctly; this only repairs the direct-path write.

## Test plan

Added `BaseCompressionRoundtripTest` (with subclasses for Spark 3.4 and 3.5; reused by 4.0 / 4.1 via `add-test-source`) covering:

- [x] SQL `TBLPROPERTIES` path — lz4, zstd, none
- [x] Mixed per-column codecs (lz4 on one column, zstd on another)
- [x] DataFrame `writeTo().tableProperty()` path
- [x] Multiple appends reuse the table's compression settings
- [x] Direct-path `df.write().option(...).save(path)` — this is the scenario the fix addresses

Each test verifies both data integrity and the on-disk codec by parsing the Lance v2 footer and column-metadata protobuf to extract `BufferCompression.scheme`. Tests use `file_format_version = '2.2'` (block-level compression, no 4 KB miniblock threshold) and 10 K rows of compressible strings.