### PR TITLE
chore: update lance dependency to v7.0.0-beta.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.10</lance.version>
+        <lance.version>7.0.0-beta.12</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.10` to `7.0.0-beta.12`.
- Checked `docker/Dockerfile` hardcoded versions: `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.5.0`) and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version declared by the `lance-core` `v7.0.0-beta.12` tag (`0.7.5`).
- Triggering tag: refs/tags/v7.0.0-beta.12

## Verification
- `make lint` passed.
- `make install` initially failed because `org.lance:lance-core:7.0.0-beta.12` is not yet available from Maven Central.
- Installed `lance-core:7.0.0-beta.12` locally from the tagged Lance source with `./mvnw install -DskipTests -Dskip.build.jni=true`, then reran `make install`; it passed for Spark 3.5 / Scala 2.12.
