### PR TITLE
fix(benchmark): correct Spark extension class in TPC-DS submit scripts

### DIFF
--- a/benchmark/scripts/submit-benchmark.sh
+++ b/benchmark/scripts/submit-benchmark.sh
@@ -274,7 +274,7 @@ if [[ -n "${EXECUTOR_CORES}" ]]; then
 fi
 
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 if [[ -n "${BUNDLE_JAR}" ]] && [[ "${BUNDLE_JAR}" != "${SPARK_HOME}"/jars/* ]]; then
     SUBMIT_ARGS+=("--jars" "${BUNDLE_JAR}")

--- a/benchmark/scripts/submit-datagen.sh
+++ b/benchmark/scripts/submit-datagen.sh
@@ -279,7 +279,7 @@ fi
 SUBMIT_ARGS+=("--conf" "spark.dynamicAllocation.maxExecutors=${MAX_EXECUTORS}")
 
 # Lance extension
-SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.LanceSparkSessionExtension")
+SUBMIT_ARGS+=("--conf" "spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions")
 
 # Kyuubi TPC-DS catalog
 SUBMIT_ARGS+=("--conf" "spark.sql.catalog.tpcds=org.apache.kyuubi.spark.connector.tpcds.TPCDSCatalog")


### PR DESCRIPTION
`submit-datagen.sh:282` and `submit-benchmark.sh:277` referenced the non-existent `org.lance.spark.LanceSparkSessionExtension` (singular, wrong package). Silently failed to load at runtime. Corrected to `org.lance.spark.extensions.LanceSparkSessionExtensions`, matching `generate-data.sh:89` / `run-benchmark.sh:95`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)