### PR TITLE
fix: keep Arrow reader vectors reusable across batches

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
@@ -156,7 +156,7 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
           throw new IllegalStateException(
               "Lance scan did not return expected field '" + fieldName + "'");
         }
-        LanceArrowColumnVector colVec = new LanceArrowColumnVector(vector);
+        LanceArrowColumnVector colVec = new LanceArrowColumnVector(vector, false);
 
         // Set blob reference context so getBinary() produces blob references
         if (rowAddresses != null && blobColumnNames.contains(fieldName)) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
@@ -59,9 +59,15 @@ public class LanceArrowColumnVector extends ColumnVector {
   private TimestampUnitAccessor timestampUnitAccessor;
   private LanceStructAccessor structAccessor;
   private ArrowColumnVector arrowColumnVector;
+  private final boolean closeVectorOnClose;
 
   public LanceArrowColumnVector(ValueVector vector) {
+    this(vector, true);
+  }
+
+  public LanceArrowColumnVector(ValueVector vector, boolean closeVectorOnClose) {
     super(LanceArrowUtils.fromArrowField(vector.getField()));
+    this.closeVectorOnClose = closeVectorOnClose;
 
     if (vector instanceof UInt1Vector) {
       uInt1Accessor = new UInt1Accessor((UInt1Vector) vector);
@@ -115,6 +121,9 @@ public class LanceArrowColumnVector extends ColumnVector {
 
   @Override
   public void close() {
+    if (!closeVectorOnClose) {
+      return;
+    }
     if (uInt1Accessor != null) {
       uInt1Accessor.close();
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/vectorized/LanceArrowColumnVectorTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/vectorized/LanceArrowColumnVectorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.vectorized;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LanceArrowColumnVectorTest {
+
+  @Test
+  public void nonOwningCloseKeepsArrowReaderOwnedStructVectorsReusable() {
+    Field structField =
+        new Field(
+            "metadata",
+            FieldType.nullable(new ArrowType.Struct()),
+            Arrays.asList(
+                Field.nullable("field0", new ArrowType.Int(32, true)),
+                Field.nullable("field1", new ArrowType.Int(32, true)),
+                Field.nullable("field2", new ArrowType.Int(32, true)),
+                Field.nullable("field3", new ArrowType.Int(32, true)),
+                Field.nullable("field4", new ArrowType.Int(32, true)),
+                Field.nullable("field5", new ArrowType.Int(32, true))));
+
+    try (BufferAllocator allocator = new RootAllocator();
+        StructVector vector = (StructVector) structField.createVector(allocator)) {
+      LanceArrowColumnVector columnVector = new LanceArrowColumnVector(vector, false);
+
+      columnVector.close();
+
+      assertEquals(6, vector.getChildrenFromFields().size());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix a vector lifecycle bug in the columnar scan path where Spark could close LanceArrowColumnVector wrappers around ArrowReader-owned vectors between batches.

## Root Cause

LanceFragmentColumnarBatchScanner reuses the ArrowReader VectorSchemaRoot across loadNextBatch calls. The scanner previously wrapped root field vectors in owning LanceArrowColumnVector instances. When Spark closed a returned ColumnarBatch, the wrapper closed the underlying Arrow vector. For StructVector, close clears the child vectors. On the next ArrowReader.loadNextBatch call, Arrow Java still had a schema with struct children, but the reused StructVector had zero children, so VectorLoader failed with: should have as many children as in the schema: found 0 expected N.

## Fix

Add a non-owning LanceArrowColumnVector mode and use it for vectors returned from LanceFragmentColumnarBatchScanner. The scanner and ArrowReader keep ownership of the root vectors and close them when the scanner closes, while Spark may still close each ColumnarBatch wrapper normally.

## Testing

- ./mvnw -pl lance-spark-3.5_2.12 -am -Dtest=org.lance.spark.vectorized.LanceArrowColumnVectorTest -Dsurefire.failIfNoSpecifiedTests=false test