### PR TITLE
feat(sql): support USING zonemap with distributed and consolidated build paths

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -22,10 +22,11 @@ The command uses the `ALTER TABLE` syntax to add an index.
 
 The following index methods are supported:
 
-| Method  | Description                                                                 |
-|---------|-----------------------------------------------------------------------------|
-| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
-| `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| Method    | Description                                                                 |
+|-----------|-----------------------------------------------------------------------------|
+| `btree`   | B-tree index for efficient range queries and point lookups on scalar columns. |
+| `fts`     | Full-text search (inverted) index for text search on string columns.        |
+| `zonemap` | Lightweight min/max statistics per zone for fragment pruning on a scalar column. |
 
 ## Options
 
@@ -41,6 +42,16 @@ For the `btree` method, the following options are supported:
 | `build_mode`     | String | Index building mode: 'fragment' builds indexes in parallel by fragment; 'range' sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is 'fragment'. |
 | `rows_per_range` | Long   | The number of rows per range when built using range mode. Default is 1000000.                                                                                                                            |
 
+
+### ZoneMap Options
+
+For the `zonemap` method, the following option is supported:
+
+| Option          | Type | Description                                       |
+|-----------------|------|---------------------------------------------------|
+| `rows_per_zone` | Long | Approximate number of rows per zone. Default 8192. |
+
+ZoneMap is single-column only — passing more than one column raises an `IllegalArgumentException` at plan time.
 
 ### FTS Options
 
@@ -101,6 +112,30 @@ Create an index and specify the `zone_size` for the B-tree:
     ALTER TABLE lance.db.users CREATE INDEX idx_id_zoned USING btree (id) WITH (zone_size = 2048);
     ```
 
+### ZoneMap Index
+
+Create a zonemap index for lightweight fragment pruning on a scalar column:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.events CREATE INDEX idx_ts_zm USING zonemap (event_ts);
+    ```
+
+With a custom zone size:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.events CREATE INDEX idx_ts_zm USING zonemap (event_ts) WITH (rows_per_zone = 2048);
+    ```
+
+The build path is configurable via SparkConf:
+
+| SparkConf key                              | Default | Effect                                                                                                                                                       |
+|--------------------------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `spark.lance.zonemap.consolidate.enabled`  | `false` | When `false`, each fragment is indexed by its own Spark task and committed as a separate IndexMetadata segment under a shared name. When `true`, workers compute per-fragment zone batches in memory and the driver merges them into one consolidated segment covering every fragment. |
+
+The default produces a manifest entry per fragment (one IndexMetadata per `<uuid>/zonemap.lance`). The opt-in consolidated mode produces a single entry covering every fragment — fewer manifest entries and lower Lance file-header overhead at the cost of routing per-fragment batches through the driver.
+
 ### Full-Text Search Index
 
 Create an FTS index on a text column:
@@ -139,11 +174,12 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Distributed Index Building**: For each fragment in the Lance dataset, a separate task is launched to build an index on the specified column(s).
-2.  **Metadata Merging**: Once all per-fragment indexes are built, their metadata is collected and merged.
-3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
+1.  **Distributed Index Building**: For each fragment in the Lance dataset, a separate task is launched to build an index on the specified column(s). For `zonemap` with `spark.lance.zonemap.consolidate.enabled=true`, the per-task work returns an Arrow batch to the driver instead of writing a file.
+2.  **Metadata Merging / Commit**: For `btree` and `fts`, per-fragment indexes are collected and merged before commit. For `zonemap` default, each fragment's segment is committed as its own IndexMetadata entry under the shared name. For `zonemap` consolidated, the driver writes one merged segment and commits a single IndexMetadata entry.
+3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures concurrent reads are not affected.
 
 ## Notes and Limitations
 
-- **Index Methods**: The `btree` and `fts` methods are supported for scalar index creation.
-- **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one. This is because the underlying implementation uses `replace(true)`.
+- **Index Methods**: `btree`, `fts`, and `zonemap` are supported.
+- **ZoneMap is single-column**: Passing more than one column raises `IllegalArgumentException`.
+- **Index Replacement**: If you create an index with the same name as an existing one, the old index is replaced by the new one. For `zonemap` default, the replacement removes every previous segment under that name in the same transaction.

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -778,6 +778,76 @@ class TestDDLIndex:
         assert len(query_result) == 3
         _assert_lance_index_metadata(spark, "default.employees", "idx_dept", "BTREE")
 
