### PR TITLE
feat: add LOCATION support to CREATE TABLE for custom paths and existing datasets

### DIFF
--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/TestLocationSupport.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/TestLocationSupport.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class TestLocationSupport extends BaseTestLocationSupport {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -606,14 +606,8 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> tableProperties = copyUserTableProperties(properties);
 
       if (lanceDatasetExists(userLocation)) {
-        // Register existing dataset
         return registerExistingTable(
-            userLocation,
-            tableIdList,
-            processedSchema,
-            tableProperties,
-            fileFormatVersion,
-            shardingSpec);
+            userLocation, tableIdList, processedSchema, tableProperties, null, shardingSpec);
       }
 
       // Create new table at custom location

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -32,6 +32,7 @@ import org.lance.namespace.model.DropNamespaceRequest;
 import org.lance.namespace.model.DropTableRequest;
 import org.lance.namespace.model.ListTablesRequest;
 import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RenameTableRequest;
 import org.lance.operation.UpdateConfig;
 import org.lance.operation.UpdateMap;
@@ -594,6 +595,96 @@ public abstract class BaseLanceNamespaceSparkCatalog
           "Namespace not configured. Use 'impl' config for namespace-based access.");
     }
 
+    // Extract user-specified LOCATION before properties are filtered
+    String userLocation = properties.get(CREATE_TABLE_PROPERTY_LOCATION);
+
+    if (userLocation != null && !userLocation.trim().isEmpty()) {
+      Identifier actualIdent = transformIdentifierForApi(ident);
+      List<String> tableIdList = buildTableId(actualIdent);
+      StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+      String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+      Map<String, String> tableProperties = copyUserTableProperties(properties);
+
+      if (lanceDatasetExists(userLocation)) {
+        // Register existing dataset
+        return registerExistingTable(
+            userLocation,
+            tableIdList,
+            processedSchema,
+            tableProperties,
+            fileFormatVersion,
+            shardingSpec);
+      }
+
+      // Create new table at custom location
+      // We use the server-returned location (not userLocation) for both reads and writes so that
+      // the write URI matches what the catalog recorded. The server may normalize the path
+      // (e.g., trailing slash, URI scheme canonicalization).
+      DeclareTableRequest declareRequest = new DeclareTableRequest();
+      tableIdList.forEach(declareRequest::addIdItem);
+      declareRequest.setLocation(userLocation);
+      DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
+      String location = declareResponse.getLocation();
+      Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
+      boolean managedVersioning = Boolean.TRUE.equals(declareResponse.getManagedVersioning());
+
+      try {
+        Map<String, String> merged =
+            LanceRuntime.mergeStorageOptions(
+                catalogConfig.getStorageOptions(), initialStorageOptions);
+        WriteDatasetBuilder writeBuilder =
+            Dataset.write()
+                .allocator(LanceRuntime.allocator())
+                .uri(location)
+                .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
+                .mode(WriteParams.WriteMode.CREATE)
+                .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
+                .storageOptions(merged);
+        if (fileFormatVersion != null) {
+          writeBuilder.dataStorageVersion(fileFormatVersion);
+        }
+        try (Dataset dataset = writeBuilder.execute()) {
+          SparkLanceShardingUtils.initializeMemWal(
+              dataset,
+              SparkLanceShardingUtils.fromSparkTransforms(partitions, dataset.getLanceSchema()));
+          Map<String, String> propertiesToPersist =
+              tablePropertiesToPersistOnCreate(properties, managedVersioning);
+          if (!propertiesToPersist.isEmpty()) {
+            persistTableProperties(dataset, propertiesToPersist, managedVersioning, tableIdList);
+          }
+        }
+
+        LanceSparkReadOptions readOptions =
+            createReadOptions(
+                location,
+                catalogConfig,
+                Optional.empty(),
+                Optional.of(namespace),
+                Optional.of(tableIdList),
+                name);
+        return createDataset(
+            readOptions,
+            processedSchema,
+            initialStorageOptions,
+            namespaceImpl,
+            namespaceProperties,
+            managedVersioning,
+            fileFormatVersion,
+            tableProperties,
+            shardingSpec);
+      } catch (Exception e) {
+        // Cleanup declared table on failure
+        DeregisterTableRequest deregisterRequest = new DeregisterTableRequest();
+        tableIdList.forEach(deregisterRequest::addIdItem);
+        try {
+          namespace.deregisterTable(deregisterRequest);
+        } catch (Exception cleanupEx) {
+          logger.warn("Failed to cleanup declared table after creation failure", cleanupEx);
+        }
+        throw new RuntimeException("Failed to create table at location: " + location, e);
+      }
+    }
+
     Identifier actualIdent = transformIdentifierForApi(ident);
 
     // Build the table ID for credential vending
