### PR TITLE
test: pin down CDF version-column behavior for UPDATE COLUMNS, MERGE INTO, and INSERT OVERWRITE

### DIFF
--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/cdf/BaseCdfVersionTrackingTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/cdf/BaseCdfVersionTrackingTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * Tests for Change Data Feed (CDF) version tracking columns: _row_created_at_version and
  * _row_last_updated_at_version.
@@ -226,6 +228,54 @@ public abstract class BaseCdfVersionTrackingTest {
         Arrays.asList(
             CdfRow.ofWithVersions(1, "Alice", 200, 1L, 4L),
             CdfRow.ofWithVersions(3, "Charlie", 600, 1L, 4L)));
+  }
+
+  /**
+   * INSERT OVERWRITE replaces the table contents with a new fragment set. The post-overwrite rows
+   * are new rows (no row-identity continuity with the pre-overwrite rows), so both version columns
+   * must equal the overwrite commit version.
+   */
+  @Test
+  public void testInsertOverwriteResetsBothVersionColumns() {
+    CdfTestHelper helper = new CdfTestHelper(spark, catalogName);
+    helper.create();
+
+    // v2: initial insert
+    helper.insert(
+        Arrays.asList(
+            CdfRow.of(1, "Alice", 100), CdfRow.of(2, "Bob", 200), CdfRow.of(3, "Charlie", 300)));
+
+    // v3: update so pre-overwrite rows have non-trivial last_updated
+    helper.update("value = value + 1", "id = 1");
+
+    // v4: INSERT OVERWRITE — pre-overwrite rows are gone, new rows must show overwrite version on
+    // both version columns.
+    spark.sql(
+        String.format(
+            "INSERT OVERWRITE %s VALUES (10, 'Xavier', 1000), (11, 'Yvonne', 1100)",
+            helper.getTableName()));
+
+    List<CdfRow> after = helper.getAllWithVersions();
+    assertEquals(2, after.size(), "overwrite should leave exactly the new rows");
+
+    Long overwriteVersion = null;
+    for (CdfRow row : after) {
+      assertEquals(
+          row.createdAtVersion,
+          row.lastUpdatedAtVersion,
+          "overwritten row id=" + row.id + " must have created_at == last_updated");
+      if (overwriteVersion == null) {
+        overwriteVersion = row.createdAtVersion;
+      } else {
+        assertEquals(
+            overwriteVersion,
+            row.createdAtVersion,
+            "all overwritten rows must share the same commit version");
+      }
+      org.junit.jupiter.api.Assertions.assertTrue(
+          row.createdAtVersion >= 4L,
+          "overwrite commit must be at or after v4 (got " + row.createdAtVersion + ")");
+    }
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseMergeIntoTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseMergeIntoTest.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public abstract class BaseMergeIntoTest {
@@ -174,6 +176,145 @@ public abstract class BaseMergeIntoTest {
             + spark.sparkContext().master()
             + ", shuffle.partitions="
             + spark.conf().get("spark.sql.shuffle.partitions"));
+  }
+
+  /**
+   * Pins down per-branch version-column behavior of MERGE INTO on a stable-row-id table:
+   *
+   * <ul>
+   *   <li>UPDATE branch: advances {@code _row_last_updated_at_version}. Lance recalculates {@code
+   *       _row_created_at_version} downward (to v1) for rewritten rows — matching the row-level
+   *       UPDATE semantics already pinned in BaseCdfVersionTrackingTest.
+   *   <li>DELETE branch: row disappears.
+   *   <li>Untouched rows: both versions preserved.
+   *   <li>INSERT branch: <strong>known CDF gap</strong> — rows from MERGE's NOT MATCHED branch flow
+   *       through the same fragment-rewrite path as updated rows, so their {@code
+   *       _row_created_at_version} is <em>not</em> set to the merge commit version. CDF consumers
+   *       cannot distinguish merge-inserted rows from updated rows via created_at.
+   * </ul>
+   *
+   * <p>Tracking upstream fix for the INSERT-branch gap:
+   * https://github.com/lance-format/lance/issues/6735 — once that lands, change the inserted-row
+   * {@code created_at} assertion below from {@code <= initialInsertVersion} to {@code ==
+   * mergeCommitLastUpdated} (i.e. created_at should equal last_updated, both at the merge commit
+   * version).
+   */
+  @Test
+  public void testMergeIntoTracksVersionColumnsPerBranch() {
+    String tableName = "merge_versions_" + UUID.randomUUID().toString().replace("-", "");
+    String fullTable = catalogName + ".default." + tableName;
+
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT NOT NULL, value INT) "
+                + "TBLPROPERTIES ('enable_stable_row_ids' = 'true')",
+            fullTable));
+    spark.sql(String.format("INSERT INTO %s VALUES (1, 10), (2, 20), (3, 30), (4, 40)", fullTable));
+
+    Map<Integer, Long> beforeLastUpdated = new HashMap<>();
+    Long initialInsertVersion = null;
+    for (org.apache.spark.sql.Row row :
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _row_created_at_version, _row_last_updated_at_version "
+                        + "FROM %s ORDER BY id",
+                    fullTable))
+            .collectAsList()) {
+      beforeLastUpdated.put(row.getInt(0), row.getLong(2));
+      if (initialInsertVersion == null) {
+        initialInsertVersion = row.getLong(1);
+      }
+    }
+    Assertions.assertNotNull(initialInsertVersion, "initial insert version must be observable");
+
+    spark
+        .createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1, 110), // UPDATE branch
+                RowFactory.create(2, null), // DELETE branch
+                RowFactory.create(5, 50), // INSERT branch
+                RowFactory.create(6, 60)), // INSERT branch
+            new org.apache.spark.sql.types.StructType().add("id", "int").add("value", "int"))
+        .createOrReplaceTempView("merge_version_source");
+
+    spark.sql(
+        String.format(
+            "MERGE INTO %s t USING merge_version_source s ON t.id = s.id "
+                + "WHEN MATCHED AND s.value IS NULL THEN DELETE "
+                + "WHEN MATCHED THEN UPDATE SET value = s.value "
+                + "WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)",
+            fullTable));
+
+    List<org.apache.spark.sql.Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, value, _row_created_at_version, _row_last_updated_at_version "
+                        + "FROM %s ORDER BY id",
+                    fullTable))
+            .collectAsList();
+
+    // id=2 deleted; surviving ids: 1, 3, 4, 5, 6.
+    Assertions.assertEquals(5, rows.size(), "expected 5 surviving rows after merge");
+
+    Long mergeCommitLastUpdated = null;
+    for (org.apache.spark.sql.Row row : rows) {
+      int id = row.getInt(0);
+      long createdAt = row.getLong(2);
+      long lastUpdated = row.getLong(3);
+      switch (id) {
+        case 1:
+          // UPDATE branch: last_updated advances; created_at gets recalculated downward.
+          Assertions.assertTrue(
+              lastUpdated > beforeLastUpdated.get(1),
+              "id=1 last_updated must advance across UPDATE branch (before="
+                  + beforeLastUpdated.get(1)
+                  + ", after="
+                  + lastUpdated
+                  + ")");
+          Assertions.assertTrue(
+              createdAt <= beforeLastUpdated.get(1),
+              "id=1 created_at must not jump forward across UPDATE (got " + createdAt + ")");
+          mergeCommitLastUpdated = lastUpdated;
+          break;
+        case 3:
+        case 4:
+          // Untouched rows: not hit by any branch — both versions preserved.
+          Assertions.assertEquals(
+              initialInsertVersion.longValue(),
+              createdAt,
+              "id=" + id + " created_at must be preserved (no branch matched)");
+          Assertions.assertEquals(
+              beforeLastUpdated.get(id).longValue(),
+              lastUpdated,
+              "id=" + id + " last_updated must be preserved (no branch matched)");
+          break;
+        case 5:
+        case 6:
+          // INSERT branch sharing the merge commit: last_updated equals the UPDATE branch's
+          // last_updated (single commit). created_at is currently NOT set to the commit version
+          // (it gets recalculated like an UPDATE rewrite). Tracked in
+          // lance-format/lance#6735 — flip the created_at assertion when fixed.
+          Assertions.assertEquals(
+              mergeCommitLastUpdated == null ? lastUpdated : mergeCommitLastUpdated.longValue(),
+              lastUpdated,
+              "id=" + id + " inserted row last_updated must match the merge commit");
+          Assertions.assertTrue(
+              createdAt <= initialInsertVersion,
+              "id="
+                  + id
+                  + " inserted row created_at currently does NOT reflect the merge commit "
+                  + "(initial="
+                  + initialInsertVersion
+                  + ", got="
+                  + createdAt
+                  + "). If this changes, update the assertion.");
+          break;
+        default:
+          Assertions.fail("unexpected surviving id=" + id);
+      }
+    }
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
@@ -102,6 +102,19 @@ public abstract class BaseUpdateColumnsBackfillTest {
             fullTable));
   }
 
