### PR TITLE
chore: update lance dependency to v7.0.0-beta.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0</lance-spark.version>
-        <lance.version>7.0.0-beta.14</lance.version>
+        <lance.version>7.0.0-beta.16</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-beta.14` to `7.0.0-beta.16`.
- Checked Docker hardcoded versions: `LANCE_SPARK_VERSION` already matches `lance-spark.version` (`0.5.0`), and `LANCE_NS_VERSION` already matches the `lance-namespace-core` version in the `v7.0.0-beta.16` `lance-core` POM (`0.7.5`).
- Triggering tag: https://github.com/lance-format/lance/releases/tag/v7.0.0-beta.16 (`refs/tags/v7.0.0-beta.16`).

## Verification
- `make lint` passed.
- `make install` initially could not resolve `org.lance:lance-core:7.0.0-beta.16` from Maven Central, so I checked out `lance-format/lance` at `refs/tags/v7.0.0-beta.16` and installed the Java artifact locally with `mvn install -DskipTests -Dskip.build.jni=true`.
- `make install` then passed for the default Spark 3.5 / Scala 2.12 build.
