### PR TITLE
chore: update lance dependency to v7.2.0-beta.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>7.2.0-beta.5</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Bump `lance.version` to `7.2.0-beta.5`.
- Verified Docker hardcoded versions against Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0` already matched, so no Dockerfile changes were needed.
- Triggering tag: refs/tags/v7.2.0-beta.5

## Verification

- `make lint` passed.
- `make install` initially could not resolve `org.lance:lance-core:7.2.0-beta.5` from Maven Central. Maven Central metadata currently lists through `7.2.0-beta.4`.
- Checked out `lancedb/lance` at `refs/tags/v7.2.0-beta.5`, installed the tagged Java artifact locally with `mvn install -DskipTests -Dskip.build.jni=true`, then reran `make install` successfully.