@@ -712,6 +803,75 @@ public abstract class BaseLanceNamespaceSparkCatalog
         fileFormatVersion,
         tableProperties,
         null);
+  }
+
+  /** Probe whether a Lance dataset already exists at the given location. */
+  private boolean lanceDatasetExists(String location) {
+    try {
+      LanceSparkReadOptions probeOptions =
+          createReadOptions(
+              location, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
+      try (Dataset ds = Utils.openDatasetBuilder(probeOptions).build()) {
+        return true;
+      }
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /**
+   * Register an existing Lance dataset at the given location with the namespace server, then return
+   * a Spark Table backed by it.
+   */
+  private Table registerExistingTable(
+      String location,
+      List<String> tableIdList,
+      StructType schema,
+      Map<String, String> tableProperties,
+      String fileFormatVersion,
+      ShardingSpec shardingSpec) {
+    try {
+      RegisterTableRequest registerRequest = new RegisterTableRequest();
+      tableIdList.forEach(registerRequest::addIdItem);
+      registerRequest.setLocation(location);
+      namespace.registerTable(registerRequest);
+
+      DescribeTableRequest describeRequest = new DescribeTableRequest();
+      tableIdList.forEach(describeRequest::addIdItem);
+      DescribeTableResponse describeResponse = namespace.describeTable(describeRequest);
+      Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
+      boolean managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
+
+      // Note: we intentionally do NOT persist table properties for registered external tables.
+      // The dataset already exists with its own configuration; overwriting could corrupt it.
+      LanceSparkReadOptions readOptions =
+          createReadOptions(
+              location,
+              catalogConfig,
+              Optional.empty(),
+              Optional.of(namespace),
+              Optional.of(tableIdList),
+              name);
+      return createDataset(
+          readOptions,
+          schema,
+          initialStorageOptions,
+          namespaceImpl,
+          namespaceProperties,
+          managedVersioning,
+          fileFormatVersion,
+          tableProperties,
+          shardingSpec);
+    } catch (Exception e) {
+      DeregisterTableRequest deregisterRequest = new DeregisterTableRequest();
+      tableIdList.forEach(deregisterRequest::addIdItem);
+      try {
+        namespace.deregisterTable(deregisterRequest);
+      } catch (Exception cleanupEx) {
+        logger.warn("Failed to cleanup registered table after failure", cleanupEx);
+      }
+      throw new RuntimeException("Failed to register existing table at location: " + location, e);
+    }
   }
 
   @Override
@@ -893,12 +1053,17 @@ public abstract class BaseLanceNamespaceSparkCatalog
           "Namespace not configured. Use 'impl' config for namespace-based access.");
     }
 
+    String userLocation = properties.get(CREATE_TABLE_PROPERTY_LOCATION);
+
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
 
     DeclareTableRequest declareRequest = new DeclareTableRequest();
     tableIdList.forEach(declareRequest::addIdItem);
+    if (userLocation != null && !userLocation.trim().isEmpty()) {
+      declareRequest.setLocation(userLocation);
+    }
     DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
     String location = declareResponse.getLocation();
     Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
@@ -1084,6 +1249,8 @@ public abstract class BaseLanceNamespaceSparkCatalog
           "Namespace not configured. Use 'impl' config for namespace-based access.");
     }
 
+    String userLocation = properties.get(CREATE_TABLE_PROPERTY_LOCATION);
+
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
     StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
@@ -1096,6 +1263,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
     if (!exists) {
       DeclareTableRequest declareRequest = new DeclareTableRequest();
       tableIdList.forEach(declareRequest::addIdItem);
+      if (userLocation != null && !userLocation.trim().isEmpty()) {
+        declareRequest.setLocation(userLocation);
+      }
       DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
       location = declareResponse.getLocation();
       initialStorageOptions = declareResponse.getStorageOptions();

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -595,82 +595,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
           "Namespace not configured. Use 'impl' config for namespace-based access.");
     }
 
