### PR TITLE
chore: update lance dependency to v7.0.0-beta.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.10</lance.version>
+        <lance.version>7.0.0-beta.13</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `org.lance:lance-core` via `lance.version` from `7.0.0-beta.10` to `7.0.0-beta.13`.
- Verified Docker hardcoded versions: `LANCE_SPARK_VERSION=0.5.0` already matches `lance-spark.version`, and `LANCE_NS_VERSION=0.7.5` matches the `lance-namespace-core` version used by the latest available `lance-core` 7.0 beta POM.
- Triggering tag: refs/tags/v7.0.0-beta.13 (`lancedb/lance`).

## Verification
- `make lint` passed.
- `make install` currently fails because Maven Central does not yet publish `org.lance:lance-core:7.0.0-beta.13`; metadata still lists `7.0.0-beta.12` as latest. Rechecked with `./mvnw -U dependency:get -Dartifact=org.lance:lance-core:7.0.0-beta.13 -Dtransitive=false`, which fails for the same missing artifact.
