### PR TITLE
fix: preserve Arrow field metadata for nested List/FixedSizeList/Map children

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -47,6 +47,19 @@ object LanceArrowUtils {
   val ARROW_LARGE_VAR_CHAR_KEY = LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY
   val ARROW_DATE_MILLISECOND_KEY = DateMilliUtils.ARROW_DATE_MILLISECOND_KEY
 
+  // Namespaced keys used to embed child Spark Metadata on a parent StructField when the
+  // child sits inside an ArrayType/MapType — Spark has no per-element metadata slot of its
+  // own. The value is the child Metadata serialized as JSON (the same shape produced by
+  // `Metadata#json`), so deeply nested cases work transparently.
+  val LANCE_ELEMENT_METADATA_KEY = "_lance.element"
+  val LANCE_MAP_KEY_METADATA_KEY = "_lance.key"
+  val LANCE_MAP_VALUE_METADATA_KEY = "_lance.value"
+
+  private val LANCE_INTERNAL_METADATA_KEYS = Set(
+    LANCE_ELEMENT_METADATA_KEY,
+    LANCE_MAP_KEY_METADATA_KEY,
+    LANCE_MAP_VALUE_METADATA_KEY)
+
   def fromArrowField(field: Field): DataType = {
     field.getType match {
       // Handle unsigned integers by mapping to larger signed types
@@ -69,7 +82,7 @@ object LanceArrowUtils {
         val elementType = fromArrowField(elementField)
         val containsNull = elementField.isNullable
         ArrayType(elementType, containsNull)
-      case struct: ArrowType.Struct =>
+      case _: ArrowType.Struct =>
         // Always recurse through LanceArrowUtils for struct children so special cases
         // like Date(MILLISECOND), FixedSizeBinary, etc. are applied in nested schemas too.
         val blobField = isBlobField(field)
@@ -81,16 +94,11 @@ object LanceArrowUtils {
               LongType
             case _ => fromArrowField(childField)
           }
-          val baseMeta = Metadata.fromJson(mapper.writeValueAsString(childField.getMetadata))
-          val childMeta = childField.getType match {
-            case d: ArrowType.Date if d.getUnit == DateUnit.MILLISECOND =>
-              new MetadataBuilder()
-                .withMetadata(baseMeta)
-                .putString(ARROW_DATE_MILLISECOND_KEY, DateMilliUtils.ARROW_DATE_MILLISECOND_VALUE)
-                .build()
-            case _ => baseMeta
-          }
-          StructField(childField.getName, childType, childField.isNullable, childMeta)
+          StructField(
+            childField.getName,
+            childType,
+            childField.isNullable,
+            buildFieldMetadata(childField))
         }.toArray
         StructType(fields)
       case largeBinary: ArrowType.LargeBinary if isBlobField(field) =>
@@ -162,32 +170,85 @@ object LanceArrowUtils {
 
   def fromArrowSchema(schema: Schema): StructType = {
     StructType(schema.getFields.asScala.map { field =>
-      val dt = fromArrowField(field)
-      // Preserve type information in metadata for types that need special handling on write
-      val metadata = field.getType match {
-        case fixedSizeList: ArrowType.FixedSizeList =>
-          val builder = new MetadataBuilder()
-            .putLong(ARROW_FIXED_SIZE_LIST_SIZE_KEY, fixedSizeList.getListSize)
-          if (Float16Utils.isFloat16ArrowField(field)) {
-            builder.putString(ARROW_FLOAT16_KEY, "true")
-          }
-          builder.build()
-        case _: ArrowType.LargeUtf8 =>
-          // Preserve LargeUtf8 type info so subsequent writes use LargeVarCharVector
-          new MetadataBuilder()
-            .putString(ARROW_LARGE_VAR_CHAR_KEY, "true")
-            .build()
-        case date: ArrowType.Date if date.getUnit == DateUnit.MILLISECOND =>
-          val base = Metadata.fromJson(mapper.writeValueAsString(field.getMetadata))
-          new MetadataBuilder()
-            .withMetadata(base)
-            .putString(ARROW_DATE_MILLISECOND_KEY, DateMilliUtils.ARROW_DATE_MILLISECOND_VALUE)
-            .build()
-        case _ => Metadata.fromJson(
-            mapper.writeValueAsString(field.getMetadata))
-      }
-      StructField(field.getName, dt, field.isNullable, metadata)
+      StructField(
+        field.getName,
+        fromArrowField(field),
+        field.isNullable,
+        buildFieldMetadata(field))
     }.toArray)
+  }
+
+  /**
+   * Build Spark Metadata for the given Arrow field, capturing type information that Spark's
+   * DataType cannot represent on its own (Date(MILLISECOND), LargeUtf8, Float16, FixedSizeList
+   * size). For Arrow types that nest a Spark DataType lacking a metadata slot for its element
+   * (List, FixedSizeList, Map), the child's Spark Metadata is serialized as JSON under
+   * `_lance.element`, `_lance.key`, and `_lance.value` so writeback can reconstruct it.
+   */
+  private[util] def buildFieldMetadata(field: Field): Metadata = {
+    // Start from the Arrow field's user metadata so non-Lance keys (if any) survive.
+    val arrowMeta = Metadata.fromJson(mapper.writeValueAsString(field.getMetadata))
+    val builder = new MetadataBuilder().withMetadata(arrowMeta)
+    augmentTypeMarkers(builder, field)
+    augmentChildMetadata(builder, field)
+    builder.build()
+  }
+
+  private def augmentTypeMarkers(builder: MetadataBuilder, field: Field): Unit = {
+    field.getType match {
+      case fixedSizeList: ArrowType.FixedSizeList =>
+        builder.putLong(ARROW_FIXED_SIZE_LIST_SIZE_KEY, fixedSizeList.getListSize.toLong)
+        if (Float16Utils.isFloat16ArrowField(field)) {
+          builder.putString(ARROW_FLOAT16_KEY, Float16Utils.ARROW_FLOAT16_VALUE)
+        }
+      case _: ArrowType.LargeUtf8 =>
+        builder.putString(ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
+      case date: ArrowType.Date if date.getUnit == DateUnit.MILLISECOND =>
+        builder.putString(ARROW_DATE_MILLISECOND_KEY, DateMilliUtils.ARROW_DATE_MILLISECOND_VALUE)
+      case _ =>
+    }
+  }
+
+  private def augmentChildMetadata(builder: MetadataBuilder, field: Field): Unit = {
+    field.getType match {
+      case _: ArrowType.FixedSizeList | _: ArrowType.List =>
+        val children = field.getChildren
+        if (!children.isEmpty && !Float16Utils.isFloat16ArrowField(field)) {
+          // For Float16 vectors, the child's HALF type is encoded in `arrow.float16` on the
+          // parent, so there is no extra child-side metadata worth embedding.
+          val childMeta = buildFieldMetadata(children.get(0))
+          if (hasContent(childMeta)) {
+            builder.putString(LANCE_ELEMENT_METADATA_KEY, childMeta.json)
+          }
+        }
+      case _: ArrowType.Map =>
+        val children = field.getChildren
+        if (!children.isEmpty) {
+          val entryChildren = children.get(0).getChildren
+          if (entryChildren.size() >= 2) {
+            val keyMeta = buildFieldMetadata(entryChildren.get(0))
+            val valueMeta = buildFieldMetadata(entryChildren.get(1))
+            if (hasContent(keyMeta)) {
+              builder.putString(LANCE_MAP_KEY_METADATA_KEY, keyMeta.json)
+            }
+            if (hasContent(valueMeta)) {
+              builder.putString(LANCE_MAP_VALUE_METADATA_KEY, valueMeta.json)
+            }
+          }
+        }
+      case _ =>
+    }
+  }
+
+  private def hasContent(metadata: Metadata): Boolean =
+    metadata != null && metadata.json != "{}"
+
+  private def parseEmbeddedMetadata(parent: Metadata, key: String): Metadata = {
+    if (parent == null || !parent.contains(key)) {
+      Metadata.empty
+    } else {
+      Metadata.fromJson(parent.getString(key))
+    }
   }
 
   def toArrowSchema(
@@ -235,11 +296,17 @@ object LanceArrowUtils {
 
       meta = mapper
         .readValue(metadata.json, classOf[java.util.LinkedHashMap[_, _]])
-        .asScala.map { case (k, v) => (k.toString, String.valueOf(v)) }.toMap
+        .asScala
+        .collect {
+          case (k, v) if !LANCE_INTERNAL_METADATA_KEYS.contains(k.toString) =>
+            (k.toString, String.valueOf(v))
+        }
+        .toMap
     }
 
     dt match {
       case ArrayType(elementType, containsNull) =>
+        val elementMetadata = parseEmbeddedMetadata(metadata, LANCE_ELEMENT_METADATA_KEY)
         if (shouldBeFixedSizeList(metadata, elementType)) {
           val listSize = metadata.getLong(ARROW_FIXED_SIZE_LIST_SIZE_KEY).toInt
           val fieldType =
@@ -265,7 +332,8 @@ object LanceArrowUtils {
               elementType,
               containsNull,
               timeZoneId,
-              largeVarTypes = largeVarTypes)
+              elementMetadata,
+              largeVarTypes)
           }
           new Field(
             name,
@@ -282,7 +350,8 @@ object LanceArrowUtils {
                 elementType,
                 containsNull,
                 timeZoneId,
-                largeVarTypes = largeVarTypes)).asJava)
+                elementMetadata,
+                largeVarTypes)).asJava)
         }
       case StructType(fields) =>
         val fieldType = new FieldType(nullable, ArrowType.Struct.INSTANCE, null, meta.asJava)
@@ -299,6 +368,8 @@ object LanceArrowUtils {
               largeVarTypes)
           }.toSeq.asJava)
       case MapType(keyType, valueType, valueContainsNull) =>