-    // Extract user-specified LOCATION before properties are filtered
+    // Custom LOCATION: register an existing dataset, or create a new one at the given path.
     String userLocation = properties.get(CREATE_TABLE_PROPERTY_LOCATION);
-
     if (userLocation != null && !userLocation.trim().isEmpty()) {
-      Identifier actualIdent = transformIdentifierForApi(ident);
-      List<String> tableIdList = buildTableId(actualIdent);
-      StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
-      String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-      Map<String, String> tableProperties = copyUserTableProperties(properties);
-
-      if (lanceDatasetExists(userLocation)) {
-        return registerExistingTable(
-            userLocation, tableIdList, processedSchema, tableProperties, null, shardingSpec);
-      }
-
-      // Create new table at custom location
-      // We use the server-returned location (not userLocation) for both reads and writes so that
-      // the write URI matches what the catalog recorded. The server may normalize the path
-      // (e.g., trailing slash, URI scheme canonicalization).
-      DeclareTableRequest declareRequest = new DeclareTableRequest();
-      tableIdList.forEach(declareRequest::addIdItem);
-      declareRequest.setLocation(userLocation);
-      DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
-      String location = declareResponse.getLocation();
-      Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
-      boolean managedVersioning = Boolean.TRUE.equals(declareResponse.getManagedVersioning());
-
-      try {
-        Map<String, String> merged =
-            LanceRuntime.mergeStorageOptions(
-                catalogConfig.getStorageOptions(), initialStorageOptions);
-        WriteDatasetBuilder writeBuilder =
-            Dataset.write()
-                .allocator(LanceRuntime.allocator())
-                .uri(location)
-                .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
-                .mode(WriteParams.WriteMode.CREATE)
-                .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
-                .storageOptions(merged);
-        if (fileFormatVersion != null) {
-          writeBuilder.dataStorageVersion(fileFormatVersion);
-        }
-        try (Dataset dataset = writeBuilder.execute()) {
-          SparkLanceShardingUtils.initializeMemWal(
-              dataset,
-              SparkLanceShardingUtils.fromSparkTransforms(partitions, dataset.getLanceSchema()));
-          Map<String, String> propertiesToPersist =
-              tablePropertiesToPersistOnCreate(properties, managedVersioning);
-          if (!propertiesToPersist.isEmpty()) {
-            persistTableProperties(dataset, propertiesToPersist, managedVersioning, tableIdList);
-          }
-        }
-
-        LanceSparkReadOptions readOptions =
-            createReadOptions(
-                location,
-                catalogConfig,
-                Optional.empty(),
-                Optional.of(namespace),
-                Optional.of(tableIdList),
-                name);
-        return createDataset(
-            readOptions,
-            processedSchema,
-            initialStorageOptions,
-            namespaceImpl,
-            namespaceProperties,
-            managedVersioning,
-            fileFormatVersion,
-            tableProperties,
-            shardingSpec);
-      } catch (Exception e) {
-        // Cleanup declared table on failure
-        deregisterQuietly(tableIdList);
-        throw new RuntimeException("Failed to create table at location: " + location, e);
-      }
+      return createTableAtLocation(
+          ident, schema, partitions, properties, userLocation, shardingSpec);
     }
 
     Identifier actualIdent = transformIdentifierForApi(ident);
@@ -737,6 +666,92 @@ public abstract class BaseLanceNamespaceSparkCatalog
         fileFormatVersion,
         tableProperties,
         null);
