### PR TITLE
chore: update lance dependency to v7.1.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.1.0-beta.3</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-rc.1` to `7.1.0-beta.3`.
- Verified Docker version pins against Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`; no Dockerfile change was required because the existing values already matched exactly.
- Triggering Lance tag: https://github.com/lance-format/lance/releases/tag/v7.1.0-beta.3 (`refs/tags/v7.1.0-beta.3`).

## Verification
- `make lint` passed.
- `make install` passed after installing `org.lance:lance-core:7.1.0-beta.3` locally from the `lance-format/lance` tag because Maven Central had not yet published `7.1.0-beta.3` at verification time.
