### PR TITLE
chore: update lance dependency to v7.0.0-beta.14

### DIFF
--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2512,26 +2512,26 @@ class TestStableRowIds:
       _row_created_at_version for all rows in that fragment.
     """
 
-    def test_tblproperties_enable_stable_row_ids(self, spark):
+    def test_tblproperties_enable_stable_row_ids(self, spark, test_table):
         """Test that TBLPROPERTIES enables CDF version columns."""
-        spark.sql("""
-            CREATE TABLE default.test_table (
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
                 id INT,
                 name STRING,
                 value INT
             ) TBLPROPERTIES ('enable_stable_row_ids' = 'true')
         """)
 
-        spark.sql("""
-            INSERT INTO default.test_table VALUES
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
             (1, 'Alice', 100),
             (2, 'Bob', 200),
             (3, 'Charlie', 300)
         """)
 
-        result = spark.sql("""
+        result = spark.sql(f"""
             SELECT id, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             ORDER BY id
         """).collect()
 
@@ -2540,30 +2540,30 @@ class TestStableRowIds:
             assert row._row_created_at_version is not None
             assert row._row_last_updated_at_version is not None
 
-    def test_default_behavior_no_stable_row_ids(self, spark):
+    def test_default_behavior_no_stable_row_ids(self, spark, test_table):
         """Test version columns without enable_stable_row_ids.
 
         Without enable_stable_row_ids the Lance engine still populates
         _row_created_at_version and _row_last_updated_at_version, but
         returns a baseline value of 1 instead of the actual operation version.
         """
-        spark.sql("""
-            CREATE TABLE default.test_table (
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
                 id INT,
                 name STRING,
                 value INT
             )
         """)
 
-        spark.sql("""
-            INSERT INTO default.test_table VALUES
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
             (1, 'Alice', 100),
             (2, 'Bob', 200)
         """)
 
