### PR TITLE
chore: update lance dependency to v7.2.0-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.2.0-beta.1</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-rc.1` to `7.2.0-beta.1`.
- Verified Docker hardcoded versions already match Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`.
- Verified the connector build with `make lint` and `make install`.

## Verification
- `make lint`
- `make install`

Triggering tag: refs/tags/v7.2.0-beta.1

Note: `org.lance:lance-core:7.2.0-beta.1` was not yet available in Maven Central during verification, so I built and installed the artifact locally from the upstream Lance `refs/tags/v7.2.0-beta.1` tag before rerunning `make install`.
