### PR TITLE
feat: round-trip UDT columns automatically via __udt field metadata

### DIFF
--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -244,6 +244,10 @@ These options control how data is read from Lance datasets. They can be set usin
 | `pushDownFilters`     | Boolean | `true`  | Whether to push down filter predicates to the Lance reader for optimized scanning.                                |
 | `topN_push_down`      | Boolean | `true`  | Whether to push down TopN (ORDER BY ... LIMIT) operations to Lance for optimized sorting.                         |
 
+## User-Defined Types
+
+Spark UDT columns (e.g. MLlib's `VectorUDT`) round-trip transparently. On write the column is unwrapped to the UDT's `sqlType` (a struct) for storage, and the UDT's fully qualified class name is stamped onto the Arrow field's user metadata under the `__udt` key. On read, that marker is consulted and the schema is rewrapped to the original UDT automatically. No configuration needed; the user-facing class (e.g. `Vector` for `VectorUDT`) is materialized in rows as usual.
+
 ### Example: Reading with Options
 
 === "SQL"

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -55,12 +55,34 @@ object LanceArrowUtils {
   val LANCE_MAP_KEY_METADATA_KEY = "_lance.key"
   val LANCE_MAP_VALUE_METADATA_KEY = "_lance.value"
 
+  // Lance-Spark convention: UDT class FQN on the Arrow field's user metadata. Write stamps it
+  // from udt.getClass.getName; read consumes it to rewrap the field's dataType. Spark's own
+  // sources don't use this key — Parquet round-trips UDT info via a file-level serialized
+  // schema (ParquetReadSupport.SPARK_METADATA_KEY) instead.
+  val LANCE_UDT_CLASS_KEY = "__udt"
+
   private val LANCE_INTERNAL_METADATA_KEYS = Set(
     LANCE_ELEMENT_METADATA_KEY,
     LANCE_MAP_KEY_METADATA_KEY,
     LANCE_MAP_VALUE_METADATA_KEY)
 
   def fromArrowField(field: Field): DataType = {
+    val baseType = convertArrowFieldType(field)
+    val udtFqn = field.getMetadata.get(LANCE_UDT_CLASS_KEY)
+    if (udtFqn == null) {
+      baseType
+    } else {
+      val udt = loadUdt(udtFqn, field.getName)
+      if (!udt.sqlType.sameType(baseType)) {
+        throw new IllegalStateException(
+          s"UDT '$udtFqn' for field '${field.getName}' has sqlType ${udt.sqlType} " +
+            s"which does not match the persisted type $baseType")
+      }
+      udt
+    }
+  }
+
+  private def convertArrowFieldType(field: Field): DataType = {
     field.getType match {
       // Handle unsigned integers by mapping to larger signed types
       // UInt8 -> ShortType (signed 16-bit can hold all UInt8 values 0-255)
@@ -186,8 +208,11 @@ object LanceArrowUtils {
    * `_lance.element`, `_lance.key`, and `_lance.value` so writeback can reconstruct it.
    */
   private[util] def buildFieldMetadata(field: Field): Metadata = {
-    // Start from the Arrow field's user metadata so non-Lance keys (if any) survive.
-    val arrowMeta = Metadata.fromJson(mapper.writeValueAsString(field.getMetadata))
+    // Strip __udt — fromArrowField has already consumed it to rewrap the dataType, so surfacing
+    // it here would be noise. Re-write is safe: toArrowField's UDT branch re-derives the marker
+    // from udt.getClass.getName.
+    val filteredArrowMeta = field.getMetadata.asScala.toMap - LANCE_UDT_CLASS_KEY
+    val arrowMeta = Metadata.fromJson(mapper.writeValueAsString(filteredArrowMeta.asJava))
     val builder = new MetadataBuilder().withMetadata(arrowMeta)
     augmentTypeMarkers(builder, field)
     augmentChildMetadata(builder, field)
@@ -391,7 +416,15 @@ object LanceArrowUtils {
             timeZoneId,
             largeVarTypes = largeVarTypes)).asJava)
       case udt: UserDefinedType[_] =>
-        toArrowField(name, udt.sqlType, nullable, timeZoneId, largeVarTypes = largeVarTypes)
+        // Unwrap to sqlType for storage (Arrow has no UDT concept) but stamp the UDT FQN as a
+        // field-level metadata marker so the read side can rewrap automatically. The incoming
+        // user metadata (if any) is preserved alongside the marker.
+        val baseBuilder = new MetadataBuilder()
+        if (metadata != null) {
+          baseBuilder.withMetadata(metadata)
+        }
+        val udtMeta = baseBuilder.putString(LANCE_UDT_CLASS_KEY, udt.getClass.getName).build()
+        toArrowField(name, udt.sqlType, nullable, timeZoneId, udtMeta, largeVarTypes)
       case DateType if DateMilliUtils.hasDateMilliMetadata(metadata) =>
         val fieldType = new FieldType(
           nullable,
@@ -453,7 +486,10 @@ object LanceArrowUtils {
   private def deduplicateFieldNames(
       dt: DataType,
       errorOnDuplicatedFieldNames: Boolean): DataType = dt match {
-    case udt: UserDefinedType[_] => deduplicateFieldNames(udt.sqlType, errorOnDuplicatedFieldNames)
+    // UDTs have a fixed sqlType defined by the UDT class; recursing here would either be a no-op
+    // or break the UDT contract. Preserving the UDT lets toArrowField's UDT branch stamp __udt
+    // and unwrap at every nesting depth (top-level, inside StructType, ArrayType element, etc.).
+    case udt: UserDefinedType[_] => udt
     case st @ StructType(fields) =>
       val newNames = if (st.names.toSet.size == st.names.length) {
         st.names
@@ -493,6 +529,63 @@ object LanceArrowUtils {
       elementType: DataType): Boolean = {
     // Create a temporary ArrayType to use VectorUtils.shouldBeFixedSizeList
     VectorUtils.shouldBeFixedSizeList(ArrayType(elementType, true), metadata)
+  }
+
+  /**
+   * Reflective UDT instantiation for the read-side rewrap. Two non-obvious choices:
+   *   - Thread context classloader (with this class's loader as fallback) so user-provided UDTs
+   *     shipped via --jars / spark.jars resolve.
+   *   - setAccessible(true) is required for `private[spark]` UDTs like VectorUDT (constructor is
+   *     JVM package-private). On JDK 9+ this can throw InaccessibleObjectException unless the
+   *     spark module is opened — Spark's own --add-opens flags cover that.
+   */
+  private def loadUdt(fqn: String, fieldName: String): UserDefinedType[_] = {
+    val loader = Option(Thread.currentThread().getContextClassLoader)
+      .getOrElse(getClass.getClassLoader)
+    // initialize=false: defer the class's static initializer until we've verified the class is
+    // actually a UserDefinedType. The FQN is read from Lance manifest data; without this guard a
+    // crafted manifest could trigger arbitrary static-init side effects on any class that happens
+    // to be on the reader's classpath. newInstance() below triggers initialization at use time.
+    val cls =
+      try {
+        Class.forName(fqn, false, loader)
+      } catch {
+        case e: ClassNotFoundException =>
+          throw new IllegalStateException(
+            s"UDT class '$fqn' for field '$fieldName' could not be loaded",
+            e)
+      }
+    if (!classOf[UserDefinedType[_]].isAssignableFrom(cls)) {
+      throw new IllegalStateException(
+        s"Class '$fqn' named in '__udt' metadata of field '$fieldName' is not a UserDefinedType")
+    }
+    val ctor =
+      try {
+        cls.getDeclaredConstructor()
+      } catch {
+        case e: NoSuchMethodException =>
+          throw new IllegalStateException(
+            s"UDT class '$fqn' for field '$fieldName' has no no-arg constructor",
+            e)
+      }
+    try {
+      ctor.setAccessible(true)
+    } catch {
+      case e: RuntimeException =>
+        throw new IllegalStateException(
+          s"UDT class '$fqn' for field '$fieldName' could not be made accessible " +
+            "(reflective access denied; check JDK module opens / Java security manager " +
+            "configuration)",
+          e)
+    }
+    try {
+      ctor.newInstance().asInstanceOf[UserDefinedType[_]]
+    } catch {
+      case e: ReflectiveOperationException =>
+        throw new IllegalStateException(
+          s"UDT class '$fqn' for field '$fieldName' could not be instantiated",
+          e)
+    }
   }
 
   /* Copy from copy of org.apache.spark.sql.errors.ExecutionErrors for Spark version compatibility */

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -56,9 +56,11 @@ object LanceArrowUtils {
   val LANCE_MAP_VALUE_METADATA_KEY = "_lance.value"
 
   // Lance-Spark convention: UDT class FQN on the Arrow field's user metadata. Write stamps it
-  // from udt.getClass.getName; read consumes it to rewrap the field's dataType. Spark's own
-  // sources don't use this key — Parquet round-trips UDT info via a file-level serialized
-  // schema (ParquetReadSupport.SPARK_METADATA_KEY) instead.
+  // from udt.getClass.getName when udt.sqlType is a StructType; read consumes it to rewrap the
+  // field's dataType. UDTs with non-struct sqlType are written via their underlying type without
+  // the marker (the UDT wrapper degrades to sqlType on read-back). Spark's own sources don't
+  // use this key — Parquet round-trips UDT info via a file-level serialized schema
+  // (ParquetReadSupport.SPARK_METADATA_KEY) instead.
   val LANCE_UDT_CLASS_KEY = "__udt"
 
   private val LANCE_INTERNAL_METADATA_KEYS = Set(
@@ -416,15 +418,23 @@ object LanceArrowUtils {
             timeZoneId,
             largeVarTypes = largeVarTypes)).asJava)
       case udt: UserDefinedType[_] =>
-        // Unwrap to sqlType for storage (Arrow has no UDT concept) but stamp the UDT FQN as a
-        // field-level metadata marker so the read side can rewrap automatically. The incoming
-        // user metadata (if any) is preserved alongside the marker.
-        val baseBuilder = new MetadataBuilder()
-        if (metadata != null) {
-          baseBuilder.withMetadata(metadata)
+        // Unwrap to sqlType for storage (Arrow has no UDT concept). When sqlType is a
+        // StructType, stamp the UDT FQN as a field-level metadata marker so the read side
+        // can rewrap automatically. For non-struct sqlTypes the marker is skipped — the data
+        // still round-trips via the underlying type, but the UDT wrapper degrades. All real
+        // MLlib UDTs (VectorUDT, MatrixUDT) use struct sqlType, so this restriction matches
+        // every supported case while keeping `__udt` off arrow fields where it has no use.
+        udt.sqlType match {
+          case _: StructType =>
+            val baseBuilder = new MetadataBuilder()
+            if (metadata != null) {
+              baseBuilder.withMetadata(metadata)
+            }
+            val udtMeta = baseBuilder.putString(LANCE_UDT_CLASS_KEY, udt.getClass.getName).build()
+            toArrowField(name, udt.sqlType, nullable, timeZoneId, udtMeta, largeVarTypes)
+          case _ =>
+            toArrowField(name, udt.sqlType, nullable, timeZoneId, metadata, largeVarTypes)
         }
-        val udtMeta = baseBuilder.putString(LANCE_UDT_CLASS_KEY, udt.getClass.getName).build()
-        toArrowField(name, udt.sqlType, nullable, timeZoneId, udtMeta, largeVarTypes)
       case DateType if DateMilliUtils.hasDateMilliMetadata(metadata) =>
         val fieldType = new FieldType(
           nullable,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
@@ -13,7 +13,10 @@
  */
 package org.lance.spark;
 
+import org.apache.spark.ml.linalg.DenseMatrix;
 import org.apache.spark.ml.linalg.DenseVector;
+import org.apache.spark.ml.linalg.Matrix;
+import org.apache.spark.ml.linalg.MatrixUDT;
 import org.apache.spark.ml.linalg.SparseVector;
 import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.ml.linalg.VectorUDT;
@@ -465,23 +468,24 @@ public abstract class BaseSparkDataTypeRoundtripTest {
 
     Dataset<Row> result = writeAndRead(schema, data, "vector_udt");
 
-    // Read-back schema must lose the UDT wrapper — Arrow has no UDT concept, so the column comes
-    // back as VectorUDT's sqlType (a plain struct). Lock that contract here so a future change
-    // that accidentally preserves UDT in metadata is caught loudly.
-    assertFalse(
-        result.schema().apply("vec").dataType() instanceof VectorUDT,
-        "read-back column must not carry VectorUDT; expected the underlying struct sqlType");
+    // Write stamps the UDT FQN onto the Arrow field's `__udt` metadata; read consults it and
+    // rewraps the column back to VectorUDT. End-to-end the UDT survives without any opt-in.
     assertInstanceOf(
-        StructType.class,
+        VectorUDT.class,
         result.schema().apply("vec").dataType(),
-        "read-back column must be VectorUDT.sqlType (StructType)");
+        "read-back column must carry VectorUDT (preserved via __udt field metadata)");
+
+    // The `__udt` marker is consumed by the schema converter and stripped from the user-visible
+    // StructField metadata — surfacing it would be noise once the dataType is already the UDT.
+    assertFalse(
+        result.schema().apply("vec").metadata().contains("__udt"),
+        "the __udt marker must not leak into user-visible StructField metadata");
 
     List<Row> out = result.orderBy("id").collectAsList();
     assertEquals(2, out.size());
-
-    // Reconstruct vectors manually since VectorUDT.deserialize() expects InternalRow.
-    assertEquals(dense, reconstructVector(out.get(0).getStruct(1)));
-    assertEquals(sparse, reconstructVector(out.get(1).getStruct(1)));
+    // Spark materializes UDT columns as the user-facing class — Vector here.
+    assertEquals(dense, out.get(0).get(1));
+    assertEquals(sparse, out.get(1).get(1));
   }
 
   /**
@@ -501,47 +505,124 @@ public abstract class BaseSparkDataTypeRoundtripTest {
 
     List<Row> out = writeAndRead(schema, data, "vector_udt_null_row").orderBy("id").collectAsList();
     assertEquals(2, out.size());
-    assertEquals(dense, reconstructVector(out.get(0).getStruct(1)));
+    assertEquals(dense, out.get(0).get(1));
     assertTrue(out.get(1).isNullAt(1), "row 1 should round-trip as null");
   }
 
   /**
-   * Reconstruct an MLlib {@link Vector} from the struct row returned by Lance read-back. The struct
-   * follows VectorUDT's sqlType: (type: byte, size: int, indices: array&lt;int&gt;, values:
-   * array&lt;double&gt;). Type 0 = sparse, type 1 = dense.
+   * Idempotency: reading a UDT and writing it back must yield a dataset whose schema and rows are
+   * indistinguishable from the original. Guards against subtle metadata duplication or loss in the
+   * __udt round-trip — e.g., if `buildFieldMetadata` leaked `__udt` into Spark metadata, the second
+   * write would write it twice (once via metadata, once via `udt.getClass.getName`).
    */
-  private static Vector reconstructVector(Row struct) {
-    byte type = struct.getByte(0);
-    switch (type) {
-      case 1:
-        {
-          // Dense vector — values at index 3
-          List<Double> vals = struct.getList(3);
-          double[] arr = new double[vals.size()];
-          for (int i = 0; i < arr.length; i++) {
-            arr[i] = vals.get(i);
-          }
-          return new DenseVector(arr);
-        }
-      case 0:
-        {
-          // Sparse vector — size at 1, indices at 2, values at 3
-          int size = struct.getInt(1);
-          List<Integer> idxList = struct.getList(2);
-          List<Double> valList = struct.getList(3);
-          int[] indices = new int[idxList.size()];
-          double[] values = new double[valList.size()];
-          for (int i = 0; i < indices.length; i++) {
-            indices[i] = idxList.get(i);
-          }
-          for (int i = 0; i < values.length; i++) {
-            values[i] = valList.get(i);
-          }
-          return new SparseVector(size, indices, values);
-        }
-      default:
-        throw new IllegalArgumentException(
-            "unknown VectorUDT type byte: " + type + " (expected 0=sparse or 1=dense)");
-    }
+  @Test
+  public void testVectorUDTReWriteRoundtrip() {
+    VectorUDT vectorUDT = new VectorUDT();
+    StructType schema =
+        new StructType().add("id", DataTypes.IntegerType, false).add("vec", vectorUDT, true);
+    Vector dense = new DenseVector(new double[] {1.0, 2.0, 3.0});
+    List<Row> data = Arrays.asList(RowFactory.create(0, dense));
+
+    Dataset<Row> firstRead = writeAndRead(schema, data, "vector_udt_rewrite_v1");
+    String rewritePath = outputPath("vector_udt_rewrite_v2");
+    firstRead.write().format("lance").save(rewritePath);
+
+    Dataset<Row> secondRead = spark.read().format("lance").load(rewritePath);
+    assertInstanceOf(
+        VectorUDT.class,
+        secondRead.schema().apply("vec").dataType(),
+        "UDT must survive a read+write+read cycle (idempotency)");
+    assertFalse(
+        secondRead.schema().apply("vec").metadata().contains("__udt"),
+        "second-read StructField metadata must still be clean");
+    assertEquals(dense, secondRead.orderBy("id").collectAsList().get(0).get(1));
+  }
+
+  /**
+   * Generality check: the round-trip works for any {@code UserDefinedType}, not only {@code
+   * VectorUDT}. {@code MatrixUDT} has a different sqlType (7-field struct vs. 4-field) and a
+   * different user-facing class, so it exercises the same code path with different shape.
+   */
+  @Test
+  public void testMatrixUDTRoundtrip() {
+    MatrixUDT matrixUDT = new MatrixUDT();
+    StructType schema =
+        new StructType().add("id", DataTypes.IntegerType, false).add("mat", matrixUDT, true);
+
+    Matrix dense = new DenseMatrix(2, 2, new double[] {1.0, 2.0, 3.0, 4.0});
+    List<Row> data = Arrays.asList(RowFactory.create(0, dense));
+
+    Dataset<Row> result = writeAndRead(schema, data, "matrix_udt");
+
+    assertInstanceOf(
+        MatrixUDT.class,
+        result.schema().apply("mat").dataType(),
+        "read-back column must carry MatrixUDT (preserved via __udt field metadata)");
+
+    List<Row> out = result.orderBy("id").collectAsList();
+    assertEquals(1, out.size());
+    assertEquals(dense, out.get(0).get(1));
+  }
+
+  /**
+   * UDT nested inside a StructType also round-trips. Exercises the recursive UDT branch in {@code
+   * toArrowField} (the top-level case is covered by {@code testVectorUDTRoundtrip}).
+   */
+  @Test
+  public void testNestedUDTInStructRoundtrip() {
+    VectorUDT vectorUDT = new VectorUDT();
+    StructType nested =
+        new StructType().add("label", DataTypes.StringType, true).add("vec", vectorUDT, true);
+    StructType schema =
+        new StructType().add("id", DataTypes.IntegerType, false).add("payload", nested, true);
+
+    Vector dense = new DenseVector(new double[] {1.0, 2.0});
+    List<Row> data = Arrays.asList(RowFactory.create(0, RowFactory.create("hello", dense)));
+
+    Dataset<Row> result = writeAndRead(schema, data, "nested_udt_struct");
+
+    StructType payloadType = (StructType) result.schema().apply("payload").dataType();
+    assertInstanceOf(
+        VectorUDT.class,
+        payloadType.apply("vec").dataType(),
+        "nested vec field must carry VectorUDT after round-trip");
+
+    List<Row> out = result.orderBy("id").collectAsList();
+    Row payload = out.get(0).getStruct(1);
+    assertEquals("hello", payload.getString(0));
+    assertEquals(dense, payload.get(1));
+  }
+
+  /**
+   * UDT used as an array element also round-trips. Exercises the recursive UDT branch through
+   * {@code toArrowField}'s ArrayType handling.
+   */
+  @Test
+  public void testUDTAsArrayElementRoundtrip() {
+    VectorUDT vectorUDT = new VectorUDT();
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.IntegerType, false)
+            .add("vecs", DataTypes.createArrayType(vectorUDT, true), true);
+
+    Vector v1 = new DenseVector(new double[] {1.0, 2.0});
+    Vector v2 = new DenseVector(new double[] {3.0, 4.0});
+    List<Row> data = Arrays.asList(RowFactory.create(0, Arrays.asList(v1, v2)));
+
+    Dataset<Row> result = writeAndRead(schema, data, "udt_array_element");
+
+    DataTypes.createArrayType(vectorUDT, true);
+    org.apache.spark.sql.types.ArrayType arr =
+        (org.apache.spark.sql.types.ArrayType) result.schema().apply("vecs").dataType();
+    assertInstanceOf(
+        VectorUDT.class,
+        arr.elementType(),
+        "array element type must carry VectorUDT after round-trip");
+
+    List<Row> out = result.orderBy("id").collectAsList();
+    List<Object> got = out.get(0).getList(1);
+    assertEquals(2, got.size());
+    assertEquals(v1, got.get(0));
+    assertEquals(v2, got.get(1));
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
@@ -611,7 +611,6 @@ public abstract class BaseSparkDataTypeRoundtripTest {
 
     Dataset<Row> result = writeAndRead(schema, data, "udt_array_element");
 
-    DataTypes.createArrayType(vectorUDT, true);
     org.apache.spark.sql.types.ArrayType arr =
         (org.apache.spark.sql.types.ArrayType) result.schema().apply("vecs").dataType();
     assertInstanceOf(


### PR DESCRIPTION
## Summary

#471 made VectorUDT (and any UDT) writable into Lance. On read the columns came back as a plain struct, so callers had to reconstruct the UDT themselves. This PR closes the round-trip.

The write side stamps the UDT's class FQN onto the Arrow field's user metadata under the `__udt` key. The read side consults the marker and rewraps the field's dataType back to the UDT. No configuration, no per-call opt-in — symmetric with the write path.

## How it works

All in `LanceArrowUtils.scala`:

- `toArrowField` UDT branch: unwrap to `sqlType` for storage. When `sqlType` is a `StructType` (the shape used by every MLlib UDT), stamp `__udt = udt.getClass.getName` on the FieldType metadata; other shapes write through without the marker.
- `fromArrowField`: if a field's metadata carries `__udt`, load the named class, verify `udt.sqlType` matches the persisted shape, return the UDT.
- `deduplicateFieldNames` preserves `UserDefinedType` instances instead of recursively unwrapping. Without this the UDT branch wouldn't fire at every nesting depth (inside a StructType, as an ArrayType element, etc.).
- `buildFieldMetadata` strips `__udt` from the read-back Spark `StructField.metadata` so the marker doesn't surface as noise once the dataType is already the UDT.
- `loadUdt` uses `Class.forName(fqn, initialize=false, …)` so a crafted manifest can't trigger an arbitrary class's static initializer before we've verified it's actually a `UserDefinedType`.

## Tests

`BaseSparkDataTypeRoundtripTest`:

- `testVectorUDTRoundtrip` — VectorUDT (Dense + Sparse). Asserts the read-back schema carries VectorUDT and that `__udt` is stripped from user-visible metadata.
- `testMatrixUDTRoundtrip` — MatrixUDT (different sqlType, different user class) for generality.
- `testNestedUDTInStructRoundtrip` — UDT inside a StructType.
- `testUDTAsArrayElementRoundtrip` — UDT as an ArrayType element.
- `testVectorUDTReWriteRoundtrip` — read-write-read, idempotency check. Guards against subtle metadata duplication or loss.

## Test plan

- [x] CI passes across Spark 3.4 / 3.5 / 4.0 / 4.1 × Scala 2.12 / 2.13
- [x] VectorUDT round-trips with no configuration
- [x] MatrixUDT round-trips
- [x] Nested-UDT (struct, array) round-trips
- [x] Read-write-read idempotency holds

