### PR TITLE
chore: update lance dependency to v8.0.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.3</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-rc.1` to `8.0.0-beta.3`.
- Checked `docker/Dockerfile` hardcoded versions against Maven properties:
  - `LANCE_SPARK_VERSION=0.5.0-beta.1` matches `lance-spark.version`.
  - `LANCE_NS_IMPL_VERSION=0.3.0` matches `lance-namespace-impl.version`.
- Triggering tag: `refs/tags/v8.0.0-beta.3`.

## Verification
- `make lint` passed.
- `make install` was run, but currently fails during dependency resolution because `org.lance:lance-core:8.0.0-beta.3` is not available from Maven Central on this runner. Maven Central metadata currently lists `8.0.0-beta.1` and `8.0.0-beta.2`, but not `8.0.0-beta.3`.