+  }
+
+  /**
+   * Handles {@code CREATE TABLE ... LOCATION '<path>'} for namespace-based catalogs. If a Lance
+   * dataset already exists at {@code userLocation}, it is registered as an external table;
+   * otherwise a new dataset is created at that location.
+   */
+  private Table createTableAtLocation(
+      Identifier ident,
+      StructType schema,
+      Transform[] partitions,
+      Map<String, String> properties,
+      String userLocation,
+      ShardingSpec shardingSpec) {
+    Identifier actualIdent = transformIdentifierForApi(ident);
+    List<String> tableIdList = buildTableId(actualIdent);
+    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    Map<String, String> tableProperties = copyUserTableProperties(properties);
+
+    if (lanceDatasetExists(userLocation)) {
+      return registerExistingTable(
+          userLocation, tableIdList, processedSchema, tableProperties, null, shardingSpec);
+    }
+
+    // Create a new dataset at the requested location.
+    // We use the server-returned location (not userLocation) for both reads and writes so that
+    // the write URI matches what the catalog recorded. The server may normalize the path
+    // (e.g., trailing slash, URI scheme canonicalization).
+    DeclareTableRequest declareRequest = new DeclareTableRequest();
+    tableIdList.forEach(declareRequest::addIdItem);
+    declareRequest.setLocation(userLocation);
+    DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
+    String location = declareResponse.getLocation();
+    Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
+    boolean managedVersioning = Boolean.TRUE.equals(declareResponse.getManagedVersioning());
+    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+
+    try {
+      Map<String, String> merged =
+          LanceRuntime.mergeStorageOptions(
+              catalogConfig.getStorageOptions(), initialStorageOptions);
+      WriteDatasetBuilder writeBuilder =
+          Dataset.write()
+              .allocator(LanceRuntime.allocator())
+              .uri(location)
+              .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
+              .mode(WriteParams.WriteMode.CREATE)
+              .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
+              .storageOptions(merged);
+      if (fileFormatVersion != null) {
+        writeBuilder.dataStorageVersion(fileFormatVersion);
+      }
+      try (Dataset dataset = writeBuilder.execute()) {
+        SparkLanceShardingUtils.initializeMemWal(
+            dataset,
+            SparkLanceShardingUtils.fromSparkTransforms(partitions, dataset.getLanceSchema()));
+        Map<String, String> propertiesToPersist =
+            tablePropertiesToPersistOnCreate(properties, managedVersioning);
+        if (!propertiesToPersist.isEmpty()) {
+          persistTableProperties(dataset, propertiesToPersist, managedVersioning, tableIdList);
+        }
+      }
+
+      LanceSparkReadOptions readOptions =
+          createReadOptions(
+              location,
+              catalogConfig,
+              Optional.empty(),
+              Optional.of(namespace),
+              Optional.of(tableIdList),
+              name);
+      return createDataset(
+          readOptions,
+          processedSchema,
+          initialStorageOptions,
+          namespaceImpl,
+          namespaceProperties,
+          managedVersioning,
+          fileFormatVersion,
+          tableProperties,
+          shardingSpec);
+    } catch (Exception e) {
+      // Cleanup declared table on failure
+      deregisterQuietly(tableIdList);
+      throw new RuntimeException("Failed to create table at location: " + location, e);
+    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -674,13 +674,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             shardingSpec);
       } catch (Exception e) {
         // Cleanup declared table on failure
-        DeregisterTableRequest deregisterRequest = new DeregisterTableRequest();
-        tableIdList.forEach(deregisterRequest::addIdItem);
-        try {
-          namespace.deregisterTable(deregisterRequest);
-        } catch (Exception cleanupEx) {
-          logger.warn("Failed to cleanup declared table after creation failure", cleanupEx);
-        }
+        deregisterQuietly(tableIdList);
         throw new RuntimeException("Failed to create table at location: " + location, e);
       }
     }
@@ -814,7 +808,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       try (Dataset ds = Utils.openDatasetBuilder(probeOptions).build()) {
         return true;
       }
-    } catch (Exception e) {
+    } catch (IllegalArgumentException e) {
       return false;
     }
   }