+  /** Same row count as prepareDataset() but with stable row IDs for CDF version columns. */
+  protected void prepareDatasetWithStableRowIds() {
+    spark.sql(
+        String.format(
+            "create table %s (id int, value int, name string) using lance "
+                + "TBLPROPERTIES ('enable_stable_row_ids' = 'true')",
+            fullTable));
+    spark.sql(
+        String.format(
+            "insert into %s (id, value, name) values (1, 10, 'one'), (2, 20, 'two'), (3, 30, 'three');",
+            fullTable));
+  }
+
   @Test
   public void testUpdateMatchingRows() {
     // Test case: target has id 1, 2, 3; source has id 2, 4
@@ -253,6 +266,67 @@ public abstract class BaseUpdateColumnsBackfillTest {
           originalMeta.get(i).getInt(2),
           newMeta.get(i).getInt(2),
           "Row " + i + " should preserve _fragid");
+    }
+  }
+
+  /**
+   * Pins down the version-column behavior of UPDATE COLUMNS FROM on a stable-row-id table.
+   *
+   * <p>UPDATE COLUMNS goes through Lance's {@code Update} operation, which (unlike ADD COLUMNS via
+   * {@code Merge} and unlike row-level UPDATE) does <strong>not</strong> bump {@code
+   * _row_last_updated_at_version}. CDF consumers therefore cannot detect column-level rewrites via
+   * the version columns today.
+   *
+   * <p>This test pins down current behavior so a future change to make UPDATE COLUMNS CDF-aware
+   * shows up as a deliberate test update rather than a silent regression.
+   *
+   * <p>Tracking upstream fix: https://github.com/lance-format/lance/issues/6734 — once that lands,
+   * flip the {@code _row_last_updated_at_version} assertion below from {@code assertEquals} to a
+   * strict-greater check (mirroring the ADD COLUMNS version test).
+   */
+  @Test
+  public void testUpdateColumnsPreservesCreatedAtAndAdvancesLastUpdatedWithStableRowIds() {
+    prepareDatasetWithStableRowIds();
+
+    List<Row> before =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _row_created_at_version, _row_last_updated_at_version FROM %s ORDER BY id",
+                    fullTable))
+            .collectAsList();
+
+    spark.sql(
+        String.format(
+            "CREATE TEMPORARY VIEW tmp_view_cdf AS SELECT _rowaddr, _fragid, value * 100 AS value FROM %s",
+            fullTable));
+    spark.sql(String.format("ALTER TABLE %s UPDATE COLUMNS value FROM tmp_view_cdf", fullTable));
+
+    List<Row> after =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _row_created_at_version, _row_last_updated_at_version FROM %s ORDER BY id",
+                    fullTable))
+            .collectAsList();
+
+    assertEquals(before.size(), after.size());
+    for (int i = 0; i < before.size(); i++) {
+      Row b = before.get(i);
+      Row a = after.get(i);
+      assertEquals(b.getInt(0), a.getInt(0));
+      assertEquals(
+          b.getLong(1),
+          a.getLong(1),
+          "_row_created_at_version must be unchanged for id=" + b.getInt(0));
+      // Known gap (lance-format/lance#6734): UPDATE COLUMNS does not currently advance
+      // last_updated. When that issue is fixed, flip this assertion to a strict-greater check.
+      assertEquals(
+          b.getLong(2),
+          a.getLong(2),
+          "_row_last_updated_at_version is currently NOT advanced by UPDATE COLUMNS (id="
+              + b.getInt(0)
+              + ") — if this changes, update the assertion");
     }
   }
 


