### PR TITLE
chore: update lance dependency to v8.0.0-beta.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.1</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` to `8.0.0-beta.1`.
- Confirm `docker/Dockerfile` version pins already match Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`.
- Verify lint and the default install build for Spark 3.5 / Scala 2.12.

## Verification
- `make lint`
- `make install`

Note: `org.lance:lance-core:8.0.0-beta.1` was not yet available from Maven Central during verification, so I built and installed it locally from the triggering tag `refs/tags/v8.0.0-beta.1` before rerunning `make install`.
