### PR TITLE
fix: reject DECIMAL256 columns at schema resolution time with actiona…

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -138,6 +138,14 @@ object LanceArrowUtils {
           if fp.getPrecision == FloatingPointPrecision.HALF =>
         // Widen float16 to float32 for Spark (Spark has no native float16 type)
         FloatType
+      case d: ArrowType.Decimal if d.getBitWidth == 256 =>
+        // Spark only supports 128-bit decimal (precision <= 38).
+        // Throw at schema time rather than a cryptic UnsupportedOperationException
+        // when LanceArrowColumnVector tries to read the data.
+        throw unsupportedDataTypeError(
+          s"DECIMAL256(${d.getPrecision}, ${d.getScale}) in column '${field.getName}'." +
+          " Lance-Spark only supports 128-bit decimal (precision <= 38)." +
+          " Consider converting the column to a compatible DECIMAL type before reading.")
       case _ => ArrowUtils.fromArrowField(field)
     }
   }
@@ -384,6 +392,13 @@ object LanceArrowUtils {
     new SparkUnsupportedOperationException(
       errorClass = "UNSUPPORTED_DATATYPE",
       messageParameters = Map("typeName" -> ("\"" + typeName.sql.toUpperCase(Locale.ROOT) + "\"")))
+  }
+
+  /* For unsupported Arrow types where a DataType cannot be constructed (e.g. DECIMAL256) */
+  private def unsupportedDataTypeError(typeName: String): SparkUnsupportedOperationException = {
+    new SparkUnsupportedOperationException(
+      errorClass = "UNSUPPORTED_DATATYPE",
+      messageParameters = Map("typeName" -> ("\"" + typeName + "\"")))
   }
 
   /* Copy from copy of org.apache.spark.sql.errors.ExecutionErrors for Spark version compatibility */

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -144,8 +144,8 @@ object LanceArrowUtils {
         // when LanceArrowColumnVector tries to read the data.
         throw unsupportedDataTypeError(
           s"DECIMAL256(${d.getPrecision}, ${d.getScale}) in column '${field.getName}'." +
-          " Lance-Spark only supports 128-bit decimal (precision <= 38)." +
-          " Consider converting the column to a compatible DECIMAL type before reading.")
+            " Lance-Spark only supports 128-bit decimal (precision <= 38)." +
+            " Consider converting the column to a compatible DECIMAL type before reading.")
       case _ => ArrowUtils.fromArrowField(field)
     }
   }

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -83,6 +83,20 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     roundtrip(DayTimeIntervalType())
   }
 
+  test("decimal256 field throws SparkUnsupportedOperationException") {
+    val field = new Field(
+      "amount",
+      new FieldType(true, new ArrowType.Decimal(38, 5, 256), null, null),
+      java.util.Collections.emptyList())
+    val ex = intercept[SparkUnsupportedOperationException] {
+      LanceArrowUtils.fromArrowField(field)
+    }
+    assert(ex.getMessage.contains("amount"), s"field name missing: ${ex.getMessage}")
+    assert(ex.getMessage.contains("256"), s"bit-width missing: ${ex.getMessage}")
+    assert(ex.getMessage.contains("128"), s"128-bit hint missing: ${ex.getMessage}")
+    assert(ex.getMessage.contains("38"), s"precision limit hint missing: ${ex.getMessage}")
+  }
+
   test("timestamp") {
 
     def roundtripWithTz(timeZoneId: String): Unit = {


### PR DESCRIPTION
## Problem
When a Lance dataset contains a DECIMAL256 column (256-bit decimal, precision > 38), reading it through the Spark connector previously fell through to Spark's upstream `ArrowUtils.fromArrowField`, which would throw a cryptic, non-actionable `UnsupportedOperationException` deep inside the data-reading path. 

## Approach
This PR intercepts that case at schema resolution time in `LanceArrowUtils.fromArrowField` and raises a clear `SparkUnsupportedOperationException` with the column name, bit-width, and a concrete remediation hint.

## Test Coverage
- DECIMAL256 field (precision=38, scale=5, bitWidth=256) passed to `fromArrowField` throws `SparkUnsupportedOperationException`.
- Exception message contains the column name (`amount`), the unsupported bit-width (`256`), the supported bit-width hint (`128`), and the precision limit (`38`).