### PR TITLE
chore: update lance dependency to v6.0.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.4.0-beta.3</lance-spark.version>
-        <lance.version>6.0.0-beta.2</lance.version>
+        <lance.version>6.0.0-beta.3</lance.version>
         <lance-namespace-impl.version>0.1.3</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `6.0.0-beta.2` to `6.0.0-beta.3`.
- Verified `docker/Dockerfile` version pins: `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.4.0-beta.3`) and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version (`0.6.1`) in the tagged Lance source.
- Triggering tag: https://github.com/lance-format/lance/tree/refs/tags/v6.0.0-beta.3

## Verification
- `make lint` passed.
- `make install` passed after installing `org.lance:lance-core:6.0.0-beta.3` from the triggering tag into the runner's local Maven cache because Maven Central did not yet resolve that artifact during this run.
