### PR TITLE
fix: use describeIndices to list indices to improve performance

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
@@ -46,13 +46,13 @@ case class ShowIndexesExec(
 
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
-      val indexes = dataset.getIndexes().asScala.toSeq
+      val indexes = dataset.describeIndices().asScala.toSeq
       val fieldIdToName = dataset.getLanceSchema().fields().asScala
         .map(f => (java.lang.Integer.valueOf(f.getId), f.getName))
         .toMap
 
       indexes.map { idx =>
-        val fieldIds = idx.fields()
+        val fieldIds = idx.getFieldIds
         val fieldNamesArray =
           if (fieldIds == null) {
             null
@@ -64,7 +64,7 @@ case class ShowIndexesExec(
             new GenericArrayData(names.toArray[AnyRef])
           }
 
-        val name = idx.name()
+        val name = idx.getName
         val stats = dataset.getIndexStatistics(name)
         val indexTypeValue = stats.get("index_type")
         val indexTypeUtf8 =


### PR DESCRIPTION
Currently `Dataset.getIndexes` will return all indexed fragments for each index. If the fragment number is huge, this method becomes slow and consume too much memory.

`Dataset.describeIndices` can improve performance and avoid too much memory consumption.