### PR TITLE
chore: update lance dependency to v7.1.0-beta.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-beta.16</lance.version>
+        <lance.version>7.1.0-beta.2</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bumps `lance.version` to `7.1.0-beta.2`.
- Checked Docker hardcoded versions against Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0` already matched, so no Dockerfile change was needed.
- Triggering tag: refs/tags/v7.1.0-beta.2

## Verification
- `make lint` passed.
- `make install` passed for the default Spark 3.5 / Scala 2.12 build after installing `org.lance:lance-core:7.1.0-beta.2` from the tagged Lance source into the runner local Maven cache because the artifact is not yet available on Maven Central.
