### PR TITLE
perf(read): consolidate driver-side Dataset opens and pin version for…

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -107,7 +107,7 @@ public class LanceSparkReadOptions implements Serializable {
   private final String datasetName;
   private final boolean pushDownFilters;
   private final Integer blockSize;
-  private final Integer version;
+  private final Long version;
   private final Integer indexCacheSize;
   private final Integer metadataCacheSize;
   private final int batchSize;
@@ -238,7 +238,7 @@ public class LanceSparkReadOptions implements Serializable {
     return blockSize;
   }
 
-  public Integer getVersion() {
+  public Long getVersion() {
     return version;
   }
 
@@ -312,7 +312,7 @@ public class LanceSparkReadOptions implements Serializable {
    * @param newVersion the version to use
    * @return a new LanceSparkReadOptions with the specified version
    */
-  public LanceSparkReadOptions withVersion(int newVersion) {
+  public LanceSparkReadOptions withVersion(long newVersion) {
     return builder()
         .datasetUri(this.datasetUri)
         .pushDownFilters(this.pushDownFilters)
@@ -411,7 +411,7 @@ public class LanceSparkReadOptions implements Serializable {
     private boolean pushDownFilters = DEFAULT_PUSH_DOWN_FILTERS;
     private Integer blockSize;
     private Query nearest;
-    private Integer version;
+    private Long version;
     private Integer indexCacheSize;
     private Integer metadataCacheSize;
     private int batchSize = DEFAULT_BATCH_SIZE;
@@ -453,7 +453,7 @@ public class LanceSparkReadOptions implements Serializable {
       return this;
     }
 
-    public Builder version(Integer version) {
+    public Builder version(Long version) {
       this.version = version;
       return this;
     }
@@ -546,7 +546,7 @@ public class LanceSparkReadOptions implements Serializable {
         this.blockSize = Integer.parseInt(opts.get(CONFIG_BLOCK_SIZE));
       }
       if (opts.containsKey(CONFIG_VERSION)) {
-        this.version = Integer.parseInt(opts.get(CONFIG_VERSION));
+        this.version = Long.parseLong(opts.get(CONFIG_VERSION));
       }
       if (opts.containsKey(CONFIG_INDEX_CACHE_SIZE)) {
         this.indexCacheSize = Integer.parseInt(opts.get(CONFIG_INDEX_CACHE_SIZE));

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -89,6 +89,22 @@ public class LanceScan
    */
   private final Set<Integer> cachedSurvivingFragmentIds;
 
+  /**
+   * Splits pre-computed on the driver during {@link LanceScanBuilder#build()}. Each entry is one
+   * fragment. Built from a single {@code Dataset} handle that was already opened for manifest /
+   * schema / zonemap loading, so no second {@code Dataset.open()} is needed at {@link
+   * #planInputPartitions()} time.
+   */
+  private final List<LanceSplit> precomputedSplits;
+
+  /**
+   * Per-fragment logical row counts (after deletions), captured together with {@link
+   * #precomputedSplits} on the driver. Consumed only by {@link #pruneByLimit} — kept transient to
+   * avoid bloating the serialized plan when shipped via {@code BatchScanExec} / {@code
+   * ReusedExchange} comparisons. Effectively final after construction.
+   */
+  private final transient java.util.Map<Integer, Long> precomputedFragmentRowCounts;
+
   /** Number of partitions after pruning, set during {@link #planInputPartitions()}. */
   private transient int numPartitions = -1;
 
@@ -121,6 +137,8 @@ public class LanceScan
       LanceStatistics statistics,
       java.util.Map<String, List<ZoneStats>> zonemapStats,
       Set<Integer> survivingFragmentIds,
+      List<LanceSplit> precomputedSplits,
+      java.util.Map<Integer, Long> precomputedFragmentRowCounts,
       Expression activeShardingExpression,
       java.util.Map<Integer, Object> fragmentShardingKeys,
       java.util.Map<String, String> initialStorageOptions,
@@ -140,6 +158,11 @@ public class LanceScan
     this.statistics = statistics;
     this.zonemapStats = zonemapStats != null ? zonemapStats : Collections.emptyMap();
     this.cachedSurvivingFragmentIds = survivingFragmentIds;
+    this.precomputedSplits = precomputedSplits;
+    this.precomputedFragmentRowCounts =
+        precomputedFragmentRowCounts != null
+            ? precomputedFragmentRowCounts
+            : Collections.emptyMap();
     this.activeShardingExpression = activeShardingExpression;
     this.fragmentShardingKeys = fragmentShardingKeys;
     this.initialStorageOptions = initialStorageOptions;
@@ -154,8 +177,10 @@ public class LanceScan
 
   @Override
   public InputPartition[] planInputPartitions() {
-    LanceSplit.ScanPlanResult planResult = LanceSplit.planScan(readOptions);
-    List<LanceSplit> prunedSplits = pruneByRowAddrFilters(planResult.getSplits());
+    // Splits and per-fragment row counts are pre-computed on the driver during
+    // LanceScanBuilder.build() from the same Dataset handle that loaded manifest /
+    // schema / zonemap stats. This avoids a second Dataset.open() at plan time.
+    List<LanceSplit> prunedSplits = pruneByRowAddrFilters(precomputedSplits);
 
     // Zonemap-based fragment pruning: uses per-column min/max/null_count
     // statistics to eliminate fragments that provably cannot match
@@ -166,15 +191,13 @@ public class LanceScan
     // use per-fragment row counts to plan only enough splits to satisfy the limit.
     // This avoids scheduling hundreds of unnecessary tasks. Correctness is guaranteed
     // because Spark still keeps a global CollectLimit on top (isPartiallyPushed = true).
-    prunedSplits = pruneByLimit(prunedSplits, planResult.getFragmentRowCounts());
+    prunedSplits = pruneByLimit(prunedSplits, precomputedFragmentRowCounts);
 
     // Capture as effectively final for use in lambda
     final List<LanceSplit> finalSplits = prunedSplits;
 
-    // Use resolved version for snapshot isolation - ensures all workers read the same version
-    LanceSparkReadOptions resolvedReadOptions =
-        readOptions.withVersion((int) planResult.getResolvedVersion());
-
+    // readOptions is already pinned to the resolved version by LanceScanBuilder for
+    // snapshot isolation across all workers.
     InputPartition[] result =
         IntStream.range(0, finalSplits.size())
             .mapToObj(
@@ -192,7 +215,7 @@ public class LanceScan
                       schema,
                       i,
                       split,
-                      resolvedReadOptions,
+                      readOptions,
                       whereConditions,
                       limit,
                       offset,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -99,11 +99,11 @@ public class LanceScan
 
   /**
    * Per-fragment logical row counts (after deletions), captured together with {@link
-   * #precomputedSplits} on the driver. Consumed only by {@link #pruneByLimit} — kept transient to
-   * avoid bloating the serialized plan when shipped via {@code BatchScanExec} / {@code
-   * ReusedExchange} comparisons. Effectively final after construction.
+   * #precomputedSplits} on the driver. Consumed by {@link #pruneByLimit}. Not declared {@code
+   * transient} because Java deserialization would skip the constructor and leave the field {@code
+   * null}, which would NPE inside {@link #pruneByLimit}.
    */
-  private final transient java.util.Map<Integer, Long> precomputedFragmentRowCounts;
+  private final java.util.Map<Integer, Long> precomputedFragmentRowCounts;
 
   /** Number of partitions after pruning, set during {@link #planInputPartitions()}. */
   private transient int numPartitions = -1;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -147,123 +147,129 @@ public class LanceScanBuilder
 
   @Override
   public Scan build() {
-    // Return LocalScan if we have a metadata-only aggregation result
-    if (localScan != null) {
+    // Wrap the entire planning body in try/finally to guarantee that the lazily-opened native
+    // dataset handle (lazyDataset) is always released, including when intermediate steps such as
+    // zonemap loading or LanceSplit.planScan(dataset) throw.
+    try {
+      // Return LocalScan if we have a metadata-only aggregation result
+      if (localScan != null) {
+        return localScan;
+      }
+
+      // Get statistics from manifest summary before closing dataset
+      ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
+
+      // Collect all columns that need zonemap stats: filter columns + sharding columns.
+      Set<String> columnsToLoad = extractReferencedColumns(pushedPredicates);
+      Dataset dataset = getOrOpenDataset();
+      LanceSchema lanceSchema = dataset.getLanceSchema();
+      ShardingSpec activeShardingSpec =
+          SparkLanceShardingUtils.isEmpty(shardingSpec)
+              ? SparkLanceShardingUtils.firstShardingSpec(dataset)
+              : shardingSpec;
+      for (ShardingField field : SparkLanceShardingUtils.fields(activeShardingSpec)) {
+        columnsToLoad.add(SparkLanceShardingUtils.columnName(field, lanceSchema));
+      }
+
+      // Load zonemap stats for all requested columns in one pass.
+      Map<String, List<ZoneStats>> zonemapStats =
+          loadZonemapStats(getOrOpenDataset(), columnsToLoad);
+
+      // Detect sharding-compatible fragments from zonemap stats. Each field checks its column's
+      // zones; if every fragment has a single sharding value, we get a fragment-to-key map.
+      Map<Integer, Object> fragmentShardingKeys = null;
+      Expression activeShardingExpression = null;
+      for (ShardingField field : SparkLanceShardingUtils.fields(activeShardingSpec)) {
+        String column = SparkLanceShardingUtils.columnName(field, lanceSchema);
+        List<ZoneStats> colStats = zonemapStats.get(column);
+        if (colStats == null || colStats.isEmpty()) {
+          LOG.warn(
+              "Sharding column '{}' (transform={}) has no zonemap stats;"
+                  + " sharding detection disabled",
+              column,
+              field.transform().orElse(null));
+          continue;
+        }
+        java.util.Optional<Map<Integer, Object>> keys =
+            SparkLanceShardingUtils.detectFragmentKeys(field, lanceSchema, colStats);
+        if (keys.isPresent()) {
+          fragmentShardingKeys = keys.get();
+          activeShardingExpression = SparkLanceShardingUtils.toSparkExpression(field, lanceSchema);
+          LOG.info(
+              "Detected Lance sharding field {}('{}') with {} fragments",
+              field.transform().orElse(null),
+              column,
+              fragmentShardingKeys.size());
+          break;
+        }
+      }
+
+      // Pre-compute fragment pruning so we can (a) estimate post-pruning statistics for
+      // JoinSelection (BroadcastHashJoin vs SortMergeJoin) and (b) pass the cached result
+      // to LanceScan to avoid re-computing during planInputPartitions().
+      Set<Integer> survivingFragmentIds = null;
+      if (pushedPredicates.length > 0 && !zonemapStats.isEmpty()) {
+        survivingFragmentIds =
+            ZonemapFragmentPruner.pruneFragments(pushedPredicates, zonemapStats).orElse(null);
+      }
+
+      // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
+      // LanceStatistics.estimateProjected apply the column-width ratio on top
+      // (when the projected schema is narrower than the full schema).
+      long projectedRows = summary.getTotalRows();
+      long projectedFullSize = summary.getTotalFilesSize();
+      if (survivingFragmentIds != null && summary.getTotalFragments() > 0) {
+        double ratio = (double) survivingFragmentIds.size() / summary.getTotalFragments();
+        projectedRows = (long) (projectedRows * ratio);
+        projectedFullSize = (long) (projectedFullSize * ratio);
+      }
+      LanceStatistics statistics =
+          LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
+      if (survivingFragmentIds != null) {
+        LOG.debug(
+            "Scan statistics after pruning: {} of {} fragments survive,"
+                + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
+            survivingFragmentIds.size(),
+            summary.getTotalFragments(),
+            statistics.sizeInBytes(),
+            statistics.numRows(),
+            summary.getTotalFilesSize(),
+            summary.getTotalRows());
+      }
+
+      // Pre-compute splits and per-fragment row counts from the same Dataset handle that we
+      // already opened above. This consolidates two driver-side opens into one and lets us pin
+      // the resolved version onto the read options shipped to workers, providing snapshot
+      // isolation across all tasks of this query. The version is kept as a long end-to-end so
+      // long-lived high-write-frequency datasets do not silently truncate to a wrong version.
+      LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset);
+      LanceSparkReadOptions resolvedReadOptions =
+          readOptions.withVersion(scanPlan.getResolvedVersion());
+
+      Optional<String> whereCondition =
+          FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);
+      return new LanceScan(
+          schema,
+          resolvedReadOptions,
+          whereCondition,
+          limit,
+          offset,
+          topNSortOrders,
+          pushedAggregation,
+          pushedPredicates,
+          statistics,
+          zonemapStats,
+          survivingFragmentIds,
+          scanPlan.getSplits(),
+          scanPlan.getFragmentRowCounts(),
+          activeShardingExpression,
+          fragmentShardingKeys,
+          initialStorageOptions,
+          namespaceImpl,
+          namespaceProperties);
+    } finally {
       closeLazyDataset();
-      return localScan;
     }
-
-    // Get statistics from manifest summary before closing dataset
-    ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
-
-    // Collect all columns that need zonemap stats: filter columns + sharding columns.
-    Set<String> columnsToLoad = extractReferencedColumns(pushedPredicates);
-    Dataset dataset = getOrOpenDataset();
-    LanceSchema lanceSchema = dataset.getLanceSchema();
-    ShardingSpec activeShardingSpec =
-        SparkLanceShardingUtils.isEmpty(shardingSpec)
-            ? SparkLanceShardingUtils.firstShardingSpec(dataset)
-            : shardingSpec;
-    for (ShardingField field : SparkLanceShardingUtils.fields(activeShardingSpec)) {
-      columnsToLoad.add(SparkLanceShardingUtils.columnName(field, lanceSchema));
-    }
-
-    // Load zonemap stats for all requested columns in one pass.
-    Map<String, List<ZoneStats>> zonemapStats = loadZonemapStats(getOrOpenDataset(), columnsToLoad);
-
-    // Detect sharding-compatible fragments from zonemap stats. Each field checks its column's
-    // zones; if every fragment has a single sharding value, we get a fragment-to-key map.
-    Map<Integer, Object> fragmentShardingKeys = null;
-    Expression activeShardingExpression = null;
-    for (ShardingField field : SparkLanceShardingUtils.fields(activeShardingSpec)) {
-      String column = SparkLanceShardingUtils.columnName(field, lanceSchema);
-      List<ZoneStats> colStats = zonemapStats.get(column);
-      if (colStats == null || colStats.isEmpty()) {
-        LOG.warn(
-            "Sharding column '{}' (transform={}) has no zonemap stats; sharding detection disabled",
-            column,
-            field.transform().orElse(null));
-        continue;
-      }
-      java.util.Optional<Map<Integer, Object>> keys =
-          SparkLanceShardingUtils.detectFragmentKeys(field, lanceSchema, colStats);
-      if (keys.isPresent()) {
-        fragmentShardingKeys = keys.get();
-        activeShardingExpression = SparkLanceShardingUtils.toSparkExpression(field, lanceSchema);
-        LOG.info(
-            "Detected Lance sharding field {}('{}') with {} fragments",
-            field.transform().orElse(null),
-            column,
-            fragmentShardingKeys.size());
-        break;
-      }
-    }
-
-    // Pre-compute fragment pruning so we can (a) estimate post-pruning statistics for
-    // JoinSelection (BroadcastHashJoin vs SortMergeJoin) and (b) pass the cached result
-    // to LanceScan to avoid re-computing during planInputPartitions().
-    Set<Integer> survivingFragmentIds = null;
-    if (pushedPredicates.length > 0 && !zonemapStats.isEmpty()) {
-      survivingFragmentIds =
-          ZonemapFragmentPruner.pruneFragments(pushedPredicates, zonemapStats).orElse(null);
-    }
-
-    // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
-    // LanceStatistics.estimateProjected apply the column-width ratio on top
-    // (when the projected schema is narrower than the full schema).
-    long projectedRows = summary.getTotalRows();
-    long projectedFullSize = summary.getTotalFilesSize();
-    if (survivingFragmentIds != null && summary.getTotalFragments() > 0) {
-      double ratio = (double) survivingFragmentIds.size() / summary.getTotalFragments();
-      projectedRows = (long) (projectedRows * ratio);
-      projectedFullSize = (long) (projectedFullSize * ratio);
-    }
-    LanceStatistics statistics =
-        LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
-    if (survivingFragmentIds != null) {
-      LOG.debug(
-          "Scan statistics after pruning: {} of {} fragments survive,"
-              + " estimatedSize={}, estimatedRows={} (full: size={}, rows={})",
-          survivingFragmentIds.size(),
-          summary.getTotalFragments(),
-          statistics.sizeInBytes(),
-          statistics.numRows(),
-          summary.getTotalFilesSize(),
-          summary.getTotalRows());
-    }
-
-    // Pre-compute splits and per-fragment row counts from the same Dataset handle that we
-    // already opened above. This consolidates two driver-side opens into one and lets us pin
-    // the resolved version onto the read options shipped to workers, providing snapshot
-    // isolation across all tasks of this query.
-    LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset);
-    LanceSparkReadOptions resolvedReadOptions =
-        readOptions.withVersion((int) scanPlan.getResolvedVersion());
-
-    // Close the lazily opened dataset - it's no longer needed after build
-    closeLazyDataset();
-
-    Optional<String> whereCondition =
-        FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);
-    return new LanceScan(
-        schema,
-        resolvedReadOptions,
-        whereCondition,
-        limit,
-        offset,
-        topNSortOrders,
-        pushedAggregation,
-        pushedPredicates,
-        statistics,
-        zonemapStats,
-        survivingFragmentIds,
-        scanPlan.getSplits(),
-        scanPlan.getFragmentRowCounts(),
-        activeShardingExpression,
-        fragmentShardingKeys,
-        initialStorageOptions,
-        namespaceImpl,
-        namespaceProperties);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -232,6 +232,14 @@ public class LanceScanBuilder
           summary.getTotalRows());
     }
 
+    // Pre-compute splits and per-fragment row counts from the same Dataset handle that we
+    // already opened above. This consolidates two driver-side opens into one and lets us pin
+    // the resolved version onto the read options shipped to workers, providing snapshot
+    // isolation across all tasks of this query.
+    LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset);
+    LanceSparkReadOptions resolvedReadOptions =
+        readOptions.withVersion((int) scanPlan.getResolvedVersion());
+
     // Close the lazily opened dataset - it's no longer needed after build
     closeLazyDataset();
 
@@ -239,7 +247,7 @@ public class LanceScanBuilder
         FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);
     return new LanceScan(
         schema,
-        readOptions,
+        resolvedReadOptions,
         whereCondition,
         limit,
         offset,
@@ -249,6 +257,8 @@ public class LanceScanBuilder
         statistics,
         zonemapStats,
         survivingFragmentIds,
+        scanPlan.getSplits(),
+        scanPlan.getFragmentRowCounts(),
         activeShardingExpression,
         fragmentShardingKeys,
         initialStorageOptions,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -75,17 +75,30 @@ public class LanceSplit implements Serializable {
    */
   public static ScanPlanResult planScan(LanceSparkReadOptions readOptions) {
     try (Dataset dataset = Utils.openDatasetBuilder(readOptions).build()) {
-      List<Fragment> fragments = dataset.getFragments();
-      List<LanceSplit> splits = new ArrayList<>(fragments.size());
-      Map<Integer, Long> fragmentRowCounts = new HashMap<>(fragments.size());
-      for (Fragment fragment : fragments) {
-        int id = fragment.getId();
-        splits.add(new LanceSplit(Collections.singletonList(id)));
-        fragmentRowCounts.put(id, fragment.metadata().getNumRows());
-      }
-      long resolvedVersion = dataset.getVersion().getId();
-      return new ScanPlanResult(splits, resolvedVersion, fragmentRowCounts);
+      return planScan(dataset);
     }
+  }
+
+  /**
+   * Generates splits and resolves the dataset version using an already-opened dataset.
+   *
+   * <p>Prefer this overload over {@link #planScan(LanceSparkReadOptions)} when the caller already
+   * holds an open {@link Dataset} (e.g. in scan planning), to avoid re-opening the dataset and
+   * paying the manifest IO cost twice.
+   *
+   * <p>The caller retains ownership of the dataset; this method does not close it.
+   */
+  public static ScanPlanResult planScan(Dataset dataset) {
+    List<Fragment> fragments = dataset.getFragments();
+    List<LanceSplit> splits = new ArrayList<>(fragments.size());
+    Map<Integer, Long> fragmentRowCounts = new HashMap<>(fragments.size());
+    for (Fragment fragment : fragments) {
+      int id = fragment.getId();
+      splits.add(new LanceSplit(Collections.singletonList(id)));
+      fragmentRowCounts.put(id, fragment.metadata().getNumRows());
+    }
+    long resolvedVersion = dataset.getVersion().getId();
+    return new ScanPlanResult(splits, resolvedVersion, fragmentRowCounts);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -85,7 +85,7 @@ public class Utils {
     private OpenDatasetBuilder(LanceSparkReadOptions opts) {
       this.uri = opts.getDatasetUri();
       this.storageOptions = opts.getStorageOptions();
-      this.version = opts.getVersion() != null ? opts.getVersion().longValue() : null;
+      this.version = opts.getVersion();
       this.catalogName = opts.getCatalogName();
       this.namespace = opts.getNamespace();
       this.tableId = opts.getTableId();
@@ -197,7 +197,7 @@ public class Utils {
             .catalogName(catalogName);
 
     if (versionId.isPresent()) {
-      builder.version(versionId.get().intValue());
+      builder.version(versionId.get());
     }
     if (tableId.isPresent()) {
       builder.tableId(tableId.get());

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
@@ -278,6 +278,38 @@ public class LanceScanBuilderTest {
     assertEquals(TEST_SCHEMA, scan.readSchema());
   }
 
+  /**
+   * Asserts the contract that splits planned during {@link LanceScanBuilder#build()} match what
+   * {@link LanceScan#planInputPartitions()} returns. This guarantees the second {@code
+   * Dataset.open()} that previously happened during {@code planInputPartitions()} is gone — the
+   * scan now consumes pre-computed splits instead of re-enumerating fragments.
+   */
+  @Test
+  public void testBuildPrecomputesSplitsForPlanInputPartitions() {
+    int expectedSplits =
+        LanceSplit.planScan(TestUtils.TestTable1Config.readOptions).getSplits().size();
+    LanceScanBuilder builder = createBuilder();
+    LanceScan scan = (LanceScan) builder.build();
+    assertEquals(expectedSplits, scan.planInputPartitions().length);
+  }
+
+  /**
+   * Asserts that {@link LanceScanBuilder#build()} pins the resolved dataset version onto the read
+   * options shipped to workers, so all tasks of one query observe a consistent snapshot even under
+   * concurrent writes.
+   */
+  @Test
+  public void testBuildPinsResolvedVersionOnReadOptions() {
+    LanceScanBuilder builder = createBuilder();
+    LanceScan scan = (LanceScan) builder.build();
+    org.apache.spark.sql.connector.read.InputPartition[] partitions = scan.planInputPartitions();
+    assertTrue(partitions.length > 0);
+    LanceInputPartition first = (LanceInputPartition) partitions[0];
+    Long pinned = first.getReadOptions().getVersion();
+    assertNotNull(pinned, "build() must pin the resolved version onto readOptions");
+    assertTrue(pinned > 0);
+  }
+
   @Test
   public void testBuildWithCountStarReturnsLocalScan() {
     LanceScanBuilder builder = createBuilder();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -195,6 +195,7 @@ public class LanceScanTest {
     fragKeys.put(1, "west");
     Expression partitionExpression = Expressions.column("region");
 
+    LanceSplit.ScanPlanResult plan = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
     LanceScan scan =
         new LanceScan(
             TEST_SCHEMA,
@@ -208,6 +209,8 @@ public class LanceScanTest {
             null,
             Collections.emptyMap(),
             null,
+            plan.getSplits(),
+            plan.getFragmentRowCounts(),
             partitionExpression,
             fragKeys,
             Collections.emptyMap(),
@@ -246,6 +249,8 @@ public class LanceScanTest {
     fragKeys.put(2, 2);
     Expression partitionExpression = Expressions.bucket(4, "region");
 
+    LanceSplit.ScanPlanResult bucketPlan =
+        LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
     LanceScan scan =
         new LanceScan(
             TEST_SCHEMA,
@@ -259,6 +264,8 @@ public class LanceScanTest {
             null,
             Collections.emptyMap(),
             null,
+            bucketPlan.getSplits(),
+            bucketPlan.getFragmentRowCounts(),
             partitionExpression,
             fragKeys,
             Collections.emptyMap(),

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceSplitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceSplitTest.java
@@ -13,7 +13,9 @@
  */
 package org.lance.spark.read;
 
+import org.lance.Dataset;
 import org.lance.spark.TestUtils;
+import org.lance.spark.utils.Utils;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,6 +55,40 @@ public class LanceSplitTest {
             "Row count should be non-negative for fragment " + fragmentId);
       }
     }
+  }
+
+  /**
+   * Contract test: {@link LanceSplit#planScan(Dataset)} must not close the externally-owned dataset
+   * handle. {@link LanceScanBuilder#build()} relies on this so it can keep using the single open
+   * handle for both manifest/zonemap loading and split planning.
+   */
+  @Test
+  public void testPlanScanWithDatasetDoesNotCloseExternalDataset() {
+    try (Dataset dataset =
+        Utils.openDatasetBuilder(TestUtils.TestTable1Config.readOptions).build()) {
+      LanceSplit.ScanPlanResult result = LanceSplit.planScan(dataset);
+      assertFalse(result.getSplits().isEmpty());
+
+      // If planScan(Dataset) accidentally closed the handle, subsequent native calls would
+      // throw. Re-issue native calls to assert the dataset is still usable.
+      assertFalse(dataset.getFragments().isEmpty());
+      assertTrue(dataset.getVersion().getId() > 0);
+    }
+  }
+
+  /**
+   * Contract test: the long-typed resolved version returned by {@link LanceSplit#planScan(Dataset)}
+   * must round-trip through {@link org.lance.spark.LanceSparkReadOptions#withVersion(long)} without
+   * truncation. This guards against silently casting to {@code int}, which would corrupt the
+   * snapshot-isolation guarantee for long-lived high-write-frequency datasets.
+   */
+  @Test
+  public void testResolvedVersionRoundTripsAsLong() {
+    LanceSplit.ScanPlanResult result = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
+    long resolved = result.getResolvedVersion();
+    assertEquals(
+        resolved,
+        TestUtils.TestTable1Config.readOptions.withVersion(resolved).getVersion().longValue());
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
… snapshot isolation

## Summary

Consolidate the two driver-side `Dataset.open()` calls during scan planning into one, and pin the resolved table version onto the read options shipped to executors. This reduces manifest IO and closes a cross-task snapshot-isolation gap on large tables.

## Motivation

For each Spark scan, `LanceScanBuilder.build()` opens a dataset to read manifest summary, schema, sharding spec, and zonemap stats. Then `LanceScan.planInputPartitions()` opens the dataset *again* via `LanceSplit.planScan(readOptions)` to enumerate fragments and per-fragment row counts.

Two issues:

1. **Performance** — Driver pays the manifest IO / `Dataset.open()` cost twice per query. On very large tables this measurably increases planning latency.
2. **Snapshot isolation bug** — When the user does not specify a version, both opens resolve "latest" independently. If a concurrent writer commits a new version between the two opens (or between the driver-side open and an executor-side open), tasks can observe a newer version than the one used for fragment pruning / statistics. The query then sees an inconsistent view.

## Changes

### `LanceSplit`
- New overload `planScan(Dataset)` that accepts an already-opened dataset and does not close it.
- Existing `planScan(LanceSparkReadOptions)` becomes a thin wrapper, kept for tests and external callers.

### `LanceScanBuilder.build()`
- Calls `LanceSplit.planScan(dataset)` against the same handle used for manifest / zonemap loading, before `closeLazyDataset()`.
- Calls `readOptions.withVersion(resolvedVersion)` to produce a pinned, immutable copy of the read options.
- Passes the pre-computed splits, per-fragment row counts, and pinned options to `LanceScan`.

### `LanceScan`
- Constructor accepts `precomputedSplits` and `precomputedFragmentRowCounts`.
- `planInputPartitions()` no longer opens the dataset; it consumes the pre-computed result and skips the redundant `withVersion` wrap (the options are already pinned upstream).
- The per-fragment row-count map is marked `transient` so it does not bloat plan-tree serialization or affect `BatchScanExec` / `ReusedExchange` comparisons.

### Tests
- `LanceScanTest` updated for the new constructor parameters.
- `LanceSplitTest` unchanged — both overloads remain covered.

## Why this is safe

- `LanceSparkReadOptions.withVersion(...)` returns a new instance via the existing builder; the user-supplied options object is never mutated.
- When the user explicitly pinned a version upstream, `dataset.getVersion().getId()` returns that same version, so the pin is a no-op.
- All existing pruning paths (`pruneByRowAddrFilters`, `pruneByZonemapStats`, `pruneByLimit`) continue to operate on the same `List<LanceSplit>` shape; only the source of the list changed.

## Performance impact

- Driver `Dataset.open()` calls per scan: **2 → 1**.
- Manifest reads per scan: **2 → 1**.
- No change to executor-side IO.

## Correctness impact

- All tasks of a single query are now guaranteed to read the same dataset version, even under concurrent writes.

