### PR TITLE
fix: wrong LANCE_SPARK_VERSION and package name

### DIFF
--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -92,7 +92,7 @@ jobs:
           1. Update the lance.version property in pom.xml. Find the line "<lance.version>X.Y.Z...</lance.version>" in the properties section and update it to "<lance.version>${VERSION}</lance.version>".
           2. Update the hardcoded versions in docker/Dockerfile if they exist:
              - Update LANCE_SPARK_VERSION to match the EXACT current lance-spark version from pom.xml (lance-spark.version property). You MUST preserve the full version string including any pre-release suffixes (e.g., -beta.1, -rc.2). Do NOT strip or modify the version string. Extract it using: mvn help:evaluate -Dexpression=lance-spark.version -q -DforceStdout
-             - Update LANCE_NS_VERSION to match the lance-namespace-core version that is transitively included via lance-core. You can find this by checking the lance-core pom.xml dependencies at https://repo1.maven.org/maven2/org/lance/lance-core/${VERSION}/lance-core-${VERSION}.pom or by running "mvn dependency:tree" after updating pom.xml.
+             - Update LANCE_NS_IMPL_VERSION to match the lance-namespace-impl.version property in pom.xml. Extract it using: mvn help:evaluate -Dexpression=lance-namespace-impl.version -q -DforceStdout
           3. Run "make lint" to check for any linting issues. If there are issues, run "make format" to fix them and rerun "make lint" until it passes.
           4. Run "make install" to verify the build works with the new dependency (this builds Spark 3.5/Scala 2.12 by default).
           5. Inspect "git status --short" and "git diff" to confirm the dependency update and any required fixes.

--- a/.github/workflows/codex-update-lance-dependency.yml
+++ b/.github/workflows/codex-update-lance-dependency.yml
@@ -91,7 +91,7 @@ jobs:
           Follow these steps exactly:
           1. Update the lance.version property in pom.xml. Find the line "<lance.version>X.Y.Z...</lance.version>" in the properties section and update it to "<lance.version>${VERSION}</lance.version>".
           2. Update the hardcoded versions in docker/Dockerfile if they exist:
-             - Update LANCE_SPARK_VERSION to match the current lance-spark version from pom.xml (lance-spark.version property).
+             - Update LANCE_SPARK_VERSION to match the EXACT current lance-spark version from pom.xml (lance-spark.version property). You MUST preserve the full version string including any pre-release suffixes (e.g., -beta.1, -rc.2). Do NOT strip or modify the version string. Extract it using: mvn help:evaluate -Dexpression=lance-spark.version -q -DforceStdout
              - Update LANCE_NS_VERSION to match the lance-namespace-core version that is transitively included via lance-core. You can find this by checking the lance-core pom.xml dependencies at https://repo1.maven.org/maven2/org/lance/lance-core/${VERSION}/lance-core-${VERSION}.pom or by running "mvn dependency:tree" after updating pom.xml.
           3. Run "make lint" to check for any linting issues. If there are issues, run "make format" to fix them and rerun "make lint" until it passes.
           4. Run "make install" to verify the build works with the new dependency (this builds Spark 3.5/Scala 2.12 by default).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ WORKDIR ${SPARK_HOME}
 ENV SPARK_VERSION=${SPARK_DOWNLOAD_VERSION}
 ENV SPARK_MAJOR_VERSION=${SPARK_MAJOR_VERSION}
 ENV SCALA_VERSION=${SCALA_VERSION}
-ENV LANCE_SPARK_VERSION=0.5.0
+ENV LANCE_SPARK_VERSION=0.5.0-beta.1
 ENV LANCE_NS_VERSION=0.7.5
 
 # Download spark
@@ -52,11 +52,11 @@ RUN mkdir -p ${SPARK_HOME} \
  && rm -rf spark.tgz
 
 # Download lance-spark bundle JAR from Maven
-RUN curl -fL https://repo1.maven.org/maven2/com/lancedb/lance-spark-bundle-3.5_2.12/${LANCE_SPARK_VERSION}/lance-spark-bundle-3.5_2.12-${LANCE_SPARK_VERSION}.jar \
+RUN curl -fL https://repo1.maven.org/maven2/org/lance/lance-spark-bundle-3.5_2.12/${LANCE_SPARK_VERSION}/lance-spark-bundle-3.5_2.12-${LANCE_SPARK_VERSION}.jar \
  -o /opt/spark/jars/lance-spark-bundle_2.12-${LANCE_SPARK_VERSION}.jar
 
 # Download additional Lance namespace implementation jars from Maven
-RUN curl -fL https://repo1.maven.org/maven2/com/lancedb/lance-namespace-glue/${LANCE_NS_VERSION}/lance-namespace-glue-${LANCE_NS_VERSION}.jar \
+RUN curl -fL https://repo1.maven.org/maven2/org/lance/lance-namespace-glue/${LANCE_NS_VERSION}/lance-namespace-glue-${LANCE_NS_VERSION}.jar \
  -o /opt/spark/jars/lance-namespace-glue-${LANCE_NS_VERSION}.jar
 
 # For local testing, uncomment the lines below and comment out the Maven downloads above:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,7 +43,7 @@ ENV SPARK_VERSION=${SPARK_DOWNLOAD_VERSION}
 ENV SPARK_MAJOR_VERSION=${SPARK_MAJOR_VERSION}
 ENV SCALA_VERSION=${SCALA_VERSION}
 ENV LANCE_SPARK_VERSION=0.5.0-beta.1
-ENV LANCE_NS_VERSION=0.7.5
+ENV LANCE_NS_IMPL_VERSION=0.3.0
 
 # Download spark
 RUN mkdir -p ${SPARK_HOME} \
@@ -56,12 +56,12 @@ RUN curl -fL https://repo1.maven.org/maven2/org/lance/lance-spark-bundle-3.5_2.1
  -o /opt/spark/jars/lance-spark-bundle_2.12-${LANCE_SPARK_VERSION}.jar
 
 # Download additional Lance namespace implementation jars from Maven
-RUN curl -fL https://repo1.maven.org/maven2/org/lance/lance-namespace-glue/${LANCE_NS_VERSION}/lance-namespace-glue-${LANCE_NS_VERSION}.jar \
- -o /opt/spark/jars/lance-namespace-glue-${LANCE_NS_VERSION}.jar
+RUN curl -fL https://repo1.maven.org/maven2/org/lance/lance-namespace-glue/${LANCE_NS_IMPL_VERSION}/lance-namespace-glue-${LANCE_NS_IMPL_VERSION}.jar \
+ -o /opt/spark/jars/lance-namespace-glue-${LANCE_NS_IMPL_VERSION}.jar
 
 # For local testing, uncomment the lines below and comment out the Maven downloads above:
 #COPY lance-spark-bundle-${SPARK_MAJOR_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-${SPARK_MAJOR_VERSION}_${SCALA_VERSION}-${LANCE_SPARK_VERSION}.jar /opt/spark/jars/
-#COPY lance-namespace-glue-${LANCE_NS_VERSION}.jar /opt/spark/jars/
+#COPY lance-namespace-glue-${LANCE_NS_IMPL_VERSION}.jar /opt/spark/jars/
 
 # Download OpenDAL native libraries for Linux architectures
 ENV OPENDAL_VERSION=0.48.0


### PR DESCRIPTION
Currently, the Dockerfile has two issues:

* The prompt for extracting `LANCE_SPARK_VERSION` is not right;
* The package name is also wrong;