### PR TITLE
chore: update lance dependency to v7.2.0-beta.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.2.0-beta.4</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump the Lance Java dependency from `7.0.0-rc.1` to `7.2.0-beta.4`.
- Verified Docker hardcoded versions against the current POM properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`; no Dockerfile changes were needed because they already matched.
- Triggering tag: refs/tags/v7.2.0-beta.4

## Verification
- `mvn help:evaluate -Dexpression=lance-spark.version -q -DforceStdout`
- `mvn help:evaluate -Dexpression=lance-namespace-impl.version -q -DforceStdout`
- `make lint`
- `make install`
