### PR TITLE
chore: update lance dependency to v7.0.0-beta.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.10</lance.version>
+        <lance.version>7.0.0-beta.11</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.10` to `7.0.0-beta.11`.
- Verified Docker pins: `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.5.0`), and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version transitively included by `lance-core` (`0.7.5`).
- Verified the Spark 3.5 / Scala 2.12 install build after installing the upstream tagged `lance-core` artifact locally, because Maven Central did not yet publish `org.lance:lance-core:7.0.0-beta.11` at verification time.

Triggering tag: refs/tags/v7.0.0-beta.11

## Verification
- `make lint`
- `./mvnw install -DskipTests -Dskip.build.jni=true` in `lance-format/lance` at `refs/tags/v7.0.0-beta.11` to make the requested `lance-core` artifact available locally
- `make install`
