### PR TITLE
chore: update lance dependency to v8.0.0-beta.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.4</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-rc.1` to `8.0.0-beta.4`.
- Checked `docker/Dockerfile` hardcoded versions against Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0` already matched, so no Dockerfile diff was needed.

## Verification
- `make lint` passed.
- `make install` initially could not resolve `org.lance:lance-core:8.0.0-beta.4` from Maven Central because the artifact returned 404.
- Checked out `lance-format/lance` at `refs/tags/v8.0.0-beta.4` and locally installed `org.lance:lance-core:8.0.0-beta.4` with `./mvnw install -Dskip.build.jni -DskipTests` for compile verification.
- Reran `make install`; it passed for the default Spark 3.5 / Scala 2.12 build.

Triggered by `refs/tags/v8.0.0-beta.4`.
