### PR TITLE
fix(catalog): propagate namespace storage options into read options

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -71,6 +71,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.lance.spark.utils.Utils.createPathBasedReadOptions;
 import static org.lance.spark.utils.Utils.createReadOptions;
 
 public abstract class BaseLanceNamespaceSparkCatalog
@@ -527,7 +528,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
   private boolean tableExistsAtPath(Identifier ident) {
     String datasetUri = getDatasetUri(ident);
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
     try (Dataset dataset = Utils.openDatasetBuilder(readOptions).build()) {
       return true;
@@ -609,6 +610,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.empty(),
             Optional.of(namespace),
             Optional.of(tableIdList),
+            Optional.ofNullable(initialStorageOptions),
             name);
     return createDataset(
         readOptions,
@@ -632,7 +634,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
     String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
@@ -848,6 +850,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.empty(),
             Optional.of(namespace),
             Optional.of(tableIdList),
+            Optional.ofNullable(initialStorageOptions),
             name);
 
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
@@ -881,7 +884,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
 
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
@@ -955,7 +958,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
 
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
     Dataset ds;
@@ -1035,6 +1038,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.empty(),
             Optional.of(namespace),
             Optional.of(tableIdList),
+            Optional.ofNullable(initialStorageOptions),
             name);
 
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
@@ -1078,7 +1082,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
 
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
     boolean exists = tableExistsAtPath(ident);
@@ -1143,7 +1147,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     if (isPathBasedIdentifier(ident)) {
       String datasetUri = getDatasetUri(ident);
       LanceSparkReadOptions readOptions =
-          createReadOptions(
+          createPathBasedReadOptions(
               datasetUri,
               catalogConfig,
               Optional.empty(),
@@ -1171,6 +1175,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             Optional.empty(),
             Optional.of(namespace),
             Optional.of(tableIdList),
+            Optional.ofNullable(describeResponse.getStorageOptions()),
             name);
     return new ResolvedTable(readOptions, describeResponse, tableIdList);
   }
@@ -1328,6 +1333,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
               versionId,
               Optional.of(namespace),
               Optional.of(resolved.tableIdList),
+              Optional.ofNullable(initialStorageOptions),
               name);
     } else {
       readOptions = resolved.readOptions;
@@ -1394,7 +1400,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       versionId = Optional.of(Utils.parseVersion(version.get()));
     } else if (timestamp.isPresent()) {
       LanceSparkReadOptions readOptions =
-          createReadOptions(
+          createPathBasedReadOptions(
               datasetUri,
               catalogConfig,
               Optional.empty(),
@@ -1409,7 +1415,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     }
 
     LanceSparkReadOptions readOptions =
-        createReadOptions(
+        createPathBasedReadOptions(
             datasetUri, catalogConfig, versionId, Optional.empty(), Optional.empty(), name);
 
     // Read schema, file format version, and config from the dataset

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -173,13 +173,16 @@ public class Utils {
   }
 
   /**
-   * Creates LanceSparkReadOptions for this catalog.
+   * Creates LanceSparkReadOptions for a namespace-backed table.
    *
    * @param location the dataset URI
    * @param catalogConfig catalog configuration
    * @param versionId optional dataset version id
    * @param namespace optional namespace for credential vending
    * @param tableId optional table identifier
+   * @param storageOptions optional per-table storage options returned by the namespace service
+   *     (e.g. vended credentials from {@code describeTable} / {@code declareTable}); wins over
+   *     {@code catalogConfig} storage options on key collisions
    * @param catalogName catalog name for cache isolation
    * @return a new LanceSparkReadOptions with catalog settings
    */
@@ -189,12 +192,10 @@ public class Utils {
       Optional<Long> versionId,
       Optional<LanceNamespace> namespace,
       Optional<List<String>> tableId,
+      Optional<Map<String, String>> storageOptions,
       String catalogName) {
     LanceSparkReadOptions.Builder builder =
-        LanceSparkReadOptions.builder()
-            .datasetUri(location)
-            .withCatalogDefaults(catalogConfig)
-            .catalogName(catalogName);
+        LanceSparkReadOptions.builder().datasetUri(location).catalogName(catalogName);
 
     if (versionId.isPresent()) {
       builder.version(versionId.get().intValue());
@@ -205,8 +206,30 @@ public class Utils {
     if (namespace.isPresent()) {
       builder.namespace(namespace.get());
     }
-
+    if (storageOptions.isPresent() && !storageOptions.get().isEmpty()) {
+      builder.storageOptions(storageOptions.get());
+    }
+    // Order matters: storage options above are set first so withCatalogDefaults
+    // treats catalog values as fallbacks under them, not overrides.
+    builder.withCatalogDefaults(catalogConfig);
     return builder.build();
+  }
+
+  /**
+   * Convenience overload for path-based callers that have no namespace-vended storage options.
+   * Namespace-based call sites must use {@link #createReadOptions} with an explicit {@code
+   * storageOptions} argument so that credentials vended by the namespace service reach the read
+   * path.
+   */
+  public static LanceSparkReadOptions createPathBasedReadOptions(
+      String location,
+      LanceSparkCatalogConfig catalogConfig,
+      Optional<Long> versionId,
+      Optional<LanceNamespace> namespace,
+      Optional<List<String>> tableId,
+      String catalogName) {
+    return createReadOptions(
+        location, catalogConfig, versionId, namespace, tableId, Optional.empty(), catalogName);
   }
 
   // Determine if the timestamp is in microseconds or nanoseconds and convert to Instant


### PR DESCRIPTION
describeTable/declareTable responses can carry per-table storage options (vended credentials, region overrides) that must reach the read path. Pass them through createReadOptions at all five namespace-based call sites (createTable, stageCreate, stageCreateOrReplace, resolveIdentifier, and the time-travel rebuild in loadTableInternal).

previously, if we get vended credentials via rest namespace, load table will fail, since storage options is not set to readOptions