### PR TITLE
fix: backtick-quote multipart identifiers in range-based BTree index job

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/ParserUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/ParserUtils.java
@@ -34,4 +34,26 @@ public final class ParserUtils {
     }
     return text;
   }
+
+  /**
+   * Backtick-quotes an identifier for use in a Spark multipart identifier string. Idempotent: if
+   * the input is already surrounded by backticks it is returned unchanged. Throws when the input
+   * has an unbalanced leading or trailing backtick.
+   *
+   * @param identifier a bare or already-quoted identifier
+   * @return the backtick-quoted identifier
+   * @throws IllegalArgumentException if the identifier has a backtick on only one side
+   */
+  public static String quoteIdentifier(String identifier) {
+    boolean startsWithBacktick = identifier.startsWith("`");
+    boolean endsWithBacktick = identifier.endsWith("`");
+    if (identifier.length() >= 2 && startsWithBacktick && endsWithBacktick) {
+      return identifier;
+    }
+    if (startsWithBacktick || endsWithBacktick) {
+      throw new IllegalArgumentException(
+          "Malformed identifier (unbalanced backticks): " + identifier);
+    }
+    return "`" + identifier + "`";
+  }
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -32,7 +32,7 @@ import org.lance.index.scalar.{BTreeIndexParams, ScalarIndexParams}
 import org.lance.operation.{CreateIndex => AddIndexOperation}
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceDataset, LanceRuntime, LanceSparkReadOptions}
 import org.lance.spark.arrow.LanceArrowWriter
-import org.lance.spark.utils.{CloseableUtil, Utils}
+import org.lance.spark.utils.{CloseableUtil, ParserUtils, Utils}
 import org.lance.spark.write.SingleBatchArrowReader
 
 import java.time.Instant
@@ -393,14 +393,16 @@ class RangeBasedBTreeIndexJob(
     val columns = addIndexExec.columns.toList
     val zoneSize = addIndexExec.args.find(_.name == "zone_size").map(_.value.asInstanceOf[Long])
 
-    // Build a fully qualified table name to read data back through Spark.
+    // Build a fully qualified table name to read data back through Spark. Every segment is
+    // backtick-quoted so that Spark's multipart identifier parser does not split on dots,
+    // hyphens, or other special characters inside catalog/namespace/table names.
     val namespace = Option(ident.namespace()).map(_.toSeq).getOrElse(Seq.empty)
-    val parts = if (namespace.isEmpty) {
+    val rawParts = if (namespace.isEmpty) {
       Seq(catalog.name(), ident.name())
     } else {
       catalog.name() +: namespace :+ ident.name()
     }
-    val fullTableName = parts.mkString(".")
+    val fullTableName = rawParts.map(ParserUtils.quoteIdentifier).mkString(".")
 
     // Read specific column and _rowid from dataset
     val df = session.table(fullTableName)

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/ParserUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/ParserUtilsTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/** Unit tests for {@link ParserUtils#cleanIdentifier}. */
+/** Unit tests for {@link ParserUtils#cleanIdentifier} and {@link ParserUtils#quoteIdentifier}. */
 public class ParserUtilsTest {
 
   @Test
@@ -77,5 +77,46 @@ public class ParserUtilsTest {
   @Test
   public void testNullInput() {
     assertNull(ParserUtils.cleanIdentifier(null));
+  }
+
+  @Test
+  public void testQuoteBareIdentifier() {
+    assertEquals("`my_table`", ParserUtils.quoteIdentifier("my_table"));
+  }
+
+  @Test
+  public void testQuoteIdentifierWithDots() {
+    assertEquals("`schema.table`", ParserUtils.quoteIdentifier("schema.table"));
+  }
+
+  @Test
+  public void testQuoteEmptyString() {
+    assertEquals("``", ParserUtils.quoteIdentifier(""));
+  }
+
+  @Test
+  public void testQuoteAlreadyQuotedIsIdempotent() {
+    assertEquals("`my_table`", ParserUtils.quoteIdentifier("`my_table`"));
+  }
+
+  @Test
+  public void testQuoteAlreadyQuotedEmpty() {
+    assertEquals("``", ParserUtils.quoteIdentifier("``"));
+  }
+
+  @Test
+  public void testQuoteUnbalancedLeadingBacktickThrows() {
+    assertThrows(IllegalArgumentException.class, () -> ParserUtils.quoteIdentifier("`my_table"));
+  }
+
+  @Test
+  public void testQuoteUnbalancedTrailingBacktickThrows() {
+    assertThrows(IllegalArgumentException.class, () -> ParserUtils.quoteIdentifier("my_table`"));
+  }
+
+  @Test
+  public void testQuoteSingleBacktickThrows() {
+    // Single backtick: starts and ends with `, but length < 2 — treated as unbalanced.
+    assertThrows(IllegalArgumentException.class, () -> ParserUtils.quoteIdentifier("`"));
   }
 }


### PR DESCRIPTION
A path-based identifier is already  unquoted in RangeBasedBTreeIndexJob, when feeds it to SparkSession.table(String), result in exception 