### PR TITLE
feat: support ddl for branch operation

### DIFF
--- a/docs/src/operations/ddl/.pages
+++ b/docs/src/operations/ddl/.pages
@@ -12,5 +12,8 @@ nav:
   - drop-table.md
   - create-index.md
   - show-indexes.md
+  - create-branch.md
+  - drop-branch.md
+  - show-branches.md
   - optimize.md
   - vacuum.md

--- a/docs/src/operations/ddl/create-branch.md
+++ b/docs/src/operations/ddl/create-branch.md
@@ -1,0 +1,101 @@
+# CREATE BRANCH
+
+Create a named branch for a Lance table.
+
+!!! warning "Spark Extension Required"
+    This feature requires the Lance Spark SQL extension to be enabled. See [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
+
+## Overview
+
+The `CREATE BRANCH` command creates a new branch that points to a specific table state. A branch can be created from:
+
+- the latest version of `main`
+- a specific version on `main`
+- the head of another branch
+- a specific version on another branch
+- a tag
+
+Creating a branch records a new reference in table metadata. It does not duplicate the table's data files.
+
+## Syntax
+
+=== "SQL"
+
+    ```sql
+    ALTER TABLE <table> CREATE BRANCH [IF NOT EXISTS] <branch_name>;
+
+    ALTER TABLE <table> CREATE BRANCH [IF NOT EXISTS] <branch_name>
+    AS OF VERSION <version>;
+
+    ALTER TABLE <table> CREATE BRANCH [IF NOT EXISTS] <branch_name>
+    AS OF BRANCH <source_branch>;
+
+    ALTER TABLE <table> CREATE BRANCH [IF NOT EXISTS] <branch_name>
+    AS OF BRANCH <source_branch> VERSION <version>;
+
+    ALTER TABLE <table> CREATE BRANCH [IF NOT EXISTS] <branch_name>
+    AS OF TAG <tag_name>;
+    ```
+
+If the `AS OF` clause is omitted, the new branch is created from the latest version of `main`.
+
+## Examples
+
+### Create a branch from the latest `main`
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE BRANCH feature_x;
+    ```
+
+### Create a branch from a specific `main` version
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE BRANCH IF NOT EXISTS snapshot_v5
+    AS OF VERSION 5;
+    ```
+
+### Create a branch from another branch head
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE BRANCH experiment_b
+    AS OF BRANCH experiment_a;
+    ```
+
+### Create a branch from a specific version on another branch
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE BRANCH experiment_b_v3
+    AS OF BRANCH experiment_a VERSION 3;
+    ```
+
+### Create a branch from a tag
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE BRANCH release_fix
+    AS OF TAG release_candidate;
+    ```
+
+## Output
+
+The `CREATE BRANCH` command returns:
+
+| Column | Type   | Description                |
+|--------|--------|----------------------------|
+| `name` | String | The name of the new branch |
+
+## Notes and Limitations
+
+- `CREATE BRANCH` is implemented as a Spark SQL extension command.
+- The referenced table must be a Lance table.
+- Creating a branch from a non-existent branch, tag, or version returns an error.
+- The branch name is returned even when the command result contains only a single row.
+
+## See Also
+
+- [SHOW BRANCHES](./show-branches.md)
+- [DROP BRANCH](./drop-branch.md)

--- a/docs/src/operations/ddl/drop-branch.md
+++ b/docs/src/operations/ddl/drop-branch.md
@@ -1,0 +1,44 @@
+# DROP BRANCH
+
+Remove a branch from a Lance table.
+
+!!! warning "Spark Extension Required"
+    This feature requires the Lance Spark SQL extension to be enabled. See [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
+
+## Overview
+
+The `DROP BRANCH` command deletes a named branch reference from a Lance table. This removes the branch metadata entry, but does not rewrite data on `main` or on any other existing branch.
+
+## Syntax
+
+=== "SQL"
+    ```sql
+    ALTER TABLE <table> DROP BRANCH [IF EXISTS] <branch_name>;
+    ```
+
+## Example
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users DROP BRANCH IF EXISTS feature_x;
+    ```
+
+## Output
+
+The `DROP BRANCH` command returns:
+
+| Column | Type   | Description                    |
+|--------|--------|--------------------------------|
+| `name` | String | The name of the dropped branch |
+
+## Notes and Limitations
+
+- `DROP BRANCH` is implemented as a Spark SQL extension command.
+- The target table must be a Lance table.
+- `IF EXISTS` can be used when dropping a branch conditionally.
+- Use [SHOW BRANCHES](./show-branches.md) to inspect existing branches before deleting one.
+
+## See Also
+
+- [CREATE BRANCH](./create-branch.md)
+- [SHOW BRANCHES](./show-branches.md)

--- a/docs/src/operations/ddl/show-branches.md
+++ b/docs/src/operations/ddl/show-branches.md
@@ -1,0 +1,62 @@
+# SHOW BRANCHES
+
+List branches defined on a Lance table.
+
+!!! warning "Spark Extension Required"
+    This feature requires the Lance Spark SQL extension to be enabled. See [Spark SQL Extensions](../../config.md#spark-sql-extensions) for configuration details.
+
+## Overview
+
+The `SHOW BRANCHES` command returns one row for each branch on a Lance table. It is useful for inspecting branch lineage, verifying branch creation, and understanding which version each branch points to.
+
+## Syntax
+
+=== "SQL"
+    ```sql
+    SHOW BRANCHES FROM <table>;
+    SHOW BRANCHES IN <table>;
+    SHOW BRANCH FROM <table>;
+    SHOW BRANCH IN <table>;
+    ```
+
+Both plural and singular forms are accepted. Both `FROM` and `IN` are accepted.
+
+## Examples
+
+### List all branches on a table
+
+=== "SQL"
+    ```sql
+    SHOW BRANCHES FROM lance.db.users;
+    ```
+
+### Use the singular alias
+
+=== "SQL"
+    ```sql
+    SHOW BRANCH IN lance.db.users;
+    ```
+
+## Output
+
+The `SHOW BRANCHES` command returns the following columns:
+
+| Column | Type | Description                                                                      |
+|--------|------|----------------------------------------------------------------------------------|
+| `name` | String | Branch name                                                                      |
+| `parent_branch` | String | Source branch name if the branch was created from another branch; otherwise NULL |
+| `parent_version` | Long | Version used as the branch starting point                                        |
+| `created_at` | Long | Branch creation timestamp as returned by Lance metadata                          |
+| `manifest_size` | Integer | Manifest size recorded for the branch                                            |
+
+## Notes
+
+- `SHOW BRANCHES` is implemented as a Spark SQL extension command.
+- The target table must be a Lance table.
+- The result includes one row per branch currently registered in the table metadata.
+- Use [CREATE BRANCH](./create-branch.md) to add a branch and [DROP BRANCH](./drop-branch.md) to remove one.
+
+## See Also
+
+- [CREATE BRANCH](./create-branch.md)
+- [DROP BRANCH](./drop-branch.md)

--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -145,7 +145,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
       ifNotExists)
   }
 