@@ -863,14 +857,19 @@ public abstract class BaseLanceNamespaceSparkCatalog
           tableProperties,
           shardingSpec);
     } catch (Exception e) {
-      DeregisterTableRequest deregisterRequest = new DeregisterTableRequest();
-      tableIdList.forEach(deregisterRequest::addIdItem);
-      try {
-        namespace.deregisterTable(deregisterRequest);
-      } catch (Exception cleanupEx) {
-        logger.warn("Failed to cleanup registered table after failure", cleanupEx);
-      }
+      deregisterQuietly(tableIdList);
       throw new RuntimeException("Failed to register existing table at location: " + location, e);
+    }
+  }
+
+  /** Best-effort rollback: deregister a table from the namespace, logging any failure. */
+  private void deregisterQuietly(List<String> tableIdList) {
+    try {
+      DeregisterTableRequest request = new DeregisterTableRequest();
+      tableIdList.forEach(request::addIdItem);
+      namespace.deregisterTable(request);
+    } catch (Exception cleanupEx) {
+      logger.warn("Failed to deregister table during rollback", cleanupEx);
     }
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseTestLocationSupport.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseTestLocationSupport.java
@@ -20,14 +20,21 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Regression tests for LOCATION support in BaseLanceNamespaceSparkCatalog.
+ * Tests for {@code CREATE TABLE ... LOCATION} support in {@link BaseLanceNamespaceSparkCatalog}.
  *
- * <p>Custom LOCATION for new tables requires a REST namespace backend (e.g., Gravitino) that
- * supports DeclareTableRequest.setLocation(). The DirectoryNamespace backend enforces server-
- * assigned paths and rejects custom locations. Full LOCATION tests run as integration tests against
- * a live REST namespace server.
+ * <p>Custom LOCATION (both creating a new dataset at a path and registering an existing one) is
+ * only meaningful for namespace backends that accept caller-supplied locations, such as the
+ * REST/Gravitino backend. The {@code DirectoryNamespace} backend used by these unit tests owns its
+ * storage layout and requires every table to live at a server-assigned, hash-prefixed path under
+ * the catalog root: it rejects a custom location for a new table outright, and only round-trips
+ * locations relative to the catalog root, so an absolute external location registers but is not
+ * readable. The positive create-new and register-existing paths are therefore exercised by
+ * integration tests against a live REST namespace server; the tests below cover the
+ * directory-backend regression (no LOCATION) and the directory-backend boundaries.
  */
 public abstract class BaseTestLocationSupport extends BaseTestSparkDirectoryNamespace {
 
@@ -46,5 +53,72 @@ public abstract class BaseTestLocationSupport extends BaseTestSparkDirectoryName
     assertEquals("alice", rows.get(0).getString(1));
     assertEquals(2, rows.get(1).getInt(0));
     assertEquals("bob", rows.get(1).getString(1));
+  }
+
+  @Test
+  public void testCreateTableWithLocationOnNewPathRejectedByDirectoryNamespace() {
+    String fullName = catalogName + ".default." + generateTableName("loc_new");
+    String customLocation = tempDir.resolve("custom_new.lance").toString();
+
+    // DirectoryNamespace assigns its own storage path, so declaring a table at a custom location
+    // is rejected. The catalog wraps this in a runtime exception.
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () ->
+                spark.sql(
+                    "CREATE TABLE "
+                        + fullName
+                        + " (id INT) USING lance LOCATION '"
+                        + customLocation
+                        + "'"));
+    assertTrue(
+        rootCauseMessage(ex).contains("must be at location"),
+        "Expected DirectoryNamespace to reject a custom location, but got: " + ex);
+  }
+
+  @Test
+  public void testCreateTableRegisteringExistingDatasetNotReadableOnDirectoryNamespace() {
+    // Produce a real Lance dataset by creating a managed table, then read back its absolute path.
+    String src = generateTableName("loc_src");
+    String srcFull = catalogName + ".default." + src;
+    spark.sql("CREATE TABLE " + srcFull + " (id INT, name STRING)");
+    spark.sql("INSERT INTO " + srcFull + " VALUES (1, 'alice')");
+    String existingLocation = locationOf(srcFull);
+
+    // Pointing LOCATION at the existing dataset takes the register-existing branch. The
+    // DirectoryNamespace records the location as a path relative to the catalog root, so an
+    // absolute external location does not round-trip: registration is accepted but the table is
+    // not readable. (REST backends accept absolute external locations; see class doc.)
+    String regFull = catalogName + ".default." + generateTableName("loc_reg");
+    spark.sql(
+        "CREATE TABLE "
+            + regFull
+            + " (id INT, name STRING) USING lance LOCATION '"
+            + existingLocation
+            + "'");
+    assertThrows(Exception.class, () -> spark.sql("SELECT * FROM " + regFull).collectAsList());
+  }
+
+  /** Reads the on-disk location of an already-created table via DESCRIBE EXTENDED. */
+  private String locationOf(String fullTableName) {
+    List<Row> rows =
+        spark
+            .sql("DESCRIBE EXTENDED " + fullTableName)
+            .filter("col_name = 'Location'")
+            .collectAsList();
+    return rows.get(0).getString(1);
+  }
+
+  private static String rootCauseMessage(Throwable t) {
+    Throwable cur = t;
+    StringBuilder sb = new StringBuilder();
+    while (cur != null) {
+      if (cur.getMessage() != null) {
+        sb.append(cur.getMessage()).append(' ');
+      }
+      cur = cur.getCause();
+    }
+    return sb.toString();
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseTestLocationSupport.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseTestLocationSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for LOCATION support in BaseLanceNamespaceSparkCatalog.
+ *
+ * <p>Custom LOCATION for new tables requires a REST namespace backend (e.g., Gravitino) that
+ * supports DeclareTableRequest.setLocation(). The DirectoryNamespace backend enforces server-
+ * assigned paths and rejects custom locations. Full LOCATION tests run as integration tests against
+ * a live REST namespace server.
+ */
+public abstract class BaseTestLocationSupport extends BaseTestSparkDirectoryNamespace {
+
+  @Test
+  public void testCreateTableWithoutLocationUnchanged() {
+    String tableName = generateTableName("loc_managed");
+    String fullName = catalogName + ".default." + tableName;
+
+    spark.sql("CREATE TABLE " + fullName + " (id INT, name STRING)");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'alice'), (2, 'bob')");
+
+    Dataset<Row> result = spark.sql("SELECT * FROM " + fullName + " ORDER BY id");
+    List<Row> rows = result.collectAsList();
+    assertEquals(2, rows.size());
+    assertEquals(1, rows.get(0).getInt(0));
+    assertEquals("alice", rows.get(0).getString(1));
+    assertEquals(2, rows.get(1).getInt(0));
+    assertEquals("bob", rows.get(1).getString(1));
+  }
+}