-        result = spark.sql("""
+        result = spark.sql(f"""
             SELECT id, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             ORDER BY id
         """).collect()
 
@@ -2574,14 +2574,14 @@ class TestStableRowIds:
             assert row._row_last_updated_at_version == 1
 
     @requires_update_or_merge
-    def test_cdc_incremental_ingestion_pattern(self, spark):
+    def test_cdc_incremental_ingestion_pattern(self, spark, test_table):
         """Test CDC incremental ingestion pipeline pattern.
 
         Simulates a CDC pipeline that tracks the last processed version and
         incrementally processes changes using version tracking columns.
         """
-        spark.sql("""
-            CREATE TABLE default.test_table (
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
                 id INT,
                 name STRING,
                 value INT
@@ -2589,8 +2589,8 @@ class TestStableRowIds:
         """)
 
         # v2: Initial data load
-        spark.sql("""
-            INSERT INTO default.test_table VALUES
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
             (1, 'Alice', 100),
             (2, 'Bob', 200),
             (3, 'Charlie', 300)
@@ -2600,7 +2600,7 @@ class TestStableRowIds:
         last_processed_version = 1
         batch1 = spark.sql(f"""
             SELECT id, name, value, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             WHERE (_row_created_at_version > {last_processed_version})
                OR (_row_last_updated_at_version > {last_processed_version})
             ORDER BY id
@@ -2611,13 +2611,13 @@ class TestStableRowIds:
         last_processed_version = 2
 
         # v3: Update one row, v4: Insert new row
-        spark.sql("UPDATE default.test_table SET value = value + 50 WHERE id = 1")
-        spark.sql("INSERT INTO default.test_table VALUES (4, 'David', 400)")
+        spark.sql(f"UPDATE {test_table} SET value = value + 50 WHERE id = 1")
+        spark.sql(f"INSERT INTO {test_table} VALUES (4, 'David', 400)")
 
         # CDC Pipeline: Process batch 2 (changes since v2)
         batch2 = spark.sql(f"""
             SELECT id, name, value, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             WHERE (_row_created_at_version > {last_processed_version})
                OR (_row_last_updated_at_version > {last_processed_version})
             ORDER BY id
@@ -2637,12 +2637,12 @@ class TestStableRowIds:
         last_processed_version = 4
 
         # v5: More updates
-        spark.sql("UPDATE default.test_table SET value = value + 100 WHERE id IN (2, 3)")
+        spark.sql(f"UPDATE {test_table} SET value = value + 100 WHERE id IN (2, 3)")
 
         # CDC Pipeline: Process batch 3 (changes since v4)
         batch3 = spark.sql(f"""
             SELECT id, name, value, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             WHERE (_row_created_at_version > {last_processed_version})
                OR (_row_last_updated_at_version > {last_processed_version})
             ORDER BY id
@@ -2659,12 +2659,12 @@ class TestStableRowIds:
         last_processed_version = 5
 
         # v6: Update entire table
-        spark.sql("UPDATE default.test_table SET value = value * 2")
+        spark.sql(f"UPDATE {test_table} SET value = value * 2")
 
         # CDC Pipeline: Process batch 4 (changes since v5)
         batch4 = spark.sql(f"""
             SELECT id, name, value, _row_created_at_version, _row_last_updated_at_version
-            FROM default.test_table
+            FROM {test_table}
             WHERE (_row_created_at_version > {last_processed_version})
                OR (_row_last_updated_at_version > {last_processed_version})
             ORDER BY id
@@ -2710,14 +2710,15 @@ class TestStableRowIds:
 
         return catalog_name
 
-    def test_catalog_level_stable_row_ids(self, spark):
+    def test_catalog_level_stable_row_ids(self, spark, test_table):
         """Test that catalog-level enable_stable_row_ids enables version columns without TBLPROPERTIES."""
         catalog_name = self._register_cdf_catalog(spark)
+        cdf_table = f"{catalog_name}.{test_table}"
 
         try:
             # CREATE TABLE without TBLPROPERTIES — relies on catalog-level default
             spark.sql(f"""
-                CREATE TABLE {catalog_name}.default.test_table (
+                CREATE TABLE {cdf_table} (
                     id INT,
                     name STRING,
                     value INT
@@ -2725,14 +2726,14 @@ class TestStableRowIds:
             """)
 
             spark.sql(f"""
-                INSERT INTO {catalog_name}.default.test_table VALUES
+                INSERT INTO {cdf_table} VALUES
                 (1, 'Alice', 100),
                 (2, 'Bob', 200)
             """)
 
             result = spark.sql(f"""
                 SELECT id, _row_created_at_version, _row_last_updated_at_version
-                FROM {catalog_name}.default.test_table
+                FROM {cdf_table}
                 ORDER BY id
             """).collect()
 
@@ -2742,20 +2743,20 @@ class TestStableRowIds:
                 assert row._row_last_updated_at_version is not None
         finally:
             try:
-                spark.sql(f"DROP TABLE IF EXISTS {catalog_name}.default.test_table PURGE")
+                spark.sql(f"DROP TABLE IF EXISTS {cdf_table} PURGE")
             except Exception as e:
-                print(f"Failed to clean up {catalog_name}.default.test_table: {e}")
+                print(f"Failed to clean up {cdf_table}: {e}")
 
 
     @requires_update_or_merge
-    def test_update_preserves_row_ids(self, spark):
+    def test_update_preserves_row_ids(self, spark, test_table):
         """Test that UPDATE preserves _rowid values when stable row IDs are enabled.
 
         Verifies the native DeltaWriter.update() path with RowIdMeta attachment
         keeps row IDs stable across updates, including multi-fragment scenarios.
         """
-        spark.sql("""
-            CREATE TABLE default.test_table (
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
                 id INT,
                 name STRING,
                 value INT
@@ -2763,31 +2764,31 @@ class TestStableRowIds:
         """)
 
         # Insert across two fragments
-        spark.sql("""
-            INSERT INTO default.test_table VALUES
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
             (1, 'Alice', 100),
             (2, 'Bob', 200),
             (3, 'Charlie', 300)
         """)
-        spark.sql("""
-            INSERT INTO default.test_table VALUES
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
             (4, 'Dave', 400),
             (5, 'Eve', 500)
         """)
 
         # Capture row IDs before update
-        before = spark.sql("""
-            SELECT id, _rowid FROM default.test_table ORDER BY id
+        before = spark.sql(f"""
+            SELECT id, _rowid FROM {test_table} ORDER BY id
         """).collect()
         row_ids_before = {row.id: row._rowid for row in before}
         assert len(row_ids_before) == 5
 
         # Update rows spanning both fragments
-        spark.sql("UPDATE default.test_table SET value = value + 1 WHERE value >= 200")
+        spark.sql(f"UPDATE {test_table} SET value = value + 1 WHERE value >= 200")
 
         # Capture row IDs after update
-        after = spark.sql("""
-            SELECT id, _rowid, value FROM default.test_table ORDER BY id
+        after = spark.sql(f"""
+            SELECT id, _rowid, value FROM {test_table} ORDER BY id
         """).collect()
         row_ids_after = {row.id: row._rowid for row in after}
 

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
@@ -76,6 +76,7 @@ public class LancePositionDeltaDataset extends LanceDataset implements SupportsR
         getInitialStorageOptions(),
         getNamespaceImpl(),
         getNamespaceProperties(),
+        getManagedVersioning(),
         getFileFormatVersion(),
         properties());
   }

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -99,6 +99,13 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
     if (fileFormatVersion != null) {
       writeOptionsBuilder.fileFormatVersion(fileFormatVersion);
     }
+    if (tableProperties != null) {
+      String stableRowIds =
+          tableProperties.get(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS);
+      if (stableRowIds != null) {
+        writeOptionsBuilder.enableStableRowIds(Boolean.parseBoolean(stableRowIds));
+      }
+    }
     LanceSparkWriteOptions writeOptions = writeOptionsBuilder.build();
     return new SparkPositionDeltaWriteBuilder(
         sparkSchema,

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -44,6 +44,8 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
 
   private final Map<String, String> namespaceProperties;
 
+  private final boolean managedVersioning;
+
   private final String fileFormatVersion;
 
   private final Map<String, String> tableProperties;
@@ -55,6 +57,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       String fileFormatVersion,
       Map<String, String> tableProperties) {
     this.command = command;
@@ -63,6 +66,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.fileFormatVersion = fileFormatVersion;
     this.tableProperties = tableProperties;
   }
@@ -102,6 +106,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         readOptions.getTableId());
   }
 

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceRowLevelOperationBuilder.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LanceRowLevelOperationBuilder.java
@@ -35,6 +35,8 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
 
   private final Map<String, String> namespaceProperties;
 
+  private final boolean managedVersioning;
+
   private final String fileFormatVersion;
 
   private final Map<String, String> tableProperties;
@@ -46,6 +48,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       String fileFormatVersion,
       Map<String, String> tableProperties) {
     this.command = command;
@@ -54,6 +57,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.fileFormatVersion = fileFormatVersion;
     this.tableProperties = tableProperties;
   }
@@ -67,6 +71,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         fileFormatVersion,
         tableProperties);
   }

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -196,7 +196,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
         CommitBuilder commitBuilder =
             new CommitBuilder(dataset).writeParams(writeOptions.getStorageOptions());