-  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+  private def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
     try {
       java.lang.Long.valueOf(value)
     } catch {

--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,8 +15,8 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceDropBranch, LanceDropIndex, LanceNamedArgument, LanceShowBranches, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
 import scala.collection.JavaConverters._

--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -13,6 +13,7 @@
  */
 package org.apache.spark.sql.catalyst.parser.extensions
 
+import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
@@ -113,6 +114,71 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val indexName = cleanIdentifier(ctx.indexName.getText)
     LanceDropIndex(table, indexName)
+  }
+
+  override def visitCreateBranchRefMain(ctx: LanceSqlExtensionsParser.CreateBranchRefMainContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refMainVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofMain(), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofMain(_parseVersion(ctx, ctx.refMainVersion.getText)),
+      ifNotExists)
+  }
+
+  override def visitCreateBranchRefBranch(
+      ctx: LanceSqlExtensionsParser.CreateBranchRefBranchContext): LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refBranchName = cleanIdentifier(ctx.refBranchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refBranchVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofBranch(refBranchName), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofBranch(refBranchName, _parseVersion(ctx, ctx.refBranchVersion.getText)),
+      ifNotExists)
+  }
+
+  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+    try {
+      java.lang.Long.valueOf(value)
+    } catch {
+      case _: NumberFormatException =>
+        throw new ParseException(
+          errorClass = "INVALID_TYPED_LITERAL",
+          messageParameters = Map(
+            "valueType" -> "LONG",
+            "value" -> value),
+          ctx)
+    }
+  }
+
+  override def visitCreateBranchRefTag(ctx: LanceSqlExtensionsParser.CreateBranchRefTagContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refTagName = cleanIdentifier(ctx.refTagName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    LanceCreateBranch(table, branchName, org.lance.Ref.ofTag(refTagName), ifNotExists)
+  }
+
+  override def visitDropBranch(ctx: LanceSqlExtensionsParser.DropBranchContext): LanceDropBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifExists = ctx.EXISTS() != null
+    LanceDropBranch(table, branchName, ifExists)
+  }
+
+  override def visitShowBranches(ctx: LanceSqlExtensionsParser.ShowBranchesContext)
+      : LanceShowBranches = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    LanceShowBranches(table)
   }
 
   override def visitSetUnenforcedPrimaryKey(

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/branch/BranchDDLTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/branch/BranchDDLTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.branch;
+
+public class BranchDDLTest extends BaseBranchDDLTest {}

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
@@ -189,4 +189,67 @@ public class LanceSqlExtensionsAstBuilderTest {
     assertEquals(
         List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
   }
+
+  @Test
+  public void testCreateBranchFromMain() {
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE `my-catalog`.`my-table` CREATE BRANCH IF NOT EXISTS `branch-a` AS OF VERSION 7");
+    org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranch plan =
+        (org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranch)
+            astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifNotExists());
+    assertTrue(plan.ref().getBranchName().isEmpty());
+    assertEquals(7, plan.ref().getVersionNumber().get());
+  }
+
+  @Test
+  public void testCreateBranchFromBranch() {
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE `my-catalog`.`my-table` CREATE BRANCH IF NOT EXISTS `branch-a` AS OF BRANCH `source-branch` VERSION 7");
+    org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranch plan =
+        (org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranch)
+            astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifNotExists());
+    assertEquals("source-branch", plan.ref().getBranchName().get());
+    assertEquals(7, plan.ref().getVersionNumber().get());
+  }
+
+  @Test
+  public void testDropBranch() {
+    LanceSqlExtensionsParser parser =
+        createParser("ALTER TABLE `my-catalog`.`my-table` DROP BRANCH IF EXISTS `branch-a`");
+    org.apache.spark.sql.catalyst.plans.logical.LanceDropBranch plan =
+        (org.apache.spark.sql.catalyst.plans.logical.LanceDropBranch)
+            astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifExists());
+  }
+
+  @Test
+  public void testShowBranch() {
+    LanceSqlExtensionsParser parser = createParser("SHOW BRANCH IN `my-catalog`.`my-table`");
+    org.apache.spark.sql.catalyst.plans.logical.LanceShowBranches plan =
+        (org.apache.spark.sql.catalyst.plans.logical.LanceShowBranches)
+            astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
 }

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -149,7 +149,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     }
   }
 