### PR DESCRIPTION
## Summary
Support `CREATE TABLE ... LOCATION 'path'` for namespace-based catalogs (e.g., REST catalogs backed by Gravitino or other Lance namespace servers).
| `LOCATION` provided? | Data exists? | Behavior |
|---|---|---|
| No | N/A | Managed table at server-assigned path (unchanged) |
| Yes | No | Create new empty dataset at the custom path |
| Yes | Yes | Register existing dataset (schema read from disk) |

Closes #158


## Motivation
Users need to create tables at arbitrary storage paths through a centralized catalog — for example, registering existing Lance datasets or placing new tables in specific storage accounts. Without this fix, LOCATION is silently ignored and all tables go to the server-assigned default path. This follows standard Spark/Iceberg semantics where LOCATION controls the physical storage location of a table's data.


## Changes
All changes are in `BaseLanceNamespaceSparkCatalog.java`:
- **`createTable()`**: Extract LOCATION from properties before `copyUserTableProperties()` strips it. If data exists at the path, register via `RegisterTableRequest`. Otherwise, pass location to `DeclareTableRequest.setLocation()` and create a new empty dataset there. Includes cleanup (deregister) on failure to avoid dangling catalog entries.
- **`stageCreate()`**: Pass LOCATION to `DeclareTableRequest` when present.
- **`stageCreateOrReplace()`**: Same, in the `!exists` branch.
- **`lanceDatasetExists()`**: New helper — probes whether a Lance dataset exists at a given path.
- **`registerExistingTable()`**: New helper — registers existing data via `RegisterTableRequest` with cleanup on failure.


## Design Decisions
- **LOCATION is extracted before `copyUserTableProperties()`** strips it — this preserves the existing behavior where LOCATION is not persisted as a table property, while still using it to control storage placement.
- **Existing data detection**: When LOCATION points to an existing Lance dataset, we register it (similar to #314) rather than failing. This enables the common use case of cataloging pre-existing datasets.
- **Cleanup on failure**: Both the declare-new and register-existing paths clean up via `deregisterTable` if downstream operations fail, preventing dangling catalog entries.
- **Table properties are not persisted for registered external tables** — the dataset already exists with its own configuration.


## Related
- #158 — LOCATION silently ignored (this PR closes it)
- #314 — External table registration via LOCATION (handles existing data only; this PR handles both new + existing)
- apache/gravitino#9520 — Gravitino server-side support for custom locations (already resolved)


## Test plan
- [x] 362 existing unit tests pass (0 failures)
- [x] Lint + format pass (`make lint`, `make format`)
- [x] Integration test: CREATE TABLE without LOCATION — managed table works as before
- [x] Integration test: CREATE TABLE with LOCATION on empty path — new dataset created at custom path
- [x] Integration test: CREATE TABLE with LOCATION on existing data — registers and reads data
- [x] Integration test: Normal Spark operations unaffected after LOCATION usage
- All integration tests run against a live Gravitino Lance REST server