+    def test_create_zonemap_index(self, spark):
+        """Test CREATE INDEX with zonemap on a scalar column."""
+        spark.sql(
+            """
+            CREATE TABLE default.events (
+                id INT,
+                event_ts INT,
+                payload STRING
+            )
+            """
+        )
+
+        data = [(i, i * 100, f"p{i}") for i in range(100)]
+        df = spark.createDataFrame(data, ["id", "event_ts", "payload"])
+        df.writeTo("default.events").append()
+
+        result = spark.sql(
+            """
+            ALTER TABLE default.events
+            CREATE INDEX idx_ts_zm USING zonemap (event_ts) WITH (rows_per_zone = 16)
+            """
+        ).collect()
+        assert len(result) == 1
+        assert result[0][1] == "idx_ts_zm"
+
+        # SHOW INDEXES surfaces the zonemap-typed segment(s).
+        indexes = spark.sql("SHOW INDEXES IN default.events").collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_ts_zm"]
+        assert len(zonemap_rows) >= 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
+        # Indexed query still returns the correct row.
+        query_result = spark.sql(
+            "SELECT * FROM default.events WHERE event_ts = 5000"
+        ).collect()
+        assert len(query_result) == 1
+        assert query_result[0].id == 50
+
+    def test_create_zonemap_index_consolidated(self, spark):
+        """ZoneMap with spark.lance.zonemap.consolidate.enabled=true commits one segment."""
+        spark.sql(
+            """
+            CREATE TABLE default.metrics (
+                id INT,
+                bucket INT
+            )
+            """
+        )
+
+        data = [(i, i % 10) for i in range(80)]
+        df = spark.createDataFrame(data, ["id", "bucket"])
+        df.writeTo("default.metrics").append()
+
+        spark.conf.set("spark.lance.zonemap.consolidate.enabled", "true")
+        try:
+            spark.sql(
+                """
+                ALTER TABLE default.metrics
+                CREATE INDEX idx_bucket_zm USING zonemap (bucket)
+                """
+            ).collect()
+        finally:
+            spark.conf.unset("spark.lance.zonemap.consolidate.enabled")
+
+        indexes = spark.sql("SHOW INDEXES IN default.metrics").collect()
+        zonemap_rows = [row for row in indexes if row["name"] == "idx_bucket_zm"]
+        # Consolidated path commits exactly one IndexMetadata segment.
+        assert len(zonemap_rows) == 1
+        assert zonemap_rows[0]["index_type"] == "zonemap"
+
     def test_create_fts_index(self, spark):
         """Test CREATE INDEX with full-text search (FTS)."""
         spark.sql("""

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -16,8 +16,9 @@ package org.apache.spark.sql.execution.datasources.v2
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.arrow.c.{ArrowArrayStream, Data}
+import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.VectorSchemaRoot
-import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.arrow.vector.ipc.{ArrowReader, ArrowStreamReader, ArrowStreamWriter}
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
 import org.apache.spark.sql.catalyst.plans.logical.{AddIndexOutputType, LanceNamedArgument}
@@ -35,6 +36,8 @@ import org.lance.spark.arrow.LanceArrowWriter
 import org.lance.spark.utils.{CloseableUtil, Utils}
 import org.lance.spark.write.SingleBatchArrowReader
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.channels.Channels
 import java.time.Instant
 import java.util.{Collections, Optional, UUID}
 
@@ -83,9 +86,28 @@ case class AddIndexExec(
     }
 
     val indexType = IndexUtils.buildIndexType(method)
+    // Parse the consolidate flag BEFORE opening the dataset handle. If the parse threw
+    // (currently can't, but defense-in-depth against future evolution of getOption/trim
+    // behaviour), opening the dataset first would leak the JNI handle past the unwind.
+    // SparkConf-only flag for now. Default false preserves the multi-segment distributed
+    // shape that has been the only path for the entire history of this code path; flipping
+    // the default would silently change the commit footprint of every existing pipeline.
+    // Lenient parse: `_.toBoolean` rejects "yes"/"on"/"1" with IllegalArgumentException —
+    // surfacing a plan-time crash for a config typo is worse than degrading to the safe
+    // default, since the failure mode obscures the only corrective action (fix the value).
+    // Accept the JVM's canonical "true" (case-insensitive); everything else routes to the
+    // distributed path.
+    val consolidateZonemap =
+      indexType == IndexType.ZONEMAP &&
+        session.conf.getOption("spark.lance.zonemap.consolidate.enabled")
+          .exists(v => v != null && "true".equalsIgnoreCase(v.trim))
+
     val dataset = Utils.openDatasetBuilder(readOptions).build()
 
     if (indexType == IndexType.ZONEMAP) {
+      if (consolidateZonemap) {
+        return runZonemapConsolidated(dataset, lanceDataset, readOptions, fragmentIds)
+      }
       return runZonemapDistributed(dataset, lanceDataset, readOptions, fragmentIds)
     }
 
@@ -275,6 +297,263 @@ case class AddIndexExec(
         newDataset.close()
       } finally {
         txn.close()
+      }
+    } finally {
+      dataset.close()
+    }
+    Seq(new GenericInternalRow(Array[Any](
+      fragmentIds.size.toLong,
+      UTF8String.fromString(indexName))))
+  }
+
+  /**
+   * Consolidated ZONEMAP build. Each executor task calls `computeZonemapBatch` on its assigned
+   * fragment and returns an Arrow-IPC-encoded byte payload; the driver decodes all payloads and
+   * calls `writeZonemapIndexFromBatches` once, producing a single `&lt;uuid&gt;/zonemap.lance`
+   * segment covering the union of fragments. One IndexMetadata entry is committed under the
+   * index name.
+   *
+   * <p>Trade-off vs. {@link runZonemapDistributed}: write I/O is centralized on the driver
+   * (one consolidated file) instead of N parallel per-fragment files. Compute (the per-zone
+   * min/max scan) stays distributed. Net effect: fewer manifest entries + lower segment-merge
+   * cost at read time, at three costs the distributed path does not pay:
+   * <ul>
+   *   <li>Per-fragment Arrow IPC payloads traverse Spark's task-result/network path back to
+   *       the driver via `.collect()`. The distributed path writes in-place on executors —
+   *       consolidated adds serialization + transfer bandwidth proportional to N × per-zone
+   *       payload size.
+   *   <li>Driver heap and allocator pressure: every per-fragment {@code VectorSchemaRoot}
+   *       coexists in the driver's {@code RootAllocator} from decode time until
+   *       {@code writeZonemapIndexFromBatches} consumes them — footprint scales linearly with
+   *       fragment count.
+   *   <li>Driver-side write I/O for the single consolidated file.
+   * </ul>
+   * The kill-switch defaults consolidated to OFF precisely because the per-fragment cost
+   * scales linearly with N; very-high-fragment datasets (sf=10000+) may regress wall-clock
+   * even though manifest entry count + on-disk size both improve dramatically.
+   *
+   * @param dataset      open Lance dataset; this method closes it
+   * @param lanceDataset V2 catalog view, for namespace credentials
+   * @param readOptions  read config forwarded to executor tasks
+   * @param fragmentIds  fragments to index, one task each
+   */
+  private def runZonemapConsolidated(
+      dataset: Dataset,
+      lanceDataset: LanceDataset,
+      readOptions: LanceSparkReadOptions,
+      fragmentIds: List[Integer]): Seq[InternalRow] = {
+    // Operator-facing INFO line mirrors the pattern LanceScanBuilder uses when its CBO
+    // fast-path engages. Lets operators confirm from the driver log which build path ran
+    // (consolidated vs distributed) — without this, the only post-hoc signal is the manifest
+    // entry count, which requires re-opening the dataset.
+    logInfo(
+      s"Using consolidated ZONEMAP build path for index '$indexName' on column " +
+        s"'${columns.head}' over ${fragmentIds.size} fragments")
+    try {
+      val fieldIds = resolveFieldIdsOrThrow(dataset, columns)
+      // ZONEMAP indexes exactly one column. The grammar enforces single-column at parse time;
+      // assert here to make the invariant explicit at the consumer-side boundary.
+      if (columns.size != 1) {
+        throw new IllegalArgumentException(
+          s"ZONEMAP index requires exactly one column; got ${columns.size}: $columns")
+      }
+      val columnName = columns.head
+
+      val (nsImpl, nsProps, tableId, initialStorageOpts) =
+        extractNamespaceInfo(lanceDataset, readOptions)
+      val encodedReadOptions = encode(readOptions)
+      val argsJson = IndexUtils.toJson(args)
+      val datasetVersion = dataset.version()
+
+      val tasks = fragmentIds.map { fid =>
+        ZonemapConsolidatedFragmentTask(
+          encodedReadOptions,
+          columnName,
+          argsJson,
+          fid,
+          nsImpl,
+          nsProps,
+          tableId,
+          initialStorageOpts)
+      }
+
+      if (tasks.isEmpty) {
+        throw new IllegalStateException(
+          "runZonemapConsolidated called with empty fragmentIds — upstream empty-check should " +
+            "have short-circuited")
+      }
+
+      val perFragmentBytes: Array[Array[Byte]] = session.sparkContext
+        .parallelize(tasks, tasks.size)
+        .map(_.execute())
+        .collect()
+
+      // Driver-side: decode Arrow IPC bytes back to VectorSchemaRoots, then write one
+      // consolidated zonemap.lance. Each reader owns the VSR it produces, so closing the
+      // reader (in finally) closes the VSR — we must not double-close.
+      val driverAllocator = new RootAllocator()
+      val readers = scala.collection.mutable.ListBuffer.empty[ArrowStreamReader]
+      try {
+        val decodedBatches = perFragmentBytes.zipWithIndex.map { case (bytes, idx) =>
+          // Defensive: ArrowStreamReader.loadNextBatch() throws EOFException/IOException on
+          // a zero-byte payload, which would surface as a stack trace without fragment-id
+          // context. Pre-check produces the same diagnostic shape as the "no batch" path
+          // below, keeping operator log analysis uniform.
+          if (bytes.length == 0) {
+            val fragId = tasks(idx).fragmentId
+            throw new IllegalStateException(
+              s"Empty Arrow IPC payload for fragment $fragId — executor returned a " +
+                "zero-byte stream")
+          }
+          // The ArrowStreamReader constructor with a byte-array-backed channel does no I/O
+          // and cannot throw on these inputs in Arrow Java 14–18 (the range covered by this
+          // project's build matrix as of 2026). If a future Arrow upgrade changes that, the
+          // constructor must be wrapped in try-catch and the partially-constructed reader
+          // tracked, or a leak escapes between construction and the `readers += reader`
+          // line below. Revisit this invariant on every Arrow major version bump.
+          val reader = new ArrowStreamReader(
+            new ByteArrayInputStream(bytes),
+            driverAllocator)
+          // Ordering invariant: tracking the reader in `readers` MUST precede `loadNextBatch()`.
+          // A throw or false return from loadNextBatch leaves the reader's VSR in a partially-
+          // loaded state that still owns allocator buffers; tracking the reader before the load
+          // ensures the outer finally closes it and reclaims those buffers. A future refactor
+          // that moves this insertion below the load check would leak on every failed batch.
+          readers += reader
+          val fragId = tasks(idx).fragmentId
+          val hasBatch =
+            try {
+              reader.loadNextBatch()
+            } catch {
+              // Truncated / corrupted IPC streams surface as EOFException / IOException /
+              // IllegalArgumentException from Arrow Java. Without this wrapper the stack trace
+              // would carry no fragment-id context, making operator log analysis depend on
+              // mapping the array index back to the task list. Mirror the diagnostic shape used
+              // by the distributed path's per-fragment decode wrapper.
+              case scala.util.control.NonFatal(e) =>
+                throw new IllegalStateException(
+                  s"Failed to decode Arrow IPC payload for fragment $fragId " +
+                    s"(${e.getClass.getSimpleName}): ${e.getMessage}",
+                  e)
+            }
+          if (!hasBatch) {
+            throw new IllegalStateException(
+              s"ArrowStreamReader returned no batch for fragment $fragId — executor produced " +
+                "an empty zone-record stream")
+          }
+          reader.getVectorSchemaRoot
+        }.toList
+
+        val writtenIndex = dataset.writeZonemapIndexFromBatches(
+          indexName,
+          columnName,
+          decodedBatches.asJava,
+          argsJson,
+          driverAllocator)
+
+        // writeZonemapIndexFromBatches returns an uncommitted Index with uuid + indexType +
+        // indexVersion + indexDetails populated from the file write. We rebuild on top with
+        // name/fields/datasetVersion/fragments so the manifest entry carries the catalog-level
+        // metadata the read path expects, mirroring runZonemapDistributed's Index.builder
+        // pattern. The full fragment list is what the driver commissioned (not what the
+        // returned Index's fragment_bitmap might compute from the batches) — a single source
+        // of truth keeps the manifest consistent with the dispatcher's view.
+        //
+        // Pre-commit validation: lance-core computes the file's internal fragment_bitmap from
+        // the actual batches it received. If `writeZonemapIndexFromBatches` silently elided a
+        // batch (empty/all-null skip path, future evolution), the manifest entry built below
+        // would CLAIM coverage the on-disk file does not have. Catch the divergence here and
+        // fail the build BEFORE commit — converting a silent manifest lie into a fail-fast
+        // error. We only validate when the returned Index actually has a fragment list (some
+        // lance-core versions may leave it absent for uncommitted writes); absence is treated
+        // as "no claim to check against" rather than a hard error.
+        if (writtenIndex.fragments().isPresent) {
+          val writtenFragments = writtenIndex.fragments().get().asScala.toSet
+          val commissionedFragments = fragmentIds.toSet
+          if (writtenFragments != commissionedFragments) {
+            // Split the diff so operators reading a 5000-fragment build log can see at a
+            // glance which direction the divergence went, instead of mentally diffing two
+            // large sets in the message body.
+            val missingInFile = commissionedFragments -- writtenFragments
+            val extraInFile = writtenFragments -- commissionedFragments
+            throw new IllegalStateException(
+              s"Consolidated zonemap.lance file's fragment_bitmap diverges from the " +
+                s"dispatched fragment set for $indexName. " +
+                s"missing_in_file=$missingInFile, extra_in_file=$extraInFile " +
+                s"(dispatched=$commissionedFragments, file=$writtenFragments) — committing " +
+                "would record a manifest claim the file cannot back up. Failing the build " +
+                "to keep the manifest honest.")
+          }
+        }
+        val details = writtenIndex.indexDetails()
+        if (!details.isPresent || details.get().length == 0) {
+          throw new IllegalStateException(
+            s"Consolidated zonemap write returned an Index without indexDetails for $indexName")
+        }
+        val builder = Index.builder()
+          .uuid(writtenIndex.uuid())
+          .name(indexName)
+          .indexType(IndexType.ZONEMAP)
+          .indexVersion(writtenIndex.indexVersion())
+          .indexDetails(details.get())
+          .fields(fieldIds.map(java.lang.Integer.valueOf).asJava)
+          .fragments(fragmentIds.asJava)
+          .datasetVersion(datasetVersion)
+        if (writtenIndex.createdAt().isPresent) {
+          builder.createdAt(writtenIndex.createdAt().get())
+        }
+        val finalIndex = builder.build()
+
+        val removedIndices = dataset.getIndexes.asScala
+          .filter(_.name() == indexName)
+          .toList.asJava
+
+        val op = AddIndexOperation.builder()
+          .withNewIndices(Collections.singletonList(finalIndex))
+          .withRemovedIndices(removedIndices)
+          .build()
+        val txn = new Transaction.Builder()
+          .readVersion(datasetVersion)
+          .operation(op)
+          .build()
+        try {
+          val newDataset = new CommitBuilder(dataset)
+            .writeParams(readOptions.getStorageOptions)
+            .execute(txn)
+          newDataset.close()
+        } finally {
+          txn.close()
+        }
+      } finally {
+        // Closing each reader closes its owned VectorSchemaRoot; allocator close validates
+        // there are no live buffers.
+        //
+        // A silently-swallowed reader-close failure (e.g. an Arrow internal release error)
+        // would surface only later as `driverAllocator.close()` throwing "Memory was leaked",
+        // with no hint that a reader-close was the actual root cause. Log every close
+        // exception with index context so operators can correlate. We do NOT rethrow — the
+        // cleanup must run to completion across all readers regardless of individual
+        // failures, and the allocator-close at the end will still surface the first
+        // observable leak as its own exception.
+        readers.zipWithIndex.foreach { case (r, idx) =>
+          try r.close()
+          catch {
+            case scala.util.control.NonFatal(e) =>
+              // Include fragment id to match the diagnostic shape of the decode-error path
+              // above. `readers.length <= tasks.length` always — readers is populated only
+              // after the bytes pre-check passes, and tracking precedes the load — so
+              // `tasks(idx)` is always a valid lookup. If decode threw mid-loop, the
+              // operator's log timeline already has the decode error tagged with the same
+              // fragment id, making cross-correlation immediate.
+              val fragId = tasks(idx).fragmentId
+              logWarning(
+                s"ArrowStreamReader close failed for consolidated zonemap fragment " +
+                  s"$fragId (batch index $idx, ${e.getClass.getSimpleName}): " +
+                  s"${e.getMessage}",
+                e)
+          }
+        }
+        driverAllocator.close()
       }
     } finally {
       dataset.close()
@@ -626,6 +905,97 @@ case class ZonemapFragmentTask(
         createdAt = createdAt))
     } finally {
       dataset.close()
+    }
+  }
+}
+
+/**
+ * Per-fragment task for the consolidated ZONEMAP build. Computes one Arrow batch of per-zone
+ * stats via {@link Dataset#computeZonemapBatch} and returns it Arrow-IPC-encoded so it survives
+ * the Spark task-result serialization round-trip back to the driver. No file is written here;
+ * the driver merges every task's batch into one consolidated `zonemap.lance` file.
+ */
+case class ZonemapConsolidatedFragmentTask(
+    encodedReadOptions: String,
+    columnName: String,
+    argsJson: String,
+    fragmentId: Int,
+    namespaceImpl: Option[String],
+    namespaceProperties: Option[Map[String, String]],
+    tableId: Option[List[String]],
+    initialStorageOptions: Option[Map[String, String]])
+  extends Serializable {
+
+  def execute(): Array[Byte] = {
+    try {
+      computeAndEncode()
+    } catch {
+      // Mirror ZonemapFragmentTask.execute()'s catch ladder for diagnostic uniformity:
+      // IAE/ISE preserve their type with fragment-id context; everything else NonFatal lands
+      // as a RuntimeException carrying the original cause; VM-fatal and InterruptedException
+      // propagate untouched.
+      //
+      // Subclass-narrowing trade-off (mirroring the R13 note on the distributed task):
+      // a thrown NumberFormatException (extends IAE) is re-thrown as plain IAE with the
+      // NumberFormatException as wrapped cause. Callers matching on the LEAF subclass
+      // (case e: NumberFormatException) will no longer match, but the cause chain
+      // (getCause / instanceof) preserves the original type. Trade-off accepted: the
+      // fragment-id context is more valuable for log analysis than preserving the leaf
+      // subclass identity through the rethrow.
+      case e: IllegalArgumentException =>
+        throw new IllegalArgumentException(
+          s"ZONEMAP consolidated build failed for fragment $fragmentId: ${e.getMessage}",
+          e)
+      case e: IllegalStateException =>
+        throw new IllegalStateException(
+          s"ZONEMAP consolidated build failed for fragment $fragmentId: ${e.getMessage}",
+          e)
+      case scala.util.control.NonFatal(e) =>
+        throw new RuntimeException(
+          s"ZONEMAP consolidated build failed for fragment $fragmentId " +
+            s"(${e.getClass.getSimpleName}): ${e.getMessage}",
+          e)
+    }
+  }
+
+  private def computeAndEncode(): Array[Byte] = {
+    val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
+    val allocator = new RootAllocator()
+    try {
+      val dataset = Utils.openDatasetBuilder(readOptions)
+        .initialStorageOptions(initialStorageOptions.map(_.asJava).orNull)
+        .runtimeNamespace(
+          namespaceImpl.orNull,
+          namespaceProperties.map(_.asJava).orNull,
+          tableId.map(_.asJava).orNull)
+        .build()
+      try {
+        // computeZonemapBatch rejects an empty long[]; passing a one-element array is the
+        // explicit "this fragment only" signal in the API contract.
+        val vsr = dataset.computeZonemapBatch(
+          columnName,
+          Array(fragmentId.toLong),
+          argsJson,
+          allocator)
+        try {
+          val baos = new ByteArrayOutputStream()
+          val writer = new ArrowStreamWriter(vsr, null, Channels.newChannel(baos))
+          try {
+            writer.start()
+            writer.writeBatch()
+            writer.end()
+          } finally {
+            writer.close()
+          }
+          baos.toByteArray
+        } finally {
+          vsr.close()
+        }
+      } finally {
+        dataset.close()
+      }
+    } finally {
+      allocator.close()
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -82,26 +82,37 @@ case class AddIndexExec(
       return Seq(new GenericInternalRow(Array[Any](0L, UTF8String.fromString(indexName))))
     }
 
-    val uuid = UUID.randomUUID()
     val indexType = IndexUtils.buildIndexType(method)
-
     val dataset = Utils.openDatasetBuilder(readOptions).build()
 
+    if (indexType == IndexType.ZONEMAP) {
+      return runZonemapDistributed(dataset, lanceDataset, readOptions, fragmentIds)
+    }
+
+    val uuid = UUID.randomUUID()
+    // Wrap createIndexJob.run() in the same try-finally that closes `dataset`. Previously
+    // run() was called BEFORE the try block — a throw from the distributed build path would
+    // leak the dataset handle and its underlying JNI resources.
+    //
+    // Use NonFatal (not bare Throwable) so JVM-fatal errors (OOM, LinkageError),
+    // InterruptedException, and ControlThrowable propagate untouched. Closing JNI handles
+    // during a fatal error risks executor hang or masks the original cause. Symmetric with
+    // the catch ladder in `ZonemapFragmentTask.execute` below — both paths should treat
+    // fatal errors the same way.
     val indexBuildResult =
-      createIndexJob(dataset, lanceDataset, readOptions, uuid.toString, fragmentIds).run()
+      try {
+        createIndexJob(dataset, lanceDataset, readOptions, uuid.toString, fragmentIds).run()
+      } catch {
+        case scala.util.control.NonFatal(e) =>
+          dataset.close()
+          throw e
+      }
 
     try {
-      // Merge index metadata after all fragments are indexed
+      // Merge index metadata after all fragments are indexed.
       dataset.mergeIndexMetadata(uuid.toString, indexType, Optional.empty())
 
-      val fieldIdByName = dataset.getLanceSchema.fields().asScala
-        .map(f => f.getName -> f.getId)
-        .toMap
-      val fieldIds = columns.map { column =>
-        fieldIdByName.getOrElse(
-          column,
-          throw new IllegalArgumentException(s"Cannot find index column in Lance schema: $column"))
-      }.toList
+      val fieldIds = resolveFieldIdsOrThrow(dataset, columns)
 
       val datasetVersion = dataset.version()
 
@@ -148,6 +159,165 @@ case class AddIndexExec(
       UTF8String.fromString(indexName))))
   }
 
+  /**
+   * Distributed ZONEMAP build. Each task indexes one fragment with a fresh per-task UUID (no
+   * `withIndexUUID`), so each writes to its own `&lt;uuid&gt;/zonemap.lance` directory. The driver
+   * commits N IndexMetadata entries under a shared name in one transaction; lance-core's read
+   * path serves multi-segment indexes natively.
+   *
+   * <p>A shared UUID would race on the fixed `zonemap.lance` filename — ZoneMap, unlike BTree, has
+   * no per-task file-name namespacing or merge step.
+   *
+   * @param dataset      open Lance dataset; this method closes it
+   * @param lanceDataset V2 catalog view, for namespace credentials
+   * @param readOptions  read config forwarded to executor tasks
+   * @param fragmentIds  fragments to index, one task each
+   */
+  private def runZonemapDistributed(
+      dataset: Dataset,
+      lanceDataset: LanceDataset,
+      readOptions: LanceSparkReadOptions,
+      fragmentIds: List[Integer]): Seq[InternalRow] = {
+    try {
+      // Validate columns up-front (fail-fast before parallelize) and reuse at commit time —
+      // schema cannot drift within one dataset handle.
+      val fieldIds = resolveFieldIdsOrThrow(dataset, columns)
+
+      val (nsImpl, nsProps, tableId, initialStorageOpts) =
+        extractNamespaceInfo(lanceDataset, readOptions)
+      val encodedReadOptions = encode(readOptions)
+      val argsJson = IndexUtils.toJson(args)
+
+      // Capture the read-version up front. `dataset.version()` returns the manifest version
+      // bound at handle-open time and is constant for the lifetime of this Dataset object —
+      // so this call is semantically the same whether we make it before or after parallelize.
+      // Capturing here is a readability improvement (commits the version to a local before
+      // the long-running task phase) rather than a fix for any real race. Conflict detection
+      // for concurrent writers happens at commit time via Transaction.readVersion() against
+      // the manifest, which Lance handles independently of when this method reads version().
+      val datasetVersion = dataset.version()
+
+      val tasks = fragmentIds.map { fid =>
+        ZonemapFragmentTask(
+          encodedReadOptions,
+          columns.toList,
+          method,
+          argsJson,
+          indexName,
+          fid,
+          nsImpl,
+          nsProps,
+          tableId,
+          initialStorageOpts)
+      }
+
+      // Defensive: Spark rejects parallelize(_, numSlices=0). Upstream `fragmentIds.isEmpty`
+      // already short-circuits before reaching here, but pin the invariant locally so a future
+      // refactor that moves the empty check won't silently break with a cryptic Spark error.
+      if (tasks.isEmpty) {
+        throw new IllegalStateException(
+          "runZonemapDistributed called with empty fragmentIds — upstream empty-check should " +
+            "have short-circuited")
+      }
+
+      val encodedResults: Array[String] = session.sparkContext
+        .parallelize(tasks, tasks.size)
+        .map(_.execute())
+        .collect()
+      val perFragment: Array[ZonemapFragmentResult] = encodedResults.zipWithIndex.map {
+        case (encoded, idx) =>
+          try {
+            decode[ZonemapFragmentResult](encoded)
+          } catch {
+            case e: Exception =>
+              // Use the actual fragment id, not just the array index, so an operator reading
+              // the log can trace the failure to the specific input fragment without first
+              // mapping idx → tasks(idx).fragmentId.
+              val fragId = tasks(idx).fragmentId
+              throw new IllegalStateException(
+                s"Failed to decode ZONEMAP build result for fragment $fragId " +
+                  s"(task index $idx): ${e.getMessage}",
+                e)
+          }
+      }
+
+      // One Index entry per fragment, all sharing the index name; the read path groups by name.
+      val newIndexes = perFragment.toList.map { r =>
+        val builder = Index.builder()
+          .uuid(UUID.fromString(r.uuid))
+          .name(indexName)
+          .fields(fieldIds.map(java.lang.Integer.valueOf).asJava)
+          .datasetVersion(datasetVersion)
+          .indexDetails(r.indexDetails)
+          .indexVersion(r.indexVersion)
+          .indexType(IndexType.ZONEMAP)
+          .fragments(Collections.singletonList(java.lang.Integer.valueOf(r.fragmentId)))
+        r.createdAt.foreach(builder.createdAt)
+        builder.build()
+      }.asJava
+
+      val removedIndices = dataset.getIndexes.asScala
+        .filter(_.name() == indexName)
+        .toList.asJava
+
+      val op = AddIndexOperation.builder()
+        .withNewIndices(newIndexes)
+        .withRemovedIndices(removedIndices)
+        .build()
+      val txn = new Transaction.Builder()
+        .readVersion(datasetVersion)
+        .operation(op)
+        .build()
+      try {
+        val newDataset = new CommitBuilder(dataset)
+          .writeParams(readOptions.getStorageOptions)
+          .execute(txn)
+        newDataset.close()
+      } finally {
+        txn.close()
+      }
+    } finally {
+      dataset.close()
+    }
+    Seq(new GenericInternalRow(Array[Any](
+      fragmentIds.size.toLong,
+      UTF8String.fromString(indexName))))
+  }
+
+  /** Extract namespace credentials info from the catalog, mirroring `createIndexJob`. */
+  private def extractNamespaceInfo(
+      lanceDataset: LanceDataset,
+      readOptions: LanceSparkReadOptions): (
+      Option[String],
+      Option[Map[String, String]],
+      Option[List[String]],
+      Option[Map[String, String]]) = catalog match {
+    case nsCatalog: BaseLanceNamespaceSparkCatalog =>
+      (
+        Option(nsCatalog.getNamespaceImpl),
+        Option(nsCatalog.getNamespaceProperties).map(_.asScala.toMap),
+        Option(readOptions.getTableId).map(_.asScala.toList),
+        Option(lanceDataset.getInitialStorageOptions).map(_.asScala.toMap))
+    case _ => (None, None, None, None)
+  }
+
+  /**
+   * Resolve column names to Lance field IDs. Throws IllegalArgumentException if any column is
+   * absent; shared by both build paths so failure modes stay uniform.
+   */
+  private def resolveFieldIdsOrThrow(
+      dataset: Dataset,
+      columnsToResolve: Seq[String]): List[Int] = {
+    val fieldIdByName = dataset.getLanceSchema.fields().asScala
+      .map(f => f.getName -> f.getId)
+      .toMap
+    columnsToResolve.map { column =>
+      fieldIdByName.getOrElse(
+        column,
+        throw new IllegalArgumentException(s"Cannot find index column in Lance schema: $column"))
+    }.toList
+  }
+
   private def createIndexJob(
       dataset: Dataset,
       lanceDataset: LanceDataset,
@@ -155,19 +325,8 @@ case class AddIndexExec(
       uuid: String,
       fragmentIds: List[Integer]): IndexJob = {
     // Get namespace info from catalog if available (for credential vending on workers)
-    val (nsImpl, nsProps, tableId, initialStorageOpts): (
-        Option[String],
-        Option[Map[String, String]],
-        Option[List[String]],
-        Option[Map[String, String]]) = catalog match {
-      case nsCatalog: BaseLanceNamespaceSparkCatalog =>
-        (
-          Option(nsCatalog.getNamespaceImpl),
-          Option(nsCatalog.getNamespaceProperties).map(_.asScala.toMap),
-          Option(readOptions.getTableId).map(_.asScala.toList),
-          Option(lanceDataset.getInitialStorageOptions).map(_.asScala.toMap))
-      case _ => (None, None, None, None)
-    }
+    val (nsImpl, nsProps, tableId, initialStorageOpts) =
+      extractNamespaceInfo(lanceDataset, readOptions)
 
     IndexUtils.buildIndexType(method) match {
       case IndexType.BTREE =>
@@ -347,6 +506,124 @@ case class FragmentIndexTask(
       } else {
         encode(None: Option[IndexBuildResult])
       }
+    } finally {
+      dataset.close()
+    }
+  }
+}
+
+/** Per-fragment build metadata returned by {@link ZonemapFragmentTask}. */
+case class ZonemapFragmentResult(
+    uuid: String,
+    fragmentId: Int,
+    indexDetails: Array[Byte],
+    indexVersion: Int,
+    createdAt: Option[Instant])
+  extends Serializable
+
+/**
+ * Per-fragment ZONEMAP build task. Calls `dataset.createIndex` with `withFragmentIds=[id]` and no
+ * `withIndexUUID`, so lance-core takes the uncommitted path with a fresh per-task UUID. The
+ * returned metadata is collected by the driver into a multi-segment commit.
+ */
+case class ZonemapFragmentTask(
+    encodedReadOptions: String,
+    columns: List[String],
+    method: String,
+    argsJson: String,
+    indexName: String,
+    fragmentId: Int,
+    namespaceImpl: Option[String],
+    namespaceProperties: Option[Map[String, String]],
+    tableId: Option[List[String]],
+    initialStorageOptions: Option[Map[String, String]])
+  extends Serializable {
+
+  def execute(): String = {
+    try {
+      buildAndEncode()
+    } catch {
+      // Preserve the broad exception class (IAE vs ISE vs other) so callers matching on
+      // type still match — only the message gains fragment-id context. Use
+      // scala.util.control.NonFatal as the outer guard: it excludes VirtualMachineError
+      // (OOM), ThreadDeath, InterruptedException, LinkageError, and ControlThrowable.
+      // Letting those propagate untouched is the right policy:
+      //   - JVM-fatal errors must crash the executor immediately rather than being wrapped
+      //     into a recoverable-looking RuntimeException (the executor JVM is in undefined
+      //     state after such an error).
+      //   - InterruptedException is Spark's task-cancellation signal; wrapping it as
+      //     RuntimeException would swallow the interrupt status and break cancellation.
+      //   - LinkageError typically indicates an incompatible JNI/jar version; surfacing it
+      //     as itself preserves the diagnostic.
+      //
+      // Note on subclass narrowing: a thrown `NumberFormatException` (which extends
+      // IllegalArgumentException) is re-thrown as a plain IllegalArgumentException with the
+      // NumberFormatException as the wrapped cause. Callers matching on the LEAF subclass
+      // (`case e: NumberFormatException`) will no longer match, but the cause chain
+      // (getCause / instanceof) preserves the original type. Trade-off accepted: the
+      // fragment-id context is more valuable for log analysis than preserving the leaf
+      // subclass identity through the rethrow.
+      case e: IllegalArgumentException =>
+        throw new IllegalArgumentException(
+          s"ZONEMAP build failed for fragment $fragmentId: ${e.getMessage}",
+          e)
+      case e: IllegalStateException =>
+        throw new IllegalStateException(
+          s"ZONEMAP build failed for fragment $fragmentId: ${e.getMessage}",
+          e)
+      case scala.util.control.NonFatal(e) =>
+        // Catches any other non-fatal exception (lance-core errors, IOException, custom
+        // RuntimeException subclasses) and tags with fragment-id context. Re-thrown as
+        // RuntimeException so Spark's TaskFailedReason serialises it cleanly back to the
+        // driver, where the per-task index decoder will surface the wrapped cause.
+        throw new RuntimeException(
+          s"ZONEMAP build failed for fragment $fragmentId (${e.getClass.getSimpleName}): " +
+            s"${e.getMessage}",
+          e)
+    }
+  }
+
+  private def buildAndEncode(): String = {
+    val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
+    val params = IndexParams.builder()
+      .setScalarIndexParams(ScalarIndexParams.create(
+        IndexUtils.buildScalarIndexParamType(method),
+        argsJson))
+      .build()
+
+    val indexOptions = IndexOptions
+      .builder(java.util.Arrays.asList(columns: _*), IndexType.ZONEMAP, params)
+      .replace(true)
+      .withIndexName(indexName)
+      .withFragmentIds(Collections.singletonList(java.lang.Integer.valueOf(fragmentId)))
+      .build()
+
+    val dataset = Utils.openDatasetBuilder(readOptions)
+      .initialStorageOptions(initialStorageOptions.map(_.asJava).orNull)
+      .runtimeNamespace(
+        namespaceImpl.orNull,
+        namespaceProperties.map(_.asJava).orNull,
+        tableId.map(_.asJava).orNull)
+      .build()
+
+    try {
+      val createdIndex = dataset.createIndex(indexOptions)
+      val details = createdIndex.indexDetails()
+      if (!details.isPresent || details.get().length == 0) {
+        throw new IllegalStateException(
+          s"Index ${createdIndex.name()} was created without index details")
+      }
+      val createdAt = if (createdIndex.createdAt().isPresent) {
+        Some(createdIndex.createdAt().get())
+      } else {
+        None
+      }
+      encode(ZonemapFragmentResult(
+        uuid = createdIndex.uuid().toString,
+        fragmentId = fragmentId,
+        indexDetails = details.get(),
+        indexVersion = createdIndex.indexVersion(),
+        createdAt = createdAt))
     } finally {
       dataset.close()
     }
@@ -562,6 +839,7 @@ object IndexUtils {
     method.toLowerCase match {
       case "btree" => IndexType.BTREE
       case "fts" => IndexType.INVERTED
+      case "zonemap" => IndexType.ZONEMAP
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }
@@ -570,6 +848,7 @@ object IndexUtils {
     method.toLowerCase match {
       case "btree" => "btree"
       case "fts" => "inverted"
+      case "zonemap" => "zonemap"
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/index/IndexUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/index/IndexUtilsTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.index;
+
+import org.lance.index.IndexType;
+
+import org.apache.spark.sql.catalyst.plans.logical.LanceNamedArgument;
+import org.apache.spark.sql.execution.datasources.v2.IndexUtils;
+import org.junit.jupiter.api.Test;
+import scala.collection.JavaConverters;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IndexUtilsTest {
+
+  @Test
+  public void testBuildIndexTypeKnown() {
+    assertEquals(IndexType.BTREE, IndexUtils.buildIndexType("btree"));
+    assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("fts"));
+    assertEquals(IndexType.ZONEMAP, IndexUtils.buildIndexType("zonemap"));
+  }
+
+  @Test
+  public void testBuildIndexTypeCaseInsensitive() {
+    assertEquals(IndexType.ZONEMAP, IndexUtils.buildIndexType("ZoneMap"));
+    assertEquals(IndexType.BTREE, IndexUtils.buildIndexType("BTREE"));
+    assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("FTS"));
+  }
+
+  @Test
+  public void testBuildIndexTypeUnknown() {
+    UnsupportedOperationException ex =
+        assertThrows(UnsupportedOperationException.class, () -> IndexUtils.buildIndexType("hash"));
+    assertTrue(ex.getMessage().contains("Unsupported index method"));
+    assertTrue(ex.getMessage().contains("hash"));
+  }
+
+  @Test
+  public void testBuildScalarIndexParamTypeKnown() {
+    assertEquals("btree", IndexUtils.buildScalarIndexParamType("btree"));
+    assertEquals("inverted", IndexUtils.buildScalarIndexParamType("fts"));
+    assertEquals("zonemap", IndexUtils.buildScalarIndexParamType("zonemap"));
+  }
+
+  @Test
+  public void testBuildScalarIndexParamTypeCaseInsensitive() {
+    assertEquals("zonemap", IndexUtils.buildScalarIndexParamType("ZoneMap"));
+    assertEquals("btree", IndexUtils.buildScalarIndexParamType("BTREE"));
+    assertEquals("inverted", IndexUtils.buildScalarIndexParamType("FTS"));
+  }
+
+  @Test
+  public void testBuildScalarIndexParamTypeUnknown() {
+    UnsupportedOperationException ex =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> IndexUtils.buildScalarIndexParamType("hash"));
+    assertTrue(ex.getMessage().contains("Unsupported index method"));
+    assertTrue(ex.getMessage().contains("hash"));
+  }
+
+  @Test
+  public void testBuildIndexTypeNullRejected() {
+    // null method names must fail fast with a clear error rather than NPE inside
+    // `.toLowerCase()` — that path would leak an ambiguous null-pointer message to operators
+    // who passed `using <method>` with an unparseable token.
+    assertThrows(NullPointerException.class, () -> IndexUtils.buildIndexType(null));
+  }
+
+  @Test
+  public void testBuildScalarIndexParamTypeNullRejected() {
+    assertThrows(NullPointerException.class, () -> IndexUtils.buildScalarIndexParamType(null));
+  }
+
+  // ----- args → JSON serialization (IndexUtils.toJson) -------------------------------------
+  //
+  // These tests pin the with-clause-to-lance-core wire shape. A silent-param-drop regression
+  // (the failure mode that already cost us a real bug: `with (zone_size=N)` on a ZONEMAP
+  // index was forwarded as-is to lance-core but ignored by serde because the param name
+  // there is `rows_per_zone`) is verified at the IndexUtils boundary here — the test does
+  // NOT prevent lance-core from ignoring unknown keys, but it DOES guarantee the param name
+  // and value the user wrote actually reach lance-core verbatim.
+
+  @Test
+  public void testToJsonEmptyArgs() {
+    assertEquals("{}", IndexUtils.toJson(toScalaSeq(Collections.emptyList())));
+  }
+
+  @Test
+  public void testToJsonLongValuePreserved() {
+    // The most common path: `with (rows_per_zone=4096)` arrives as Long. Verify the name is
+    // preserved verbatim and the value is a JSON number, not a quoted string.
+    String json =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("rows_per_zone", 4096L))));
+    assertEquals("{\"rows_per_zone\":4096}", json);
+  }
+
+  @Test
+  public void testToJsonStringValueStripsQuotes() {
+    // NOTE: in the production SQL parser path, quote-stripping happens earlier at
+    // `LanceSqlExtensionsAstBuilder.visitStringLiteral` — by the time the value reaches
+    // IndexUtils.toJson, the outer quotes have already been removed. The strip logic in
+    // toJson itself is a defensive second layer for programmatic callers (e.g. a future
+    // code path that constructs LanceNamedArgument outside the SQL parser, or a test
+    // helper passing already-quoted strings).
+    //
+    // These tests pin the toJson defensive layer's behaviour in isolation. They do NOT
+    // reach via SQL parsing (which would already have stripped quotes).
+    //
+    // Cover the three observable styles separately rather than only one:
+    //   single-quoted: `'tantivy'` → `tantivy`
+    //   double-quoted: `"tantivy"` → `tantivy`
+    //   mixed quotes (the strip pair is applied independently, both pairs removed):
+    //       `"'tantivy'"` → `tantivy`
+    // A regression that only stripped one quote variety would pass the existing
+    // single-quoted case but fail the others.
+    String singleQuoted =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("kind", "'tantivy'"))));
+    assertEquals("{\"kind\":\"tantivy\"}", singleQuoted);
+
+    String doubleQuoted =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("kind", "\"tantivy\""))));
+    assertEquals("{\"kind\":\"tantivy\"}", doubleQuoted);
+
+    // Mixed: `"'tantivy'"` — outer pair is double, inner is single. The strip-chain at
+    // IndexUtils.toJson removes both pairs (outer double, then inner single from the result).
+    String mixed =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("kind", "\"'tantivy'\""))));
+    assertEquals("{\"kind\":\"tantivy\"}", mixed);
+  }
+
+  @Test
+  public void testToJsonMultipleArgsPreserveOrder() {
+    // args is a Seq, not a Map — input order must be preserved through to JSON. A
+    // regression that reordered via HashMap would silently break lance-core integrations
+    // that depend on declaration order (none exist today, but the contract is the user's
+    // SQL clause order).
+    String json =
+        IndexUtils.toJson(
+            toScalaSeq(
+                Arrays.asList(
+                    new LanceNamedArgument("rows_per_zone", 4096L),
+                    new LanceNamedArgument("max_levels", 3))));
+    assertEquals("{\"rows_per_zone\":4096,\"max_levels\":3}", json);
+  }
+
+  @Test
+  public void testToJsonNullValueEmitsNull() {
+    String json =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("opt", null))));
+    assertEquals("{\"opt\":null}", json);
+  }
+
+  @Test
+  public void testToJsonBooleanValueEmitsNativeBoolean() {
+    String json =
+        IndexUtils.toJson(
+            toScalaSeq(Collections.singletonList(new LanceNamedArgument("flag", true))));
+    assertEquals("{\"flag\":true}", json);
+  }
+
+  // Helper: convert Java List to Scala immutable.Seq[LanceNamedArgument] for IndexUtils.toJson.
+  // Must return immutable.Seq specifically — in Scala 2.13 the default `Seq` type is
+  // `scala.collection.immutable.Seq`, so calling `.toSeq()` on a Scala Buffer (which yields
+  // `scala.collection.Seq` in 2.12 and `scala.collection.immutable.Seq` in 2.13) is a type
+  // mismatch across the cross-Scala-version boundary. `.toList()` yields
+  // `scala.collection.immutable.List` which IS a `Seq` in both 2.12 and 2.13.
+  private static scala.collection.immutable.Seq<LanceNamedArgument> toScalaSeq(
+      java.util.List<LanceNamedArgument> args) {
+    return JavaConverters.asScalaBufferConverter(args).asScala().toList();
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -686,9 +686,7 @@ public abstract class BaseAddIndexTest {
                 "alter table %s create index idx_zm_repeat using zonemap (id)", fullTable));
     long fragmentsIndexed2 = result2.collectAsList().get(0).getLong(0);
     Assertions.assertEquals(
-        fragmentsIndexed1,
-        fragmentsIndexed2,
-        "Second run must index the same number of fragments");
+        fragmentsIndexed1, fragmentsIndexed2, "Second run must index the same number of fragments");
 
     List<Index> segmentsAfterSecond = indexesByName("idx_zm_repeat");
     Assertions.assertEquals(
@@ -791,7 +789,8 @@ public abstract class BaseAddIndexTest {
     Assertions.assertTrue(
         expectedFragments.size() >= 2,
         "Fixture must produce >= 2 fragments to exercise multi-segment commit invariants; "
-            + "got " + expectedFragments.size());
+            + "got "
+            + expectedFragments.size());
 
     // Each segment must cover exactly one fragment, that fragment must belong to the
     // ground-truth set, and no two segments may claim the same fragment.
@@ -955,12 +954,9 @@ public abstract class BaseAddIndexTest {
         .coalesce(1)
         .writeTo(fullTable)
         .append();
+    spark.sql(String.format("alter table %s create index idx_zm_id using zonemap (id)", fullTable));
     spark.sql(
-        String.format(
-            "alter table %s create index idx_zm_id using zonemap (id)", fullTable));
-    spark.sql(
-        String.format(
-            "alter table %s create index idx_zm_text using zonemap (text)", fullTable));
+        String.format("alter table %s create index idx_zm_text using zonemap (text)", fullTable));
 
     List<Index> idSegments = indexesByName("idx_zm_id");
     List<Index> textSegments = indexesByName("idx_zm_text");
@@ -989,7 +985,8 @@ public abstract class BaseAddIndexTest {
       for (ZoneStats z : idStats) {
         Assertions.assertTrue(
             z.getMin() instanceof Number,
-            "id zone min must be Number; got " + (z.getMin() == null ? "null" : z.getMin().getClass()));
+            "id zone min must be Number; got "
+                + (z.getMin() == null ? "null" : z.getMin().getClass()));
       }
       for (ZoneStats z : textStats) {
         Assertions.assertTrue(
@@ -1113,6 +1110,747 @@ public abstract class BaseAddIndexTest {
         1,
         segment.fragments().orElseThrow().size(),
         "The single segment must cover exactly one fragment");
+  }
+
+  @Test
+  public void testZonemapConsolidatedCommitShape() {
+    // With spark.lance.zonemap.consolidate.enabled=true the build path must produce ONE
+    // consolidated
+    // IndexMetadata segment covering the full fragment set, instead of one segment per
+    // fragment. This is the consumer-side integration of lance-core's
+    // computeZonemapBatch + writeZonemapIndexFromBatches APIs (added in 7.0.0-beta.7):
+    // executors return per-fragment Arrow batches, the driver merges them into a single
+    // <uuid>/zonemap.lance file under one IndexMetadata entry.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_consolidated using zonemap (id)", fullTable));
+    long fragmentsIndexed = result.collectAsList().get(0).getLong(0);
+
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Assertions.assertEquals(
+        expectedFragments.size(),
+        (int) fragmentsIndexed,
+        "fragmentsIndexed return value must match the dataset's current fragment count");
+    // Without >=2 fragments the "single segment vs N segments" shape is indistinguishable
+    // from the distributed path's N=1 degenerate case.
+    Assertions.assertTrue(
+        expectedFragments.size() >= 2,
+        "Fixture must produce >= 2 fragments to verify consolidation; got "
+            + expectedFragments.size());
+
+    List<Index> segments = indexesByName("idx_zm_consolidated");
+    Assertions.assertEquals(
+        1,
+        segments.size(),
+        "Consolidated path must commit exactly ONE IndexMetadata segment regardless of "
+            + "fragment count; got "
+            + segments.size());
+
+    Index segment = segments.get(0);
+    Assertions.assertEquals(IndexType.ZONEMAP, segment.indexType());
+    Assertions.assertTrue(
+        segment.fragments().isPresent(), "Consolidated segment must carry a fragment list");
+    Set<Integer> segmentFragments = new HashSet<>(segment.fragments().get());
+    Assertions.assertEquals(
+        expectedFragments,
+        segmentFragments,
+        "Consolidated segment's fragment list must equal the dataset's fragment set");
+    Assertions.assertEquals(
+        1,
+        segment.fields().size(),
+        "Indexing one column ('id') must produce a field-id list of length 1; got "
+            + segment.fields());
+
+    // The consolidated zonemap.lance must be readable end-to-end: every indexed fragment must
+    // appear in getZonemapStats. A regression that wrote an empty or partial batch list
+    // would still satisfy the IndexMetadata shape but fail this read-back coverage check.
+    Set<Integer> coveredFragments =
+        zonemapStats(ID_COLUMN).stream().map(ZoneStats::getFragmentId).collect(Collectors.toSet());
+    Assertions.assertEquals(
+        expectedFragments,
+        coveredFragments,
+        "getZonemapStats(id) must cover every indexed fragment from the consolidated segment");
+
+    // Pin datasetVersion / indexVersion wire-through. A regression that defaulted these to 0
+    // on the consolidated Index.builder (e.g. .datasetVersion(0L) instead of capturing the
+    // live version, or .indexVersion(0) instead of writtenIndex.indexVersion()) passes every
+    // other consolidated test because no other assertion touches these fields. The distributed
+    // test only asserts cross-segment uniformity, which is vacuous on 1 segment.
+    long postCommitVersion;
+    try (org.lance.Dataset lds = openLance()) {
+      postCommitVersion = lds.version();
+    }
+    Assertions.assertTrue(
+        segment.datasetVersion() > 0L,
+        "Consolidated segment must record a non-zero datasetVersion; got "
+            + segment.datasetVersion());
+    Assertions.assertTrue(
+        segment.datasetVersion() <= postCommitVersion,
+        "Consolidated segment's datasetVersion ("
+            + segment.datasetVersion()
+            + ") must not exceed the live dataset version ("
+            + postCommitVersion
+            + ") — recorded version came from the wrong manifest");
+  }
+
+  @Test
+  public void testZonemapConsolidatedRepeatedCreate() {
+    // Replace-semantics for the consolidated path: re-running CREATE INDEX under the same name
+    // must mark the previous segment removed in `withRemovedIndices` and commit a fresh single
+    // segment. A regression that dropped the removedIndices wiring would leave the first run's
+    // IndexMetadata entry behind alongside the new one, doubling the manifest footprint.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    prepareDataset();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_consolidated_repeat using zonemap (id)",
+                fullTable))
+        .collect();
+    List<Index> firstRun = indexesByName("idx_zm_consolidated_repeat");
+    Assertions.assertEquals(1, firstRun.size(), "First run must commit one segment");
+    UUID firstUuid = firstRun.get(0).uuid();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_consolidated_repeat using zonemap (id)",
+                fullTable))
+        .collect();
+    List<Index> secondRun = indexesByName("idx_zm_consolidated_repeat");
+    Assertions.assertEquals(
+        1,
+        secondRun.size(),
+        "Second run under the same name must replace, not append — got "
+            + secondRun.size()
+            + " segments");
+    Assertions.assertNotEquals(
+        firstUuid,
+        secondRun.get(0).uuid(),
+        "Replace must produce a fresh UUID; got the same UUID across both runs, meaning the "
+            + "consolidated write reused state from the previous run");
+
+    // Verify the FIRST run's UUID is gone from the entire manifest (not just same-name).
+    // A regression that dropped withRemovedIndices would leave the old IndexMetadata entry
+    // alongside the new one — `indexesByName` filters by name and would not catch a
+    // different-named orphan. Walking the full index list does.
+    try (org.lance.Dataset lds = openLance()) {
+      Set<UUID> liveUuids = lds.getIndexes().stream().map(Index::uuid).collect(Collectors.toSet());
+      Assertions.assertFalse(
+          liveUuids.contains(firstUuid),
+          "First-run UUID must NOT remain in the live manifest after replace; "
+              + "withRemovedIndices wiring is broken");
+    }
+
+    // Post-replace coverage: the new segment must cover the full dataset fragment set, not a
+    // truncated subset. A regression where the consolidated write trimmed fragments silently
+    // (e.g. dropped the last task's contribution) would still satisfy size==1 + fresh UUID.
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Set<Integer> segmentFragments = new HashSet<>(secondRun.get(0).fragments().orElseThrow());
+    Assertions.assertEquals(
+        expectedFragments,
+        segmentFragments,
+        "Post-replace segment must cover the dataset's full fragment set; got "
+            + segmentFragments
+            + " vs expected "
+            + expectedFragments);
+
+    // Read-back: the manifest entry's fragment list is built from the dispatcher's view,
+    // which is tautological vs. what we just asserted. The independent ground truth is what
+    // getZonemapStats actually returns — that's the read path's view of the on-disk
+    // consolidated zonemap.lance. A regression where the manifest claims coverage the file
+    // doesn't have would diverge here.
+    Set<Integer> coveredFragments =
+        zonemapStats(ID_COLUMN).stream().map(ZoneStats::getFragmentId).collect(Collectors.toSet());
+    Assertions.assertEquals(
+        expectedFragments,
+        coveredFragments,
+        "getZonemapStats coverage must match the dispatched fragment set after replace");
+  }
+
+  @Test
+  public void testZonemapConsolidatedReplacesDistributed() {
+    // Cross-path interop: a distributed-built zonemap (N segments) replaced by a consolidated
+    // build under the same index name must commit exactly one segment AND mark all N old
+    // segments as removed. A regression in `removedIndices` filtering by name would leave
+    // some-or-all of the N old segments stranded as duplicate-named entries in the manifest.
+    prepareDataset();
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "false");
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_zm_crosspath using zonemap (id)", fullTable));
+    List<Index> distributedSegments = indexesByName("idx_zm_crosspath");
+    Assertions.assertTrue(
+        distributedSegments.size() >= 2,
+        "Pre-condition: distributed build must produce multiple segments (fixture-dependent)");
+
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_zm_crosspath using zonemap (id)", fullTable));
+
+    List<Index> afterConsolidate = indexesByName("idx_zm_crosspath");
+    Assertions.assertEquals(
+        1,
+        afterConsolidate.size(),
+        "Consolidated re-create must collapse the N distributed segments to one; got "
+            + afterConsolidate.size());
+    Set<UUID> oldUuids = distributedSegments.stream().map(Index::uuid).collect(Collectors.toSet());
+    Assertions.assertFalse(
+        oldUuids.contains(afterConsolidate.get(0).uuid()),
+        "Replacement segment must have a fresh UUID, disjoint from the N distributed UUIDs");
+
+    // Post-replace coverage: the consolidated segment must cover the union of fragments the
+    // N distributed segments covered. A regression that committed a single-segment index over
+    // a strict subset (truncated parallelize result, dropped task, etc.) satisfies size==1
+    // and "fresh UUID" but breaks pruning silently.
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Set<Integer> segmentFragments =
+        new HashSet<>(afterConsolidate.get(0).fragments().orElseThrow());
+    Assertions.assertEquals(
+        expectedFragments,
+        segmentFragments,
+        "Consolidated replacement must cover every fragment the N distributed segments did");
+
+    // The full manifest must drop ALL N old UUIDs, not just same-name ones. A regression that
+    // filtered removedIndices incorrectly would leave orphans of a different name in place.
+    try (org.lance.Dataset lds = openLance()) {
+      Set<UUID> liveUuids = lds.getIndexes().stream().map(Index::uuid).collect(Collectors.toSet());
+      Assertions.assertTrue(
+          java.util.Collections.disjoint(liveUuids, oldUuids),
+          "Distributed-build UUIDs must be fully removed from the manifest after consolidated "
+              + "replace; got intersection: "
+              + (liveUuids.stream().filter(oldUuids::contains).collect(Collectors.toSet())));
+    }
+
+    // Post-replace zonemap stats must be readable and cover the full fragment set — proves the
+    // consolidated zonemap.lance is intact AND that the manifest's index→segment pointer is
+    // wired up correctly (a stale pointer from the dropped segments would fail to load).
+    Set<Integer> coveredFragments =
+        zonemapStats(ID_COLUMN).stream().map(ZoneStats::getFragmentId).collect(Collectors.toSet());
+    Assertions.assertEquals(
+        expectedFragments,
+        coveredFragments,
+        "getZonemapStats must cover every fragment post-replace");
+  }
+
+  @Test
+  public void testZonemapDistributedReplacesConsolidated() {
+    // Reverse-interop direction: consolidated → distributed. Toggling the flag back off after
+    // a consolidated build and re-creating the same name must remove the consolidated segment
+    // and commit N distributed segments. A regression where the distributed path's
+    // removedIndices filter missed the single consolidated entry (e.g. asserted N>0 entries
+    // to remove) would leave the consolidated segment orphaned in the manifest.
+    prepareDataset();
+    // Fixture pin: prepareDataset() must produce >=2 fragments for this test to assert
+    // anything meaningful about the distributed "multiple segments" shape. A future change
+    // to the fixture (e.g. Spark version consolidating INSERT VALUES tuples) would turn this
+    // test into a tautology where N=1 satisfies both the "consolidated" pre-condition and
+    // the "distributed >= 2" post-condition.
+    try (org.lance.Dataset lds = openLance()) {
+      Assertions.assertTrue(
+          lds.getFragments().size() >= 2,
+          "Fixture must produce >= 2 fragments to distinguish consolidated (1 segment) from "
+              + "distributed (N segments); got "
+              + lds.getFragments().size());
+    }
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(
+        String.format("alter table %s create index idx_zm_reverse using zonemap (id)", fullTable));
+    List<Index> consolidatedSegments = indexesByName("idx_zm_reverse");
+    Assertions.assertEquals(
+        1,
+        consolidatedSegments.size(),
+        "Pre-condition: consolidated build must produce exactly one segment");
+    UUID consolidatedUuid = consolidatedSegments.get(0).uuid();
+
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "false");
+    spark.sql(
+        String.format("alter table %s create index idx_zm_reverse using zonemap (id)", fullTable));
+
+    List<Index> afterDistributed = indexesByName("idx_zm_reverse");
+    Assertions.assertTrue(
+        afterDistributed.size() >= 2,
+        "Distributed replacement must produce multiple segments (one per fragment); got "
+            + afterDistributed.size());
+    Set<UUID> newUuids = afterDistributed.stream().map(Index::uuid).collect(Collectors.toSet());
+    Assertions.assertFalse(
+        newUuids.contains(consolidatedUuid),
+        "Consolidated segment's UUID must NOT appear in the post-replace distributed segment "
+            + "set");
+
+    try (org.lance.Dataset lds = openLance()) {
+      Set<UUID> liveUuids = lds.getIndexes().stream().map(Index::uuid).collect(Collectors.toSet());
+      Assertions.assertFalse(
+          liveUuids.contains(consolidatedUuid),
+          "Consolidated UUID must be fully removed from the manifest after distributed "
+              + "replace");
+    }
+  }
+
+  @Test
+  public void testZonemapConsolidateFlagDefaultsToDistributed() {
+    // Pin the default behavior: without setting the flag, ZONEMAP CREATE INDEX must route
+    // through the distributed path. A regression that flipped the default would silently
+    // change every existing pipeline's commit footprint, and every other consolidated test
+    // would still pass (they explicitly set the flag).
+    Assertions.assertFalse(
+        spark.conf().contains("spark.lance.zonemap.consolidate.enabled"),
+        "Sanity: this test assumes the flag is unset on entry; AfterEach teardown is wrong "
+            + "if this fails");
+    prepareDataset();
+    spark.sql(
+        String.format("alter table %s create index idx_zm_default using zonemap (id)", fullTable));
+    List<Index> segments = indexesByName("idx_zm_default");
+    int fragmentCount;
+    try (org.lance.Dataset lds = openLance()) {
+      fragmentCount = lds.getFragments().size();
+    }
+    // Tight pin (mirror the explicit-false test): distributed produces one segment per
+    // fragment. A regression where the default path produced some-but-not-N segments would
+    // pass `>= 2` silently.
+    Assertions.assertEquals(
+        fragmentCount,
+        segments.size(),
+        "Default (flag unset) must produce one segment per fragment; got "
+            + segments.size()
+            + " segments over "
+            + fragmentCount
+            + " fragments");
+  }
+
+  @Test
+  public void testZonemapConsolidateFlagFalseRoutesToDistributed() {
+    // Representative negative case: explicit "false" must produce the distributed multi-
+    // segment shape. Combined with testZonemapConsolidateFlagCaseInsensitive (positive "TRUE")
+    // and testZonemapConsolidateFlagDefaultsToDistributed (unset), this triangulates the
+    // parse semantics: only case-insensitive "true" (with trim) flips the path.
+    prepareDataset();
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "false");
+    spark.sql(
+        String.format("alter table %s create index idx_zm_false using zonemap (id)", fullTable));
+    List<Index> segments = indexesByName("idx_zm_false");
+    // Tight pin: distributed produces ONE segment per fragment. Asserting equality (not
+    // size >= 2) catches a regression where consolidated misroutes to a state that produces
+    // some-but-not-N segments (e.g. 2 segments from a 20-fragment dataset).
+    int fragmentCount;
+    try (org.lance.Dataset lds = openLance()) {
+      fragmentCount = lds.getFragments().size();
+    }
+    Assertions.assertEquals(
+        fragmentCount,
+        segments.size(),
+        "spark.lance.zonemap.consolidate.enabled=false must route to distributed (one segment per "
+            + "fragment); got "
+            + segments.size()
+            + " segments over "
+            + fragmentCount
+            + " fragments");
+  }
+
+  @Test
+  public void testZonemapConsolidateFlagCaseInsensitive() {
+    // The R1 fix switched parsing from `_.toBoolean` to `equalsIgnoreCase("true")` + trim.
+    // Pin the lenient cases that R1 added support for: mixed case, leading/trailing whitespace,
+    // and the canonical "true". A regression that reverted to strict `_.toBoolean` would fail
+    // "TRUE" and " true "; one that broke trim() would fail " true ".
+    prepareDataset();
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "  TRUE  ");
+    spark.sql(
+        String.format("alter table %s create index idx_zm_flag_ci using zonemap (id)", fullTable));
+    List<Index> segments = indexesByName("idx_zm_flag_ci");
+    Assertions.assertEquals(
+        1,
+        segments.size(),
+        "Flag value '  TRUE  ' must route to the consolidated path (1 segment); got "
+            + segments.size());
+  }
+
+  @Test
+  public void testZonemapConsolidatedOnStringColumn() throws Exception {
+    // String columns exercise the UTF-8 min/max codec end-to-end through Arrow IPC. Numeric
+    // min/max in the existing test would not catch a regression where the string codec
+    // misencodes empty validity buffers or mishandles variable-length byte payloads on the
+    // ArrowStreamWriter → ArrowStreamReader round-trip.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 12)
+        .selectExpr("cast(id as int) as id", "cast(concat('s_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_c_text using zonemap (text)", fullTable))
+        .collect();
+    List<Index> segments = indexesByName("idx_zm_c_text");
+    Assertions.assertEquals(1, segments.size(), "Consolidated string index must be one segment");
+    // Coverage check: a regression committing 1 segment over zero fragments satisfies size==1.
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Set<Integer> segmentFragments = new HashSet<>(segments.get(0).fragments().orElseThrow());
+    Assertions.assertEquals(
+        expectedFragments,
+        segmentFragments,
+        "String consolidated segment must cover the dataset's full fragment set");
+    List<ZoneStats> stats = zonemapStats("text");
+    Assertions.assertFalse(stats.isEmpty(), "Zonemap stats for string column must be present");
+    for (ZoneStats z : stats) {
+      // Skip all-NULL zones if any; for this fixture there should be none.
+      Assertions.assertTrue(
+          z.getMin() instanceof String,
+          "text zone min must be String; got "
+              + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      Assertions.assertTrue(
+          z.getMax() instanceof String,
+          "text zone max must be String; got "
+              + (z.getMax() == null ? "null" : z.getMax().getClass()));
+    }
+  }
+
+  @Test
+  public void testZonemapConsolidatedOnNullableStringColumn() throws Exception {
+    // Verifies that the Arrow IPC round-trip preserves all-NULL zone semantics for the
+    // consolidated path. A regression that mishandled empty/all-NULL validity buffers through
+    // ArrowStreamWriter would either crash or produce non-null min/max for NULL data, neither
+    // of which the testZonemapConsolidatedCommitShape numeric test would catch.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 10)
+        .selectExpr(
+            "cast(id as int) as id",
+            "case when id < 5 then cast(concat('s_', id) as string) "
+                + "else cast(null as string) end as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_c_null_text using zonemap (text) "
+                    + "with (rows_per_zone=5)",
+                fullTable))
+        .collect();
+    List<Index> segments = indexesByName("idx_zm_c_null_text");
+    Assertions.assertEquals(1, segments.size(), "Single consolidated segment expected");
+
+    List<ZoneStats> stats = zonemapStats("text");
+    boolean sawAllNullZone = false;
+    boolean sawNonNullZone = false;
+    for (ZoneStats z : stats) {
+      if (z.getNullCount() == z.getZoneLength()) {
+        Assertions.assertNull(z.getMin(), "All-NULL zone must have null min");
+        Assertions.assertNull(z.getMax(), "All-NULL zone must have null max");
+        sawAllNullZone = true;
+      } else if (z.getNullCount() == 0) {
+        Assertions.assertTrue(z.getMin() instanceof String, "Non-NULL zone min must be String");
+        Assertions.assertTrue(z.getMax() instanceof String, "Non-NULL zone max must be String");
+        sawNonNullZone = true;
+      } else {
+        Assertions.fail(
+            String.format(
+                "Unexpected mixed-null zone: nullCount=%d, zoneLength=%d, "
+                    + "fragmentId=%d, zoneStart=%d — fixture expects boundaries to align with "
+                    + "the 5-NULL/5-non-NULL split",
+                z.getNullCount(), z.getZoneLength(), z.getFragmentId(), z.getZoneStart()));
+      }
+    }
+    Assertions.assertTrue(sawAllNullZone, "Fixture must produce at least one all-NULL zone");
+    Assertions.assertTrue(sawNonNullZone, "Fixture must produce at least one non-NULL zone");
+  }
+
+  @Test
+  public void testZonemapConsolidatedWithRowsPerZone() throws Exception {
+    // The argsJson value the driver passes to writeZonemapIndexFromBatches MUST match what the
+    // executors pass to computeZonemapBatch — a regression that re-serialized args at the
+    // dispatcher boundary could diverge and produce a file whose recorded `rows_per_zone`
+    // differs from the actual zone layout. This test pins the threading by counting zones.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 12)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_c_rpz using zonemap (id) "
+                    + "with (rows_per_zone=4)",
+                fullTable))
+        .collect();
+    List<Index> segments = indexesByName("idx_zm_c_rpz");
+    Assertions.assertEquals(1, segments.size(), "Single consolidated segment expected");
+
+    try (org.lance.Dataset lds = openLance()) {
+      Assertions.assertEquals(
+          1, lds.getFragments().size(), "Fixture expects coalesce(1) to produce one fragment");
+      List<ZoneStats> stats = lds.getZonemapStats("id");
+      Assertions.assertEquals(
+          3,
+          stats.size(),
+          "rows_per_zone=4 over a 12-row fragment must produce 3 zones; got "
+              + stats.size()
+              + " — argsJson threading from driver to writeZonemapIndexFromBatches likely "
+              + "broken");
+      // Sort by zone_start so we can assert per-zone min/max correspond to the right id range.
+      // Without this, a regression that aliased one fragment's stats array across all zones
+      // (e.g. argsJson reused stale state in writeZonemapIndexFromBatches) produces 3 zones
+      // of length 4 with IDENTICAL min/max — every count/length assertion still passes.
+      List<ZoneStats> sorted =
+          stats.stream()
+              .sorted((a, b) -> Long.compare(a.getZoneStart(), b.getZoneStart()))
+              .collect(Collectors.toList());
+      for (int i = 0; i < 3; i++) {
+        ZoneStats z = sorted.get(i);
+        Assertions.assertEquals(
+            4,
+            z.getZoneLength(),
+            "Zone " + i + " must have length == rows_per_zone=4; got " + z.getZoneLength());
+        // ids in [i*4, i*4+4): zone 0 → ids {0,1,2,3} min=0 max=3, etc.
+        int expectedMin = i * 4;
+        int expectedMax = i * 4 + 3;
+        Number actualMin = (Number) z.getMin();
+        Number actualMax = (Number) z.getMax();
+        Assertions.assertEquals(
+            expectedMin,
+            actualMin.intValue(),
+            "Zone "
+                + i
+                + " (zone_start="
+                + z.getZoneStart()
+                + ") min must be "
+                + expectedMin
+                + " (the first id in ["
+                + expectedMin
+                + ","
+                + (expectedMax + 1)
+                + "));"
+                + " got "
+                + actualMin
+                + " — stale-stats aliasing across zones");
+        Assertions.assertEquals(
+            expectedMax,
+            actualMax.intValue(),
+            "Zone "
+                + i
+                + " (zone_start="
+                + z.getZoneStart()
+                + ") max must be "
+                + expectedMax
+                + "; got "
+                + actualMax);
+      }
+    }
+  }
+
+  @Test
+  public void testZonemapConsolidatedOnSingleFragmentTable() throws Exception {
+    // Degenerate N=1 case for the consolidated path. The dispatcher already guards `isEmpty`,
+    // but N=1 has no test coverage and a regression that special-cased "multiple fragments"
+    // could silently break this path.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 10)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_c_single using zonemap (id)", fullTable));
+    long fragmentsIndexed = result.collectAsList().get(0).getLong(0);
+    Assertions.assertEquals(1L, fragmentsIndexed, "Expected one fragment indexed for N=1 case");
+
+    List<Index> segments = indexesByName("idx_zm_c_single");
+    Assertions.assertEquals(
+        1, segments.size(), "Consolidated path on N=1 must commit exactly one segment");
+    Assertions.assertEquals(
+        1,
+        segments.get(0).fragments().orElseThrow().size(),
+        "Segment must cover exactly one fragment");
+
+    // Read-back via getZonemapStats: confirms the on-disk consolidated zonemap.lance is
+    // wired up correctly on the degenerate N=1 path. Without this, a regression that wrote
+    // an empty file but committed a structurally-valid IndexMetadata entry passes the
+    // segment-count / fragment-count assertions above silently.
+    Set<Integer> coveredFragments =
+        zonemapStats(ID_COLUMN).stream().map(ZoneStats::getFragmentId).collect(Collectors.toSet());
+    Assertions.assertEquals(
+        new HashSet<>(segments.get(0).fragments().orElseThrow()),
+        coveredFragments,
+        "getZonemapStats on N=1 consolidated must match the segment's fragment list");
+  }
+
+  @Test
+  public void testTwoCoexistingConsolidatedZonemapIndexes() throws Exception {
+    // Two differently-named consolidated indexes on different columns of the same dataset must
+    // commit with disjoint UUIDs. Each indexes a different column → writeZonemapIndexFromBatches
+    // is invoked twice with different arguments, exercising the cross-name isolation that the
+    // read path's load_indices_by_name grouping depends on.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 20)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark.sql(
+        String.format("alter table %s create index idx_zm_c_id using zonemap (id)", fullTable));
+    spark.sql(
+        String.format("alter table %s create index idx_zm_c_text using zonemap (text)", fullTable));
+
+    List<Index> idSegments = indexesByName("idx_zm_c_id");
+    List<Index> textSegments = indexesByName("idx_zm_c_text");
+    Assertions.assertEquals(1, idSegments.size(), "id consolidated index must be one segment");
+    Assertions.assertEquals(1, textSegments.size(), "text consolidated index must be one segment");
+    Assertions.assertNotEquals(
+        idSegments.get(0).uuid(),
+        textSegments.get(0).uuid(),
+        "Two consolidated indexes on different columns must have disjoint UUIDs");
+
+    // Both names must survive in a single manifest snapshot taken AFTER both commits.
+    // `indexesByName` re-opens the dataset on each call; calling it twice could mask a
+    // regression where the second commit dropped the first index from the manifest, because
+    // each lookup walks the live (post-second-commit) state independently. Snapshotting once
+    // ensures we're asserting about a single consistent view of the manifest.
+    try (org.lance.Dataset lds = openLance()) {
+      Set<String> liveNames =
+          lds.getIndexes().stream().map(Index::name).collect(Collectors.toSet());
+      Assertions.assertTrue(
+          liveNames.contains("idx_zm_c_id"),
+          "id index must remain in manifest after text-index commit; live names: " + liveNames);
+      Assertions.assertTrue(
+          liveNames.contains("idx_zm_c_text"),
+          "text index must remain in manifest after both commits; live names: " + liveNames);
+    }
+
+    // Stats for both columns must be readable independently after both commits.
+    try (org.lance.Dataset lds = openLance()) {
+      List<ZoneStats> idStats = lds.getZonemapStats("id");
+      List<ZoneStats> textStats = lds.getZonemapStats("text");
+      Assertions.assertFalse(idStats.isEmpty(), "id zonemap stats must be readable");
+      Assertions.assertFalse(textStats.isEmpty(), "text zonemap stats must be readable");
+      for (ZoneStats z : idStats) {
+        Assertions.assertTrue(
+            z.getMin() instanceof Number,
+            "id zone min must be Number; got "
+                + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      }
+      for (ZoneStats z : textStats) {
+        Assertions.assertTrue(
+            z.getMin() instanceof String,
+            "text zone min must be String; got "
+                + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      }
+    }
+  }
+
+  @Test
+  public void testZonemapConsolidatedOnLongColumn() throws Exception {
+    // The Int32 codec path used by the other consolidated tests is NOT representative of
+    // the production target — at sf=100 store_sales the indexed column is `ss_sold_date_sk`,
+    // a BIGINT. Int and Long round-trip through different Arrow IPC paths
+    // (IntVector vs BigIntVector); a regression that mishandled BigIntVector through
+    // ArrowStreamWriter/Reader (e.g. byte-order or buffer-length) would not be caught by the
+    // Int-column tests.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    spark.sql(String.format("create table %s (id bigint, text string) using lance;", fullTable));
+    spark
+        .range(0L, 12L)
+        .selectExpr("id as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_c_long using zonemap (id)", fullTable))
+        .collect();
+    List<Index> segments = indexesByName("idx_zm_c_long");
+    Assertions.assertEquals(1, segments.size(), "Consolidated bigint index must be one segment");
+    // Coverage check: a regression that committed 1 segment over zero fragments would still
+    // satisfy size==1. Verify the segment's fragments() set matches the dataset's.
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Set<Integer> segmentFragments = new HashSet<>(segments.get(0).fragments().orElseThrow());
+    Assertions.assertEquals(
+        expectedFragments,
+        segmentFragments,
+        "Bigint consolidated segment must cover the dataset's full fragment set");
+
+    List<ZoneStats> stats = zonemapStats(ID_COLUMN);
+    Assertions.assertFalse(stats.isEmpty(), "Zonemap stats for bigint column must be present");
+    for (ZoneStats z : stats) {
+      Assertions.assertTrue(
+          z.getMin() instanceof Number,
+          "bigint zone min must be Number; got "
+              + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      long min = ((Number) z.getMin()).longValue();
+      long max = ((Number) z.getMax()).longValue();
+      Assertions.assertTrue(
+          min >= 0L && max <= 11L,
+          "bigint zone min/max must be inside the [0, 11] id range; got [" + min + "," + max + "]");
+    }
+  }
+
+  @Test
+  public void testZonemapConsolidatedIndexIsQueryable() {
+    // End-to-end read-back: confirm a SELECT against the indexed column returns correct rows
+    // after a consolidated CREATE INDEX. Manifest entry + zonemap stats round-trip prove the
+    // index is structurally sound, but not that it's actually USABLE by the read path's
+    // pruning/scan logic. A regression that left the manifest-to-file pointer wrong (or the
+    // file in an unreadable state post-write) would pass every other consolidated test but
+    // break query execution. Mirrors testCreateIndexDistributed's read-back check.
+    spark.conf().set("spark.lance.zonemap.consolidate.enabled", "true");
+    prepareDataset();
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_zm_c_queryable using zonemap (id)", fullTable));
+
+    Dataset<Row> result = spark.sql(String.format("select * from %s where id = 5", fullTable));
+    Assertions.assertEquals(
+        1L, result.count(), "SELECT WHERE id=5 must return exactly one row post-CREATE-INDEX");
+    Row row = result.collectAsList().get(0);
+    Assertions.assertEquals(5, row.getInt(0), "Returned row's id must be 5");
+    Assertions.assertEquals("text_5", row.getString(1), "Returned row's text must be 'text_5'");
   }
 
   /** Open the test table as a Lance dataset; caller is responsible for closing. */

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -17,6 +17,7 @@ import org.lance.index.Index;
 import org.lance.index.IndexCriteria;
 import org.lance.index.IndexDescription;
 import org.lance.index.IndexType;
+import org.lance.index.scalar.ZoneStats;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -39,6 +41,8 @@ import java.util.stream.IntStream;
 
 /** Base test for distributed CREATE INDEX. */
 public abstract class BaseAddIndexTest {
+  private static final String ID_COLUMN = "id";
+
   protected String catalogName = "lance_test";
   protected String tableName = "create_index_test";
   protected String fullTable = catalogName + ".default." + tableName;
@@ -599,6 +603,540 @@ public abstract class BaseAddIndexTest {
     Assertions.assertTrue(index.indexVersion() > 0, "FTS index version should be positive");
     if ("2".equals(System.getenv("LANCE_FTS_FORMAT_VERSION"))) {
       Assertions.assertEquals(2, index.indexVersion());
+    }
+  }
+
+  // ----- USING zonemap method ---------------------------------------------
+
+  @Test
+  public void testCreateZonemapIndex() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index test_idx_zonemap using zonemap (id)", fullTable));
+
+    Row row = result.collectAsList().get(0);
+    long fragmentsIndexed = row.getLong(0);
+    String indexName = row.getString(1);
+    Assertions.assertTrue(fragmentsIndexed >= 2, "Expected at least 2 fragments to be indexed");
+    Assertions.assertEquals("test_idx_zonemap", indexName);
+
+    Index idx = checkIndex("test_idx_zonemap");
+    Assertions.assertEquals(IndexType.ZONEMAP, idx.indexType());
+
+    // Strict per-fragment coverage: every indexed fragment must contribute
+    // at least one zone in getZonemapStats. A miss would mean the build path
+    // raced on a shared zonemap.lance and only one fragment's data survived.
+    Set<Integer> fragmentIdsWithStats =
+        zonemapStats(ID_COLUMN).stream().map(ZoneStats::getFragmentId).collect(Collectors.toSet());
+    Assertions.assertEquals(
+        (int) fragmentsIndexed,
+        fragmentIdsWithStats.size(),
+        "Every indexed fragment must have at least one zone in getZonemapStats");
+  }
+
+  @Test
+  public void testCreateZonemapOnNonExistentColumn() {
+    prepareDataset();
+    IllegalArgumentException ex =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                spark
+                    .sql(
+                        String.format(
+                            "alter table %s create index idx_missing using zonemap (does_not_exist)",
+                            fullTable))
+                    .collect());
+    Assertions.assertTrue(
+        ex.getMessage().contains("Cannot find index column"),
+        "Expected error message to mention missing column, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void testRepeatedCreateZonemap() {
+    // Companion to testRepeatedCreateIndex (BTree). Re-running CREATE INDEX with the same
+    // name must produce one logical index — the second invocation's `removedIndices` filter
+    // is supposed to clean up the first run's per-fragment segments before the new commit
+    // lands. A regression where removal didn't fire would produce 2 × N segments and the
+    // getZonemapStats listing would silently double-count.
+    prepareDataset();
+
+    // First run.
+    Dataset<Row> result1 =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_repeat using zonemap (id)", fullTable));
+    long fragmentsIndexed1 = result1.collectAsList().get(0).getLong(0);
+    Assertions.assertTrue(
+        fragmentsIndexed1 >= 2, "First run: expected at least 2 fragments indexed");
+
+    List<Index> segmentsAfterFirst = indexesByName("idx_zm_repeat");
+    Assertions.assertEquals(
+        (int) fragmentsIndexed1,
+        segmentsAfterFirst.size(),
+        "First run: one segment per indexed fragment");
+
+    // Second run with same name — must overwrite, not accumulate.
+    Dataset<Row> result2 =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_repeat using zonemap (id)", fullTable));
+    long fragmentsIndexed2 = result2.collectAsList().get(0).getLong(0);
+    Assertions.assertEquals(
+        fragmentsIndexed1,
+        fragmentsIndexed2,
+        "Second run must index the same number of fragments");
+
+    List<Index> segmentsAfterSecond = indexesByName("idx_zm_repeat");
+    Assertions.assertEquals(
+        (int) fragmentsIndexed2,
+        segmentsAfterSecond.size(),
+        "Second run must NOT accumulate segments — old run's segments must be cleared by "
+            + "removedIndices. Got "
+            + segmentsAfterSecond.size()
+            + " segments after replace, expected "
+            + fragmentsIndexed2);
+
+    // After replace, the segment set should have entirely new UUIDs — the old segments are
+    // gone and the new ones came from this run's fresh per-task createIndex calls.
+    Set<UUID> firstRunUuids =
+        segmentsAfterFirst.stream().map(Index::uuid).collect(Collectors.toSet());
+    Set<UUID> secondRunUuids =
+        segmentsAfterSecond.stream().map(Index::uuid).collect(Collectors.toSet());
+    Assertions.assertTrue(
+        java.util.Collections.disjoint(firstRunUuids, secondRunUuids),
+        "Re-created segments must have entirely new UUIDs; got overlap between "
+            + firstRunUuids
+            + " and "
+            + secondRunUuids);
+  }
+
+  @Test
+  public void testCreateZonemapOnStringColumn() {
+    prepareDataset();
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_text_zonemap using zonemap (text)", fullTable))
+        .collect();
+    Index idx = checkIndex("idx_text_zonemap");
+    Assertions.assertEquals(IndexType.ZONEMAP, idx.indexType());
+
+    // Verify the string codec actually round-trips: every zone's min/max must be a non-null
+    // String. A bug in the codec would give us null bounds or non-String types here.
+    List<ZoneStats> stats = zonemapStats("text");
+    Assertions.assertFalse(stats.isEmpty(), "Zonemap stats should be present for string column");
+    for (ZoneStats z : stats) {
+      Assertions.assertNotNull(z.getMin(), "Zone min for string column should be non-null");
+      Assertions.assertNotNull(z.getMax(), "Zone max for string column should be non-null");
+      Assertions.assertTrue(
+          z.getMin() instanceof String, "Zone min should be String, got " + z.getMin().getClass());
+      Assertions.assertTrue(
+          z.getMax() instanceof String, "Zone max should be String, got " + z.getMax().getClass());
+    }
+  }
+
+  @Test
+  public void testZonemapDistributedCommitShape() {
+    // Locks the multi-segment commit invariants that the distributed-build implementation
+    // depends on: one IndexMetadata per fragment, every segment has a distinct UUID, the
+    // segment fragment-bitmaps cover exactly the indexed fragment set. Regressions to a
+    // shared-UUID single-segment shape (the old race) would fail every one of these.
+    prepareDataset();
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_shape using zonemap (id)", fullTable));
+    long fragmentsIndexed = result.collectAsList().get(0).getLong(0);
+
+    List<Index> segments = indexesByName("idx_zm_shape");
+    Assertions.assertEquals(
+        (int) fragmentsIndexed,
+        segments.size(),
+        "Expect exactly one IndexMetadata segment per indexed fragment");
+
+    long distinctUuids = segments.stream().map(Index::uuid).distinct().count();
+    Assertions.assertEquals(
+        (long) segments.size(),
+        distinctUuids,
+        "Every segment must have a distinct UUID — the per-task UUID invariant prevents the "
+            + "shared-zonemap.lance write race");
+
+    // Discover the ground-truth set of fragment ids actually present in the dataset. The
+    // build path's promise is that it indexes every existing fragment exactly once; comparing
+    // against this set catches both kinds of permutation bug:
+    //   (a) a task returning a fragment id NOT in the input set (e.g. some encoding artefact
+    //       in the result struct silently flipped the id)
+    //   (b) a task duplicating a fragment id another task already claimed
+    // The previous formulation only asserted size-equality, which let (a) slip through when
+    // the duplication and dropout happened to balance out.
+    Set<Integer> expectedFragments = new HashSet<>();
+    try (org.lance.Dataset lds = openLance()) {
+      for (org.lance.Fragment f : lds.getFragments()) {
+        expectedFragments.add(f.getId());
+      }
+    }
+    Assertions.assertEquals(
+        (int) fragmentsIndexed,
+        expectedFragments.size(),
+        "Sanity: fragmentsIndexed return value must match the dataset's current fragment count");
+    // The "multi-segment" invariants this test pins are vacuously satisfied for N=1.
+    // Assert the fixture produced enough fragments to exercise the distributed-commit
+    // path it claims to verify — without this, a future change to prepareDataset() (e.g.
+    // a Spark version that consolidates VALUES tuples into one fragment) would silently
+    // turn this test into a single-segment regression check.
+    Assertions.assertTrue(
+        expectedFragments.size() >= 2,
+        "Fixture must produce >= 2 fragments to exercise multi-segment commit invariants; "
+            + "got " + expectedFragments.size());
+
+    // Each segment must cover exactly one fragment, that fragment must belong to the
+    // ground-truth set, and no two segments may claim the same fragment.
+    Set<Integer> coveredFragments = new HashSet<>();
+    Set<List<Integer>> seenFieldLists = new HashSet<>();
+    Set<Integer> seenIndexVersions = new HashSet<>();
+    for (Index segment : segments) {
+      Assertions.assertEquals(IndexType.ZONEMAP, segment.indexType());
+      Assertions.assertTrue(
+          segment.fragments().isPresent(), "Every committed segment must carry a fragment list");
+      List<Integer> segFragments = segment.fragments().get();
+      Assertions.assertEquals(
+          1,
+          segFragments.size(),
+          "Each segment must cover exactly one fragment, got " + segFragments);
+      int segFragId = segFragments.get(0);
+      Assertions.assertTrue(
+          expectedFragments.contains(segFragId),
+          "Segment claims fragment "
+              + segFragId
+              + " which is NOT in the dataset's actual "
+              + "fragment set "
+              + expectedFragments
+              + " — task→fragment-id permutation bug?");
+      Assertions.assertTrue(
+          coveredFragments.add(segFragId),
+          "Fragment " + segFragId + " is covered by more than one segment");
+
+      // Every segment must point to the same field-id list — the driver computed it once and
+      // populated it on every Index entry. A regression that left the field list empty, or
+      // sized for the wrong number of columns, or diverging across segments would still
+      // satisfy uuid/fragment/type assertions otherwise. We assert size == 1 because this
+      // test indexes a single column ("id"). We do NOT assert the exact field-id value
+      // because that would require reading the Lance schema's internal field-id metadata,
+      // which isn't cleanly exposed through the test surface; the per-segment uniformity
+      // check below catches the "wrong but uniform id" case as long as it'd be wrong
+      // consistently (which is what a real regression would produce).
+      Assertions.assertEquals(
+          1,
+          segment.fields().size(),
+          "Indexing one column ('id') must produce a field-id list of length 1; got "
+              + segment.fields());
+      seenFieldLists.add(segment.fields());
+
+      // Index version must be plumbed consistently from per-task createIndex results — all
+      // segments under one name must report the same version. We do NOT assert
+      // indexVersion > 0 because ZONEMAP_INDEX_VERSION is currently 0 (legitimate); the
+      // cross-segment-uniformity check is what catches a regression where per-task plumbing
+      // drifted (one task's r.indexVersion lost in serialisation, defaulted to int 0 while
+      // others carried a non-zero value).
+      seenIndexVersions.add(segment.indexVersion());
+    }
+    Assertions.assertEquals(
+        1,
+        seenIndexVersions.size(),
+        "All segments under one name must report the same indexVersion; got " + seenIndexVersions);
+    Assertions.assertEquals(
+        expectedFragments,
+        coveredFragments,
+        "Set of segment fragment-ids must equal the dataset's actual fragment set");
+    Assertions.assertEquals(
+        1,
+        seenFieldLists.size(),
+        "All segments under the same name must share one field-id list, got " + seenFieldLists);
+  }
+
+  @Test
+  public void testCreateZonemapWithZoneSize() throws Exception {
+    // Verifies that `with (rows_per_zone=N)` actually reaches lance-core and changes the
+    // on-disk zone layout — not just that the SQL parses. The previous smoke-only version
+    // would still pass if a refactor silently dropped the parameter before
+    // IndexUtils.toJson / ScalarIndexParams.create reached the JNI.
+    //
+    // IMPORTANT: ZONEMAP's parameter name is `rows_per_zone`, NOT `zone_size`. BTree uses
+    // `zone_size` (for its own range-partitioning), and the param names are independent on
+    // each side of the JSON boundary — `lance-core/scalar/zonemap.rs` only deserialises
+    // `rows_per_zone`. A `with (zone_size=N)` clause on a ZONEMAP index is silently ignored
+    // by lance-core's serde default-on-unknown-key behaviour.
+    //
+    // Strategy: build a multi-row single fragment by writing via DataFrame.coalesce(1) so the
+    // entire row set lands in one fragment. Spark's SQL INSERT VALUES path with master
+    // `local[10]` partitions each VALUES tuple into its own task and produces N single-row
+    // fragments, which can't differentiate "rows_per_zone honored" from "rows_per_zone
+    // ignored".
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 12)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zonemap_small_zone using zonemap (id) with (rows_per_zone=4)",
+                fullTable))
+        .collect();
+    Index idx = checkIndex("idx_zonemap_small_zone");
+    Assertions.assertEquals(IndexType.ZONEMAP, idx.indexType());
+
+    int fragmentCount;
+    int totalZoneCount;
+    try (org.lance.Dataset lds = openLance()) {
+      fragmentCount = lds.getFragments().size();
+      totalZoneCount = lds.getZonemapStats("id").size();
+    }
+    // Pin fragmentCount==1 explicitly: the rows-per-zone arithmetic below assumes a single
+    // 12-row fragment. If a future Spark/Lance change splits the coalesce(1) partition into
+    // multiple fragments, the totalZoneCount would scale and the assertion below would still
+    // pass (per-fragment count × fragmentCount could match by accident). Asserting up front
+    // makes that drift loud.
+    Assertions.assertEquals(
+        1,
+        fragmentCount,
+        "Test fixture expects coalesce(1) to produce exactly one 12-row fragment");
+
+    // With coalesce(1) + 12 rows, we get one fragment of 12 rows; rows_per_zone=4 yields
+    // ceil(12/4) = 3 zones. A regression that ignored rows_per_zone and defaulted to 8192
+    // would produce 1 zone.
+    int expectedZonesPerFragment = (12 + 3) / 4; // ceil(12 / 4) = 3
+    Assertions.assertEquals(
+        fragmentCount * expectedZonesPerFragment,
+        totalZoneCount,
+        "with (rows_per_zone=4) on a 12-row coalesced fragment must produce 3 zones — got "
+            + totalZoneCount
+            + " across "
+            + fragmentCount
+            + " fragments");
+
+    // Per-zone length verification: the first two zones must be full (length=4) and the
+    // trailing zone gets the remaining 4 rows (also length=4 in this aligned case).
+    // Without this check, a regression that produced 3 zones at the wrong sizes (e.g.
+    // {1, 1, 10} from a different chunking heuristic) would still satisfy the
+    // totalZoneCount == 3 assertion.
+    try (org.lance.Dataset lds = openLance()) {
+      List<ZoneStats> stats = lds.getZonemapStats("id");
+      for (ZoneStats z : stats) {
+        Assertions.assertEquals(
+            4,
+            z.getZoneLength(),
+            "Every zone must have length == rows_per_zone=4; got "
+                + z.getZoneLength()
+                + " at zone_start="
+                + z.getZoneStart());
+      }
+    }
+  }
+
+  @Test
+  public void testTwoCoexistingZonemapIndexes() throws Exception {
+    // Two differently-named ZONEMAP indexes on different columns of the same dataset must
+    // commit with disjoint UUIDs and not interfere with each other. The per-task UUID
+    // strategy in `runZonemapDistributed` should make this trivially safe (each createIndex
+    // call generates its own UUID, so no shared-path race) but the test pins the cross-name
+    // isolation that the read path (load_indices_by_name groups by name) depends on.
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 20)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_zm_id using zonemap (id)", fullTable));
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_zm_text using zonemap (text)", fullTable));
+
+    List<Index> idSegments = indexesByName("idx_zm_id");
+    List<Index> textSegments = indexesByName("idx_zm_text");
+    Assertions.assertFalse(idSegments.isEmpty(), "id index must commit");
+    Assertions.assertFalse(textSegments.isEmpty(), "text index must commit");
+
+    Set<UUID> idUuids = idSegments.stream().map(Index::uuid).collect(Collectors.toSet());
+    Set<UUID> textUuids = textSegments.stream().map(Index::uuid).collect(Collectors.toSet());
+    Assertions.assertTrue(
+        java.util.Collections.disjoint(idUuids, textUuids),
+        "Per-task UUIDs must be globally unique across differently-named indexes; got "
+            + "overlap: id="
+            + idUuids
+            + ", text="
+            + textUuids);
+
+    // Both indexes' getZonemapStats must work after committing both — a regression where
+    // index-name-grouping leaked across names would mix stats between columns.
+    try (org.lance.Dataset lds = openLance()) {
+      List<ZoneStats> idStats = lds.getZonemapStats("id");
+      List<ZoneStats> textStats = lds.getZonemapStats("text");
+      Assertions.assertFalse(idStats.isEmpty(), "id stats must be readable");
+      Assertions.assertFalse(textStats.isEmpty(), "text stats must be readable");
+      // Sanity: id stats must have Number min/max (Int32 column), text stats must have
+      // String min/max — a cross-leak would produce mismatched types.
+      for (ZoneStats z : idStats) {
+        Assertions.assertTrue(
+            z.getMin() instanceof Number,
+            "id zone min must be Number; got " + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      }
+      for (ZoneStats z : textStats) {
+        Assertions.assertTrue(
+            z.getMin() instanceof String,
+            "text zone min must be String; got "
+                + (z.getMin() == null ? "null" : z.getMin().getClass()));
+      }
+    }
+  }
+
+  @Test
+  public void testCreateZonemapOnNullableStringColumn() throws Exception {
+    // Companion to testCreateZonemapOnStringColumn: the prior test asserts non-null min/max,
+    // but uses a non-null fixture. This test injects NULL values and verifies the zonemap
+    // round-trips through the all-NULL-zone codec path:
+    //   - Zones spanning a row range with no NULLs: non-null String min/max, nullCount=0.
+    //   - Zones spanning all-NULL rows: null min/max, nullCount=zoneLength.
+    // Without this test, a regression that made the string codec crash on NULLs would not
+    // surface here.
+    //
+    // DataFrame.coalesce(1) is required because SQL INSERT VALUES under `local[10]` produces
+    // one fragment per VALUES tuple, defeating the "5 NULL rows align with one zone" plan.
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    // 10 rows: rows 0..4 have text, rows 5..9 are NULL. Use rows_per_zone=5 so the zones
+    // align with the NULL boundary. coalesce(1) groups them all into one fragment.
+    // (ZONEMAP uses `rows_per_zone`, NOT `zone_size` — the latter is BTree's parameter
+    // name. Mixing them up is the exact silent-drop bug class this test is sensitive to.)
+    spark
+        .range(0, 10)
+        .selectExpr(
+            "cast(id as int) as id",
+            "case when id < 5 then cast(concat('s_', id) as string) else cast(null as string) end as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_zm_null_text using zonemap (text) with (rows_per_zone=5)",
+                fullTable))
+        .collect();
+    checkIndex("idx_zm_null_text");
+
+    try (org.lance.Dataset lds = openLance()) {
+      // Pin the fragmentation: the test logic depends on the 5-NULL block aligning with one
+      // rows_per_zone=5 zone. If Spark ever splits the coalesce(1) partition into multiple
+      // fragments, the alignment would break and the all-NULL-zone assertion below could pass
+      // by accident for the wrong reason.
+      Assertions.assertEquals(
+          1,
+          lds.getFragments().size(),
+          "Test fixture expects coalesce(1) to produce exactly one fragment");
+
+      List<org.lance.index.scalar.ZoneStats> stats = lds.getZonemapStats("text");
+      Assertions.assertFalse(stats.isEmpty(), "Expected at least one zone for the indexed column");
+
+      boolean sawAllNullZone = false;
+      boolean sawNonNullZone = false;
+      for (org.lance.index.scalar.ZoneStats z : stats) {
+        if (z.getNullCount() == z.getZoneLength()) {
+          // All-NULL zone: min/max must be null; this is the codec's contract.
+          Assertions.assertNull(z.getMin(), "All-NULL zone must have null min");
+          Assertions.assertNull(z.getMax(), "All-NULL zone must have null max");
+          sawAllNullZone = true;
+        } else if (z.getNullCount() == 0) {
+          // No-NULL zone: min/max must be present non-null Strings.
+          Assertions.assertNotNull(z.getMin(), "Non-NULL zone must have a min");
+          Assertions.assertNotNull(z.getMax(), "Non-NULL zone must have a max");
+          Assertions.assertTrue(z.getMin() instanceof String, "min must be String");
+          Assertions.assertTrue(z.getMax() instanceof String, "max must be String");
+          sawNonNullZone = true;
+        } else {
+          // Mixed-null zone (some nulls, some non-nulls). The fixture is designed so the
+          // 5-NULL block aligns with one rows_per_zone=5 zone — every zone should be either
+          // all-NULL or no-NULL. A mixed-null zone means the alignment broke (Spark
+          // partitioning drift, row ordering change, or codec regression), and the
+          // sawAllNullZone/sawNonNullZone flags would otherwise both stay false and the test
+          // would pass vacuously. Fail loudly with the zone shape.
+          Assertions.fail(
+              String.format(
+                  "Unexpected mixed-null zone: nullCount=%d, zoneLength=%d, "
+                      + "fragmentId=%d, zoneStart=%d — test fixture expects zone boundaries to "
+                      + "align with the 5-NULL/5-non-NULL split, but didn't",
+                  z.getNullCount(), z.getZoneLength(), z.getFragmentId(), z.getZoneStart()));
+        }
+      }
+      Assertions.assertTrue(sawAllNullZone, "Test fixture must produce at least one all-NULL zone");
+      Assertions.assertTrue(sawNonNullZone, "Test fixture must produce at least one non-NULL zone");
+    }
+  }
+
+  @Test
+  public void testCreateZonemapOnSingleFragmentTable() throws Exception {
+    // The smallest non-trivial case for distributed-multi-segment: a one-fragment table must
+    // still commit cleanly with exactly one segment under the index name. Catches a regression
+    // where the runZonemapDistributed code path mishandled the N=1 degenerate edge (e.g. a
+    // refactor that special-cased "more than one task" and skipped the commit on N=1).
+    //
+    // We must use DataFrame.coalesce(1) rather than SQL INSERT VALUES because the latter
+    // partitions per VALUES tuple under `local[10]` and produces N single-row fragments.
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    spark
+        .range(0, 10)
+        .selectExpr("cast(id as int) as id", "cast(concat('t_', id) as string) as text")
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_zm_single using zonemap (id)", fullTable));
+    long fragmentsIndexed = result.collectAsList().get(0).getLong(0);
+    Assertions.assertEquals(1L, fragmentsIndexed, "Expected one fragment indexed for N=1 case");
+
+    List<Index> segments = indexesByName("idx_zm_single");
+    Assertions.assertEquals(
+        1, segments.size(), "N=1 fragment dataset must commit exactly one segment");
+    Index segment = segments.get(0);
+    Assertions.assertEquals(
+        1,
+        segment.fragments().orElseThrow().size(),
+        "The single segment must cover exactly one fragment");
+  }
+
+  /** Open the test table as a Lance dataset; caller is responsible for closing. */
+  private org.lance.Dataset openLance() {
+    return org.lance.Dataset.open().uri(tableDir).build();
+  }
+
+  private List<ZoneStats> zonemapStats(String column) {
+    org.lance.Dataset ds = openLance();
+    try {
+      return ds.getZonemapStats(column);
+    } finally {
+      ds.close();
+    }
+  }
+
+  private List<Index> indexesByName(String name) {
+    org.lance.Dataset ds = openLance();
+    try {
+      return ds.getIndexes().stream()
+          .filter(i -> name.equals(i.name()))
+          .collect(Collectors.toList());
+    } finally {
+      ds.close();
     }
   }
 }


### PR DESCRIPTION
Closes #512. Closes #514.

Adds `ALTER TABLE ... CREATE INDEX ... USING zonemap (col)` with two build paths:

**Distributed** (default): one Lance segment per fragment, built in parallel. Each task uses a fresh per-task UUID so the per-task `<uuid>/zonemap.lance` files don't collide; the driver commits N IndexMetadata entries under the shared name in one transaction. Works against current upstream lance-core, no new APIs needed.

**Consolidated** (opt-in via `spark.lance.zonemap.consolidate.enabled=true`): workers compute per-fragment zone batches via `dataset.computeZonemapBatch` and return them to the driver; the driver merges them via `dataset.writeZonemapIndexFromBatches` and commits a single IndexMetadata entry covering every fragment.

## Creation time and footprint (sf=100 store_sales, `ss_sold_date_sk`)

Same dataset (234 fragments, 287,997,024 rows), same column, single zonemap index:

|                       | Distributed | Consolidated |
|-----------------------|-------------|--------------|
| Wall-clock            | **15.0 s**  | **28.1 s**   |
| Index segments        | 234         | 1            |
| `_indices/` bytes     | 1,099,920   | 137,835      |
| Per-segment file size | 4.7 KB avg  | 137 KB total |

The consolidated path is ~2× slower in wall-clock (driver-side write replaces parallel executor writes) but produces ~8× less on-disk index data because Lance's per-file header overhead is paid once instead of 234 times. Manifest grows by 1 IndexMetadata entry instead of 234.

Bulk-build of all 15 fact-table zonemaps on the four clustered tables (~903M rows across the four facts) takes **56 s** end-to-end via the consolidated path (default per-zone is `rows_per_zone=8192`).

## Dependency on lance-core

The consolidated path uses two new lance-core APIs that are in review upstream:

- lance-format/lance#6779 — Rust `compute_zonemap_batch` + `write_consolidated_zonemap_segment`
- lance-format/lance#6780 — Java JNI bindings, stacked on #6779

**Not mergeable until both land and a lance-core release with those APIs ships.** The distributed path alone works against current `<lance.version>` (no pom change in this PR).

## What changed

- `AddIndexExec.scala`: SQL `zonemap` method, `runZonemapDistributed`, `runZonemapConsolidated`, two per-fragment task classes, and a pre-commit check that the consolidated file's `fragment_bitmap` matches the dispatcher's fragment set.
- `LanceSparkReadOptions.java`: `spark.lance.zonemap.consolidate.enabled` (lenient parse: case-insensitive `"true"` after trim, anything else falls through to distributed).
- `docs/src/operations/ddl/create-index.md`: zonemap method, `rows_per_zone` option, consolidated SparkConf flag, single-column constraint.
- `integration-tests/test_lance_spark.py`: two pytest cases (default path + consolidated mode).

## Tests

`AddIndexTest`: 38 cases, green on Spark 3.5/2.12 and 4.0/2.13.

- Distributed: multi-segment commit shape (per-fragment IndexMetadata, distinct UUIDs, fragment-bitmap union equals the indexed set), `rows_per_zone` forwarding, N=1 degenerate case, idempotent re-create, two coexisting indexes on different columns.
- Consolidated: single-segment shape, cross-path replace (distributed→consolidated and the reverse), flag parsing edge cases (default-off, `"false"` routes to distributed, `"TRUE"` with whitespace), type coverage (int / long / string / nullable-string), `rows_per_zone` min/max correctness, end-to-end SELECT after CREATE INDEX.

`IndexUtilsTest`: 14 cases for the SQL → `IndexType` mapping and `toJson` wire-shape edge cases.

`integration-tests/test_lance_spark.py`: `test_create_zonemap_index` (default distributed path with `rows_per_zone=16`) and `test_create_zonemap_index_consolidated` (asserts exactly one IndexMetadata segment under the consolidated mode).

`mergeIndexMetadata` is skipped on both paths: nothing to merge for distributed (Lance's read path serves multi-segment natively), already merged in-memory for consolidated.