-  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+  private def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
     try {
       java.lang.Long.valueOf(value)
     } catch {

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,8 +15,8 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceDropBranch, LanceDropIndex, LanceNamedArgument, LanceShowBranches, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
 import scala.collection.JavaConverters._

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -13,6 +13,7 @@
  */
 package org.apache.spark.sql.catalyst.parser.extensions
 
+import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
@@ -113,6 +114,75 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val indexName = cleanIdentifier(ctx.indexName.getText)
     LanceDropIndex(table, indexName)
+  }
+
+  override def visitCreateBranchRefMain(ctx: LanceSqlExtensionsParser.CreateBranchRefMainContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refMainVersion == null) {
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofMain(), ifNotExists)
+    } else {
+      LanceCreateBranch(
+        table,
+        branchName,
+        org.lance.Ref.ofMain(_parseVersion(ctx, ctx.refMainVersion.getText)),
+        ifNotExists)
+    }
+  }
+
+  override def visitCreateBranchRefBranch(
+      ctx: LanceSqlExtensionsParser.CreateBranchRefBranchContext): LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refBranchName = cleanIdentifier(ctx.refBranchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refBranchVersion == null) {
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofBranch(refBranchName), ifNotExists)
+    } else {
+      LanceCreateBranch(
+        table,
+        branchName,
+        org.lance.Ref.ofBranch(refBranchName, _parseVersion(ctx, ctx.refBranchVersion.getText)),
+        ifNotExists)
+    }
+  }
+
+  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+    try {
+      java.lang.Long.valueOf(value)
+    } catch {
+      case _: NumberFormatException =>
+        throw new ParseException(
+          errorClass = "INVALID_TYPED_LITERAL",
+          messageParameters = Map(
+            "valueType" -> "LONG",
+            "value" -> value),
+          ctx)
+    }
+  }
+
+  override def visitCreateBranchRefTag(ctx: LanceSqlExtensionsParser.CreateBranchRefTagContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refTagName = cleanIdentifier(ctx.refTagName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    LanceCreateBranch(table, branchName, org.lance.Ref.ofTag(refTagName), ifNotExists)
+  }
+
+  override def visitDropBranch(ctx: LanceSqlExtensionsParser.DropBranchContext): LanceDropBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifExists = ctx.EXISTS() != null
+    LanceDropBranch(table, branchName, ifExists)
+  }
+
+  override def visitShowBranches(ctx: LanceSqlExtensionsParser.ShowBranchesContext)
+      : LanceShowBranches = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    LanceShowBranches(table)
   }
 
   override def visitSetUnenforcedPrimaryKey(

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/branch/BranchDDLTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/branch/BranchDDLTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.branch;
+
+public class BranchDDLTest extends BaseBranchDDLTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
@@ -22,6 +22,9 @@ import org.apache.spark.sql.catalyst.parser.extensions.LanceSqlExtensionsLexer;
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSqlExtensionsParser;
 import org.apache.spark.sql.catalyst.plans.logical.AddColumnsBackfill;
 import org.apache.spark.sql.catalyst.plans.logical.AddIndex;
+import org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranch;
+import org.apache.spark.sql.catalyst.plans.logical.LanceDropBranch;
+import org.apache.spark.sql.catalyst.plans.logical.LanceShowBranches;
 import org.apache.spark.sql.catalyst.plans.logical.Optimize;
 import org.apache.spark.sql.catalyst.plans.logical.ShowIndexes;
 import org.apache.spark.sql.catalyst.plans.logical.UpdateColumnsBackfill;
@@ -205,6 +208,65 @@ public class LanceSqlExtensionsAstBuilderTest {
   public void testVacuumWithBacktickedTableName() {
     LanceSqlExtensionsParser parser = createParser("VACUUM `my-catalog`.`my-table`");
     Vacuum plan = (Vacuum) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
+
+  @Test
+  public void testCreateBranchFromMain() {
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE `my-catalog`.`my-table` CREATE BRANCH IF NOT EXISTS `branch-a` AS OF VERSION 7");
+    LanceCreateBranch plan =
+        (LanceCreateBranch) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifNotExists());
+    assertTrue(plan.ref().getBranchName().isEmpty());
+    assertEquals(7, plan.ref().getVersionNumber().get());
+  }
+
+  @Test
+  public void testCreateBranchFromBranch() {
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE `my-catalog`.`my-table` CREATE BRANCH IF NOT EXISTS `branch-a` AS OF BRANCH `source-branch` VERSION 7");
+    LanceCreateBranch plan =
+        (LanceCreateBranch) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifNotExists());
+    assertEquals("source-branch", plan.ref().getBranchName().get());
+    assertEquals(7, plan.ref().getVersionNumber().get());
+  }
+
+  @Test
+  public void testDropBranch() {
+    LanceSqlExtensionsParser parser =
+        createParser("ALTER TABLE `my-catalog`.`my-table` DROP BRANCH IF EXISTS `branch-a`");
+    LanceDropBranch plan =
+        (LanceDropBranch) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
+    assertEquals(
+        List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+    assertEquals("branch-a", plan.branchName());
+    assertEquals(true, plan.ifExists());
+  }
+
+  @Test
+  public void testShowBranch() {
+    LanceSqlExtensionsParser parser = createParser("SHOW BRANCH IN `my-catalog`.`my-table`");
+    LanceShowBranches plan =
+        (LanceShowBranches) astBuilder.visitSingleStatement(parser.singleStatement());
 
     UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
     assertEquals(

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -145,7 +145,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
       ifNotExists)
   }
 
-  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+  private def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
     try {
       java.lang.Long.valueOf(value)
     } catch {

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -13,6 +13,7 @@
  */
 package org.apache.spark.sql.catalyst.parser.extensions
 
+import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
@@ -113,6 +114,71 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val indexName = cleanIdentifier(ctx.indexName.getText)
     LanceDropIndex(table, indexName)
+  }
+
+  override def visitCreateBranchRefMain(ctx: LanceSqlExtensionsParser.CreateBranchRefMainContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refMainVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofMain(), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofMain(_parseVersion(ctx, ctx.refMainVersion.getText)),
+      ifNotExists)
+  }
+
+  override def visitCreateBranchRefBranch(
+      ctx: LanceSqlExtensionsParser.CreateBranchRefBranchContext): LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refBranchName = cleanIdentifier(ctx.refBranchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refBranchVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofBranch(refBranchName), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofBranch(refBranchName, _parseVersion(ctx, ctx.refBranchVersion.getText)),
+      ifNotExists)
+  }
+
+  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+    try {
+      java.lang.Long.valueOf(value)
+    } catch {
+      case _: NumberFormatException =>
+        throw new ParseException(
+          errorClass = "INVALID_TYPED_LITERAL",
+          messageParameters = Map(
+            "valueType" -> "LONG",
+            "value" -> value),
+          ctx)
+    }
+  }
+
+  override def visitCreateBranchRefTag(ctx: LanceSqlExtensionsParser.CreateBranchRefTagContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refTagName = cleanIdentifier(ctx.refTagName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    LanceCreateBranch(table, branchName, org.lance.Ref.ofTag(refTagName), ifNotExists)
+  }
+
+  override def visitDropBranch(ctx: LanceSqlExtensionsParser.DropBranchContext): LanceDropBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifExists = ctx.EXISTS() != null
+    LanceDropBranch(table, branchName, ifExists)
+  }
+
+  override def visitShowBranches(ctx: LanceSqlExtensionsParser.ShowBranchesContext)
+      : LanceShowBranches = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    LanceShowBranches(table)
   }
 
   override def visitSetUnenforcedPrimaryKey(

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,8 +15,8 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceDropBranch, LanceDropIndex, LanceNamedArgument, LanceShowBranches, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
 import scala.jdk.CollectionConverters._

--- a/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -145,7 +145,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
       ifNotExists)
   }
 
