### PR TITLE
fix: widen narrow numeric literals in zonemap pruner

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -335,13 +335,22 @@ public final class ZonemapFragmentPruner {
   }
 
   /**
-   * V2 {@link Literal} exposes values in Spark's internal representation ({@code UTF8String} for
-   * strings). Zone stats from lance-core store String values — normalize here so {@code compareTo}
-   * against min/max works.
+   * V2 {@link Literal} exposes values in Spark's internal representation, while Lance's JNI
+   * materializes {@code ZoneStats.min/max} with every integer width boxed as {@code Long} and every
+   * floating-point width as {@code Double}. Widen narrow Java boxed primitives (Byte / Short /
+   * Integer / Float) to match — otherwise an Integer literal against a Long zone bound would throw
+   * {@code ClassCastException} from {@code Comparable.compareTo}. Also normalizes {@code
+   * UTF8String} → {@code String} for the same reason.
    */
   private static Object normalizeLiteral(Object value) {
     if (value instanceof UTF8String) {
       return value.toString();
+    }
+    if (value instanceof Byte || value instanceof Short || value instanceof Integer) {
+      return ((Number) value).longValue();
+    }
+    if (value instanceof Float) {
+      return ((Float) value).doubleValue();
     }
     return value;
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentPrunerTest.java
@@ -20,6 +20,7 @@ import org.apache.spark.sql.connector.expressions.FieldReference;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.junit.jupiter.api.Test;
 
+import java.sql.Date;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -454,5 +455,93 @@ public class ZonemapFragmentPrunerTest {
     Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
     assertTrue(result.isPresent());
     assertEquals(Set.of(0), result.get());
+  }
+
+  @Test
+  public void testIntegerLiteralAgainstLongZoneStats() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("seq");
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("seq", 150)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1), result.get());
+  }
+
+  @Test
+  public void testShortLiteralAgainstLongZoneStats() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Predicate[] filters = new Predicate[] {TestPredicates.gt("x", (short) 150)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1, 2), result.get());
+  }
+
+  @Test
+  public void testByteLiteralAgainstLongZoneStats() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Predicate[] filters = new Predicate[] {TestPredicates.lte("x", (byte) 50)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(0), result.get());
+  }
+
+  @Test
+  public void testFloatLiteralAgainstDoubleZoneStats() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "f",
+        Arrays.asList(
+            new ZoneStats(0, 0, 100, 0.0d, 9.9d, 0),
+            new ZoneStats(1, 0, 100, 10.0d, 19.9d, 0),
+            new ZoneStats(2, 0, 100, 20.0d, 29.9d, 0)));
+
+    Predicate[] filters = new Predicate[] {TestPredicates.eq("f", 15.0f)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1), result.get());
+  }
+
+  @Test
+  public void testDateLiteralAgainstLongZoneStats() {
+    // Spark DateType literal is Integer epoch days; Date32 zone bounds are Long
+    // epoch days — same Integer→Long widening as INT32.
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "d",
+        Arrays.asList(
+            new ZoneStats(0, 0, 100, 19000L, 19099L, 0),
+            new ZoneStats(1, 0, 100, 19100L, 19199L, 0),
+            new ZoneStats(2, 0, 100, 19200L, 19299L, 0)));
+
+    Predicate[] filters =
+        new Predicate[] {TestPredicates.eq("d", Date.valueOf("2022-04-27"))}; // day 19109
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(1), result.get());
+  }
+
+  @Test
+  public void testInListWithIntegerLiteralsAgainstLongZoneStats() {
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Predicate[] filters = new Predicate[] {TestPredicates.in("x", 50, 250, 999)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(0, 2), result.get());
+  }
+
+  @Test
+  public void testInListWithMixedWidthLiteralsAgainstLongZoneStats() {
+    // Per-element widening inside analyzeIn's loop.
+    Map<String, List<ZoneStats>> stats = threeFragmentStats("x");
+    Predicate[] filters = new Predicate[] {TestPredicates.in("x", 50, 250L, (short) 70, (byte) 5)};
+
+    Optional<Set<Integer>> result = ZonemapFragmentPruner.pruneFragments(filters, stats);
+    assertTrue(result.isPresent());
+    assertEquals(Set.of(0, 2), result.get());
   }
 }


### PR DESCRIPTION
Closes #557.

`ZonemapFragmentPruner` throws `ClassCastException: Long cannot be cast to Integer` whenever a `WHERE int32_col = N` query hits a column with a zonemap index. The two sides of `target.compareTo(min)` use different Java boxes:

- Lance JNI (`scalar_value_to_java` in `lance-jni/utils.rs`) materializes `ZoneStats.min/max` with every integer width as `Long` and every float width as `Double`.
- Spark V2 `Literal.value()` keeps the Catalyst type — `Integer` for `IntegerType`, `Short` for `ShortType`, `Byte` for `ByteType`, `Float` for `FloatType`, `Integer` epoch days for `DateType`.

`Integer.compareTo(Object)` then rejects the `Long`. Same mismatch affects `tinyint`, `smallint`, `float`, and `date` predicates, plus the IN-list path. The existing `catch (ClassCastException)` in `zoneMatchesComparison` does fire on the reported workload but means we silently drop pruning instead of getting it.

## Fix

Widen the narrow boxes inside `normalizeLiteral` to match the JNI wire types: `Byte`/`Short`/`Integer` → `Long`, `Float` → `Double`. Both conversions are lossless and order-preserving; `analyzeIn` already routes each list element through the same normalizer so it gets the fix for free.

## Tests

Seven new cases in `ZonemapFragmentPrunerTest` — one per affected literal type (Integer / Short / Byte / Float / Date) plus IN-list coverage (homogeneous and mixed-width). Verified by reverting `normalizeLiteral` locally and watching all seven fail through the conservative-catch fallback.

## Out of scope (surfaced during review)

Pre-existing JNI gaps, not regressions from this PR — noting for follow-up:

- `ScalarValue::Decimal*` and other unhandled types box to `null` for both `min` and `max`. The pruner then treats those zones as all-null and excludes them — risk of silent under-pruning on decimal predicates.
- `Date64` and the four `Timestamp*` variants are all flattened to `Long` without a unit tag, so columns written with non-`Date32` / non-microsecond units cannot be safely pruned against Spark's days/micros literals.

## Test plan

- [x] \`make lint\` clean
- [x] \`./mvnw test -pl lance-spark-base_2.12 -Dtest=ZonemapFragmentPrunerTest\` (37/37 passes locally)
- [x] CI green across all Spark/Scala modules