### PR TITLE
chore: update lance dependency to v8.0.0-beta.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.2</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` to `8.0.0-beta.2`.
- Verified `docker/Dockerfile` hardcoded versions against Maven properties:
  - `LANCE_SPARK_VERSION=0.5.0-beta.1` matches `lance-spark.version`.
  - `LANCE_NS_IMPL_VERSION=0.3.0` matches `lance-namespace-impl.version`.
- Triggering tag: `refs/tags/v8.0.0-beta.2`.

## Verification
- `make lint` passed.
- `make install` passed for the default Spark 3.5 / Scala 2.12 build.

Note: `org.lance:lance-core:8.0.0-beta.2` was not yet resolvable from Maven Central on this runner, so I installed `lance-core` locally from the exact `lance-format/lance` tag `v8.0.0-beta.2` to complete the build verification.