-  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+  private def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
     try {
       java.lang.Long.valueOf(value)
     } catch {

--- a/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -13,6 +13,7 @@
  */
 package org.apache.spark.sql.catalyst.parser.extensions
 
+import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
@@ -113,6 +114,71 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val indexName = cleanIdentifier(ctx.indexName.getText)
     LanceDropIndex(table, indexName)
+  }
+
+  override def visitCreateBranchRefMain(ctx: LanceSqlExtensionsParser.CreateBranchRefMainContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refMainVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofMain(), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofMain(_parseVersion(ctx, ctx.refMainVersion.getText)),
+      ifNotExists)
+  }
+
+  override def visitCreateBranchRefBranch(
+      ctx: LanceSqlExtensionsParser.CreateBranchRefBranchContext): LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refBranchName = cleanIdentifier(ctx.refBranchName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    if (ctx.refBranchVersion == null)
+      LanceCreateBranch(table, branchName, org.lance.Ref.ofBranch(refBranchName), ifNotExists)
+    else LanceCreateBranch(
+      table,
+      branchName,
+      org.lance.Ref.ofBranch(refBranchName, _parseVersion(ctx, ctx.refBranchVersion.getText)),
+      ifNotExists)
+  }
+
+  def _parseVersion(ctx: ParserRuleContext, value: String): Long = {
+    try {
+      java.lang.Long.valueOf(value)
+    } catch {
+      case _: NumberFormatException =>
+        throw new ParseException(
+          errorClass = "INVALID_TYPED_LITERAL",
+          messageParameters = Map(
+            "valueType" -> "LONG",
+            "value" -> value),
+          ctx)
+    }
+  }
+
+  override def visitCreateBranchRefTag(ctx: LanceSqlExtensionsParser.CreateBranchRefTagContext)
+      : LanceCreateBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val refTagName = cleanIdentifier(ctx.refTagName.getText)
+    val ifNotExists = ctx.EXISTS() != null
+    LanceCreateBranch(table, branchName, org.lance.Ref.ofTag(refTagName), ifNotExists)
+  }
+
+  override def visitDropBranch(ctx: LanceSqlExtensionsParser.DropBranchContext): LanceDropBranch = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    val branchName = cleanIdentifier(ctx.branchName.getText)
+    val ifExists = ctx.EXISTS() != null
+    LanceDropBranch(table, branchName, ifExists)
+  }
+
+  override def visitShowBranches(ctx: LanceSqlExtensionsParser.ShowBranchesContext)
+      : LanceShowBranches = {
+    val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
+    LanceShowBranches(table)
   }
 
   override def visitSetUnenforcedPrimaryKey(

--- a/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -15,8 +15,8 @@ package org.apache.spark.sql.catalyst.parser.extensions
 
 import org.antlr.v4.runtime.ParserRuleContext
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedIdentifier, UnresolvedRelation}
-import org.apache.spark.sql.catalyst.parser.ParserInterface
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceDropIndex, LanceNamedArgument, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
+import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceDropBranch, LanceDropIndex, LanceNamedArgument, LanceShowBranches, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
 import scala.jdk.CollectionConverters._

