### PR TITLE
chore: update lance dependency to v8.0.0-beta.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.5</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Bump `lance.version` to `8.0.0-beta.5`.
- Verified `docker/Dockerfile` already matches the current Maven properties: `LANCE_SPARK_VERSION=0.5.0-beta.1` and `LANCE_NS_IMPL_VERSION=0.3.0`.
- Triggering tag: refs/tags/v8.0.0-beta.5

## Verification

- `make lint`
- `make install`

Note: Maven Central did not yet resolve `org.lance:lance-core:8.0.0-beta.5` from this runner, so I installed `lance-core` locally from the matching Lance source tag before rerunning `make install`.