-        if (dataset.hasStableRowIds()) {
+        if (dataset.hasStableRowIds()
+            || Boolean.TRUE.equals(writeOptions.getEnableStableRowIds())) {
           commitBuilder.useStableRowIds(true);
         }
         if (managedVersioning) {

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -19,6 +19,7 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.Transaction;
 import org.lance.WriteParams;
+import org.lance.namespace.LanceNamespace;
 import org.lance.operation.Update;
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceRuntime;
@@ -82,6 +83,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final boolean managedVersioning;
 
   public SparkPositionDeltaWrite(
       StructType sparkSchema,
@@ -89,6 +91,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       List<String> tableId) {
     this.sparkSchema = sparkSchema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
@@ -100,6 +103,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.managedVersioning = managedVersioning;
   }
 
   @Override
@@ -194,6 +198,14 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
             new CommitBuilder(dataset).writeParams(writeOptions.getStorageOptions());
         if (dataset.hasStableRowIds()) {
           commitBuilder.useStableRowIds(true);
+        }
+        if (managedVersioning) {
+          LanceNamespace namespace =
+              LanceRuntime.getOrCreateNamespace(namespaceImpl, namespaceProperties);
+          commitBuilder
+              .namespaceClient(namespace)
+              .tableId(tableId)
+              .namespaceClientManagedVersioning(true);
         }
         try (Transaction txn =
                 new Transaction.Builder().readVersion(version).operation(update).build();

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
@@ -37,6 +37,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final boolean managedVersioning;
 
   public SparkPositionDeltaWriteBuilder(
       StructType sparkSchema,
@@ -44,12 +45,14 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       List<String> tableId) {
     this.sparkSchema = sparkSchema;
     this.writeOptions = writeOptions;
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.tableId = tableId;
   }
 
@@ -60,6 +63,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         tableId);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
@@ -76,6 +76,7 @@ public class LancePositionDeltaDataset extends LanceDataset implements SupportsR
         getInitialStorageOptions(),
         getNamespaceImpl(),
         getNamespaceProperties(),
+        getManagedVersioning(),
         getFileFormatVersion(),
         properties());
   }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -99,6 +99,13 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
     if (fileFormatVersion != null) {
       writeOptionsBuilder.fileFormatVersion(fileFormatVersion);
     }
+    if (tableProperties != null) {
+      String stableRowIds =
+          tableProperties.get(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS);
+      if (stableRowIds != null) {
+        writeOptionsBuilder.enableStableRowIds(Boolean.parseBoolean(stableRowIds));
+      }
+    }
     LanceSparkWriteOptions writeOptions = writeOptionsBuilder.build();
     return new SparkPositionDeltaWriteBuilder(
         sparkSchema,

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -44,6 +44,8 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
 
   private final Map<String, String> namespaceProperties;
 
+  private final boolean managedVersioning;
+
   private final String fileFormatVersion;
 
   private final Map<String, String> tableProperties;
@@ -55,6 +57,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       String fileFormatVersion,
       Map<String, String> tableProperties) {
     this.command = command;
@@ -63,6 +66,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.fileFormatVersion = fileFormatVersion;
     this.tableProperties = tableProperties;
   }
@@ -102,6 +106,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         readOptions.getTableId());
   }
 

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceRowLevelOperationBuilder.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LanceRowLevelOperationBuilder.java
@@ -35,6 +35,8 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
 
   private final Map<String, String> namespaceProperties;
 
+  private final boolean managedVersioning;
+
   private final String fileFormatVersion;
 
   private final Map<String, String> tableProperties;
@@ -46,6 +48,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       String fileFormatVersion,
       Map<String, String> tableProperties) {
     this.command = command;
@@ -54,6 +57,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.fileFormatVersion = fileFormatVersion;
     this.tableProperties = tableProperties;
   }
@@ -67,6 +71,7 @@ public class LanceRowLevelOperationBuilder implements RowLevelOperationBuilder {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         fileFormatVersion,
         tableProperties);
   }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -20,6 +20,7 @@ import org.lance.FragmentMetadata;
 import org.lance.Transaction;
 import org.lance.WriteParams;
 import org.lance.fragment.RowIdMeta;
+import org.lance.namespace.LanceNamespace;
 import org.lance.operation.Update;
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceRuntime;
@@ -96,6 +97,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final boolean managedVersioning;
   private final boolean hasStableRowIds;
 
   public SparkPositionDeltaWrite(
@@ -104,6 +106,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       List<String> tableId) {
     this.sparkSchema = sparkSchema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
@@ -116,6 +119,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.managedVersioning = managedVersioning;
   }
 
   @Override
@@ -207,6 +211,14 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
             new CommitBuilder(dataset).writeParams(writeOptions.getStorageOptions());
         if (dataset.hasStableRowIds()) {
           commitBuilder.useStableRowIds(true);
+        }
+        if (managedVersioning) {
+          LanceNamespace namespace =
+              LanceRuntime.getOrCreateNamespace(namespaceImpl, namespaceProperties);
+          commitBuilder
+              .namespaceClient(namespace)
+              .tableId(tableId)
+              .namespaceClientManagedVersioning(true);
         }
         try (Transaction txn =
                 new Transaction.Builder().readVersion(version).operation(update).build();
@@ -425,7 +437,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
               fragment.getFiles(),
               fragment.getPhysicalRows(),
               fragment.getDeletionFile(),
-              RowIdMeta.fromRowIds(ids)));
+              RowIdMeta.fromRowIds(ids),
+              fragment.getCreatedAtVersionMeta(),
+              fragment.getLastUpdatedAtVersionMeta()));
     }
     return result;
   }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -111,7 +111,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     this.sparkSchema = sparkSchema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
       this.writeOptions = writeOptions.withVersion(ds.version());
-      this.hasStableRowIds = ds.hasStableRowIds();
+      this.hasStableRowIds =
+          ds.hasStableRowIds() || Boolean.TRUE.equals(writeOptions.getEnableStableRowIds());
       LOG.debug(
           "Resolved dataset version for position delta write: {}", this.writeOptions.getVersion());
     }
@@ -209,7 +210,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
         CommitBuilder commitBuilder =
             new CommitBuilder(dataset).writeParams(writeOptions.getStorageOptions());