+        val keyMetadata = parseEmbeddedMetadata(metadata, LANCE_MAP_KEY_METADATA_KEY)
+        val valueMetadata = parseEmbeddedMetadata(metadata, LANCE_MAP_VALUE_METADATA_KEY)
         val mapType = new FieldType(nullable, new ArrowType.Map(false), null, meta.asJava)
         // Note: Map Type struct can not be null, Struct Type key field can not be null
         new Field(
@@ -307,8 +378,8 @@ object LanceArrowUtils {
           Seq(toArrowField(
             MapVector.DATA_VECTOR_NAME,
             new StructType()
-              .add(MapVector.KEY_NAME, keyType, nullable = false)
-              .add(MapVector.VALUE_NAME, valueType, nullable = valueContainsNull),
+              .add(MapVector.KEY_NAME, keyType, nullable = false, keyMetadata)
+              .add(MapVector.VALUE_NAME, valueType, nullable = valueContainsNull, valueMetadata),
             nullable = false,
             timeZoneId,
             largeVarTypes = largeVarTypes)).asJava)

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseDateMilliRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseDateMilliRoundtripTest.java
@@ -388,12 +388,11 @@ public abstract class BaseDateMilliRoundtripTest {
   }
 
   /**
-   * Documents the known limitation: Date(MILLISECOND) inside a List degrades to Date(DAY) on
-   * roundtrip because {@code LanceArrowUtils.fromArrowField} returns {@code DataType} without
-   * metadata for array elements.
+   * Date(MILLISECOND) inside a List survives a Spark roundtrip. The inner element's metadata is
+   * embedded under {@code _lance.element} on the parent ArrayType, then restored on writeback.
    */
   @Test
-  public void testDateMilliInArrayDegradesToDay() throws Exception {
+  public void testDateMilliInArrayPreservedOnRoundtrip() throws Exception {
     String srcPath = tempDir.resolve("array_src.lance").toString();
     String dstPath = tempDir.resolve("array_dst.lance").toString();
 
@@ -441,13 +440,13 @@ public abstract class BaseDateMilliRoundtripTest {
     Dataset<Row> df = spark.read().format(LanceDataSource.name).load(srcPath);
     df.write().format(LanceDataSource.name).save(dstPath);
 
-    // Known limitation: list child degrades to Date(DAY)
+    // List child should remain Date(MILLISECOND) after Spark roundtrip.
     Schema outputSchema = openAndGetSchema(dstPath);
     Field outList = outputSchema.findField("dates");
     assertEquals(
-        new ArrowType.Date(DateUnit.DAY),
+        new ArrowType.Date(DateUnit.MILLISECOND),
         outList.getChildren().get(0).getType(),
-        "Known limitation: Date(MILLISECOND) inside List degrades to Date(DAY) on roundtrip");
+        "Date(MILLISECOND) inside List should be preserved on roundtrip");
 
     // Values should still be correct (dates are the right day values)
     List<Row> rows =

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -23,12 +23,13 @@ package org.apache.spark.sql.util
  * It has been modified by the Lance developers to fit the needs of the Lance project.
  */
 
-import org.apache.arrow.vector.types.DateUnit
+import org.apache.arrow.vector.types.{DateUnit, FloatingPointPrecision}
 import org.apache.arrow.vector.types.pojo.{Field, FieldType, Schema}
 import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
+import org.lance.spark.utils.{Float16Utils, LargeVarCharUtils, VectorUtils}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.ZoneId
@@ -339,5 +340,192 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     assert(
       structType("nested_dt").metadata.getString(
         LanceArrowUtils.ARROW_DATE_MILLISECOND_KEY) === "true")
+  }
+
+  // Helpers for building Arrow fields used by the nested-metadata tests below.
+  private def listField(name: String, child: Field): Field = {
+    new Field(
+      name,
+      new FieldType(true, ArrowType.List.INSTANCE, null, null),
+      java.util.Arrays.asList(child))
+  }
+
+  private def fixedSizeListField(name: String, size: Int, child: Field): Field = {
+    new Field(
+      name,
+      new FieldType(true, new ArrowType.FixedSizeList(size), null, null),
+      java.util.Arrays.asList(child))
+  }
+
+  private def mapField(name: String, keyField: Field, valueField: Field): Field = {
+    val entriesField = new Field(
+      "entries",
+      new FieldType(false, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(keyField, valueField))
+    new Field(
+      name,
+      new FieldType(true, new ArrowType.Map(false), null, null),
+      java.util.Arrays.asList(entriesField))
+  }
+
+  private def primitiveField(
+      name: String,
+      arrowType: ArrowType,
+      nullable: Boolean = true): Field = {
+    new Field(
+      name,
+      new FieldType(nullable, arrowType, null, null),
+      java.util.Collections.emptyList())
+  }
+
+  test("Date(MILLISECOND) inside Array roundtrips to Date(MILLISECOND)") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "arr",
+      primitiveField("element", new ArrowType.Date(DateUnit.MILLISECOND)))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    assert(sparkSchema("arr").dataType === ArrayType(DateType, containsNull = true))
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val elementType = arrowBack.findField("arr").getChildren.get(0).getType
+    assert(
+      elementType === new ArrowType.Date(DateUnit.MILLISECOND),
+      s"Array element should remain Date(MILLISECOND), got $elementType")
+  }
+
+  test("LargeUtf8 inside Array roundtrips to LargeUtf8") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "arr",
+      primitiveField("element", ArrowType.LargeUtf8.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    assert(sparkSchema("arr").dataType === ArrayType(StringType, containsNull = true))
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val elementType = arrowBack.findField("arr").getChildren.get(0).getType
+    assert(
+      elementType === ArrowType.LargeUtf8.INSTANCE,
+      s"Array element should remain LargeUtf8, got $elementType")
+  }
+
+  test("LargeUtf8 inside FixedSizeList roundtrips to LargeUtf8") {
+    val arrow = new Schema(java.util.Arrays.asList(fixedSizeListField(
+      "fsl",
+      3,
+      primitiveField("element", ArrowType.LargeUtf8.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    // FixedSizeList<LargeUtf8> is not a Lance vector (element is not numeric), so it
+    // collapses to a regular List on writeback. Element type fidelity is still required.
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val elementType = arrowBack.findField("fsl").getChildren.get(0).getType
+    assert(
+      elementType === ArrowType.LargeUtf8.INSTANCE,
+      s"FixedSizeList element should remain LargeUtf8, got $elementType")
+  }
+
+  test("Date(MILLISECOND) as Map value roundtrips to Date(MILLISECOND)") {
+    val arrow = new Schema(java.util.Arrays.asList(mapField(
+      "m",
+      primitiveField("key", ArrowType.Utf8.INSTANCE, nullable = false),
+      primitiveField("value", new ArrowType.Date(DateUnit.MILLISECOND)))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    assert(sparkSchema("m").dataType === MapType(StringType, DateType, valueContainsNull = true))
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val valueType = arrowBack
+      .findField("m").getChildren.get(0)
+      .getChildren.get(1).getType
+    assert(
+      valueType === new ArrowType.Date(DateUnit.MILLISECOND),
+      s"Map value should remain Date(MILLISECOND), got $valueType")
+  }
+
+  test("LargeUtf8 as Map key and Date(MILLISECOND) as Map value both preserved") {
+    val arrow = new Schema(java.util.Arrays.asList(mapField(
+      "m",
+      primitiveField("key", ArrowType.LargeUtf8.INSTANCE, nullable = false),
+      primitiveField("value", new ArrowType.Date(DateUnit.MILLISECOND)))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val entries = arrowBack.findField("m").getChildren.get(0).getChildren
+    assert(entries.get(0).getType === ArrowType.LargeUtf8.INSTANCE)
+    assert(entries.get(1).getType === new ArrowType.Date(DateUnit.MILLISECOND))
+  }
+
+  test("nested Array<Array<Date(MILLISECOND)>> roundtrips") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "outer",
+      listField("element", primitiveField("element", new ArrowType.Date(DateUnit.MILLISECOND))))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val inner = arrowBack.findField("outer").getChildren.get(0)
+    val innermost = inner.getChildren.get(0)
+    assert(inner.getType === ArrowType.List.INSTANCE)
+    assert(
+      innermost.getType === new ArrowType.Date(DateUnit.MILLISECOND),
+      s"Innermost element should remain Date(MILLISECOND), got ${innermost.getType}")
+  }
+
+  test("FixedSizeList(Float16) nested inside an Array preserves size + float16 markers") {
+    val float16Element = primitiveField(
+      "element",
+      new ArrowType.FloatingPoint(FloatingPointPrecision.HALF))
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "vectors",
+      fixedSizeListField("element", 4, float16Element))))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    // Read side: outer ArrayType must carry the inner FixedSizeList's metadata
+    // (size + float16 marker) under the namespaced _lance.element key, so writeback
+    // can restore it on Spark 4.0+ runtimes that support Float2Vector.
+    val outerMeta = sparkSchema("vectors").metadata
+    assert(outerMeta.contains(LanceArrowUtils.LANCE_ELEMENT_METADATA_KEY))
+    val elementMeta = org.apache.spark.sql.types.Metadata.fromJson(
+      outerMeta.getString(LanceArrowUtils.LANCE_ELEMENT_METADATA_KEY))
+    assert(elementMeta.contains(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY))
+    assert(elementMeta.getLong(VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY) === 4L)
+    assert(elementMeta.contains(Float16Utils.ARROW_FLOAT16_KEY))
+    assert(elementMeta.getString(Float16Utils.ARROW_FLOAT16_KEY) === "true")
+
+    // Write side only runs on Arrow 18+ (Spark 4.0+). On older Arrow versions
+    // toArrowSchema rightly refuses to materialize a Float16 vector.
+    if (Float16Utils.isFloat2VectorAvailable) {
+      val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+      val inner = arrowBack.findField("vectors").getChildren.get(0)
+      assert(inner.getType.isInstanceOf[ArrowType.FixedSizeList])
+      assert(inner.getType.asInstanceOf[ArrowType.FixedSizeList].getListSize === 4)
+      assert(Float16Utils.isFloat16ArrowField(inner))
+    }
+  }
+
+  test("Array<Date(MILLISECOND)> nested inside a Struct roundtrips") {
+    val dateInArray = listField(
+      "arr",
+      primitiveField("element", new ArrowType.Date(DateUnit.MILLISECOND)))
+    val structField = new Field(
+      "s",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(dateInArray))
+    val arrow = new Schema(java.util.Arrays.asList(structField))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val innerArr = arrowBack.findField("s").getChildren.get(0)
+    val element = innerArr.getChildren.get(0)
+    assert(
+      element.getType === new ArrowType.Date(DateUnit.MILLISECOND),
+      s"Struct->Array element should remain Date(MILLISECOND), got ${element.getType}")
+  }
+
+  test("LargeUtf8 inside a Struct field preserves LargeUtf8 marker on writeback") {
+    val struct = new Field(
+      "s",
+      new FieldType(true, ArrowType.Struct.INSTANCE, null, null),
+      java.util.Arrays.asList(primitiveField("name", ArrowType.LargeUtf8.INSTANCE)))
+    val arrow = new Schema(java.util.Arrays.asList(struct))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val nameType = arrowBack.findField("s").getChildren.get(0).getType
+    assert(
+      nameType === ArrowType.LargeUtf8.INSTANCE,
+      s"Struct child should remain LargeUtf8, got $nameType")
   }
 }


### PR DESCRIPTION
## Summary

Fixes #515. `LanceArrowUtils.fromArrowField` returned a bare `DataType`, so Spark's `ArrayType` and `MapType` had nowhere to carry the special-type markers (`Date(MILLISECOND)`, `LargeUtf8`, `Float16`, `FixedSizeList` size) attached to nested element / key / value fields. On writeback those types silently degraded:

- `array<date(ms)>` → `array<date(day)>`
- `array<largeutf8>` → `array<utf8>`
- `map<largeutf8, date(ms)>` → `map<utf8, date(day)>`
- `array<fsl<float16, N>>` → `array<list<float32>>`

The Struct branch in `fromArrowField` previously only carried over `Date(MILLISECOND)` — `LargeUtf8`, `Float16`, and `FixedSizeList` markers were lost on struct children too.

## Approach

The bug is structural: Spark's `ArrayType(elementType, containsNull)` and `MapType(keyType, valueType, valueContainsNull)` have no per-element metadata slot, so child Arrow-field metadata cannot ride on the Spark `DataType` itself.

Per the suggestion in the issue, this PR adopts a namespacing convention: when walking into a `List` / `FixedSizeList` / `Map`, the child's Spark `Metadata` is serialized as JSON under three namespaced keys on the parent's metadata:

| Key | Carries |
|---|---|
| `_lance.element` | Child metadata for List / FixedSizeList |
| `_lance.key` | Map key metadata |
| `_lance.value` | Map value metadata |

The same scheme nests recursively, so `map<*, array<date(ms)>>` and `array<array<date(ms)>>` both roundtrip cleanly.

Implementation:

- New private `buildFieldMetadata(field)` helper computes the full Spark metadata for any Arrow Field. Both `fromArrowSchema` and the Struct branch in `fromArrowField` now delegate to it, so struct children pick up the same set of markers as top-level fields.
- `toArrowField` parses the embedded `_lance.*` JSON, threads it through the recursive call for the element / key / value type, and strips it from the Arrow user-metadata map so it doesn't leak downstream.
- Float16 vectors are unchanged on the read side (the marker lives on the parent FixedSizeList, not the element), but the new logic ensures the marker survives when an FSL is nested inside another List or Map.

## Tests

`LanceArrowUtilsSuite` gains 9 new tests covering each affected shape:

- `Date(MILLISECOND)` inside `Array`, inside `FixedSizeList`, as `Map` value, nested `Array<Array<...>>`, inside Struct.
- `LargeUtf8` inside `Array`, inside `FixedSizeList`, as `Map` key, inside Struct.
- `FixedSizeList<Float16>` nested inside an `Array` (read-side always, writeback gated on `Float16Utils.isFloat2VectorAvailable` so Arrow 15 builds skip it).

The pre-existing `BaseDateMilliRoundtripTest.testDateMilliInArrayDegradesToDay` was pinning the buggy behavior — renamed to `testDateMilliInArrayPreservedOnRoundtrip` and flipped to assert the correct outcome.

## Test plan

- [x] `mvn test -pl lance-spark-base_2.12` (LanceArrowUtilsSuite: 24/24 pass)
- [x] `mvn test -pl lance-spark-3.5_2.12` (688 tests, 0 failures, 46 skipped — same as main)
- [x] `mvn test -pl lance-spark-4.0_2.13` (704 tests, 0 failures, 38 skipped — exercises Arrow 18 + Float2Vector paths)
- [x] `mvn checkstyle:check spotless:check -pl lance-spark-base_2.12`