### PR DESCRIPTION
## Summary
Adds regression tests that pin down current `_row_created_at_version` / `_row_last_updated_at_version` behavior for three write paths on stable-row-id tables, so future upstream Lance fixes show up as deliberate test updates rather than silent changes:

- **INSERT OVERWRITE** (`BaseCdfVersionTrackingTest`): asserts both version columns equal the overwrite commit version for the new rows (no row-identity continuity with pre-overwrite rows).
- **MERGE INTO** (`BaseMergeIntoTest`): pins per-branch behavior — UPDATE branch advances `last_updated` (and recalculates `created_at` downward, matching row-level UPDATE), DELETE removes the row, untouched rows preserve both versions, and the INSERT branch documents the known gap where merge-inserted rows do not get `created_at` set to the merge commit (tracked in [lance-format/lance#6735](https://github.com/lance-format/lance/issues/6735)).
- **UPDATE COLUMNS FROM** (`BaseUpdateColumnsBackfillTest`): pins the current behavior that `UPDATE COLUMNS` does not advance `_row_last_updated_at_version` (tracked in [lance-format/lance#6734](https://github.com/lance-format/lance/issues/6734)).

Each "known gap" assertion has an inline comment pointing at the upstream issue and the assertion flip required when the fix lands.

## Test plan
- [ ] `./mvnw test -pl lance-spark-base_2.12 -Dtest='BaseCdfVersionTrackingTest#testInsertOverwriteResetsBothVersionColumns'`
- [ ] `./mvnw test -pl lance-spark-base_2.12 -Dtest='BaseMergeIntoTest#testMergeIntoTracksVersionColumnsPerBranch'`
- [ ] `./mvnw test -pl lance-spark-base_2.12 -Dtest='BaseUpdateColumnsBackfillTest#testUpdateColumnsPreservesCreatedAtAndAdvancesLastUpdatedWithStableRowIds'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)