-        if (dataset.hasStableRowIds()) {
+        if (hasStableRowIds) {
           commitBuilder.useStableRowIds(true);
         }
         if (managedVersioning) {

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -24,6 +24,7 @@ import org.lance.namespace.LanceNamespace;
 import org.lance.operation.Update;
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceRuntime;
+import org.lance.spark.LanceSparkCatalogConfig;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.function.LanceFragmentIdWithDefaultFunction;
 import org.lance.spark.utils.Utils;
@@ -111,10 +112,11 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     this.sparkSchema = sparkSchema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
       this.writeOptions = writeOptions.withVersion(ds.version());
-      this.hasStableRowIds =
-          ds.hasStableRowIds() || Boolean.TRUE.equals(writeOptions.getEnableStableRowIds());
+      this.hasStableRowIds = hasStableRowIds(ds, writeOptions);
       LOG.debug(
-          "Resolved dataset version for position delta write: {}", this.writeOptions.getVersion());
+          "Resolved dataset version for position delta write: {}, stableRowIds={}",
+          this.writeOptions.getVersion(),
+          this.hasStableRowIds);
     }
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
@@ -420,6 +422,15 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
   // ---------------------------------------------------------------------------
   // Row ID meta helpers
   // ---------------------------------------------------------------------------
+
+  private static boolean hasStableRowIds(Dataset dataset, LanceSparkWriteOptions writeOptions) {
+    if (dataset.hasStableRowIds() || Boolean.TRUE.equals(writeOptions.getEnableStableRowIds())) {
+      return true;
+    }
+    String configured =
+        dataset.getConfig().get(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS);
+    return Boolean.parseBoolean(configured);
+  }
 
   private static List<FragmentMetadata> attachRowIdMeta(
       List<FragmentMetadata> fragments, List<Long> rowIds) {

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -72,17 +72,10 @@ import static org.lance.spark.join.FragmentAwareJoinUtils.*;
 public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrdering {
   private static final Logger LOG = LoggerFactory.getLogger(SparkPositionDeltaWrite.class);
 
-  // ---- id InternalRow column indices ----
-  // The `id` InternalRow passed to delete()/update() is a ProjectingInternalRow whose column
-  // positions are resolved by Spark's buildWriteDeltaProjections against the plan output schema.
-  // The plan output inherits the scan schema ordering from LanceDataset.METADATA_COLUMNS, which
-  // places _rowid before _rowaddr. This means the id row follows METADATA_COLUMNS order, NOT the
-  // order declared by rowId() in LancePositionDeltaOperation.
-  //
-  // METADATA_COLUMNS order: _rowid (index 0), _rowaddr (index 1), ...
-  // rowId() declaration:    {_rowaddr, _rowid}  (different order — does NOT control id layout)
-  private static final int ID_COL_ROW_ID = 0;
-  private static final int ID_COL_ROW_ADDR = 1;
+  // The `id` InternalRow passed to delete()/update() follows the order declared by
+  // LancePositionDeltaOperation.rowId(): {_rowaddr, _rowid}.
+  private static final int ID_COL_ROW_ADDR = 0;
+  private static final int ID_COL_ROW_ID = 1;
 
   private final StructType sparkSchema;
   private final LanceSparkWriteOptions writeOptions;
@@ -165,10 +158,14 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     public void commit(WriterCommitMessage[] messages) {
       List<FragmentMetadata> newFragments = new ArrayList<>();
       Map<Integer, RoaringBitmap> aggregatedDeletions = new HashMap<>();
+      boolean useStableRowIds = hasStableRowIds;
 
       for (WriterCommitMessage msg : messages) {
         DeltaWriteTaskCommit taskCommit = (DeltaWriteTaskCommit) msg;
         newFragments.addAll(taskCommit.newFragments());
+        if (taskCommit.useStableRowIds()) {
+          useStableRowIds = true;
+        }
         taskCommit
             .deletionMap()
             .forEach(
@@ -212,7 +209,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
         CommitBuilder commitBuilder =
             new CommitBuilder(dataset).writeParams(writeOptions.getStorageOptions());
-        if (hasStableRowIds) {
+        if (useStableRowIds) {
           commitBuilder.useStableRowIds(true);
         }
         if (managedVersioning) {
@@ -275,8 +272,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
       boolean useLargeVarTypes = writeOptions.isUseLargeVarTypes();
 
-      // Merge initial storage options with write options
-      WriteParams params = writeOptions.toWriteParams(initialStorageOptions);
+      LanceSparkWriteOptions fragmentWriteOptions =
+          writeOptions.toBuilder().enableStableRowIds(false).build();
+      WriteParams params = fragmentWriteOptions.toWriteParams(initialStorageOptions);
 
       // Select buffer type based on configuration
       ArrowBatchWriteBuffer writeBuffer;
@@ -350,10 +348,11 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     @Override
     public void update(InternalRow metadata, InternalRow id, InternalRow row) throws IOException {
       long rowId = id.getLong(ID_COL_ROW_ID);
+      long rowAddr = id.getLong(ID_COL_ROW_ADDR);
       if (hasStableRowIds) {
         capturedRowIds.add(rowId);
       }
-      recordDeletion(id.getLong(ID_COL_ROW_ADDR));
+      recordDeletion(rowAddr);
       writer.write(row);
     }
 
@@ -389,7 +388,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
         }
       }
 
-      return new DeltaWriteTaskCommit(newFragments, deletionMap);
+      return new DeltaWriteTaskCommit(newFragments, deletionMap, hasStableRowIds);
     }
 
     @Override
@@ -461,11 +460,20 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     private final List<FragmentMetadata> newFragments;
     private final Map<Integer, RoaringBitmap> deletionMap;
+    private final boolean useStableRowIds;
+
+    DeltaWriteTaskCommit(
+        List<FragmentMetadata> newFragments,
+        Map<Integer, RoaringBitmap> deletionMap,
+        boolean useStableRowIds) {
+      this.newFragments = newFragments;
+      this.deletionMap = deletionMap;
+      this.useStableRowIds = useStableRowIds;
+    }
 
     DeltaWriteTaskCommit(
         List<FragmentMetadata> newFragments, Map<Integer, RoaringBitmap> deletionMap) {
-      this.newFragments = newFragments;
-      this.deletionMap = deletionMap;
+      this(newFragments, deletionMap, false);
     }
 
     public List<FragmentMetadata> newFragments() {
@@ -474,6 +482,10 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     public Map<Integer, RoaringBitmap> deletionMap() {
       return deletionMap == null ? Collections.emptyMap() : deletionMap;
+    }
+
+    public boolean useStableRowIds() {
+      return useStableRowIds;
     }
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
@@ -37,6 +37,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final boolean managedVersioning;
 
   public SparkPositionDeltaWriteBuilder(
       StructType sparkSchema,
@@ -44,12 +45,14 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
+      boolean managedVersioning,
       List<String> tableId) {
     this.sparkSchema = sparkSchema;
     this.writeOptions = writeOptions;
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+    this.managedVersioning = managedVersioning;
     this.tableId = tableId;
   }
 
@@ -60,6 +63,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
+        managedVersioning,
         tableId);
   }
 }

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaConflictTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaConflictTest.java
@@ -119,9 +119,9 @@ public class SparkPositionDeltaConflictTest {
       // Both writers pin at V2
       LanceSparkWriteOptions opts = LanceSparkWriteOptions.from(datasetUri);
       SparkPositionDeltaWrite writerA =
-          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, null);
+          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, false, null);
       SparkPositionDeltaWrite writerB =
-          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, null);
+          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, false, null);
 
       // Build deletion bitmap targeting all rows in the original fragment
       Map<Integer, RoaringBitmap> deletionMapA = new HashMap<>();

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -13,7 +13,9 @@
  */
 package org.lance.spark;
 
