### PR TITLE
chore: update lance dependency to v7.2.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.2.0-beta.3</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bumps the Lance core dependency from `7.0.0-rc.1` to `7.2.0-beta.3`.
- Checked Docker hardcoded versions against Maven properties:
  - `LANCE_SPARK_VERSION=0.5.0-beta.1`
  - `LANCE_NS_IMPL_VERSION=0.3.0`
- No Dockerfile changes were needed because the existing values already match the evaluated properties exactly.

## Verification
- `make lint` passed.
- `make install` was run for the default Spark 3.5 / Scala 2.12 build. It currently fails during dependency resolution because `org.lance:lance-core:7.2.0-beta.3` is not available from Maven Central yet.

## Triggering Tag
- refs/tags/v7.2.0-beta.3
