### PR TITLE
chore: update lance dependency to v7.0.0-beta.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.14</lance.version>
+        <lance.version>7.0.0-beta.15</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.14` to `7.0.0-beta.15`.
- Checked `docker/Dockerfile`; `LANCE_SPARK_VERSION=0.5.0` already matches the project `lance-spark.version`, and `LANCE_NS_VERSION=0.7.5` matches the `lance-namespace-core` dependency in the upstream Lance `v7.0.0-beta.15` Java POM.
- Triggering tag: https://github.com/lancedb/lance/tree/refs/tags/v7.0.0-beta.15

## Verification
- `make lint`
- `make install`

Note: `org.lance:lance-core:7.0.0-beta.15` was not available from Maven Central at verification time, so I installed `lance-core` locally from the upstream `v7.0.0-beta.15` tag with `-Dskip.build.jni=true` before rerunning `make install`.