--- a/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
+++ b/lance-spark-base_2.12/src/main/antlr4/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensions.g4
@@ -22,7 +22,15 @@ statement
     : ALTER TABLE multipartIdentifier ADD COLUMNS columnList FROM identifier                    #addColumnsBackfill
     | ALTER TABLE multipartIdentifier UPDATE COLUMNS columnList FROM identifier                 #updateColumnsBackfill
     | ALTER TABLE multipartIdentifier CREATE INDEX indexName=identifier USING method=identifier '(' fieldPathList ')' (WITH '(' (namedArgument (',' namedArgument)*)? ')')? #createIndex
-    | ALTER TABLE multipartIdentifier DROP INDEX indexName=identifier                             #dropIndex
+    | ALTER TABLE multipartIdentifier DROP INDEX indexName=identifier                           #dropIndex
+    | ALTER TABLE multipartIdentifier CREATE BRANCH (IF NOT EXISTS)? branchName=identifier
+        (AS OF VERSION refMainVersion=versionNumber)?                                           #createBranchRefMain
+    | ALTER TABLE multipartIdentifier CREATE BRANCH (IF NOT EXISTS)? branchName=identifier
+        AS OF BRANCH refBranchName=identifier (VERSION refBranchVersion=versionNumber)?         #createBranchRefBranch
+    | ALTER TABLE multipartIdentifier CREATE BRANCH (IF NOT EXISTS)? branchName=identifier
+        AS OF TAG refTagName=identifier                                                         #createBranchRefTag
+    | ALTER TABLE multipartIdentifier DROP BRANCH (IF EXISTS)? branchName=identifier            #dropBranch
+    | SHOW (BRANCHES | BRANCH) (FROM | IN) multipartIdentifier                                  #showBranches
     | SHOW (INDEXES | INDEX) (FROM | IN) multipartIdentifier                                    #showIndexes
     | OPTIMIZE multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?        #optimize
     | VACUUM multipartIdentifier (WITH '(' (namedArgument (',' namedArgument)*)? ')')?          #vacuum
@@ -74,25 +82,38 @@ number
     | MINUS? DOUBLE_LITERAL             #doubleLiteral
     ;
 
+versionNumber
+    : BIGINT_LITERAL
+    ;
+
 ADD: 'ADD';
 ALTER: 'ALTER';
+AS: 'AS';
+BRANCHES: 'BRANCHES';
+BRANCH: 'BRANCH';
 COLUMNS: 'COLUMNS';
 CREATE: 'CREATE';
 DROP: 'DROP';
+EXISTS: 'EXISTS';
 FROM: 'FROM';
+IF: 'IF';
 IN: 'IN';
 INDEX: 'INDEX';
 INDEXES: 'INDEXES';
 KEY: 'KEY';
+NOT: 'NOT';
+OF: 'OF';
 OPTIMIZE: 'OPTIMIZE';
 PRIMARY: 'PRIMARY';
 SET: 'SET';
 SHOW: 'SHOW';
 TABLE: 'TABLE';
+TAG: 'TAG';
 UNENFORCED: 'UNENFORCED';
 UPDATE: 'UPDATE';
 USING: 'USING';
 VACUUM: 'VACUUM';