+import org.lance.CommitBuilder;
 import org.lance.Dataset;
+import org.lance.Transaction;
 import org.lance.WriteDatasetBuilder;
 import org.lance.WriteParams;
 import org.lance.namespace.LanceNamespace;
@@ -30,6 +32,8 @@ import org.lance.namespace.model.DropTableRequest;
 import org.lance.namespace.model.ListTablesRequest;
 import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.RenameTableRequest;
+import org.lance.operation.UpdateConfig;
+import org.lance.operation.UpdateMap;
 import org.lance.spark.function.LanceFragmentIdWithDefaultFunction;
 import org.lance.spark.utils.Optional;
 import org.lance.spark.utils.SchemaConverter;
@@ -50,6 +54,7 @@ import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.StagingTableCatalog;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
 import org.apache.spark.sql.connector.expressions.Transform;
@@ -78,6 +83,17 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
   private static final Logger logger =
       LoggerFactory.getLogger(BaseLanceNamespaceSparkCatalog.class);
+
+  private static final Set<String> SPARK_RESERVED_TABLE_PROPERTIES =
+      Collections.unmodifiableSet(
+          new HashSet<>(
+              Arrays.asList(
+                  TableCatalog.PROP_COMMENT,
+                  TableCatalog.PROP_EXTERNAL,
+                  TableCatalog.PROP_IS_MANAGED_LOCATION,
+                  TableCatalog.PROP_LOCATION,
+                  TableCatalog.PROP_OWNER,
+                  TableCatalog.PROP_PROVIDER)));
 
   /**
    * Used to specify the namespace implementation to use. Optional when using path-based access
@@ -590,16 +606,19 @@ public abstract class BaseLanceNamespaceSparkCatalog
     if (fileFormatVersion != null) {
       writeBuilder.dataStorageVersion(fileFormatVersion);
     }
-    try (Dataset dataset = writeBuilder.execute()) {
-      location = dataset.uri();
-    }
-
     // Call describeTable to get initial storage options for Spark dataset wrapper
     DescribeTableRequest describeRequest = new DescribeTableRequest();
     tableIdList.forEach(describeRequest::addIdItem);
-    DescribeTableResponse describeResponse = namespace.describeTable(describeRequest);
-    Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
-    boolean managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
+    DescribeTableResponse describeResponse;
+    Map<String, String> initialStorageOptions;
+    boolean managedVersioning;
+    try (Dataset dataset = writeBuilder.execute()) {
+      location = dataset.uri();
+      describeResponse = namespace.describeTable(describeRequest);
+      initialStorageOptions = describeResponse.getStorageOptions();
+      managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
+      persistTableProperties(dataset, properties, managedVersioning, tableIdList);
+    }
 
     // Create read options with namespace settings
     LanceSparkReadOptions readOptions =
@@ -618,7 +637,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
         namespaceProperties,
         managedVersioning,
         fileFormatVersion,
-        Collections.emptyMap());
+        copyUserTableProperties(properties));
   }
 
   /**
@@ -648,7 +667,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       if (fileFormatVersion != null) {
         writeBuilder.dataStorageVersion(fileFormatVersion);
       }
-      writeBuilder.execute().close();
+      try (Dataset dataset = writeBuilder.execute()) {
+        persistTableProperties(dataset, properties, false, null);
+      }
     } catch (IllegalArgumentException e) {
       throw new TableAlreadyExistsException(ident);
     }
@@ -660,7 +681,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
         null,
         false,
         fileFormatVersion,
-        Collections.emptyMap());
+        copyUserTableProperties(properties));
   }
 
   @Override
@@ -683,6 +704,13 @@ public abstract class BaseLanceNamespaceSparkCatalog
       }
     }
 
+    if (propsToSet.containsKey(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS)
+        || keysToRemove.contains(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS)) {
+      throw new UnsupportedOperationException(
+          LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS
+              + " can only be set at table creation.");
+    }
+
     if (propsToSet.isEmpty() && keysToRemove.isEmpty()) {
       // No changes to apply, just return the current table
       return loadTable(ident);
@@ -696,7 +724,10 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> merged = new HashMap<>(dataset.getConfig());
       merged.putAll(propsToSet);
       keysToRemove.forEach(merged::remove);
-      dataset.updateConfig(merged);
+      boolean managedVersioning =
+          resolved.describeResponse != null
+              && Boolean.TRUE.equals(resolved.describeResponse.getManagedVersioning());
+      updateDatasetConfig(dataset, merged, managedVersioning, resolved.tableIdList);
     }
 
     return loadTable(ident);
@@ -1292,6 +1323,60 @@ public abstract class BaseLanceNamespaceSparkCatalog
   private List<String> buildTableId(Identifier ident) {
     return Stream.concat(Arrays.stream(ident.namespace()), Stream.of(ident.name()))
         .collect(Collectors.toList());
+  }
+
+  private static Map<String, String> copyUserTableProperties(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> userProperties = new HashMap<>();
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      if (!SPARK_RESERVED_TABLE_PROPERTIES.contains(entry.getKey())) {
+        userProperties.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return userProperties.isEmpty() ? Collections.emptyMap() : userProperties;
+  }
+
+  private void persistTableProperties(
+      Dataset dataset,
+      Map<String, String> properties,
+      boolean managedVersioning,
+      List<String> tableIdList) {
+    Map<String, String> userProperties = copyUserTableProperties(properties);
+    if (!userProperties.isEmpty()) {
+      Map<String, String> merged = new HashMap<>(dataset.getConfig());
+      merged.putAll(userProperties);
+      updateDatasetConfig(dataset, merged, managedVersioning, tableIdList);
+    }
+  }
+
+  private void updateDatasetConfig(
+      Dataset dataset,
+      Map<String, String> config,
+      boolean managedVersioning,
+      List<String> tableIdList) {
+    if (!managedVersioning) {
+      dataset.updateConfig(config);
+      return;
+    }
+
+    UpdateMap updateMap = UpdateMap.builder().updates(config).replace(true).build();
+    UpdateConfig updateConfig = UpdateConfig.builder().configUpdates(updateMap).build();
+    CommitBuilder commitBuilder =
+        new CommitBuilder(dataset)
+            .namespaceClient(namespace)
+            .tableId(tableIdList)
+            .namespaceClientManagedVersioning(true);
+    try (Transaction txn =
+            new Transaction.Builder()
+                .readVersion(dataset.version())
+                .operation(updateConfig)
+                .build();
+        Dataset committed = commitBuilder.execute(txn)) {
+      // auto-close txn and committed dataset
+    }
   }
 
   private Table loadTableInternal(

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -617,7 +617,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       describeResponse = namespace.describeTable(describeRequest);
       initialStorageOptions = describeResponse.getStorageOptions();
       managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
-      persistTableProperties(dataset, properties, managedVersioning, tableIdList);
+      if (managedVersioning) {
+        persistTableProperties(dataset, properties, true, tableIdList);
+      }
     }
 
     // Create read options with namespace settings
@@ -667,9 +669,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       if (fileFormatVersion != null) {
         writeBuilder.dataStorageVersion(fileFormatVersion);
       }
-      try (Dataset dataset = writeBuilder.execute()) {
-        persistTableProperties(dataset, properties, false, null);
-      }
+      writeBuilder.execute().close();
     } catch (IllegalArgumentException e) {
       throw new TableAlreadyExistsException(ident);
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -329,6 +329,12 @@ public class LanceDataset
         && fileFormatVersion != null) {
       writeOptionsBuilder.fileFormatVersion(fileFormatVersion);
     }
+    if (!mergedOptions.containsKey(LanceSparkWriteOptions.CONFIG_ENABLE_STABLE_ROW_IDS)
+        && tableProperties.containsKey(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS)) {
+      writeOptionsBuilder.enableStableRowIds(
+          Boolean.parseBoolean(
+              tableProperties.get(LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS)));
+    }
     LanceSparkWriteOptions writeOptions = writeOptionsBuilder.build();
 
     List<String> backfillColumns =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
@@ -32,10 +32,10 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
   private final LanceFragmentScanner fragmentScanner;
@@ -64,19 +64,7 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
       VectorSchemaRoot root = arrowReader.getVectorSchemaRoot();
 
       List<ColumnVector> fieldVectors =
-          root.getFieldVectors().stream()
-              .map(LanceArrowColumnVector::new)
-              .collect(Collectors.toList());
-
-      // Add virtual columns for blob metadata
-      addBlobVirtualColumns(fieldVectors, root, fragmentScanner.getInputPartition());
-
-      if (fragmentScanner.withFragemtId()) {
-        ConstantColumnVector fragmentVector =
-            new ConstantColumnVector(root.getRowCount(), DataTypes.IntegerType);
-        fragmentVector.setInt(fragmentScanner.fragmentId());
-        fieldVectors.add(fragmentVector);
-      }
+          buildSparkOrderedVectors(root, fragmentScanner.getInputPartition());
 
       currentColumnarBatch =
           new ColumnarBatch(fieldVectors.toArray(new ColumnVector[] {}), root.getRowCount());
@@ -119,8 +107,8 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
     }
   }
 
-  private void addBlobVirtualColumns(
-      List<ColumnVector> fieldVectors, VectorSchemaRoot root, LanceInputPartition inputPartition) {
+  private List<ColumnVector> buildSparkOrderedVectors(
+      VectorSchemaRoot root, LanceInputPartition inputPartition) {
     StructType schema = inputPartition.getSchema();
 
     Map<String, FieldVector> actualFields = new HashMap<>();
@@ -129,10 +117,16 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
       actualFields.put(rootVectors.get(i).getField().getName(), rootVectors.get(i));
     }
 
+    List<ColumnVector> fieldVectors = new ArrayList<>(schema.size());
     StructField[] fields = schema.fields();
     for (StructField field : fields) {
       String fieldName = field.name();
-      if (fieldName.endsWith(LanceConstant.BLOB_POSITION_SUFFIX)) {
+      if (fieldName.equals(LanceConstant.FRAGMENT_ID)) {
+        ConstantColumnVector fragmentVector =
+            new ConstantColumnVector(root.getRowCount(), DataTypes.IntegerType);
+        fragmentVector.setInt(fragmentScanner.fragmentId());
+        fieldVectors.add(fragmentVector);
+      } else if (fieldName.endsWith(LanceConstant.BLOB_POSITION_SUFFIX)) {
         String baseName =
             fieldName.substring(
                 0, fieldName.length() - LanceConstant.BLOB_POSITION_SUFFIX.length());
@@ -150,8 +144,16 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
           BlobSizeColumnVector sizeVector = new BlobSizeColumnVector((StructVector) blobVector);
           fieldVectors.add(sizeVector);
         }
+      } else {
+        FieldVector vector = actualFields.get(fieldName);
+        if (vector == null) {
+          throw new IllegalStateException(
+              "Lance scan did not return expected field '" + fieldName + "'");
+        }
+        fieldVectors.add(new LanceArrowColumnVector(vector));
       }
     }
+    return fieldVectors;
   }
 
   // Virtual column vector for blob position

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -101,11 +101,13 @@ public class LanceFragmentScanner implements AutoCloseable {
       if (projectedColumns.isEmpty() && inputPartition.getSchema().isEmpty()) {
         // Lance requires at least one projected column. Use _rowid as a lightweight
         // sentinel so the scanner still returns the correct row count (e.g. SELECT 1).
-        // Only do this when the schema is truly empty; when the schema contains virtual
-        // columns (e.g. _fragid, blob position/size) that are not passed to the scanner
-        // but added later by the batch scanner, adding _rowid here would shift column
-        // indices and cause Spark to read wrong data.
         scanOptions.withRowId(true);
+      }
+      if (hasField(inputPartition.getSchema(), LanceConstant.ROW_ID)) {
+        scanOptions.withRowId(true);
+      }
+      if (hasField(inputPartition.getSchema(), LanceConstant.ROW_ADDRESS)) {
+        scanOptions.withRowAddress(true);
       }
       scanOptions.columns(projectedColumns);
       if (inputPartition.getWhereCondition().isPresent()) {
@@ -226,10 +228,9 @@ public class LanceFragmentScanner implements AutoCloseable {
   }
 
   /**
-   * Builds the projection column list for the scanner. Regular data columns come first, followed by
-   * special metadata columns in the order matching {@link
-   * org.lance.spark.LanceDataset#METADATA_COLUMNS}. All special columns (_rowid, _rowaddr, version
-   * columns) go through scanner.project() for consistent output ordering.
+   * Builds the projection column list for the scanner. Row ID and row address are requested through
+   * explicit scan flags so Lance computes them from the active fragment metadata instead of reading
+   * them as regular columns.
    */
   private static List<String> getColumnNames(StructType schema) {
     // Collect all field names in the schema for quick lookup
@@ -252,14 +253,6 @@ public class LanceFragmentScanner implements AutoCloseable {
                         && !name.endsWith(LanceConstant.BLOB_POSITION_SUFFIX)
                         && !name.endsWith(LanceConstant.BLOB_SIZE_SUFFIX))
             .collect(Collectors.toList());
-
-    // Append special columns in METADATA_COLUMNS order (must match Rust scanner output order)
-    if (schemaFields.contains(LanceConstant.ROW_ID)) {
-      columns.add(LanceConstant.ROW_ID);
-    }
-    if (schemaFields.contains(LanceConstant.ROW_ADDRESS)) {
-      columns.add(LanceConstant.ROW_ADDRESS);
-    }
     if (schemaFields.contains(LanceConstant.ROW_LAST_UPDATED_AT_VERSION)) {
       columns.add(LanceConstant.ROW_LAST_UPDATED_AT_VERSION);
     }
@@ -268,5 +261,14 @@ public class LanceFragmentScanner implements AutoCloseable {
     }
 
     return columns;
+  }
+
+  private static boolean hasField(StructType schema, String name) {
+    for (StructField field : schema.fields()) {
+      if (field.name().equals(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -150,6 +150,7 @@ public class LanceBatchWrite implements BatchWrite {
         Arrays.stream(messages)
             .map(m -> (TaskCommit) m)
             .map(TaskCommit::getFragments)
+            .map(LanceDataWriter::stripRowIdMeta)
             .flatMap(List::stream)
             .collect(Collectors.toList());
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -193,7 +193,10 @@ public class LanceBatchWrite implements BatchWrite {
         if (managedVersioning) {
           LanceNamespace namespace =
               LanceRuntime.getOrCreateNamespace(namespaceImpl, namespaceProperties);
-          commitBuilder.namespaceClient(namespace).tableId(tableId);
+          commitBuilder
+              .namespaceClient(namespace)
+              .tableId(tableId)
+              .namespaceClientManagedVersioning(true);
         }
         try (Transaction txn =
                 new Transaction.Builder().readVersion(version).operation(operation).build();

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -140,7 +140,7 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
   private void rollFragment() throws IOException {
     writeBuffer.setFinished();
     try {
-      completedFragments.addAll(fragmentCreationTask.get());
+      completedFragments.addAll(stripRowIdMeta(fragmentCreationTask.get()));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while rolling fragment on partition boundary", e);
@@ -162,7 +162,7 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     writeBuffer.setFinished();
 
     try {
-      completedFragments.addAll(fragmentCreationTask.get());
+      completedFragments.addAll(stripRowIdMeta(fragmentCreationTask.get()));
       return new LanceBatchWrite.TaskCommit(new ArrayList<>(completedFragments));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -196,6 +196,22 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
   @Override
   public void close() throws IOException {
     writeBuffer.close();
+  }
+
+  static List<FragmentMetadata> stripRowIdMeta(List<FragmentMetadata> fragments) {
+    List<FragmentMetadata> stripped = new ArrayList<>(fragments.size());
+    for (FragmentMetadata fragment : fragments) {
+      stripped.add(
+          new FragmentMetadata(
+              fragment.getId(),
+              fragment.getFiles(),
+              fragment.getPhysicalRows(),
+              fragment.getDeletionFile(),
+              null,
+              fragment.getCreatedAtVersionMeta(),
+              fragment.getLastUpdatedAtVersionMeta()));
+    }
+    return stripped;
   }
 
   /** A freshly-constructed buffer paired with the Fragment.create task that consumes from it. */
@@ -270,8 +286,9 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
       boolean useLargeVarTypes = writeOptions.isUseLargeVarTypes();
       long maxBatchBytes = writeOptions.getMaxBatchBytes();
 
-      // Merge initial storage options with write options
-      WriteParams params = writeOptions.toWriteParams(initialStorageOptions);
+      LanceSparkWriteOptions fragmentWriteOptions =
+          writeOptions.toBuilder().enableStableRowIds(false).build();
+      WriteParams params = fragmentWriteOptions.toWriteParams(initialStorageOptions);
 
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
@@ -147,7 +147,7 @@ public class StagedCommit {
 
   private void applyManagedVersioning(final CommitBuilder builder) {
     if (managedVersioning) {
-      builder.namespaceClient(namespace).tableId(tableId);
+      builder.namespaceClient(namespace).tableId(tableId).namespaceClientManagedVersioning(true);
     }
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
@@ -182,20 +182,6 @@ public abstract class SparkLanceNamespaceTestBase {
   }
 
   @Test
-  public void testCreateTablePersistsOnlyUserProperties() throws Exception {
-    String tableName = generateTableName("create_props");
-    String fullName = catalogName + ".default." + tableName;
-
-    spark.sql("CREATE TABLE " + fullName + " (id BIGINT NOT NULL) TBLPROPERTIES ('key1' = 'val1')");
-
-    Map<String, String> config = getTableConfig(tableName);
-    assertEquals("val1", config.get("key1"));
-    assertFalse(config.containsKey(TableCatalog.PROP_OWNER));
-    assertFalse(config.containsKey(TableCatalog.PROP_PROVIDER));
-    assertFalse(config.containsKey(TableCatalog.PROP_LOCATION));
-  }
-
-  @Test
   public void testListTables() throws Exception {
     String tableName1 = generateTableName("list_test_1");
     String tableName2 = generateTableName("list_test_2");

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
@@ -182,6 +182,20 @@ public abstract class SparkLanceNamespaceTestBase {
   }
 
   @Test
+  public void testCreateTablePersistsOnlyUserProperties() throws Exception {
+    String tableName = generateTableName("create_props");
+    String fullName = catalogName + ".default." + tableName;
+
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT NOT NULL) TBLPROPERTIES ('key1' = 'val1')");
+
+    Map<String, String> config = getTableConfig(tableName);
+    assertEquals("val1", config.get("key1"));
+    assertFalse(config.containsKey(TableCatalog.PROP_OWNER));
+    assertFalse(config.containsKey(TableCatalog.PROP_PROVIDER));
+    assertFalse(config.containsKey(TableCatalog.PROP_LOCATION));
+  }
+
+  @Test
   public void testListTables() throws Exception {
     String tableName1 = generateTableName("list_test_1");
     String tableName2 = generateTableName("list_test_2");
@@ -721,6 +735,25 @@ public abstract class SparkLanceNamespaceTestBase {
     Map<String, String> config = getTableConfig(tableName);
     assertEquals("val1", config.get("key1"));
     assertEquals("val2", config.get("key2"));
+  }
+
+  @Test
+  public void testAlterStableRowIdsPropertyRejected() throws Exception {
+    String tableName = generateTableName("alter_stable_row_ids");
+    String fullName = catalogName + ".default." + tableName;
+
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT NOT NULL)");
+
+    Identifier ident = Identifier.of(new String[] {"default"}, tableName);
+    UnsupportedOperationException ex =
+        assertThrows(
+            UnsupportedOperationException.class,
+            () ->
+                catalog.alterTable(
+                    ident,
+                    TableChange.setProperty(
+                        LanceSparkCatalogConfig.TABLE_OPT_ENABLE_STABLE_ROW_IDS, "true")));
+    assertTrue(ex.getMessage().contains("can only be set at table creation"));
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
@@ -75,7 +75,7 @@ public class LanceFragmentScannerTest {
             });
 
     List<String> result = callGetColumnNames(schema);
-    List<String> expected = Arrays.asList("id", "name", LanceConstant.ROW_ID);
+    List<String> expected = Arrays.asList("id", "name");
     assertEquals(expected, result);
   }
 
@@ -90,7 +90,7 @@ public class LanceFragmentScannerTest {
             });
 
     List<String> result = callGetColumnNames(schema);
-    List<String> expected = Arrays.asList("id", "name", LanceConstant.ROW_ADDRESS);
+    List<String> expected = Arrays.asList("id", "name");
     assertEquals(expected, result);
   }
 
@@ -135,14 +135,12 @@ public class LanceFragmentScannerTest {
             });
 
     List<String> result = callGetColumnNames(schema);
-    // Data columns first, then metadata columns in METADATA_COLUMNS order
-    // Note: FRAGMENT_ID is excluded as it's not included in the projection
+    // Data columns first, then version columns. Row ID, row address, and fragment ID are requested
+    // outside the projection list.
     List<String> expected =
         Arrays.asList(
             "id",
             "name",
-            LanceConstant.ROW_ID,
-            LanceConstant.ROW_ADDRESS,
             LanceConstant.ROW_LAST_UPDATED_AT_VERSION,
             LanceConstant.ROW_CREATED_AT_VERSION);
     assertEquals(expected, result);
@@ -183,14 +181,12 @@ public class LanceFragmentScannerTest {
             });
 
     List<String> result = callGetColumnNames(schema);
-    // Regular data columns in schema order, then metadata columns in METADATA_COLUMNS order
+    // Regular data columns in schema order, then projected version metadata columns.
     List<String> expected =
         Arrays.asList(
             "z_last_column",
             "a_first_column",
             "m_middle_column",
-            LanceConstant.ROW_ID,
-            LanceConstant.ROW_ADDRESS,
             LanceConstant.ROW_CREATED_AT_VERSION);
     assertEquals(expected, result);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.10</lance.version>
+        <lance.version>7.0.0-beta.14</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.10` to `7.0.0-beta.14`.
- Checked `docker/Dockerfile` hardcoded versions: `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.5.0`), and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version declared by the `v7.0.0-beta.14` `lance-core` POM (`0.7.5`).
- Triggering Lance tag: https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.14

## Verification
- `make lint`
- `make install`

Note: Maven Central metadata currently stops at `7.0.0-beta.13`, so I installed `org.lance:lance-core:7.0.0-beta.14` locally from the `lance-format/lance` `v7.0.0-beta.14` tag with `./mvnw install -DskipTests -Dskip.build.jni=true` before rerunning `make install`.
