### PR TITLE
feat: blob v2 write support

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -514,4 +514,48 @@ A column is treated as blob v2 when the Arrow field carries `ARROW:extension:nam
 
 Filter pushdown for SQL `WHERE` is disabled on blob v2 tables; Spark evaluates predicates after the scan. Zonemap-based fragment pruning still runs.
 
-The connector does not materialize blob bytes on read; queries against descriptor fields fetch metadata only.
+The connector does not materialize blob bytes on read; queries against descriptor fields fetch metadata only. See [Blob v2 Writes](#blob-v2-writes) below for the write path.
+
+## Blob v2 Writes
+
+To write blob v2 columns, set `file_format_version` to `2.2` or higher and set
+`<column>.lance.encoding = blob` in `TBLPROPERTIES`.
+
+Spark still sees the column as `BINARY` when writing. The connector converts that binary
+value into the Arrow blob write struct during encoding.
+
+On reads, blob v2 columns are exposed as descriptor structs. See
+[Blob v2 Reads](#blob-v2-reads). For writes, `INSERT` and DataFrame append still take
+`BINARY`.
+
+```sql
+CREATE TABLE lance.mydb.users (
+    id INT NOT NULL,
+    content BINARY
+) USING lance
+TBLPROPERTIES (
+    'content.lance.encoding' = 'blob',
+    'file_format_version' = '2.2'
+);
+```
+
+With `file_format_version = '2.2'` or higher, blob columns are written using blob v2
+encoding and `ARROW:extension:name = lance.blob.v2 metadata`.
+
+With an older version, or when `file_format_version` is not set, blob columns use the
+legacy v1 encoding with `lance-encoding:blob = true` metadata.
+
+Blob encoding requires a numeric `file_format_version`, such as `2.2`.
+
+Blob v2 writes must go through the catalog path. Use SQL DDL with `TBLPROPERTIES`, as
+shown above, or use the `DataFrameWriterV2` API:
+
+```python
+df.writeTo("lance.ns.users") \
+    .tableProperty("content.lance.encoding", "blob") \
+    .tableProperty("file_format_version", "2.2") \
+    .create()
+```
+
+Setting only `file_format_version` does not enable blob encoding. Without
+`<column>.lance.encoding = blob`, the column is written as plain `BINARY`.

--- a/docs/src/operations/ddl/create-table.md
+++ b/docs/src/operations/ddl/create-table.md
@@ -338,6 +338,33 @@ To create a table with blob columns, use the table property pattern `<column_nam
         .createOrReplace();
     ```
 
+### Blob v2 Columns
+
+To create blob v2 columns, set the blob encoding property and use `file_format_version = '2.2'` or higher.
+
+Spark writes blob v2 columns as `BINARY`. On reads, the same columns are exposed as
+descriptor structs. See [Blob v2 Reads](../../config.md#blob-v2-reads).
+
+=== "SQL"
+    ```sql
+    CREATE TABLE documents (
+        id INT NOT NULL,
+        content BINARY
+    ) USING lance
+    TBLPROPERTIES (
+        'content.lance.encoding' = 'blob',
+        'file_format_version' = '2.2'
+    );
+    ```
+
+=== "Python"
+    ```python
+    df.writeTo("documents") \
+        .tableProperty("content.lance.encoding", "blob") \
+        .tableProperty("file_format_version", "2.2") \
+        .createOrReplace()
+    ```
+
 ## Large String Columns
 
 Lance supports large string columns for storing very large text data. By default, Arrow uses `Utf8` (VarChar) type with 32-bit offsets, which limits total string data to 2GB per batch. For columns containing very large strings (e.g., document content, base64-encoded data), you can use `LargeUtf8` (LargeVarChar) with 64-bit offsets.

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -46,6 +46,10 @@ def _lance_storage_options(spark):
     }
 
 
+def _sql_binary_literal(data: bytes) -> str:
+    return "X'" + data.hex().upper() + "'"
+
+
 def _table_location(spark, table_name):
     rows = (
         spark.sql(f"DESCRIBE EXTENDED {table_name}")
@@ -703,6 +707,72 @@ class TestDDLColumnCompression:
 
         id_meta = schema.field("id").metadata
         assert b"lance-encoding:compression" not in (id_meta or {})
+
+
+class TestDDLBlobV2:
+    def test_blob_v2_table_reads_content_as_descriptor(self, spark):
+        spark.sql("""
+            CREATE TABLE default.test_blob_v2 (
+                id INT NOT NULL,
+                content BINARY
+            ) USING lance
+            TBLPROPERTIES (
+                'content.lance.encoding' = 'blob',
+                'file_format_version' = '2.2'
+            )
+        """)
+
+        first_content = b"SQL insert content 1"
+        second_content = b"SQL insert content 2"
+
+        spark.sql(
+            f"INSERT INTO default.test_blob_v2 VALUES (1, {_sql_binary_literal(first_content)})"
+        )
+        spark.sql(
+            f"INSERT INTO default.test_blob_v2 VALUES (2, {_sql_binary_literal(second_content)})"
+        )
+
+        describe_rows = spark.sql("DESCRIBE default.test_blob_v2").collect()
+        content_field = next(row for row in describe_rows if row.col_name == "content")
+        content_type = content_field.data_type.lower()
+
+        assert "struct" in content_type
+        assert "kind" in content_type
+        assert "blob_uri" in content_type
+
+        rows = spark.sql("""
+            SELECT id, content.size, content.kind, content.blob_id, content.blob_uri
+            FROM default.test_blob_v2
+            ORDER BY id
+        """).collect()
+
+        assert len(rows) == 2
+
+        assert rows[0].id == 1
+        assert rows[0].size == len(first_content)
+        assert rows[0].kind == 0
+
+        assert rows[1].id == 2
+        assert rows[1].size == len(second_content)
+        assert rows[1].kind == 0
+
+    def test_blob_v2_insert_rejects_non_binary_content(self, spark):
+        spark.sql("""
+            CREATE TABLE default.test_blob_v2_bad_insert (
+                id INT NOT NULL,
+                content BINARY
+            ) USING lance
+            TBLPROPERTIES (
+                'content.lance.encoding' = 'blob',
+                'file_format_version' = '2.2'
+            )
+        """)
+
+        with pytest.raises(Exception, match="got string"):
+            spark.sql("""
+                INSERT INTO default.test_blob_v2_bad_insert
+                VALUES (1, 'not-binary')
+            """)
 
 
 class TestDDLIndex:

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -599,7 +599,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
     // Build the table ID for credential vending
     List<String> tableIdList = buildTableId(actualIdent);
 
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     // Create dataset using namespace - WriteDatasetBuilder handles declareTable internally
     // and properly leverages namespace client for credential vending
@@ -613,7 +615,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
             .mode(WriteParams.WriteMode.CREATE)
             .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
             .storageOptions(catalogConfig.getStorageOptions());
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     if (fileFormatVersion != null) {
       writeBuilder.dataStorageVersion(fileFormatVersion);
     }
@@ -672,12 +673,13 @@ public abstract class BaseLanceNamespaceSparkCatalog
       throws TableAlreadyExistsException {
     String datasetUri = getDatasetUri(ident);
 
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
     LanceSparkReadOptions readOptions =
         createReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
 
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     Map<String, String> tableProperties = copyUserTableProperties(properties);
     try {
       WriteDatasetBuilder writeBuilder =
@@ -895,7 +897,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     DeclareTableRequest declareRequest = new DeclareTableRequest();
     tableIdList.forEach(declareRequest::addIdItem);
@@ -925,7 +929,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
             managedVersioning);
     StagedCommit stagedCommit = StagedCommit.forNewTable(arrowSchema, location, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     return createStagedDataset(
         readOptions,
         processedSchema,
@@ -946,7 +949,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> properties,
       ShardingSpec shardingSpec) {
     String datasetUri = getDatasetUri(ident);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     LanceSparkReadOptions readOptions =
         createReadOptions(
@@ -958,7 +963,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
             catalogConfig.getStorageOptions(), catalogConfig.isEnableStableRowIds(properties));
     StagedCommit stagedCommit = StagedCommit.forNewTable(arrowSchema, datasetUri, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     return createStagedDataset(
         readOptions,
         processedSchema,
@@ -986,7 +990,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     ResolvedTable resolved = resolveIdentifier(ident);
     DescribeTableResponse describeResponse = resolved.describeResponse;
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
     Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
     boolean managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
 
@@ -1004,7 +1010,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
     StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
     // Use specified file format version, or fall back to existing table's version
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     if (fileFormatVersion == null) {
       fileFormatVersion = ds.getLanceFileFormatVersion();
     }
@@ -1029,7 +1034,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       ShardingSpec shardingSpec)
       throws NoSuchTableException {
     String datasetUri = getDatasetUri(ident);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     LanceSparkReadOptions readOptions =
         createReadOptions(
@@ -1049,7 +1056,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
     StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
     // Use specified file format version, or fall back to existing table's version
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     if (fileFormatVersion == null) {
       fileFormatVersion = ds.getLanceFileFormatVersion();
     }
@@ -1086,7 +1092,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     boolean exists = tableExists(ident);
     String location;
@@ -1120,7 +1128,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     // Use specified file format version, or fall back to existing table's version
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     Map<String, String> merged =
         LanceRuntime.mergeStorageOptions(catalogConfig.getStorageOptions(), initialStorageOptions);
     final StagedCommitOptions commitOptions =
@@ -1161,7 +1168,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> properties,
       ShardingSpec shardingSpec) {
     String datasetUri = getDatasetUri(ident);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    StructType processedSchema =
+        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
 
     LanceSparkReadOptions readOptions =
         createReadOptions(
@@ -1174,7 +1183,6 @@ public abstract class BaseLanceNamespaceSparkCatalog
             catalogConfig.getStorageOptions(), catalogConfig.isEnableStableRowIds(properties));
     StagedCommit stagedCommit;
     // Use specified file format version, or fall back to existing table's version
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
     if (exists) {
       Dataset ds = Utils.openDatasetBuilder(readOptions).build();
       stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -18,6 +18,7 @@ import org.lance.spark.read.LanceScanBuilder;
 import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.BlobUtils;
 import org.lance.spark.write.AddColumnsBackfillWrite;
+import org.lance.spark.write.LanceWriteSchemaValidator;
 import org.lance.spark.write.SparkWrite;
 import org.lance.spark.write.StagedCommit;
 import org.lance.spark.write.UpdateColumnsBackfillWrite;
@@ -59,6 +60,14 @@ public class LanceDataset
   private static final Set<TableCapability> CAPABILITIES =
       ImmutableSet.of(
           TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.TRUNCATE);
+
+  // Blob v2 is read as descriptor structs, but written as BINARY from sparkSchema.
+  private static final Set<TableCapability> CAPABILITIES_WITH_BLOB_V2 =
+      ImmutableSet.of(
+          TableCapability.BATCH_READ,
+          TableCapability.BATCH_WRITE,
+          TableCapability.TRUNCATE,
+          TableCapability.ACCEPT_ANY_SCHEMA);
 
   public static final MetadataColumn FRAGMENT_ID_COLUMN =
       new MetadataColumn() {
@@ -318,11 +327,14 @@ public class LanceDataset
 
   @Override
   public Set<TableCapability> capabilities() {
-    return CAPABILITIES;
+    return BlobUtils.hasBlobV2Fields(sparkSchema) ? CAPABILITIES_WITH_BLOB_V2 : CAPABILITIES;
   }
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
+    if (capabilities().contains(TableCapability.ACCEPT_ANY_SCHEMA)) {
+      LanceWriteSchemaValidator.validate(sparkSchema, logicalWriteInfo.schema());
+    }
     // Merge write-time options with the base options from read options
     CaseInsensitiveStringMap sparkWriteOptions = logicalWriteInfo.options();
     Map<String, BlobSourceContext> blobSourceContexts = decodeBlobSourceContexts(sparkWriteOptions);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -26,6 +26,8 @@ import org.apache.spark.sql.types.StructType;
 
 import java.util.Map;
 
+import static org.lance.spark.utils.BlobUtils.ARROW_EXTENSION_BLOB_V2;
+import static org.lance.spark.utils.BlobUtils.ARROW_EXTENSION_NAME_KEY;
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_KEY;
 import static org.lance.spark.utils.BlobUtils.LANCE_ENCODING_BLOB_VALUE;
 import static org.lance.spark.utils.FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY;
@@ -42,8 +44,11 @@ import static org.lance.spark.utils.VectorUtils.ARROW_FIXED_SIZE_LIST_SIZE_KEY;
  */
 public class SchemaConverter {
 
-  private SchemaConverter() {
-    // Utility class
+  private SchemaConverter() {}
+
+  public static StructType processSchemaWithProperties(
+      StructType sparkSchema, Map<String, String> properties) {
+    return processSchemaWithProperties(sparkSchema, properties, null);
   }
 
   /**
@@ -52,13 +57,16 @@ public class SchemaConverter {
    *
    * @param sparkSchema the original Spark StructType
    * @param properties table properties that may contain column metadata
+   * @param fileFormatVersion the file format version (e.g. "2.1", "2.2") used to choose blob v1 vs
+   *     v2 encoding metadata on {@code BinaryType} columns. Pass {@code null} to default blob
+   *     columns to v1.
    * @return StructType with metadata added for matching columns
    */
   public static StructType processSchemaWithProperties(
-      StructType sparkSchema, Map<String, String> properties) {
+      StructType sparkSchema, Map<String, String> properties, String fileFormatVersion) {
     StructType schemaWithVectors = addVectorMetadata(sparkSchema, properties);
     StructType schemaWithFloat16 = addFloat16Metadata(schemaWithVectors, properties);
-    StructType schemaWithBlobs = addBlobMetadata(schemaWithFloat16, properties);
+    StructType schemaWithBlobs = addBlobMetadata(schemaWithFloat16, properties, fileFormatVersion);
     StructType schemaWithLargeVarChar = addLargeVarCharMetadata(schemaWithBlobs, properties);
     StructType schemaWithFixedSizeBinary =
         addFixedSizeBinaryMetadata(schemaWithLargeVarChar, properties);
@@ -195,10 +203,11 @@ public class SchemaConverter {
    *
    * @param sparkSchema the original Spark StructType
    * @param properties table properties that may contain blob column metadata
+   * @param fileFormatVersion the file format version used to choose blob v1 or v2
    * @return StructType with metadata added for blob columns
    */
   private static StructType addBlobMetadata(
-      StructType sparkSchema, Map<String, String> properties) {
+      StructType sparkSchema, Map<String, String> properties, String fileFormatVersion) {
     if (properties == null || properties.isEmpty()) {
       return sparkSchema;
     }
@@ -214,10 +223,13 @@ public class SchemaConverter {
         if ("blob".equalsIgnoreCase(encodingValue)) {
           if (field.dataType() instanceof BinaryType) {
             // Add metadata for blob encoding
+            boolean useV2 = enablesBlobV2(fileFormatVersion);
+            String metaKey = useV2 ? ARROW_EXTENSION_NAME_KEY : LANCE_ENCODING_BLOB_KEY;
+            String metaVal = useV2 ? ARROW_EXTENSION_BLOB_V2 : LANCE_ENCODING_BLOB_VALUE;
             Metadata newMetadata =
                 new MetadataBuilder()
                     .withMetadata(field.metadata())
-                    .putString(LANCE_ENCODING_BLOB_KEY, LANCE_ENCODING_BLOB_VALUE)
+                    .putString(metaKey, metaVal)
                     .build();
             newFields[i] =
                 new StructField(field.name(), field.dataType(), field.nullable(), newMetadata);
@@ -239,6 +251,26 @@ public class SchemaConverter {
     }
 
     return new StructType(newFields);
+  }
+
+  private static boolean enablesBlobV2(String fileFormatVersion) {
+    if (fileFormatVersion == null) {
+      return false;
+    }
+
+    String[] parts = fileFormatVersion.split("\\.");
+    try {
+      int major = Integer.parseInt(parts[0]);
+      int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+
+      return major > 2 || (major == 2 && minor >= 2);
+    } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Blob columns require a numeric file_format_version like '2.2'. Got: '%s'.",
+              fileFormatVersion),
+          e);
+    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceWriteSchemaValidator.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceWriteSchemaValidator.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.spark.utils.BlobUtils;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class LanceWriteSchemaValidator {
+
+  private LanceWriteSchemaValidator() {}
+
+  public static void validate(StructType tableSchema, StructType inputSchema) {
+    StructField[] tableFields = tableSchema.fields();
+    StructField[] inputFields = inputSchema.fields();
+
+    if (tableFields.length != inputFields.length) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot write to Lance table because the column count is different. "
+                  + "Table has %d columns, input has %d.",
+              tableFields.length, inputFields.length));
+    }
+
+    StructField[] resolved = resolveFields(tableFields, inputFields);
+
+    List<String> errors = new ArrayList<>();
+    for (int i = 0; i < inputFields.length; i++) {
+      checkField(resolved[i].name(), resolved[i], inputFields[i], errors);
+    }
+
+    if (errors.isEmpty()) {
+      return;
+    }
+
+    throw new IllegalArgumentException(
+        String.format(
+            "Cannot write to Lance table because the schemas do not match: %s",
+            String.join("; ", errors)));
+  }
+
+  private static void checkField(
+      String path, StructField tableField, StructField inputField, List<String> errors) {
+    if (!tableField.nullable() && inputField.nullable()) {
+      errors.add(
+          String.format(
+              "column '%s': the table column does not allow nulls, but the input does", path));
+    }
+
+    DataType tableType = tableField.dataType();
+    DataType inputType = inputField.dataType();
+
+    if (BlobUtils.isBlobV2SparkField(tableField)) {
+      if (!DataTypes.BinaryType.equals(inputType)) {
+        errors.add(
+            String.format(
+                "column '%s': blob v2 columns accept binary data; got %s",
+                path, inputType.simpleString()));
+      }
+      return;
+    }
+
+    if (tableType instanceof StructType && inputType instanceof StructType) {
+      checkStruct(path, (StructType) tableType, (StructType) inputType, errors);
+      return;
+    }
+
+    if (!tableType.equals(inputType)) {
+      errors.add(
+          String.format(
+              "column '%s': expected %s, got %s",
+              path, tableType.simpleString(), inputType.simpleString()));
+    }
+  }
+
+  private static void checkStruct(
+      String path, StructType tableStruct, StructType inputStruct, List<String> errors) {
+    StructField[] tableFields = tableStruct.fields();
+    StructField[] inputFields = inputStruct.fields();
+
+    if (tableFields.length != inputFields.length) {
+      errors.add(
+          String.format(
+              "column '%s': the struct has %d fields in the table but %d in the input",
+              path, tableFields.length, inputFields.length));
+      return;
+    }
+
+    for (int i = 0; i < tableFields.length; i++) {
+      StructField tableField = tableFields[i];
+      StructField inputField = inputFields[i];
+      if (!tableField.name().equals(inputField.name())) {
+        errors.add(
+            String.format(
+                "column '%s': struct fields are in the wrong order; expected '%s' at position %d,"
+                    + " got '%s'",
+                path, tableField.name(), i, inputField.name()));
+        return;
+      }
+      checkField(path + "." + tableField.name(), tableField, inputField, errors);
+    }
+  }
+
+  // LanceArrowWriter maps input column i to table column i. Match by name in table order,
+  // or accept Spark's SQL VALUES column names {col1, col2, ...}.
+  private static StructField[] resolveFields(StructField[] tableFields, StructField[] inputFields) {
+    Map<String, StructField> tableByName = new HashMap<>(tableFields.length);
+    for (StructField field : tableFields) {
+      tableByName.put(field.name(), field);
+    }
+
+    StructField[] resolved = new StructField[inputFields.length];
+    int matchedByName = 0;
+    for (int i = 0; i < inputFields.length; i++) {
+      resolved[i] = tableByName.get(inputFields[i].name());
+      if (resolved[i] != null) {
+        matchedByName++;
+      }
+    }
+
+    if (matchedByName == inputFields.length) {
+      for (int i = 0; i < inputFields.length; i++) {
+        if (!tableFields[i].name().equals(inputFields[i].name())) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot write to Lance table because column names match, but the "
+                      + "order is different. Expected column order: %s.",
+                  quotedNames(tableFields)));
+        }
+      }
+      return tableFields;
+    }
+    if (matchedByName == 0 && isSparkValuesColumns(inputFields)) {
+      return tableFields;
+    }
+
+    List<String> unknownFields = new ArrayList<>();
+    for (int i = 0; i < inputFields.length; i++) {
+      if (resolved[i] == null) {
+        unknownFields.add(String.format("'%s'", inputFields[i].name()));
+      }
+    }
+    throw new IllegalArgumentException(
+        String.format(
+            "Cannot write to Lance table because input columns %s are not in the table. Table"
+                + " columns: %s",
+            String.join(", ", unknownFields), quotedNames(tableFields)));
+  }
+
+  private static boolean isSparkValuesColumns(StructField[] inputFields) {
+    for (int i = 0; i < inputFields.length; i++) {
+      if (!String.format("col%d", i + 1).equals(inputFields[i].name())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static String quotedNames(StructField[] fields) {
+    List<String> names = new ArrayList<>(fields.length);
+    for (StructField field : fields) {
+      names.add(String.format("\"%s\"", field.name()));
+    }
+    return String.join(", ", names);
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -467,6 +467,19 @@ object LanceArrowUtils {
           null,
           meta.asJava)
         new Field(name, fieldType, Seq.empty[Field].asJava)
+      case _: BinaryType
+          if BLOB_V2_EXT_NAME.equals(meta.getOrElse(ARROW_EXT_NAME_KEY, "")) =>
+        // Blob v2 writes the struct lance-core expects: data, uri, position, size.
+        val structFieldType =
+          new FieldType(nullable, ArrowType.Struct.INSTANCE, null, meta.asJava)
+        new Field(
+          name,
+          structFieldType,
+          Seq(
+            toArrowField("data", BinaryType, nullable = true, timeZoneId, largeVarTypes = true),
+            toArrowField("uri", StringType, nullable = true, timeZoneId),
+            arrowUInt64Field("position"),
+            arrowUInt64Field("size")).asJava)
       case dataType =>
         val fieldType =
           new FieldType(nullable, toArrowType(dataType, timeZoneId, large, name), null, meta.asJava)
@@ -655,6 +668,12 @@ object LanceArrowUtils {
       "true".equalsIgnoreCase(metadata.get(ENCODING_BLOB))) ||
     BLOB_V2_EXT_NAME.equals(metadata.get(ARROW_EXT_NAME_KEY))
   }
+
+  private def arrowUInt64Field(name: String): Field =
+    new Field(
+      name,
+      new FieldType(true, new ArrowType.Int(64, false), null, Map.empty[String, String].asJava),
+      Seq.empty[Field].asJava)
 }
 
 /**

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.util.LanceArrowUtils
-import org.lance.spark.utils.{BlobReferenceResolver, Float16Utils}
+import org.lance.spark.utils.{BlobReferenceResolver, BlobUtils, Float16Utils}
 
 import scala.collection.JavaConverters._
 
@@ -127,6 +127,8 @@ object LanceArrowWriter {
           null,
           resolver)
         new MapWriter(vector, structVector, keyWriter, valueWriter)
+      case (BinaryType, vector: StructVector) if BlobUtils.isBlobV2SparkMetadata(metadata) =>
+        new BlobV2StructWriter(vector, createFieldWriter(vector.getChild("data"), BinaryType))
       case (StructType(fields), vector: StructVector) =>
         val children = fields.zipWithIndex.map { case (field, ordinal) =>
           createFieldWriter(
@@ -477,6 +479,55 @@ private[arrow] class MapWriter(
     keyWriter.reset()
     valueWriter.reset()
   }
+}
+
+private[arrow] class BlobV2StructWriter(
+    val valueVector: StructVector,
+    val dataWriter: LanceArrowFieldWriter) extends LanceArrowFieldWriter {
+
+  override def write(input: SpecializedGetters, ordinal: Int): Unit = {
+    if (input.isNullAt(ordinal)) {
+      dataWriter.write(input, ordinal)
+      valueVector.setNull(count)
+    } else {
+      valueVector.setIndexDefined(count)
+      dataWriter.write(input, ordinal)
+    }
+    count += 1
+  }
+
+  // Rows are written through write(). setNull and setValue are no-ops so child counts stay
+  // owned by dataWriter.write().
+  override def setNull(): Unit = ()
+
+  override def setValue(input: SpecializedGetters, ordinal: Int): Unit = ()
+
+  override def finish(): Unit = {
+    super.finish()
+    dataWriter.finish()
+    // The sibling descriptor fields (uri, position, size) are never populated on write —
+    // Lance synthesises them on read. Skip per-row null setting: setValueCount allocates the
+    // validity buffer and a fresh buffer's bits are all zero, which is "null". Saves
+    // O(rows * 3) Arrow validity writes per batch.
+    var i = 0
+    while (i < nullChildren.length) {
+      nullChildren(i).setValueCount(count)
+      i += 1
+    }
+  }
+
+  override def reset(): Unit = {
+    super.reset()
+    dataWriter.reset()
+    var i = 0
+    while (i < nullChildren.length) {
+      nullChildren(i).reset()
+      i += 1
+    }
+  }
+
+  private val nullChildren: Array[FieldVector] =
+    Array("uri", "position", "size").map(valueVector.getChild).toArray
 }
 
 private[arrow] class StructWriter(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobCreateTableTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobCreateTableTest.java
@@ -71,7 +71,7 @@ public abstract class BaseBlobCreateTableTest {
   // These tests verify that when a table is created with blob encoding property,
   // subsequent DataFrame writes don't need to set the blob encoding metadata.
 
-  /** Helper method to verify a field has blob encoding metadata set. */
+  /** Helper method to verify a field has blob v1 encoding metadata set. */
   private void assertBlobMetadata(StructType schema, String fieldName) {
     StructField field = schema.apply(fieldName);
     assertNotNull(field, fieldName + " field should exist in schema");
@@ -82,6 +82,9 @@ public abstract class BaseBlobCreateTableTest {
         BlobUtils.LANCE_ENCODING_BLOB_VALUE,
         field.metadata().getString(BlobUtils.LANCE_ENCODING_BLOB_KEY),
         BlobUtils.LANCE_ENCODING_BLOB_KEY + " metadata should be 'true'");
+    assertFalse(
+        BlobUtils.isBlobV2SparkField(field),
+        fieldName + " should not be tagged as blob v2 without file_format_version >= 2.2");
   }
 
   @Test
@@ -489,12 +492,198 @@ public abstract class BaseBlobCreateTableTest {
     spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
   }
 
-  private String bytesToHex(byte[] bytes) {
-    StringBuilder hexString = new StringBuilder();
-    for (byte b : bytes) {
-      hexString.append(String.format("%02X", b));
+  @Test
+  public void testBlobV2SupportsSqlInsertAndDataFrameAppend() {
+    String tableName = "blob_v2_sql_" + System.currentTimeMillis();
+
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + catalogName
+            + ".default."
+            + tableName
+            + " ("
+            + "id INT NOT NULL, "
+            + "data BINARY"
+            + ") USING lance "
+            + "TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', "
+            + "'file_format_version' = '2.2'"
+            + ")");
+
+    String testData1 = "SQL insert content 1";
+    String testData2 = "SQL insert content 2";
+    spark.sql(
+        "INSERT INTO "
+            + catalogName
+            + ".default."
+            + tableName
+            + " VALUES "
+            + "(1, X'"
+            + bytesToHex(testData1.getBytes(StandardCharsets.UTF_8))
+            + "'), "
+            + "(2, X'"
+            + bytesToHex(testData2.getBytes(StandardCharsets.UTF_8))
+            + "')");
+
+    List<Row> rows = new ArrayList<>();
+    Random random = new Random(42);
+    for (int i = 10; i < 13; i++) {
+      byte[] largeData = new byte[100000]; // 100KB
+      random.nextBytes(largeData);
+      rows.add(RowFactory.create(i, largeData));
     }
-    return hexString.toString();
+    StructType plainSchema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("data", DataTypes.BinaryType, true)
+            });
+    Dataset<Row> df = spark.createDataFrame(rows, plainSchema);
+    assertDoesNotThrow(() -> df.writeTo(catalogName + ".default." + tableName).append());
+
+    Dataset<Row> count = spark.sql("SELECT COUNT(*) FROM " + catalogName + ".default." + tableName);
+    assertEquals(5L, count.collectAsList().get(0).getLong(0));
+
+    List<Row> descriptors =
+        spark
+            .sql(
+                "SELECT id, data.size AS sz FROM "
+                    + catalogName
+                    + ".default."
+                    + tableName
+                    + " ORDER BY id")
+            .collectAsList();
+
+    assertEquals(5, descriptors.size());
+    assertEquals(testData1.getBytes(StandardCharsets.UTF_8).length, descriptors.get(0).getLong(1));
+    assertEquals(testData2.getBytes(StandardCharsets.UTF_8).length, descriptors.get(1).getLong(1));
+    assertEquals(100000L, descriptors.get(2).getLong(1));
+    assertBlobV2Metadata(spark.table(catalogName + ".default." + tableName).schema(), "data");
+    spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
+  }
+
+  @Test
+  public void testBlobV2SupportsSqlValuesInsert() {
+    String tableName = "blob_v2_empty_table_" + System.currentTimeMillis();
+
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + catalogName
+            + ".default."
+            + tableName
+            + " ("
+            + "id INT NOT NULL, "
+            + "text STRING, "
+            + "blob_data BINARY"
+            + ") USING lance "
+            + "TBLPROPERTIES ("
+            + "'blob_data.lance.encoding' = 'blob', "
+            + "'file_format_version' = '2.2'"
+            + ")");
+
+    assertBlobV2Metadata(spark.table(catalogName + ".default." + tableName).schema(), "blob_data");
+
+    String testData1 = "This is test blob data 1";
+    String testData2 = "This is test blob data 2";
+    spark.sql(
+        "INSERT INTO "
+            + catalogName
+            + ".default."
+            + tableName
+            + " VALUES "
+            + "(1, 'first text', X'"
+            + bytesToHex(testData1.getBytes(StandardCharsets.UTF_8))
+            + "'), "
+            + "(2, 'second text', X'"
+            + bytesToHex(testData2.getBytes(StandardCharsets.UTF_8))
+            + "')");
+
+    Dataset<Row> count = spark.sql("SELECT COUNT(*) FROM " + catalogName + ".default." + tableName);
+
+    assertEquals(2L, count.collectAsList().get(0).getLong(0));
+
+    List<Row> projection =
+        spark
+            .sql("SELECT id, text FROM " + catalogName + ".default." + tableName + " ORDER BY id")
+            .collectAsList();
+
+    assertEquals(2, projection.size());
+    assertEquals(1, projection.get(0).getInt(0));
+    assertEquals("first text", projection.get(0).getString(1));
+    assertEquals(2, projection.get(1).getInt(0));
+    assertEquals("second text", projection.get(1).getString(1));
+
+    List<Row> descriptors =
+        spark
+            .sql(
+                "SELECT id, blob_data.kind AS kind, blob_data.size AS sz FROM "
+                    + catalogName
+                    + ".default."
+                    + tableName
+                    + " ORDER BY id")
+            .collectAsList();
+
+    assertEquals(2, descriptors.size());
+    assertEquals(0, descriptors.get(0).getShort(1));
+    assertEquals(testData1.getBytes(StandardCharsets.UTF_8).length, descriptors.get(0).getLong(2));
+    assertEquals(testData2.getBytes(StandardCharsets.UTF_8).length, descriptors.get(1).getLong(2));
+
+    spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
+  }
+
+  @Test
+  public void testBlobColumnsStayBlobV1WithFileFormatVersion21() {
+    String tableName = "blob_v1_ffv_21_" + System.currentTimeMillis();
+
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + catalogName
+            + ".default."
+            + tableName
+            + " ("
+            + "id INT NOT NULL, "
+            + "data BINARY"
+            + ") USING lance "
+            + "TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', "
+            + "'file_format_version' = '2.1'"
+            + ")");
+
+    StructType schema = spark.table(catalogName + ".default." + tableName).schema();
+
+    assertBlobMetadata(schema, "data");
+    assertEquals(DataTypes.BinaryType, schema.apply("data").dataType());
+
+    spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
+  }
+
+  @Test
+  public void testCreateTableSupportsMultipleBlobV2Columns() {
+    String tableName = "blob_v2_table_multi_" + System.currentTimeMillis();
+
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + catalogName
+            + ".default."
+            + tableName
+            + " ("
+            + "id INT NOT NULL, "
+            + "blob1 BINARY, "
+            + "regular_binary BINARY, "
+            + "blob2 BINARY"
+            + ") USING lance "
+            + "TBLPROPERTIES ("
+            + "'blob1.lance.encoding' = 'blob', "
+            + "'blob2.lance.encoding' = 'blob', "
+            + "'file_format_version' = '2.2'"
+            + ")");
+
+    StructType schema = spark.table(catalogName + ".default." + tableName).schema();
+    assertBlobV2Metadata(schema, "blob1");
+    assertBlobV2Metadata(schema, "blob2");
+    assertFalse(BlobUtils.isBlobV2SparkField(schema.apply("regular_binary")));
+
+    spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
   }
 
   // ==================== Large VarChar Tests ====================
@@ -707,5 +896,20 @@ public abstract class BaseBlobCreateTableTest {
 
     // Clean up
     spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    StringBuilder hexString = new StringBuilder();
+    for (byte b : bytes) {
+      hexString.append(String.format("%02X", b));
+    }
+    return hexString.toString();
+  }
+
+  private void assertBlobV2Metadata(StructType schema, String fieldName) {
+    StructField field = schema.apply(fieldName);
+    assertNotNull(field);
+    assertEquals(BlobUtils.BLOB_DESCRIPTOR_STRUCT, field.dataType());
+    assertTrue(BlobUtils.isBlobV2SparkField(field));
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/arrow/BlobV2StructWriterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/arrow/BlobV2StructWriterTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.arrow;
+
+import org.lance.spark.utils.SchemaConverter;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BlobV2StructWriterTest {
+
+  @Test
+  public void testWritesBinaryToDataChild() {
+    StructType sparkSchema = blobV2Schema();
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", true);
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      LanceArrowWriter writer = LanceArrowWriter.create(root, sparkSchema);
+
+      byte[][] payloads = {
+        "row0".getBytes(StandardCharsets.UTF_8),
+        "row1".getBytes(StandardCharsets.UTF_8),
+        "row2".getBytes(StandardCharsets.UTF_8),
+      };
+
+      for (int i = 0; i < payloads.length; i++) {
+        writer.write(new GenericInternalRow(new Object[] {i, payloads[i]}));
+      }
+
+      writer.finish();
+      StructVector content = (StructVector) root.getVector("content");
+      assertEquals(payloads.length, content.getValueCount());
+      LargeVarBinaryVector data = (LargeVarBinaryVector) content.getChild("data");
+      assertEquals(payloads.length, data.getValueCount());
+      for (int i = 0; i < payloads.length; i++) {
+        assertFalse(content.isNull(i));
+        assertArrayEquals(payloads[i], data.getObject(i));
+      }
+
+      for (String sibling : new String[] {"uri", "position", "size"}) {
+        FieldVector child = content.getChild(sibling);
+        for (int i = 0; i < payloads.length; i++) {
+          assertTrue(child.isNull(i));
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testNullRowNullsStruct() {
+    StructType sparkSchema = blobV2Schema();
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", true);
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      LanceArrowWriter writer = LanceArrowWriter.create(root, sparkSchema);
+
+      writer.write(
+          new GenericInternalRow(new Object[] {0, "first".getBytes(StandardCharsets.UTF_8)}));
+      writer.write(new GenericInternalRow(new Object[] {1, null}));
+      writer.write(
+          new GenericInternalRow(new Object[] {2, "third".getBytes(StandardCharsets.UTF_8)}));
+      writer.finish();
+
+      StructVector content = (StructVector) root.getVector("content");
+      assertEquals(3, content.getValueCount());
+      assertFalse(content.isNull(0));
+      assertTrue(content.isNull(1));
+      assertFalse(content.isNull(2));
+
+      LargeVarBinaryVector data = (LargeVarBinaryVector) content.getChild("data");
+      assertEquals(3, data.getValueCount());
+      assertArrayEquals("first".getBytes(StandardCharsets.UTF_8), data.getObject(0));
+      assertTrue(data.isNull(1));
+      assertArrayEquals("third".getBytes(StandardCharsets.UTF_8), data.getObject(2));
+    }
+  }
+
+  @Test
+  public void testResetClearsBatch() {
+    StructType sparkSchema = blobV2Schema();
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", true);
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      LanceArrowWriter writer = LanceArrowWriter.create(root, sparkSchema);
+      writer.write(
+          new GenericInternalRow(new Object[] {0, "discard".getBytes(StandardCharsets.UTF_8)}));
+      writer.write(
+          new GenericInternalRow(
+              new Object[] {1, "also-discard".getBytes(StandardCharsets.UTF_8)}));
+      writer.reset();
+
+      writer.write(
+          new GenericInternalRow(new Object[] {7, "keep".getBytes(StandardCharsets.UTF_8)}));
+      writer.finish();
+
+      StructVector content = (StructVector) root.getVector("content");
+      assertEquals(1, content.getValueCount());
+      LargeVarBinaryVector data = (LargeVarBinaryVector) content.getChild("data");
+      assertEquals(1, data.getValueCount());
+      assertArrayEquals("keep".getBytes(StandardCharsets.UTF_8), data.getObject(0));
+    }
+  }
+
+  private static StructType blobV2Schema() {
+    StructType raw =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("content", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = ImmutableMap.of("content.lance.encoding", "blob");
+    return SchemaConverter.processSchemaWithProperties(raw, properties, "2.2");
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -13,9 +13,14 @@
  */
 package org.lance.spark.utils;
 
+import com.google.common.collect.ImmutableMap;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -138,8 +143,8 @@ public class SchemaConverterTest {
             });
     Map<String, String> properties = new HashMap<>();
     properties.put("text.lance.encoding", "blob");
-    assertThrows(
-        IllegalArgumentException.class,
+    assertValidationFailure(
+        "must have BINARY type",
         () -> SchemaConverter.processSchemaWithProperties(schema, properties));
   }
 
@@ -582,5 +587,111 @@ public class SchemaConverterTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> SchemaConverter.processSchemaWithProperties(schema, properties));
+  }
+
+  @Test
+  public void testBlobV2ArrowSchemaUsesWriteStruct() {
+    StructType sparkSchema = blobSchemaWithVersion("2.2");
+
+    assertBlobV2Field(sparkSchema.apply("data"));
+
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", true);
+    Field contentField = arrowSchema.findField("data");
+
+    assertNotNull(contentField);
+    assertInstanceOf(ArrowType.Struct.class, contentField.getType());
+    assertEquals(
+        BlobUtils.ARROW_EXTENSION_BLOB_V2,
+        contentField.getMetadata().get(BlobUtils.ARROW_EXTENSION_NAME_KEY));
+  }
+
+  @Test
+  public void testBlobV1WithUnsupportedVersion() {
+    // v2 only supported on 2.2 or higher
+    assertBlobV1Field(blobSchemaWithVersion("2.1").apply("data"));
+  }
+
+  @Test
+  public void testBlobV1WhenVersionNull() {
+    assertBlobV1Field(blobSchemaWithVersion(null).apply("data"));
+  }
+
+  @Test
+  public void testBlobEncodingRequiresColumnProperty() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = ImmutableMap.of("file_format_version", "2.2");
+    StructField field =
+        SchemaConverter.processSchemaWithProperties(schema, properties, "2.2").apply("data");
+
+    assertFalse(field.metadata().contains(BlobUtils.LANCE_ENCODING_BLOB_KEY));
+    assertFalse(field.metadata().contains(BlobUtils.ARROW_EXTENSION_NAME_KEY));
+  }
+
+  @Test
+  public void testBlobEncodingRejectsUnknownFileFormatVersion() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = ImmutableMap.of("data.lance.encoding", "blob");
+
+    assertValidationFailure(
+        "Blob columns require a numeric file_format_version like '2.2'. Got: 'stable'.",
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties, "stable"));
+  }
+
+  @Test
+  public void testBlobEncodingRejectsMalformedFileFormatVersion() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = ImmutableMap.of("data.lance.encoding", "blob");
+
+    assertValidationFailure(
+        "numeric file_format_version",
+        () -> SchemaConverter.processSchemaWithProperties(schema, properties, "2.x"));
+  }
+
+  private static StructType blobSchemaWithVersion(String fileFormatVersion) {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            });
+    Map<String, String> properties = ImmutableMap.of("data.lance.encoding", "blob");
+
+    return SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+  }
+
+  private static void assertBlobV1Field(StructField field) {
+    assertEquals(DataTypes.BinaryType, field.dataType());
+    assertTrue(field.metadata().contains(BlobUtils.LANCE_ENCODING_BLOB_KEY));
+    assertEquals(
+        BlobUtils.LANCE_ENCODING_BLOB_VALUE,
+        field.metadata().getString(BlobUtils.LANCE_ENCODING_BLOB_KEY));
+    assertFalse(field.metadata().contains(BlobUtils.ARROW_EXTENSION_NAME_KEY));
+  }
+
+  private static void assertBlobV2Field(StructField field) {
+    assertEquals(DataTypes.BinaryType, field.dataType());
+    assertEquals(
+        BlobUtils.ARROW_EXTENSION_BLOB_V2,
+        field.metadata().getString(BlobUtils.ARROW_EXTENSION_NAME_KEY));
+    assertFalse(field.metadata().contains(BlobUtils.LANCE_ENCODING_BLOB_KEY));
+  }
+
+  private static void assertValidationFailure(String expectedFragment, Runnable action) {
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, action::run);
+    assertTrue(
+        e.getMessage().contains(expectedFragment),
+        () -> "expected message to contain '" + expectedFragment + "': " + e.getMessage());
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceWriteSchemaValidatorTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceWriteSchemaValidatorTest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.spark.utils.BlobUtils;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LanceWriteSchemaValidatorTest {
+
+  @Test
+  public void testValidateAcceptsBinaryInputForBlobV2Column() {
+    assertDoesNotThrow(
+        () ->
+            LanceWriteSchemaValidator.validate(
+                writeSchemaWithIdAndBlob(), inputSchemaWithIdAndBinaryContent()));
+  }
+
+  @Test
+  public void testValidateRejectsColumnCountMismatch() {
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+            });
+
+    assertValidationFailure(
+        "column count is different",
+        () -> LanceWriteSchemaValidator.validate(writeSchemaWithIdAndBlob(), input));
+  }
+
+  @Test
+  public void testValidateRejectsNonBinaryInputForBlobV2Column() {
+    StructType writeSchema = new StructType(new StructField[] {blobV2Field("content")});
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("content", DataTypes.StringType, true),
+            });
+
+    assertValidationFailure(
+        "accept binary", () -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateRejectsOutOfOrderColumns() {
+    StructType reordered =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("content", DataTypes.BinaryType, true),
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+            });
+
+    assertValidationFailure(
+        "order is different",
+        () -> LanceWriteSchemaValidator.validate(writeSchemaWithIdAndBlob(), reordered));
+  }
+
+  @Test
+  public void testValidateRejectsUnknownColumnNames() {
+    StructType foreignNames =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("identifier", DataTypes.IntegerType, false),
+              DataTypes.createStructField("payload", DataTypes.BinaryType, true),
+            });
+
+    assertValidationFailure(
+        "'identifier'",
+        () -> LanceWriteSchemaValidator.validate(writeSchemaWithIdAndBlob(), foreignNames));
+  }
+
+  @Test
+  public void testValidateAcceptsSqlValuesColumnNames() {
+    StructType sqlValuesNames =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("col1", DataTypes.IntegerType, false),
+              DataTypes.createStructField("col2", DataTypes.BinaryType, true),
+            });
+
+    assertDoesNotThrow(
+        () -> LanceWriteSchemaValidator.validate(writeSchemaWithIdAndBlob(), sqlValuesNames));
+  }
+
+  @Test
+  public void testValidateRejectsPartiallyMatchingColumnNames() {
+    StructType partial =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("payload", DataTypes.BinaryType, true),
+            });
+
+    assertValidationFailure(
+        "'payload'", () -> LanceWriteSchemaValidator.validate(writeSchemaWithIdAndBlob(), partial));
+  }
+
+  @Test
+  public void testValidateRejectsNullableInputForNonNullableColumn() {
+    StructType writeSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, false)});
+    StructType input =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, true)});
+
+    assertValidationFailure(
+        "does not allow nulls", () -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateAcceptsNonNullableInputForNullableColumn() {
+    StructType writeSchema =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, true)});
+    StructType input =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("id", DataTypes.IntegerType, false)});
+
+    assertDoesNotThrow(() -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateAcceptsMatchingNestedStruct() {
+    StructType nested =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("city", DataTypes.StringType, true),
+              DataTypes.createStructField("zip", DataTypes.IntegerType, false),
+            });
+    StructType writeSchema =
+        new StructType(new StructField[] {DataTypes.createStructField("address", nested, false)});
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "address",
+                  new StructType(
+                      new StructField[] {
+                        DataTypes.createStructField("city", DataTypes.StringType, true),
+                        DataTypes.createStructField("zip", DataTypes.IntegerType, false),
+                      }),
+                  false)
+            });
+
+    assertDoesNotThrow(() -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateRejectsNestedStructFieldTypeMismatch() {
+    StructType nested =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("city", DataTypes.StringType, true),
+              DataTypes.createStructField("zip", DataTypes.IntegerType, false),
+            });
+    StructType writeSchema =
+        new StructType(new StructField[] {DataTypes.createStructField("address", nested, true)});
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "address",
+                  new StructType(
+                      new StructField[] {
+                        DataTypes.createStructField("city", DataTypes.StringType, true),
+                        DataTypes.createStructField("zip", DataTypes.StringType, true),
+                      }),
+                  true)
+            });
+
+    assertValidationFailure(
+        "address.zip", () -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateRejectsNestedStructNullabilityMismatch() {
+    StructType nested =
+        new StructType(
+            new StructField[] {DataTypes.createStructField("zip", DataTypes.IntegerType, false)});
+    StructType writeSchema =
+        new StructType(new StructField[] {DataTypes.createStructField("address", nested, true)});
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "address",
+                  new StructType(
+                      new StructField[] {
+                        DataTypes.createStructField("zip", DataTypes.IntegerType, true)
+                      }),
+                  true)
+            });
+
+    assertValidationFailure(
+        "address.zip", () -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  @Test
+  public void testValidateRejectsNestedStructFieldCountMismatch() {
+    StructType nested =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("city", DataTypes.StringType, true),
+              DataTypes.createStructField("zip", DataTypes.IntegerType, false),
+            });
+    StructType writeSchema =
+        new StructType(new StructField[] {DataTypes.createStructField("address", nested, true)});
+    StructType input =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "address",
+                  new StructType(
+                      new StructField[] {
+                        DataTypes.createStructField("city", DataTypes.StringType, true),
+                      }),
+                  true)
+            });
+
+    assertValidationFailure(
+        "fields in the table", () -> LanceWriteSchemaValidator.validate(writeSchema, input));
+  }
+
+  private static StructField blobV2Field(String name) {
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
+    return DataTypes.createStructField(name, DataTypes.BinaryType, true, metadata);
+  }
+
+  private static StructType writeSchemaWithIdAndBlob() {
+    return new StructType(
+        new StructField[] {
+          DataTypes.createStructField("id", DataTypes.IntegerType, false), blobV2Field("content"),
+        });
+  }
+
+  private static StructType inputSchemaWithIdAndBinaryContent() {
+    return new StructType(
+        new StructField[] {
+          DataTypes.createStructField("id", DataTypes.IntegerType, false),
+          DataTypes.createStructField("content", DataTypes.BinaryType, true),
+        });
+  }
+
+  private static void assertValidationFailure(String expectedFragment, Runnable action) {
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, action::run);
+    assertTrue(
+        e.getMessage().contains(expectedFragment),
+        () -> "expected message to contain '" + expectedFragment + "': " + e.getMessage());
+  }
+}


### PR DESCRIPTION
Stack PR that depends on #548, which adds Blob v2 descriptor reads. 

This PR, allows users to create a table with `file_format_version >= 2.2` and `<column>.lance.encoding = blob`, write `BINARY` values through SQL or DataFrames, and have Lance store them using Blob v2. Reads still expose the descriptor struct from #548.

The hard part here is that the read schema and write schema are logically different and spark doesnt like this (as far as i can tell. Reads expose Blob v2 as a descriptor struct, but writes still need to accept `BINARY`.

I tried an analyzer rule first, but it runs after Spark resolves the table schema, so the write has already failed by the time the rule gets a chance to do anything.

So this uses `ACCEPT_ANY_SCHEMA`, but only for tables with Blob v2 columns. It is basically a scoped bypass for this one schema mismatch, not a free pass for all writes. Lance still validates the incoming schema in `newWriteBuilder`: Blob v2 columns must be binary, column order/names must match, Spark SQL `VALUES` columns are handled, and nested structs still follow the normal checks.

At encode time, Spark still gives us `BINARY`, and the connector maps that into the Lance Blob v2 write struct. This PR only supports inline binary writes. URI-based blob writes are not included here and can be added separately.

## Testing 

- `./mvnw test -pl lance-spark-base_2.12 -Dtest=BlobV2StructWriterTest,LanceWriteSchemaValidatorTest,SchemaConverterTest`
- Java blob v2 create/insert tests in BaseBlobCreateTableTest
- `make docker-build-test-base && make docker-build-test && make docker-test TEST_BACKENDS=local`