+VERSION: 'VERSION';
 WITH: 'WITH';
 
 TRUE: 'TRUE';

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceCreateBranch.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceCreateBranch.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+import org.lance.Ref
+
+case class LanceCreateBranch(
+    table: LogicalPlan,
+    branchName: String,
+    ref: Ref,
+    ifNotExists: Boolean = false) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = LanceCreateBranchOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    s"CreateBranch(${branchName}, ${ref}, ifNotExists=${ifNotExists})"
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan])
+      : LanceCreateBranch = {
+    copy(newChildren(0), this.branchName, this.ref, this.ifNotExists)
+  }
+}
+
+object LanceCreateBranchOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("name", DataTypes.StringType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceDropBranch.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceDropBranch.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
+case class LanceDropBranch(
+    table: LogicalPlan,
+    branchName: String,
+    ifExists: Boolean = false) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = LanceDropBranchOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    s"DropBranch(${branchName}, ifExists=${ifExists})"
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan])
+      : LanceDropBranch = {
+    copy(newChildren(0), this.branchName, this.ifExists)
+  }
+}
+
+object LanceDropBranchOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("name", DataTypes.StringType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceShowBranches.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceShowBranches.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
+case class LanceShowBranches(table: LogicalPlan) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = LanceShowBranchesOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    s"ShowBranches(${table})"
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan])
+      : LanceShowBranches = {
+    copy(newChildren(0))
+  }
+}
+
+object LanceShowBranchesOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("name", DataTypes.StringType, nullable = false),
+      StructField("parent_branch", DataTypes.StringType, nullable = true),
+      StructField("parent_version", DataTypes.LongType, nullable = false),
+      StructField("created_at", DataTypes.LongType, nullable = false),
+      StructField("manifest_size", DataTypes.IntegerType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateBranchExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateBranchExec.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.LanceCreateBranchOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.spark.LanceDataset
+import org.lance.spark.utils.Utils
+
+import scala.collection.JavaConverters._
+
+case class LanceCreateBranchExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    branchName: String,
+    ref: org.lance.Ref,
+    ifNotExists: Boolean) extends LeafV2CommandExec {
+
+  override def output: Seq[Attribute] = LanceCreateBranchOutputType.SCHEMA
+
+  override protected def run(): Seq[InternalRow] = {
+    val lanceDataset = catalog.loadTable(ident) match {
+      case d: LanceDataset => d
+      case _ => throw new UnsupportedOperationException("CreateBranch only supports LanceDataset")
+    }
+
+    val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
+      .initialStorageOptions(lanceDataset.getInitialStorageOptions)
+      .build()
+
+    try {
+      val alreadyExists = dataset.branches().list().asScala.exists(_.getName == branchName)
+      if (!ifNotExists || !alreadyExists) {
+        var branchDs: org.lance.Dataset = null
+        try {
+          val opts = dataset.getInitialStorageOptions
+          branchDs =
+            if (opts == null || opts.isEmpty) dataset.createBranch(branchName, ref)
+            else dataset.createBranch(branchName, ref, opts)
+        } finally {
+          if (branchDs != null) {
+            branchDs.close()
+          }
+        }
+      }
+    } finally {
+      dataset.close()
+    }
+
+    Seq(new GenericInternalRow(Array[Any](
+      UTF8String.fromString(branchName))))
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
@@ -51,6 +51,15 @@ case class LanceDataSourceV2Strategy(session: SparkSession) extends SparkStrateg
     case LanceDropIndex(ResolvedIdentifier(catalog, ident), indexName) =>
       LanceDropIndexExec(asTableCatalog(catalog), ident, indexName.toLowerCase) :: Nil
 
+    case LanceCreateBranch(ResolvedIdentifier(catalog, ident), branchName, ref, ifNotExists) =>
+      LanceCreateBranchExec(asTableCatalog(catalog), ident, branchName, ref, ifNotExists) :: Nil
+
+    case LanceDropBranch(ResolvedIdentifier(catalog, ident), branchName, ifExists) =>
+      LanceDropBranchExec(asTableCatalog(catalog), ident, branchName, ifExists) :: Nil
+
+    case LanceShowBranches(ResolvedIdentifier(catalog, ident)) =>
+      LanceShowBranchesExec(asTableCatalog(catalog), ident) :: Nil
+
     case SetUnenforcedPrimaryKey(ResolvedIdentifier(catalog, ident), columns) =>
       SetUnenforcedPrimaryKeyExec(asTableCatalog(catalog), ident, columns) :: Nil
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropBranchExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropBranchExec.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.LanceDropBranchOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.spark.LanceDataset
+import org.lance.spark.utils.Utils
+
+import scala.collection.JavaConverters._
+
+case class LanceDropBranchExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    branchName: String,
+    ifExists: Boolean) extends LeafV2CommandExec {
+
+  override def output: Seq[Attribute] = LanceDropBranchOutputType.SCHEMA
+
+  override protected def run(): Seq[InternalRow] = {
+    val lanceDataset = catalog.loadTable(ident) match {
+      case d: LanceDataset => d
+      case _ => throw new UnsupportedOperationException("DropBranch only supports LanceDataset")
+    }
+
+    val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
+      .initialStorageOptions(lanceDataset.getInitialStorageOptions)
+      .build()
+
+    try {
+      val exists = dataset.branches().list().asScala.exists(_.getName == branchName)
+      if (!ifExists || exists) {
+        dataset.branches().delete(branchName)
+      }
+    } finally {
+      dataset.close()
+    }
+
+    Seq(new GenericInternalRow(Array[Any](
+      UTF8String.fromString(branchName))))
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceShowBranchesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceShowBranchesExec.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.LanceShowBranchesOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
+import org.apache.spark.unsafe.types.UTF8String
+import org.lance.spark.LanceDataset
+import org.lance.spark.utils.Utils
+
+import scala.collection.JavaConverters._
+
+case class LanceShowBranchesExec(
+    catalog: TableCatalog,
+    ident: Identifier) extends LeafV2CommandExec {
+
+  override def output: Seq[Attribute] = LanceShowBranchesOutputType.SCHEMA
+
+  override protected def run(): Seq[InternalRow] = {
+    val lanceDataset = catalog.loadTable(ident) match {
+      case d: LanceDataset => d
+      case _ => throw new UnsupportedOperationException("ShowBranches only supports LanceDataset")
+    }
+
+    val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
+      .initialStorageOptions(lanceDataset.getInitialStorageOptions)
+      .build()
+
+    try {
+      dataset.branches().list().asScala.map { branch =>
+        val parentBranch = if (branch.getParentBranch.isPresent) {
+          UTF8String.fromString(branch.getParentBranch.get())
+        } else {
+          null
+        }
+        new GenericInternalRow(Array[Any](
+          UTF8String.fromString(branch.getName),
+          parentBranch,
+          branch.getParentVersion(),
+          branch.getCreateAt(),
+          branch.getManifestSize()))
+      }.toSeq
+    } finally {
+      dataset.close()
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
@@ -1,0 +1,473 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.branch;
+
+import org.lance.Ref;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** Base tests for BRANCH DDL commands. */
+public abstract class BaseBranchDDLTest {
+  protected String catalogName = "lance_test";
+  protected String tableName = "branch_test";
+  protected String fullTable = catalogName + ".default." + tableName;
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+  protected String tableDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    spark =
+        SparkSession.builder()
+            .appName("lance-branch-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", testRoot)
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .getOrCreate();
+    this.tableName = "branch_test_" + UUID.randomUUID().toString().replace("-", "");
+    this.fullTable = this.catalogName + ".default." + this.tableName;
+    this.tableDir =
+        FileSystems.getDefault().getPath(testRoot, this.tableName + ".lance").toString();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  @Test
+  public void testCreateBranchFromLatestMain() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch if not exists branch_from_main", fullTable));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("branch_from_main", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "branch_from_main");
+    Assertions.assertNull(branch.parentBranch);
+    Assertions.assertEquals(versions.latestVersion, branch.parentVersion);
+    Assertions.assertTrue(branch.createdAt > 0L, "Expected created_at to be positive");
+    Assertions.assertTrue(branch.manifestSize >= 1, "Expected manifest_size to be positive");
+  }
+
+  @Test
+  public void testCreateBranchFromSpecificMainVersion() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch if not exists branch_from_main_v1 "
+                    + "as of version %d",
+                fullTable, versions.firstInsertVersion));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("branch_from_main_v1", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "branch_from_main_v1");
+    Assertions.assertNull(branch.parentBranch);
+    Assertions.assertEquals(versions.firstInsertVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFromBranchHead() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    spark.sql(String.format("alter table %s create branch if not exists source_branch", fullTable));
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch child_branch " + "as of branch source_branch",
+                fullTable));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("child_branch", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "child_branch");
+    Assertions.assertEquals("source_branch", branch.parentBranch);
+    Assertions.assertEquals(versions.latestVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFromBranchHeadWithBacktickQuotedSourceBranchName() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    String sourceBranchName = "source-branch";
+
+    spark.sql(
+        String.format(
+            "alter table %s create branch if not exists `%s`", fullTable, sourceBranchName));
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch child_branch_from_quoted_source as of branch `%s`",
+                fullTable, sourceBranchName));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals(
+        "child_branch_from_quoted_source", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "child_branch_from_quoted_source");
+    Assertions.assertEquals(sourceBranchName, branch.parentBranch);
+    Assertions.assertEquals(versions.latestVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFromSpecificBranchVersion() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    spark.sql(
+        String.format(
+            "alter table %s create branch if not exists source_branch " + "as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch child_branch_v1 "
+                    + "as of branch source_branch version %d",
+                fullTable, versions.firstInsertVersion));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("child_branch_v1", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "child_branch_v1");
+    Assertions.assertEquals("source_branch", branch.parentBranch);
+    Assertions.assertEquals(versions.firstInsertVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFromSpecificTag() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create branch if not exists branch_from_tag " + "as of tag %s",
+                fullTable, versions.firstInsertTag));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("branch_from_tag", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "branch_from_tag");
+    Assertions.assertNull(branch.parentBranch);
+    Assertions.assertEquals(versions.firstInsertVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFailsWhenSourceBranchDoesNotExist() {
+    prepareDatasetWithHistory();
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql(
+                    String.format(
+                        "alter table %s create branch branch_from_missing_branch "
+                            + "as of branch missing_branch",
+                        fullTable))
+                .collectAsList());
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertFalse(branches.containsKey("branch_from_missing_branch"));
+  }
+
+  @Test
+  public void testCreateBranchFailsWhenSourceTagDoesNotExist() {
+    prepareDatasetWithHistory();
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql(
+                    String.format(
+                        "alter table %s create branch branch_from_missing_tag as of tag missing_tag",
+                        fullTable))
+                .collectAsList());
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertFalse(branches.containsKey("branch_from_missing_tag"));
+  }
+
+  @Test
+  public void testCreateBranchFailsWhenSourceVersionDoesNotExist() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    long missingVersion = versions.latestVersion + 1000L;
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql(
+                    String.format(
+                        "alter table %s create branch branch_from_missing_version "
+                            + "as of version %d",
+                        fullTable, missingVersion))
+                .collectAsList());
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertFalse(branches.containsKey("branch_from_missing_version"));
+  }
+
+  @Test
+  public void testCreateBranchIfNotExistsNoOpWhenBranchExists() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+
+    spark
+        .sql(String.format("alter table %s create branch existing_branch", fullTable))
+        .collectAsList();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format("alter table %s create branch if not exists existing_branch", fullTable));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("existing_branch", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    BranchInfo branch = assertBranchExists(branches, "existing_branch");
+    Assertions.assertNull(branch.parentBranch);
+    Assertions.assertEquals(versions.latestVersion, branch.parentVersion);
+  }
+
+  @Test
+  public void testCreateBranchFailsWhenBranchExistsWithoutIfNotExists() {
+    prepareDatasetWithHistory();
+
+    spark
+        .sql(String.format("alter table %s create branch duplicate_branch", fullTable))
+        .collectAsList();
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql(String.format("alter table %s create branch duplicate_branch", fullTable))
+                .collectAsList());
+  }
+
+  @Test
+  public void testDropBranch() {
+    prepareDatasetWithHistory();
+
+    spark.sql(String.format("alter table %s create branch branch_to_drop", fullTable));
+
+    Dataset<Row> result =
+        spark.sql(String.format("alter table %s drop branch if exists branch_to_drop", fullTable));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("branch_to_drop", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertFalse(branches.containsKey("branch_to_drop"));
+  }
+
+  @Test
+  public void testDropBranchIfExistsNoOpWhenBranchDoesNotExist() {
+    prepareDatasetWithHistory();
+
+    Dataset<Row> result =
+        spark.sql(String.format("alter table %s drop branch if exists missing_branch", fullTable));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals("missing_branch", result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertFalse(branches.containsKey("missing_branch"));
+  }
+
+  @Test
+  public void testDropBranchFailsWhenBranchDoesNotExistWithoutIfExists() {
+    prepareDatasetWithHistory();
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql(String.format("alter table %s drop branch missing_branch", fullTable))
+                .collectAsList());
+  }
+
+  @Test
+  public void testShowBranchAliasWithInSyntax() {
+    prepareDatasetWithHistory();
+    spark.sql(String.format("alter table %s create branch branch_for_show", fullTable));
+
+    Map<String, BranchInfo> branches = showBranches(String.format("show branch in %s", fullTable));
+
+    Assertions.assertTrue(
+        branches.containsKey("branch_for_show"), "Expected created branch to be returned");
+  }
+
+  @Test
+  public void testCreateBranchWithBacktickQuotedName() {
+    prepareDatasetWithHistory();
+    String branchName = "branch-with-dash";
+
+    Dataset<Row> result =
+        spark.sql(String.format("alter table %s create branch `%s`", fullTable, branchName));
+
+    assertSingleNameSchema(result);
+    Assertions.assertEquals(branchName, result.collectAsList().get(0).getString(0));
+
+    Map<String, BranchInfo> branches =
+        showBranches(String.format("show branches from %s", fullTable));
+    Assertions.assertTrue(
+        branches.containsKey(branchName), "Expected backtick-quoted branch to be returned");
+  }
+
+  private DatasetVersions prepareDatasetWithHistory() {
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    insertRange(0, 5);
+    long firstInsertVersion = currentVersion();
+    String firstInsertTag = "tag_" + firstInsertVersion;
+    createTag(firstInsertTag);
+    insertRange(5, 10);
+    long latestVersion = currentVersion();
+    return new DatasetVersions(firstInsertVersion, firstInsertTag, latestVersion);
+  }
+
+  private void insertRange(int startInclusive, int endExclusive) {
+    spark.sql(
+        String.format(
+            "insert into %s (id, text) values %s ;",
+            fullTable,
+            IntStream.range(startInclusive, endExclusive)
+                .boxed()
+                .map(i -> String.format("(%d, 'text_%d')", i, i))
+                .collect(Collectors.joining(","))));
+  }
+
+  private long currentVersion() {
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      return dataset.getVersion().getId();
+    }
+  }
+
+  private void createTag(String tag) {
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      dataset.tags().create(tag, Ref.ofMain());
+    }
+  }
+
+  private Map<String, BranchInfo> showBranches(String sqlText) {
+    Dataset<Row> result = spark.sql(sqlText);
+    Assertions.assertEquals(
+        "StructType(StructField(name,StringType,false),"
+            + "StructField(parent_branch,StringType,true),"
+            + "StructField(parent_version,LongType,false),"
+            + "StructField(created_at,LongType,false),"
+            + "StructField(manifest_size,IntegerType,false))",
+        result.schema().toString());
+
+    Map<String, BranchInfo> branches = new HashMap<>();
+    for (Row row : result.collectAsList()) {
+      branches.put(
+          row.getString(0),
+          new BranchInfo(row.getString(1), row.getLong(2), row.getLong(3), row.getInt(4)));
+    }
+    return branches;
+  }
+
+  private BranchInfo assertBranchExists(Map<String, BranchInfo> branches, String branchName) {
+    BranchInfo branch = branches.get(branchName);
+    Assertions.assertNotNull(branch, "Expected branch to exist: " + branchName);
+    return branch;
+  }
+
+  private void assertSingleNameSchema(Dataset<Row> result) {
+    Assertions.assertEquals(
+        "StructType(StructField(name,StringType,false))", result.schema().toString());
+  }
+
+  private static final class DatasetVersions {
+    private final long firstInsertVersion;
+    private final String firstInsertTag;
+    private final long latestVersion;
+
+    private DatasetVersions(long firstInsertVersion, String firstInsertTag, long latestVersion) {
+      this.firstInsertVersion = firstInsertVersion;
+      this.firstInsertTag = firstInsertTag;
+      this.latestVersion = latestVersion;
+    }
+  }
+
+  private static final class BranchInfo {
+    private final String parentBranch;
+    private final long parentVersion;
+    private final long createdAt;
+    private final int manifestSize;
+
+    private BranchInfo(String parentBranch, long parentVersion, long createdAt, int manifestSize) {
+      this.parentBranch = parentBranch;
+      this.parentVersion = parentVersion;
+      this.createdAt = createdAt;
+      this.manifestSize = manifestSize;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds DDL support for branch operations in Lance Spark.

Previously, branch-related operations did not support DDL workflows properly. With this change, users can perform DDL on branches more consistently, improving branch management usability and aligning branch behavior with expected table operation semantics.

## Changes

- Add DDL support for branch operations
- Enable branch-related workflows to work with DDL statements
- Improve consistency of branch management behavior in Lance Spark

## Motivation

Branch operations are an important part of versioned data workflows. Supporting DDL on branches makes these workflows more complete and practical, especially for users who need to manage schema or table-related changes in isolated branches before merging.



