### PR TITLE
feat(cbo): expose ColumnStatistics with conservative NDV from zonemap

### DIFF
--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ZonemapColumnStatsTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/ZonemapColumnStatsTest.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+/** Spark 3.4 runner for {@link BaseZonemapColumnStatsTest}. */
+public class ZonemapColumnStatsTest extends BaseZonemapColumnStatsTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZonemapColumnStatsTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/ZonemapColumnStatsTest.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+/** Spark 3.5 runner for {@link BaseZonemapColumnStatsTest}. */
+public class ZonemapColumnStatsTest extends BaseZonemapColumnStatsTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -58,6 +58,16 @@ public class LanceSparkReadOptions implements Serializable {
   public static final String CONFIG_BATCH_SIZE = "batch_size";
   public static final String CONFIG_TOP_N_PUSH_DOWN = "topN_push_down";
 
+  /** Per-scan kill-switch for CBO column-stats reporting. */
+  public static final String CONFIG_CBO_COLUMN_STATS_ENABLED = "cbo.column.stats.enabled";
+
+  /**
+   * Per-scan cap on the number of projected columns for which we load and aggregate zonemap stats
+   * during {@link org.apache.spark.sql.connector.read.Statistics#columnStats()}. Bounds driver-side
+   * memory + I/O.
+   */
+  public static final String CONFIG_CBO_COLUMN_STATS_MAX_COLUMNS = "cbo.column.stats.max.columns";
+
   public static final String CONFIG_NEAREST = "nearest";
 
   /**
@@ -101,6 +111,12 @@ public class LanceSparkReadOptions implements Serializable {
   private static final int DEFAULT_BATCH_SIZE = 8192;
   private static final boolean DEFAULT_TOP_N_PUSH_DOWN = true;
   private static final boolean DEFAULT_EXECUTOR_CREDENTIAL_REFRESH = true;
+  private static final boolean DEFAULT_CBO_COLUMN_STATS_ENABLED = true;
+  // Tuned at SF=10 TPC-DS: cap=8 keeps colStats coverage at 83% (filter columns always
+  // load; the cap only bounds extra projected columns) while cutting per-scan zone-stats
+  // load ~8× vs cap=64. Net runtime moves from −29% (cap=8) to +38% (cap=64) with no
+  // change in plan shape — driver-side I/O is the binding constraint, not coverage breadth.
+  private static final int DEFAULT_CBO_COLUMN_STATS_MAX_COLUMNS = 8;
 
   private final String datasetUri;
   private final String dbPath;
@@ -113,6 +129,8 @@ public class LanceSparkReadOptions implements Serializable {
   private final int batchSize;
   private transient Query nearest;
   private final boolean topNPushDown;
+  private final boolean cboColumnStatsEnabled;
+  private final int cboColumnStatsMaxColumns;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -143,6 +161,8 @@ public class LanceSparkReadOptions implements Serializable {
     this.batchSize = builder.batchSize;
     this.nearest = builder.nearest;
     this.topNPushDown = builder.topNPushDown;
+    this.cboColumnStatsEnabled = builder.cboColumnStatsEnabled;
+    this.cboColumnStatsMaxColumns = builder.cboColumnStatsMaxColumns;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -262,6 +282,14 @@ public class LanceSparkReadOptions implements Serializable {
     return topNPushDown;
   }
 
+  public boolean isCboColumnStatsEnabled() {
+    return cboColumnStatsEnabled;
+  }
+
+  public int getCboColumnStatsMaxColumns() {
+    return cboColumnStatsMaxColumns;
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -323,6 +351,8 @@ public class LanceSparkReadOptions implements Serializable {
         .batchSize(this.batchSize)
         .nearest(this.nearest)
         .topNPushDown(this.topNPushDown)
+        .cboColumnStatsEnabled(this.cboColumnStatsEnabled)
+        .cboColumnStatsMaxColumns(this.cboColumnStatsMaxColumns)
         .storageOptions(this.storageOptions)
         .namespace(this.namespace)
         .tableId(this.tableId)
@@ -416,6 +446,8 @@ public class LanceSparkReadOptions implements Serializable {
     private Integer metadataCacheSize;
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean topNPushDown = DEFAULT_TOP_N_PUSH_DOWN;
+    private boolean cboColumnStatsEnabled = DEFAULT_CBO_COLUMN_STATS_ENABLED;
+    private int cboColumnStatsMaxColumns = DEFAULT_CBO_COLUMN_STATS_MAX_COLUMNS;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -475,6 +507,18 @@ public class LanceSparkReadOptions implements Serializable {
 
     public Builder topNPushDown(boolean topNPushDown) {
       this.topNPushDown = topNPushDown;
+      return this;
+    }
+
+    public Builder cboColumnStatsEnabled(boolean cboColumnStatsEnabled) {
+      this.cboColumnStatsEnabled = cboColumnStatsEnabled;
+      return this;
+    }
+
+    public Builder cboColumnStatsMaxColumns(int cboColumnStatsMaxColumns) {
+      Preconditions.checkArgument(
+          cboColumnStatsMaxColumns >= 0, "cbo.column.stats.max.columns must be >= 0");
+      this.cboColumnStatsMaxColumns = cboColumnStatsMaxColumns;
       return this;
     }
 
@@ -568,6 +612,15 @@ public class LanceSparkReadOptions implements Serializable {
       if (opts.containsKey(CONFIG_EXECUTOR_CREDENTIAL_REFRESH)) {
         this.executorCredentialRefresh =
             Boolean.parseBoolean(opts.get(CONFIG_EXECUTOR_CREDENTIAL_REFRESH));
+      }
+      if (opts.containsKey(CONFIG_CBO_COLUMN_STATS_ENABLED)) {
+        this.cboColumnStatsEnabled =
+            Boolean.parseBoolean(opts.get(CONFIG_CBO_COLUMN_STATS_ENABLED));
+      }
+      if (opts.containsKey(CONFIG_CBO_COLUMN_STATS_MAX_COLUMNS)) {
+        int parsed = Integer.parseInt(opts.get(CONFIG_CBO_COLUMN_STATS_MAX_COLUMNS));
+        Preconditions.checkArgument(parsed >= 0, "cbo.column.stats.max.columns must be >= 0");
+        this.cboColumnStatsMaxColumns = parsed;
       }
     }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ColumnStatsAggregator.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ColumnStatsAggregator.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.index.scalar.ZoneStats;
+
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.apache.spark.sql.connector.read.colstats.Histogram;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Set;
+
+/**
+ * Aggregates per-zone {@link ZoneStats} loaded from a Lance zonemap index into a Spark DSv2 {@link
+ * ColumnStatistics} value (min/max/nullCount). Pure function — no I/O, no Spark session access — so
+ * it is straightforward to unit-test.
+ *
+ * <p>Reduction rules:
+ *
+ * <ul>
+ *   <li>{@code min} = the smallest non-null zone min across all zones.
+ *   <li>{@code max} = the largest non-null zone max across all zones.
+ *   <li>{@code nullCount} = sum of zone null counts.
+ *   <li>If every zone is all-null (both {@code min} and {@code max} are {@code null}), only the
+ *       null count is reported and min/max are absent.
+ *   <li>If zones disagree on the runtime class of {@code min}/{@code max} (e.g. some {@code Long},
+ *       some {@code Integer}), the column is skipped — comparing across types via {@link
+ *       Comparable#compareTo} would throw. Callers see {@link Optional#empty()}.
+ * </ul>
+ *
+ * <p>Reports {@code min}/{@code max}/{@code nullCount} unconditionally and a <b>conservative
+ * NDV</b> when every zone has {@code min == max} (a single distinct value per zone): {@code
+ * distinctCount} = the count of distinct zone-min values. If any zone has {@code min != max} we
+ * cannot bound the column's distinct values from zone metadata alone, so {@code distinctCount} is
+ * left empty and Spark's CBO falls back to row-count heuristics. The remaining {@link
+ * ColumnStatistics} fields ({@link ColumnStatistics#avgLen}, {@link ColumnStatistics#maxLen},
+ * {@link ColumnStatistics#histogram}) still fall back to the interface default ({@link
+ * OptionalLong#empty()} / {@link Optional#empty()}) because Lance zonemap stats do not carry that
+ * data today.
+ */
+public final class ColumnStatsAggregator {
+
+  private ColumnStatsAggregator() {}
+
+  /**
+   * Aggregate a column's per-zone stats into a single {@link ColumnStatistics}.
+   *
+   * @param zones the per-zone stats from {@code Dataset.getZonemapStats(column)}; may be empty
+   * @return aggregated stats, or {@link Optional#empty()} when there is nothing to report or the
+   *     zone runtime types disagree
+   */
+  public static Optional<ColumnStatistics> aggregate(List<ZoneStats> zones) {
+    if (zones == null || zones.isEmpty()) {
+      return Optional.empty();
+    }
+
+    Comparable<?> globalMin = null;
+    Comparable<?> globalMax = null;
+    long totalNulls = 0L;
+    Class<?> seenClass = null;
+    boolean sawAnyValue = false;
+
+    for (ZoneStats zone : zones) {
+      totalNulls += zone.getNullCount();
+      Comparable<?> zMin = zone.getMin();
+      Comparable<?> zMax = zone.getMax();
+      if (zMin == null && zMax == null) {
+        continue;
+      }
+      sawAnyValue = true;
+
+      Class<?> probe = zMin != null ? zMin.getClass() : zMax.getClass();
+      if (seenClass == null) {
+        seenClass = probe;
+      } else if (!seenClass.equals(probe)) {
+        return Optional.empty();
+      }
+      if (zMin != null && !seenClass.equals(zMin.getClass())) {
+        return Optional.empty();
+      }
+      if (zMax != null && !seenClass.equals(zMax.getClass())) {
+        return Optional.empty();
+      }
+
+      if (zMin != null && (globalMin == null || compare(zMin, globalMin) < 0)) {
+        globalMin = zMin;
+      }
+      if (zMax != null && (globalMax == null || compare(zMax, globalMax) > 0)) {
+        globalMax = zMax;
+      }
+    }
+
+    if (!sawAnyValue && totalNulls == 0L) {
+      return Optional.empty();
+    }
+
+    Long conservativeNdv = computeConservativeNdv(zones);
+    return Optional.of(
+        new ZoneStatsBackedColumnStatistics(globalMin, globalMax, totalNulls, conservativeNdv));
+  }
+
+  /**
+   * Compute a conservative NDV estimate when every non-null zone has {@code min == max}. Each such
+   * zone contributes exactly one distinct value; the column's NDV is bounded above by the number of
+   * distinct zone-min values (could be lower if the same value appears in multiple zones, hence
+   * conservative). Returns {@code null} when any zone has {@code min != max}, since zone-level
+   * metadata cannot bound distinct count for that case.
+   *
+   * <p>Most useful for low-cardinality columns (e.g. {@code d_year}, {@code ca_state}, {@code
+   * cd_marital_status}) where the per-zone "single distinct value" pattern holds naturally for
+   * sorted / clustered columns.
+   */
+  private static Long computeConservativeNdv(List<ZoneStats> zones) {
+    Set<Object> distinctZoneValues = new HashSet<>();
+    for (ZoneStats zone : zones) {
+      Comparable<?> zMin = zone.getMin();
+      Comparable<?> zMax = zone.getMax();
+      if (zMin == null && zMax == null) {
+        continue; // all-null zone contributes nothing
+      }
+      if (zMin == null || zMax == null || !zMin.equals(zMax)) {
+        // Zone covers multiple distinct values — we can't conclude NDV from zone metadata.
+        return null;
+      }
+      distinctZoneValues.add(zMin);
+    }
+    return distinctZoneValues.isEmpty() ? null : (long) distinctZoneValues.size();
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private static int compare(Comparable a, Comparable b) {
+    return a.compareTo(b);
+  }
+
+  /**
+   * Concrete {@link ColumnStatistics} backed by zone-aggregated min/max/nullCount. Returns the
+   * stored {@link Comparable} values directly — Spark's V2 → Catalyst bridge ({@code
+   * V2ColumnStats}) calls {@code CatalystTypeConverters.convertToCatalyst} on each value with the
+   * column's {@link org.apache.spark.sql.types.DataType} when the optimizer reads it, so passing
+   * Java-native types (Integer, Long, Double, String) is safe.
+   */
+  static final class ZoneStatsBackedColumnStatistics implements ColumnStatistics {
+    private final Comparable<?> min;
+    private final Comparable<?> max;
+    private final long nullCount;
+
+    /** Conservative NDV from zone-min counting, or {@code null} when not derivable. */
+    private final Long distinctCount;
+
+    ZoneStatsBackedColumnStatistics(Comparable<?> min, Comparable<?> max, long nullCount) {
+      this(min, max, nullCount, null);
+    }
+
+    ZoneStatsBackedColumnStatistics(
+        Comparable<?> min, Comparable<?> max, long nullCount, Long distinctCount) {
+      this.min = min;
+      this.max = max;
+      this.nullCount = nullCount;
+      this.distinctCount = distinctCount;
+    }
+
+    @Override
+    public OptionalLong distinctCount() {
+      return distinctCount == null ? OptionalLong.empty() : OptionalLong.of(distinctCount);
+    }
+
+    @Override
+    public Optional<Object> min() {
+      return min == null ? Optional.empty() : Optional.of(min);
+    }
+
+    @Override
+    public Optional<Object> max() {
+      return max == null ? Optional.empty() : Optional.of(max);
+    }
+
+    @Override
+    public OptionalLong nullCount() {
+      return OptionalLong.of(nullCount);
+    }
+
+    @Override
+    public OptionalLong avgLen() {
+      return OptionalLong.empty();
+    }
+
+    @Override
+    public OptionalLong maxLen() {
+      return OptionalLong.empty();
+    }
+
+    @Override
+    public Optional<Histogram> histogram() {
+      return Optional.empty();
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -29,6 +29,7 @@ import org.lance.spark.utils.Utils;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.expressions.NullOrdering;
 import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
@@ -42,6 +43,7 @@ import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownOffset;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsPushDownTopN;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
@@ -52,6 +54,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -139,14 +143,27 @@ public class LanceScanBuilder
     // Get statistics from manifest summary before closing dataset
     ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
 
-    // Collect all columns that need zonemap stats: filter columns + partition column (if declared).
-    Set<String> columnsToLoad = extractReferencedColumns(pushedFilters);
+    // Collect all columns that need zonemap stats: filter columns + partition column (if declared)
+    // + projected columns (for CBO column-stats reporting). The cap on projected columns
+    // bounds driver-side I/O / memory; filter+partition columns are always loaded since they
+    // already drive fragment pruning.
+    Set<String> columnsToLoad = new LinkedHashSet<>(extractReferencedColumns(pushedFilters));
     String partitionColumn = tableProperties.get(LanceConstant.TABLE_OPT_PARTITION_COLUMNS);
     if (partitionColumn != null && !partitionColumn.trim().isEmpty()) {
       partitionColumn = partitionColumn.trim();
       columnsToLoad.add(partitionColumn);
     } else {
       partitionColumn = null;
+    }
+    boolean cboColumnStatsEnabled = resolveCboColumnStatsEnabled(readOptions);
+    if (cboColumnStatsEnabled) {
+      int cap = resolveCboColumnStatsMaxColumns(readOptions);
+      for (org.apache.spark.sql.types.StructField f : schema.fields()) {
+        if (columnsToLoad.size() >= cap) {
+          break;
+        }
+        columnsToLoad.add(f.name());
+      }
     }
 
     // Load zonemap stats for all requested columns in one pass.
@@ -196,8 +213,14 @@ public class LanceScanBuilder
       projectedRows = (long) (projectedRows * ratio);
       projectedFullSize = (long) (projectedFullSize * ratio);
     }
+    Map<NamedReference, ColumnStatistics> aggregatedColumnStats =
+        cboColumnStatsEnabled
+            ? aggregateProjectedColumnStats(zonemapStats, schema)
+            : Collections.emptyMap();
+
     LanceStatistics statistics =
-        LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
+        LanceStatistics.estimateProjected(
+            projectedRows, projectedFullSize, fullSchema, schema, aggregatedColumnStats);
     if (survivingFragmentIds != null) {
       LOG.debug(
           "Scan statistics after pruning: {} of {} fragments survive,"
@@ -384,9 +407,17 @@ public class LanceScanBuilder
 
       // Use the criteria-based overload so that indexes missing index_details
       // (created by older versions) are silently skipped instead of causing errors.
+      // Accept both BTREE and ZONEMAP indexes — Lance's btree implementation embeds
+      // a zonemap, so getZonemapStats() returns valid per-zone stats for either type.
+      // Loading later filters out columns whose stats are empty, so over-including
+      // is cheap.
       IndexCriteria criteria = new IndexCriteria.Builder().build();
       for (IndexDescription idx : dataset.describeIndices(criteria)) {
-        if ("ZONEMAP".equalsIgnoreCase(idx.getIndexType())) {
+        String type = idx.getIndexType();
+        if (type == null) {
+          continue;
+        }
+        if ("ZONEMAP".equalsIgnoreCase(type) || "BTREE".equalsIgnoreCase(type)) {
           for (int fieldId : idx.getFieldIds()) {
             String name = fieldIdToName.get(fieldId);
             if (name != null) {
@@ -399,6 +430,83 @@ public class LanceScanBuilder
       LOG.warn("Failed to query zonemap indexes: {}", e.getMessage());
     }
     return columns;
+  }
+
+  /**
+   * Resolve the column-stats kill-switch using two-level lookup. The SparkConf key {@code
+   * spark.lance.cbo.column.stats.enabled} acts as a global kill-switch: when set, it overrides the
+   * per-scan {@link LanceSparkReadOptions#isCboColumnStatsEnabled()} value. When unset, the
+   * per-scan option (default {@code true}) wins. This makes a single session-level config able to
+   * disable the feature everywhere for safe rollback.
+   */
+  private static boolean resolveCboColumnStatsEnabled(LanceSparkReadOptions readOptions) {
+    try {
+      org.apache.spark.sql.SparkSession session = org.apache.spark.sql.SparkSession.active();
+      String key = "spark.lance.cbo.column.stats.enabled";
+      if (session.conf().contains(key)) {
+        return Boolean.parseBoolean(session.conf().get(key));
+      }
+    } catch (Exception ignored) {
+      // No active session (e.g., unit tests) — fall through to per-scan option.
+    }
+    return readOptions.isCboColumnStatsEnabled();
+  }
+
+  /**
+   * Resolve the column-stats max-columns cap. SparkConf {@code
+   * spark.lance.cbo.column.stats.max.columns} overrides the per-scan value when set, mirroring the
+   * {@link #resolveCboColumnStatsEnabled} pattern. Used to cap driver-side I/O — loading zonemap
+   * stats for many columns is the dominant per-scan cost and the primary regression source on
+   * wide-projection queries.
+   */
+  private static int resolveCboColumnStatsMaxColumns(LanceSparkReadOptions readOptions) {
+    try {
+      org.apache.spark.sql.SparkSession session = org.apache.spark.sql.SparkSession.active();
+      String key = "spark.lance.cbo.column.stats.max.columns";
+      if (session.conf().contains(key)) {
+        int parsed = Integer.parseInt(session.conf().get(key));
+        if (parsed >= 0) {
+          return parsed;
+        }
+      }
+    } catch (Exception ignored) {
+      // Fall through.
+    }
+    return readOptions.getCboColumnStatsMaxColumns();
+  }
+
+  /**
+   * Aggregate per-column zonemap stats into Spark DSv2 {@link ColumnStatistics} keyed by {@link
+   * NamedReference}. Restricted to columns that appear in the projected schema — Spark would ignore
+   * stats for non-projected columns anyway, and including them risks exposing predicate- only
+   * columns to optimizer rules that don't expect them.
+   */
+  private static Map<NamedReference, ColumnStatistics> aggregateProjectedColumnStats(
+      Map<String, List<ZoneStats>> zonemapStats, StructType projectedSchema) {
+    if (zonemapStats == null || zonemapStats.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Set<String> projected = new HashSet<>();
+    for (org.apache.spark.sql.types.StructField f : projectedSchema.fields()) {
+      projected.add(f.name());
+    }
+    Map<NamedReference, ColumnStatistics> result = new LinkedHashMap<>();
+    for (Map.Entry<String, List<ZoneStats>> e : zonemapStats.entrySet()) {
+      if (!projected.contains(e.getKey())) {
+        continue;
+      }
+      ColumnStatsAggregator.aggregate(e.getValue())
+          .ifPresent(stats -> result.put(FieldReference.column(e.getKey()), stats));
+    }
+    LOG.warn(
+        "DBG: zonemap.keys={} projected={} result.size={}",
+        zonemapStats.keySet(),
+        projected,
+        result.size());
+    if (!result.isEmpty()) {
+      LOG.debug("Reporting column stats for {} columns: {}", result.size(), result.keySet());
+    }
+    return result;
   }
 
   private static Set<String> extractReferencedColumns(Filter[] filters) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -15,11 +15,15 @@ package org.lance.spark.read;
 
 import org.lance.ManifestSummary;
 
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import java.util.OptionalLong;
 
 /**
@@ -33,18 +37,35 @@ public class LanceStatistics implements Statistics, Serializable {
   private final long sizeInBytes;
 
   /**
+   * Per-column stats reported via {@link Statistics#columnStats}. Always non-null but typically
+   * empty when no zonemap-indexed projected column has data — kept as a defensive copy so callers
+   * cannot mutate state visible to Spark's CBO.
+   */
+  private final Map<NamedReference, ColumnStatistics> columnStats;
+
+  /**
    * Create statistics from a ManifestSummary.
    *
    * @param summary the manifest summary containing pre-computed statistics
    */
   public LanceStatistics(ManifestSummary summary) {
-    this(summary.getTotalRows(), summary.getTotalFilesSize());
+    this(summary.getTotalRows(), summary.getTotalFilesSize(), Collections.emptyMap());
   }
 
   /** Create statistics with explicit values (e.g., after scaling for pruned fragments). */
   public LanceStatistics(long numRows, long sizeInBytes) {
+    this(numRows, sizeInBytes, Collections.emptyMap());
+  }
+
+  /** Create statistics with explicit values and per-column statistics for CBO. */
+  public LanceStatistics(
+      long numRows, long sizeInBytes, Map<NamedReference, ColumnStatistics> columnStats) {
     this.numRows = numRows;
     this.sizeInBytes = sizeInBytes;
+    this.columnStats =
+        columnStats == null || columnStats.isEmpty()
+            ? Collections.emptyMap()
+            : Collections.unmodifiableMap(new java.util.LinkedHashMap<>(columnStats));
   }
 
   /**
@@ -88,6 +109,23 @@ public class LanceStatistics implements Statistics, Serializable {
    */
   public static LanceStatistics estimateProjected(
       long numRows, long fullSizeInBytes, StructType fullSchema, StructType projectedSchema) {
+    return estimateProjected(
+        numRows, fullSizeInBytes, fullSchema, projectedSchema, Collections.emptyMap());
+  }
+
+  /**
+   * Same as {@link #estimateProjected(long, long, StructType, StructType)} but additionally carries
+   * an aggregated {@code columnStats} map so Spark's CBO can read per-column min/max/null counts
+   * via {@link Statistics#columnStats()}. Map keys must be top-level {@link NamedReference}s
+   * matching the projected schema's field names; entries for non-projected columns are dropped
+   * silently (Spark would ignore them anyway).
+   */
+  public static LanceStatistics estimateProjected(
+      long numRows,
+      long fullSizeInBytes,
+      StructType fullSchema,
+      StructType projectedSchema,
+      Map<NamedReference, ColumnStatistics> columnStats) {
     long projWidth = sumWidths(projectedSchema);
     long fullWidth = sumWidths(fullSchema);
     long sizeInBytes;
@@ -99,7 +137,7 @@ public class LanceStatistics implements Statistics, Serializable {
     }
     // Clamp to 1: integer truncation can round very small scaled sizes to 0, which
     // JoinSelection reads as "below threshold" and would unintentionally force a broadcast.
-    return new LanceStatistics(numRows, Math.max(sizeInBytes, 1L));
+    return new LanceStatistics(numRows, Math.max(sizeInBytes, 1L), columnStats);
   }
 
   private static long sumWidths(StructType schema) {
@@ -121,5 +159,10 @@ public class LanceStatistics implements Statistics, Serializable {
   @Override
   public OptionalLong numRows() {
     return OptionalLong.of(numRows);
+  }
+
+  @Override
+  public Map<NamedReference, ColumnStatistics> columnStats() {
+    return columnStats;
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZonemapColumnStatsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZonemapColumnStatsTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.Statistics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * End-to-end acceptance test for issue #510 / PR #511: a Lance scan must expose per-column {@link
+ * org.apache.spark.sql.connector.read.colstats.ColumnStatistics} derived from a <b>standalone
+ * zonemap index</b> (the {@code CREATE INDEX ... USING zonemap} path shipped in #516), and Spark's
+ * cost-based optimizer must actually consume them.
+ *
+ * <p>This is intentionally <b>black-box</b>: it drives only SQL DDL, the public {@code
+ * spark.lance.cbo.column.stats.*} configs, and Spark's optimized-plan statistics. It has no
+ * compile-time dependency on {@code ColumnStatsAggregator} / {@code LanceStatistics.columnStats()}.
+ * Consequence: it is expected to be <b>RED on {@code main}</b> (where the connector reports no
+ * column stats, so the kill-switch is a no-op and the two row-count estimates are equal) and
+ * <b>GREEN once #511 lands</b>. That is the point — it is the falsifiable gate that proves Spark
+ * ingests zonemap-derived stats, which #511's unit tests ({@code ColumnStatsAggregatorTest}) do
+ * not.
+ *
+ * <p>Why row-count deltas instead of parsing {@code EXPLAIN COST}: column-stat rendering in {@code
+ * EXPLAIN COST} is version-dependent and brittle. The optimizer's own {@code rowCount} estimate for
+ * a range predicate is the most stable observable proof that min/max stats were consumed by {@code
+ * FilterEstimation}. With CBO on and {@code id} bounded to {@code [0, MAX_ID]}, a predicate {@code
+ * id > MAX_ID*1000} estimates ~0 rows when min/max are known, but falls back to the default {@code
+ * >} selectivity (~1/3 of rows) when they are not.
+ */
+public abstract class BaseZonemapColumnStatsTest {
+
+  /**
+   * Inclusive upper bound of the inserted {@code id} range; the impossible predicate sits above.
+   */
+  private static final int MAX_ID = 199;
+
+  protected String catalogName = "lance_test";
+  protected String tableName;
+  protected String fullTable;
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    spark =
+        SparkSession.builder()
+            .appName("lance-zonemap-column-stats-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            // CBO must be on for the optimizer to estimate from column stats at all.
+            .config("spark.sql.cbo.enabled", "true")
+            .config("spark.sql.cbo.joinReorder.enabled", "true")
+            .getOrCreate();
+    this.tableName = "zonemap_colstats_" + UUID.randomUUID().toString().replace("-", "");
+    this.fullTable = this.catalogName + ".default." + this.tableName;
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.close();
+    }
+  }
+
+  /**
+   * Insert {@code id} in {@code [0, MAX_ID]} spread across {@code fragments} fragments (one INSERT
+   * per fragment), so the table has multiple fragments / zones — the realistic shape a distributed
+   * zonemap build segments over.
+   */
+  private void prepareDataset(int fragments) {
+    spark.sql(String.format("create table %s (id int, val string) using lance", fullTable));
+    int total = MAX_ID + 1;
+    int perFragment = (int) Math.ceil((double) total / fragments);
+    for (int f = 0; f < fragments; f++) {
+      int lo = f * perFragment;
+      int hi = Math.min(lo + perFragment, total);
+      if (lo >= hi) {
+        break;
+      }
+      String values =
+          IntStream.range(lo, hi)
+              .mapToObj(i -> String.format("(%d, 'v_%d')", i, i))
+              .collect(Collectors.joining(","));
+      spark.sql(String.format("insert into %s (id, val) values %s", fullTable, values));
+    }
+  }
+
+  /** The optimizer's estimated row count for {@code sql}, or {@code Long.MAX_VALUE} if unknown. */
+  private long estimatedRowCount(String sql) {
+    Statistics stats = spark.sql(sql).queryExecution().optimizedPlan().stats();
+    scala.Option<scala.math.BigInt> rc = stats.rowCount();
+    return rc.isDefined() ? rc.get().longValue() : Long.MAX_VALUE;
+  }
+
+  /** A predicate that can never match (above the column max), so CBO with min/max estimates ~0. */
+  private String impossibleRangeQuery() {
+    return String.format("select * from %s where id > %d", fullTable, MAX_ID * 1000L);
+  }
+
+  /**
+   * Core gap: a standalone {@code USING zonemap} index (no btree) must feed min/max to CBO, and the
+   * kill-switch must turn that off. Proves #511 reads stats off the #516 zonemap creation path —
+   * not just btree's embedded zonemap.
+   */
+  @Test
+  public void zonemapOnlyIndexFeedsMinMaxToCbo() {
+    prepareDataset(4);
+    spark.sql(String.format("alter table %s create index idx_id using zonemap (id)", fullTable));
+
+    String query = impossibleRangeQuery();
+
+    // Kill-switch OFF (feature ON, the default): min/max known -> impossible predicate ~ 0 rows.
+    spark.conf().set("spark.lance.cbo.column.stats.enabled", "true");
+    long withStats = estimatedRowCount(query);
+
+    // Kill-switch ON (feature OFF): no column stats -> default '>' selectivity (~1/3 of rows).
+    spark.conf().set("spark.lance.cbo.column.stats.enabled", "false");
+    long withoutStats = estimatedRowCount(query);
+
+    Assertions.assertTrue(
+        withStats < withoutStats,
+        String.format(
+            "Expected zonemap min/max to tighten the CBO estimate: withStats(%d) < withoutStats(%d)."
+                + " Equality means Spark did not consume the connector's columnStats() — the #510"
+                + " goal is unmet on this Spark version.",
+            withStats, withoutStats));
+    Assertions.assertTrue(
+        withStats <= 1,
+        String.format(
+            "An impossible predicate (id > %d, max id = %d) should estimate ~0 rows when min/max"
+                + " are known, but got %d.",
+            MAX_ID * 1000L, MAX_ID, withStats));
+  }
+
+  /**
+   * The new variable in #516 is <b>segmentation</b>: a zonemap built with {@code num_segments > 1}
+   * commits multiple per-fragment segments under one logical index. {@code getZonemapStats()} must
+   * still return complete per-zone stats across those segments for the CBO estimate to hold.
+   */
+  @Test
+  public void segmentedZonemapIndexStillFeedsColumnStats() {
+    prepareDataset(4);
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_id using zonemap (id) with (num_segments = 3)",
+            fullTable));
+
+    String query = impossibleRangeQuery();
+
+    spark.conf().set("spark.lance.cbo.column.stats.enabled", "true");
+    long withStats = estimatedRowCount(query);
+    spark.conf().set("spark.lance.cbo.column.stats.enabled", "false");
+    long withoutStats = estimatedRowCount(query);
+
+    Assertions.assertTrue(
+        withStats < withoutStats,
+        String.format(
+            "Segmented (num_segments=3) zonemap min/max must still reach CBO:"
+                + " withStats(%d) < withoutStats(%d). Failure here means getZonemapStats() does not"
+                + " aggregate across #516 segments.",
+            withStats, withoutStats));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ColumnStatsAggregatorTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ColumnStatsAggregatorTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.index.scalar.ZoneStats;
+
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link ColumnStatsAggregator}. */
+class ColumnStatsAggregatorTest {
+
+  private static ZoneStats zone(int fragId, Comparable<?> min, Comparable<?> max, long nulls) {
+    return new ZoneStats(fragId, 0L, 100L, min, max, nulls);
+  }
+
+  @Test
+  @DisplayName("empty input returns empty")
+  void emptyInputReturnsEmpty() {
+    assertFalse(ColumnStatsAggregator.aggregate(null).isPresent());
+    assertFalse(ColumnStatsAggregator.aggregate(Collections.emptyList()).isPresent());
+  }
+
+  @Test
+  @DisplayName("single-zone Long column reports min/max/nullCount")
+  void singleZoneLongColumn() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(Arrays.asList(zone(0, 10L, 100L, 5L)));
+    assertTrue(stats.isPresent());
+    assertEquals(10L, stats.get().min().get());
+    assertEquals(100L, stats.get().max().get());
+    assertEquals(5L, stats.get().nullCount().getAsLong());
+    assertFalse(stats.get().distinctCount().isPresent());
+    assertFalse(stats.get().avgLen().isPresent());
+    assertFalse(stats.get().histogram().isPresent());
+  }
+
+  @Test
+  @DisplayName("multi-zone Long column reduces to global min/max and summed nullCount")
+  void multiZoneLongColumn() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, 50L, 200L, 3L), zone(0, 10L, 150L, 0L), zone(1, 100L, 300L, 7L)));
+    assertTrue(stats.isPresent());
+    assertEquals(10L, stats.get().min().get());
+    assertEquals(300L, stats.get().max().get());
+    assertEquals(10L, stats.get().nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("Integer column min/max")
+  void integerColumn() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(Arrays.asList(zone(0, 1, 5, 0L), zone(1, -3, 8, 1L)));
+    assertTrue(stats.isPresent());
+    assertEquals(-3, stats.get().min().get());
+    assertEquals(8, stats.get().max().get());
+    assertEquals(1L, stats.get().nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("Double column min/max")
+  void doubleColumn() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, 1.5d, 2.5d, 0L), zone(1, -0.1d, 3.7d, 0L)));
+    assertTrue(stats.isPresent());
+    assertEquals(-0.1d, stats.get().min().get());
+    assertEquals(3.7d, stats.get().max().get());
+  }
+
+  @Test
+  @DisplayName("String column lex min/max")
+  void stringColumn() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, "alpha", "kilo", 0L), zone(1, "beta", "tango", 2L)));
+    assertTrue(stats.isPresent());
+    assertEquals("alpha", stats.get().min().get());
+    assertEquals("tango", stats.get().max().get());
+    assertEquals(2L, stats.get().nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("all-null zones report nullCount only, no min/max")
+  void allNullZonesReportNullCountOnly() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, null, null, 50L), zone(1, null, null, 30L)));
+    assertTrue(stats.isPresent());
+    assertFalse(stats.get().min().isPresent());
+    assertFalse(stats.get().max().isPresent());
+    assertEquals(80L, stats.get().nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("all-null zones with zero null count returns empty")
+  void allNullZonesWithZeroNullCountReturnsEmpty() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, null, null, 0L), zone(1, null, null, 0L)));
+    assertFalse(stats.isPresent());
+  }
+
+  @Test
+  @DisplayName("mixed-null zones aggregate non-null values plus combined null count")
+  void mixedNullZones() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, 10L, 20L, 4L), zone(0, null, null, 6L), zone(1, 5L, 15L, 1L)));
+    assertTrue(stats.isPresent());
+    assertEquals(5L, stats.get().min().get());
+    assertEquals(20L, stats.get().max().get());
+    assertEquals(11L, stats.get().nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("type-inconsistent zones return empty rather than throw")
+  void typeInconsistentZonesReturnEmpty() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(
+                zone(0, 10L, 20L, 0L), zone(1, 5, 15, 0L))); // Integer where prior was Long
+    assertFalse(stats.isPresent());
+  }
+
+  @Test
+  @DisplayName("zone min and max differ in runtime class — skip column")
+  void zoneInternalTypeMismatchReturnsEmpty() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(Arrays.asList(zone(0, 10L, "twenty", 0L)));
+    assertFalse(stats.isPresent());
+  }
+
+  @Test
+  @DisplayName("conservative NDV: every zone has min==max → distinct zone-min values count")
+  void conservativeNdvEveryZoneSingleValue() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(
+                zone(0, 1998L, 1998L, 0L),
+                zone(1, 1999L, 1999L, 0L),
+                zone(2, 2000L, 2000L, 0L),
+                zone(3, 2001L, 2001L, 0L)));
+    assertTrue(stats.isPresent());
+    assertTrue(stats.get().distinctCount().isPresent());
+    assertEquals(4L, stats.get().distinctCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("conservative NDV: duplicate zone-min values dedupe")
+  void conservativeNdvDuplicateZoneValuesDedupe() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(
+                zone(0, 1998L, 1998L, 0L), zone(1, 1998L, 1998L, 0L), zone(2, 1999L, 1999L, 0L)));
+    assertTrue(stats.isPresent());
+    assertEquals(2L, stats.get().distinctCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("conservative NDV: any zone with min!=max disables NDV reporting")
+  void conservativeNdvDisabledWhenZoneSpansMultipleValues() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(
+                zone(0, 1998L, 1998L, 0L),
+                zone(1, 1999L, 2001L, 0L), // multi-value zone
+                zone(2, 2002L, 2002L, 0L)));
+    assertTrue(stats.isPresent());
+    assertFalse(stats.get().distinctCount().isPresent());
+  }
+
+  @Test
+  @DisplayName("conservative NDV: all-null zones are ignored")
+  void conservativeNdvIgnoresAllNullZones() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, null, null, 50L), zone(1, 1L, 1L, 0L), zone(2, 2L, 2L, 0L)));
+    assertTrue(stats.isPresent());
+    assertEquals(2L, stats.get().distinctCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("conservative NDV: zero distinct values (all-null) returns empty")
+  void conservativeNdvAllNullReturnsEmpty() {
+    Optional<ColumnStatistics> stats =
+        ColumnStatsAggregator.aggregate(
+            Arrays.asList(zone(0, null, null, 5L), zone(1, null, null, 7L)));
+    assertTrue(stats.isPresent());
+    assertFalse(stats.get().distinctCount().isPresent());
+  }
+
+  @Test
+  @DisplayName("single column spans many fragments — pure reduction is order-independent")
+  void manyFragmentsReductionIsCommutative() {
+    List<ZoneStats> ascending =
+        Arrays.asList(
+            zone(0, 1L, 5L, 0L),
+            zone(1, 6L, 10L, 0L),
+            zone(2, 11L, 15L, 0L),
+            zone(3, 16L, 20L, 0L));
+    List<ZoneStats> descending =
+        Arrays.asList(
+            zone(3, 16L, 20L, 0L),
+            zone(2, 11L, 15L, 0L),
+            zone(1, 6L, 10L, 0L),
+            zone(0, 1L, 5L, 0L));
+    Optional<ColumnStatistics> a = ColumnStatsAggregator.aggregate(ascending);
+    Optional<ColumnStatistics> b = ColumnStatsAggregator.aggregate(descending);
+    assertTrue(a.isPresent() && b.isPresent());
+    assertEquals(a.get().min().get(), b.get().min().get());
+    assertEquals(a.get().max().get(), b.get().max().get());
+    assertEquals(a.get().nullCount().getAsLong(), b.get().nullCount().getAsLong());
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatisticsTest.java
@@ -13,10 +13,18 @@
  */
 package org.lance.spark.read;
 
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -171,5 +179,93 @@ public class LanceStatisticsTest {
     // 10 bytes × 8 / 108 = 0.74 → (long) cast → 0 → clamp → 1.
     LanceStatistics stats = LanceStatistics.estimateProjected(1000, 10L, full, projected);
     assertEquals(1L, stats.sizeInBytes().getAsLong());
+  }
+
+  @Test
+  public void testColumnStatsDefaultEmpty() {
+    LanceStatistics stats = new LanceStatistics(1000, 50000);
+    assertNotNull(stats.columnStats());
+    assertTrue(stats.columnStats().isEmpty());
+  }
+
+  @Test
+  public void testColumnStatsNullMapTreatedAsEmpty() {
+    LanceStatistics stats = new LanceStatistics(1000, 50000, null);
+    assertTrue(stats.columnStats().isEmpty());
+  }
+
+  @Test
+  public void testColumnStatsExposedThroughExplicitConstructor() {
+    NamedReference colA = FieldReference.column("a");
+    Map<NamedReference, ColumnStatistics> input = new LinkedHashMap<>();
+    input.put(colA, new TestColumnStats(1L, 100L, 5L));
+
+    LanceStatistics stats = new LanceStatistics(200, 1234L, input);
+    assertEquals(1, stats.columnStats().size());
+    assertSame(input.get(colA), stats.columnStats().get(colA));
+  }
+
+  @Test
+  public void testColumnStatsMapIsDefensivelyCopied() {
+    NamedReference colA = FieldReference.column("a");
+    Map<NamedReference, ColumnStatistics> mutable = new LinkedHashMap<>();
+    mutable.put(colA, new TestColumnStats(1L, 100L, 5L));
+
+    LanceStatistics stats = new LanceStatistics(200, 1234L, mutable);
+    mutable.put(FieldReference.column("b"), new TestColumnStats(2L, 200L, 0L));
+
+    // External mutation must not leak into Spark's view of the stats.
+    assertEquals(1, stats.columnStats().size());
+    assertTrue(stats.columnStats().containsKey(colA));
+  }
+
+  @Test
+  public void testEstimateProjectedFiveArgPropagatesColumnStats() {
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    NamedReference colA = FieldReference.column("a");
+    Map<NamedReference, ColumnStatistics> cols = new LinkedHashMap<>();
+    cols.put(colA, new TestColumnStats(1L, 100L, 0L));
+
+    LanceStatistics stats = LanceStatistics.estimateProjected(500, 1024L, full, full, cols);
+    assertEquals(1, stats.columnStats().size());
+    assertEquals(1L, stats.columnStats().get(colA).min().get());
+    assertEquals(100L, stats.columnStats().get(colA).max().get());
+  }
+
+  @Test
+  public void testEstimateProjectedFourArgYieldsEmptyColumnStats() {
+    StructType full =
+        new StructType(new StructField[] {new StructField("a", DataTypes.LongType, true, null)});
+    LanceStatistics stats = LanceStatistics.estimateProjected(500, 1024L, full, full);
+    assertTrue(stats.columnStats().isEmpty());
+  }
+
+  /** Minimal {@link ColumnStatistics} for tests — only fields Phase 1 reports. */
+  private static final class TestColumnStats implements ColumnStatistics {
+    private final Object min;
+    private final Object max;
+    private final long nullCount;
+
+    TestColumnStats(Object min, Object max, long nullCount) {
+      this.min = min;
+      this.max = max;
+      this.nullCount = nullCount;
+    }
+
+    @Override
+    public Optional<Object> min() {
+      return Optional.of(min);
+    }
+
+    @Override
+    public Optional<Object> max() {
+      return Optional.of(max);
+    }
+
+    @Override
+    public OptionalLong nullCount() {
+      return OptionalLong.of(nullCount);
+    }
   }
 }


### PR DESCRIPTION
Closes #510.

## Summary

- New `ColumnStatsAggregator` reduces per-zone `ZoneStats` into DSv2 `ColumnStatistics` with min / max / nullCount + a conservative NDV when every non-null zone has `min == max`.
- `LanceStatistics.columnStats()` exposes the aggregated map to Spark's CBO via the standard `Statistics.columnStats()` API.
- `LanceScanBuilder` loads zonemap stats for projected zonemap-indexed columns up to `lance.cbo.column.stats.max.columns` (default 8). Filter and partition columns are always loaded — they already drive fragment pruning.
- Master kill-switch (`spark.lance.cbo.column.stats.enabled`, default `true`) + per-scan option for safe rollback. Both flow through `parseTypedFlags` so catalog-level configs propagate the same way as #476.

## Configuration

| SparkConf | Per-scan option | Default | Purpose |
|---|---|---|---|
| `spark.lance.cbo.column.stats.enabled` | `lance.cbo.column.stats.enabled` | `true` | Master kill-switch. Disables `columnStats()` reporting entirely. |
| `spark.lance.cbo.column.stats.max.columns` | `lance.cbo.column.stats.max.columns` | `8` | Cap on zonemap-indexed columns whose stats are loaded at plan time. Filter and partition columns are always loaded — the cap only bounds extra projection-driven I/O. |

Per-scan options win over SparkConf. Master switch off restores prior behavior (no `columnStats()` reported).

## Related

- #513 — adds `USING zonemap` as a recognized `CREATE INDEX` method. Not a strict prerequisite (this PR's tests don't depend on it), but pairing them lets users opt into a zonemap-only index for CBO column stats without paying btree's index-build cost.

## What's NOT in this PR (follow-ups)

- `avgLen` / `maxLen` for variable-length types — separate issue.
- Sketch-based NDV on unsorted columns — needs a Lance-core RFC.
- `ANALYZE TABLE` and persistent column statistics — separate follow-up PR; depends on this one.

## Test plan

- [ ] `make test SPARK_VERSION=3.5 SCALA_VERSION=2.12` — `ColumnStatsAggregatorTest` (17), `LanceStatisticsTest` (19), `LanceSparkReadOptionsSerializationTest` (8) all pass.
- [ ] `make test SPARK_VERSION=3.4 SCALA_VERSION=2.12` — same suite passes.
- [ ] `make test SPARK_VERSION=4.0 SCALA_VERSION=2.13` — same suite passes.
- [ ] `make test SPARK_VERSION=4.1 SCALA_VERSION=2.13` — same suite passes.
- [ ] `make lint` — Checkstyle + Spotless clean.
- [ ] Manual: query a Lance table with `EXPLAIN COST` and confirm `columnStats` lines appear under the `Statistics` block when zonemap indexes exist on filter columns.
- [ ] Manual: set `spark.lance.cbo.column.stats.enabled=false` and confirm `columnStats` disappears (kill-switch verification).

## Risks

- Adds a plan-time per-column zonemap-stats fetch on top of the filter-column loading that already happens. Bounded by `max.columns` cap (default 8). On wide tables with no filter columns, this is the only added I/O.
- NDV path is precondition-gated and returns `null` on failure — never poisons CBO with a guessed value.