### PR TITLE
chore: update lance dependency to v7.0.0-beta.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.8</lance.version>
+        <lance.version>7.0.0-beta.9</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Bump `lance.version` from `7.0.0-beta.8` to `7.0.0-beta.9`.
- Verified Docker hardcoded versions: `LANCE_SPARK_VERSION=0.5.0` already matches the root `lance-spark.version`, and `LANCE_NS_VERSION=0.7.5` matches the `lance-namespace-core` version used by Lance `v7.0.0-beta.9`.
- Triggering tag: refs/tags/v7.0.0-beta.9

## Verification

- `make lint` passed.
- `make install` initially failed because `org.lance:lance-core:7.0.0-beta.9` is not available from Maven Central yet.
- Checked out `lance-format/lance` at `v7.0.0-beta.9` and installed the Java artifact locally with `./mvnw install -Dskip.build.jni=true -DskipTests`.
- Re-ran `make install`; it passed for the default Spark 3.5 / Scala 2.12 build.
