### PR TITLE
fix: allow null parent struct when children are non-nullable

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -362,7 +362,14 @@ object LanceArrowUtils {
             toArrowField(
               field.name,
               field.dataType,
-              field.nullable,
+              // Relax child nullability when the parent is nullable. A null parent row forces
+              // StructWriter.setNull() to advance every child's count (to keep child vectors
+              // aligned with the parent StructVector), and Lance's Rust writer rejects those
+              // null placeholders if any child field is non-nullable. Scoping the relaxation
+              // to nullable parents keeps user-declared non-nullability on top-level fields,
+              // and propagates naturally into nested structs. Most common unblocked case: UDT
+              // columns like VectorUDT / MatrixUDT whose sqlType marks children as non-nullable.
+              nullable || field.nullable,
               timeZoneId,
               field.metadata,
               largeVarTypes)

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseSparkDataTypeRoundtripTest.java
@@ -450,10 +450,7 @@ public abstract class BaseSparkDataTypeRoundtripTest {
    * {@code InternalRow}, so in a test context (where Spark hands back public {@link Row}s) the
    * helper reconstructs vectors manually.
    *
-   * <p>Note: a null VectorUDT row is intentionally omitted. VectorUDT's sqlType marks the inner
-   * {@code type} field as non-nullable; when the parent struct is null, the StructWriter writes
-   * null placeholders to all children — including non-nullable ones — and Lance's native writer
-   * rejects the batch. This is a known limitation of structs with non-nullable children.
+   * <p>Null parent rows are covered separately in {@link #testVectorUDTNullRowRoundtrip}.
    */
   @Test
   public void testVectorUDTRoundtrip() {
@@ -485,6 +482,27 @@ public abstract class BaseSparkDataTypeRoundtripTest {
     // Reconstruct vectors manually since VectorUDT.deserialize() expects InternalRow.
     assertEquals(dense, reconstructVector(out.get(0).getStruct(1)));
     assertEquals(sparse, reconstructVector(out.get(1).getStruct(1)));
+  }
+
+  /**
+   * Round-trip for a null VectorUDT row. Used to fail because VectorUDT's sqlType marks the inner
+   * {@code type} field as non-nullable; see {@code LanceArrowUtils.toArrowField} for the schema
+   * relaxation that fixes it.
+   */
+  @Test
+  public void testVectorUDTNullRowRoundtrip() {
+    VectorUDT vectorUDT = new VectorUDT();
+    StructType schema =
+        new StructType().add("id", DataTypes.IntegerType, false).add("vec", vectorUDT, true);
+
+    Vector dense = new DenseVector(new double[] {1.0, 2.0, 3.0});
+    List<Row> data =
+        Arrays.asList(RowFactory.create(0, dense), RowFactory.create(1, (Object) null));
+
+    List<Row> out = writeAndRead(schema, data, "vector_udt_null_row").orderBy("id").collectAsList();
+    assertEquals(2, out.size());
+    assertEquals(dense, reconstructVector(out.get(0).getStruct(1)));
+    assertTrue(out.get(1).isNullAt(1), "row 1 should round-trip as null");
   }
 
   /**


### PR DESCRIPTION
## Summary

Writing a DataFrame whose struct column has a null row fails when any child field of the struct is non-nullable:

```
Invalid user input: The field `<name>` contained null values even though the field is marked non-null in the schema
```

`StructWriter.setNull()` must advance every child's count when a row's parent struct is null (to keep child vector lengths aligned with the parent StructVector), so it writes null placeholders into the children. Lance's Rust writer then rejects those placeholders against the non-nullable child constraint. Most common impact: MLlib's `VectorUDT` / `MatrixUDT`, whose sqlType marks the inner `type` field as non-nullable. #471's test javadoc noted the gap.

## Fix

In `LanceArrowUtils.toArrowField`, when emitting the Arrow schema for a `StructType`, if the parent struct is nullable, force every child field to nullable. Scoping the relaxation to nullable parents keeps user-declared non-nullability on top-level required fields, and propagates naturally through nested structs (a grandchild becomes nullable iff its forced-nullable parent is itself nullable).

The user-declared nullability constraint survives at the Spark schema layer; only the on-disk Arrow representation widens. `sameType` ignores nullability, so #546's UDT restore round-trip check is unaffected.

## Tests

`testVectorUDTNullRowRoundtrip` writes a DataFrame with one `DenseVector` row and one null `vec` row, reads back, asserts the vector round-trips and the null row reads back as null. The existing `testVectorUDTRoundtrip` javadoc carried a stale "limitation" note about this gap; updated to cross-reference the new test.

## Test plan

- [ ] CI passes (lint, unit tests, integration tests across all Spark/Scala versions)
- [ ] \`testVectorUDTNullRowRoundtrip\` passes
- [ ] No regression in existing tests under \`lance-spark-3.5_2.12\` (695 tests pass locally)