### PR TITLE
chore: update lance dependency to v7.1.0-beta.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.1.0-beta.4</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Update the root Maven `lance.version` property to `7.1.0-beta.4`.
- Verified `docker/Dockerfile` hardcoded versions already match the evaluated Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`, so no Dockerfile change was required.
- Triggering tag: refs/tags/v7.1.0-beta.4

## Verification
- `make lint` passed.
- `make install` passed after installing `org.lance:lance-core:7.1.0-beta.4` locally from the `lance-format/lance` `v7.1.0-beta.4` tag, because Maven Central did not yet expose that artifact during verification immediately after the tag was published.
