### PR TITLE
chore: update lance dependency to v7.0.0-beta.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.8</lance.version>
+        <lance.version>7.0.0-beta.10</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.8` to `7.0.0-beta.10`.
- Checked `docker/Dockerfile`; `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.5.0`) and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version used by the Lance `v7.0.0-beta.10` source tag (`0.7.5`).
- Triggering tag: refs/tags/v7.0.0-beta.10

## Verification
- `make lint` passed.
- `make install` was run, but Maven Central could not resolve `org.lance:lance-core:7.0.0-beta.10` yet. The `v7.0.0-beta.10` tag exists upstream, but the artifact was not available from Central during this run.
