### PR TITLE
refactor: detect blob v2 descriptor column from arrow metadata

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
@@ -156,7 +156,7 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
           throw new IllegalStateException(
               "Lance scan did not return expected field '" + fieldName + "'");
         }
-        LanceArrowColumnVector colVec = new LanceArrowColumnVector(vector, false);
+        LanceArrowColumnVector colVec = new LanceArrowColumnVector(vector, false, field);
 
         // Set blob reference context so getBinary() produces blob references
         if (rowAddresses != null && blobColumnNames.contains(fieldName)) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ReadSchemaNestedStructWidening.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ReadSchemaNestedStructWidening.java
@@ -13,9 +13,12 @@
  */
 package org.lance.spark.read;
 
+import org.lance.spark.utils.BlobUtils;
+
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -53,7 +56,12 @@ final class ReadSchemaNestedStructWidening {
 
   private static StructField widenField(StructField required, StructField tableFull) {
     DataType widened = widenDataType(required.dataType(), tableFull.dataType());
-    return new StructField(required.name(), widened, required.nullable(), required.metadata());
+    // Column pruning rebuilds required fields from Catalyst attributes and drops custom metadata.
+    // For blob v2 descriptor columns keep the lance.blob.v2 flag from the table field so the
+    // scanner detects them by flag, not struct shape.
+    Metadata metadata =
+        BlobUtils.isBlobV2SparkField(tableFull) ? tableFull.metadata() : required.metadata();
+    return new StructField(required.name(), widened, required.nullable(), metadata);
   }
 
   private static DataType widenDataType(DataType required, DataType tableFull) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
@@ -13,15 +13,10 @@
  */
 package org.lance.spark.utils;
 
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-
-import java.util.List;
-import java.util.Map;
 
 public class BlobUtils {
 
@@ -102,41 +97,6 @@ public class BlobUtils {
 
     return metadata.contains(ARROW_EXTENSION_NAME_KEY)
         && ARROW_EXTENSION_BLOB_V2.equals(metadata.getString(ARROW_EXTENSION_NAME_KEY));
-  }
-
-  /**
-   * Arrow-side counterpart of {@link #isBlobV2SparkField} used inside the columnar batch scanner.
-   */
-  public static boolean isBlobV2ArrowField(Field field) {
-    if (field == null) {
-      return false;
-    }
-
-    Map<String, String> metadata = field.getMetadata();
-    if (metadata != null
-        && ARROW_EXTENSION_BLOB_V2.equals(metadata.get(ARROW_EXTENSION_NAME_KEY))) {
-      return true;
-    }
-
-    // lance-core scan batches expose the unloaded descriptor struct (no extension metadata).
-    return isBlobV2DescriptorArrowField(field);
-  }
-
-  private static boolean isBlobV2DescriptorArrowField(Field field) {
-    if (!(field.getType() instanceof ArrowType.Struct)) {
-      return false;
-    }
-    List<Field> children = field.getChildren();
-    if (children == null || children.size() != BLOB_DESCRIPTOR_STRUCT.fields().length) {
-      return false;
-    }
-    StructField[] expected = BLOB_DESCRIPTOR_STRUCT.fields();
-    for (int i = 0; i < expected.length; i++) {
-      if (!expected[i].name().equals(children.get(i).getName())) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /** Returns true if any field in {@code schema} is a blob v2 column. */

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
@@ -42,6 +42,7 @@ import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.util.LanceArrowUtils;
 import org.apache.spark.sql.vectorized.ArrowColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
@@ -71,11 +72,19 @@ public class LanceArrowColumnVector extends ColumnVector {
   private final boolean closeVectorOnClose;
 
   public LanceArrowColumnVector(ValueVector vector) {
-    this(vector, true);
+    this(vector, true, null);
   }
 
   public LanceArrowColumnVector(ValueVector vector, boolean closeVectorOnClose) {
-    super(computeDataType(vector));
+    this(vector, closeVectorOnClose, null);
+  }
+
+  public LanceArrowColumnVector(
+      ValueVector vector, boolean closeVectorOnClose, StructField sparkField) {
+    super(
+        BlobUtils.isBlobV2SparkField(sparkField)
+            ? BlobUtils.BLOB_DESCRIPTOR_STRUCT
+            : computeDataType(vector));
     this.closeVectorOnClose = closeVectorOnClose;
 
     if (vector instanceof UInt1Vector) {
@@ -90,7 +99,7 @@ public class LanceArrowColumnVector extends ColumnVector {
       fixedSizeBinaryAccessor = new FixedSizeBinaryAccessor((FixedSizeBinaryVector) vector);
     } else if (vector instanceof FixedSizeListVector) {
       fixedSizeListAccessor = new FixedSizeListAccessor((FixedSizeListVector) vector);
-    } else if (vector instanceof StructVector && BlobUtils.isBlobV2ArrowField(vector.getField())) {
+    } else if (vector instanceof StructVector && BlobUtils.isBlobV2SparkField(sparkField)) {
       structAccessor = new LanceStructAccessor((StructVector) vector);
     } else if (vector instanceof StructVector && BlobUtils.isBlobArrowField(vector.getField())) {
       blobStructAccessor = new BlobStructAccessor((StructVector) vector);
@@ -547,9 +556,6 @@ public class LanceArrowColumnVector extends ColumnVector {
   }
 
   private static DataType computeDataType(ValueVector vector) {
-    if (vector instanceof StructVector && BlobUtils.isBlobV2ArrowField(vector.getField())) {
-      return BlobUtils.BLOB_DESCRIPTOR_STRUCT;
-    }
     return LanceArrowUtils.fromArrowField(vector.getField());
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -13,18 +13,12 @@
  */
 package org.lance.spark.utils;
 
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,17 +39,6 @@ public class BlobUtilsTest {
   @Test
   public void testV1Field() {
     assertTrue(BlobUtils.isBlobSparkField(blobV1Field()));
-  }
-
-  @Test
-  public void testBlobV2ArrowFieldRejectsUnrelated() {
-    Field f =
-        new Field(
-            "payload",
-            new FieldType(true, ArrowType.Binary.INSTANCE, null, Collections.emptyMap()),
-            null);
-    assertFalse(BlobUtils.isBlobV2ArrowField(f));
-    assertFalse(BlobUtils.isBlobV2ArrowField(null));
   }
 
   @Test
@@ -100,34 +83,6 @@ public class BlobUtilsTest {
             });
     StructType rewritten = BlobUtils.applyBlobV2DescriptorSchema(schema);
     assertEquals(DataTypes.BinaryType, rewritten.apply("payload").dataType());
-  }
-
-  @Test
-  public void testUnloadedDescriptorStructRecognizedAsBlobV2() {
-    Field f =
-        new Field(
-            "payload",
-            new FieldType(true, ArrowType.Struct.INSTANCE, null, Collections.emptyMap()),
-            Arrays.asList(
-                intChild("kind"),
-                intChild("position"),
-                intChild("size"),
-                intChild("blob_id"),
-                utf8Child("blob_uri")));
-    assertTrue(BlobUtils.isBlobV2ArrowField(f));
-    assertFalse(BlobUtils.isBlobArrowField(f));
-  }
-
-  private static Field intChild(String name) {
-    return new Field(
-        name,
-        new FieldType(true, new ArrowType.Int(64, false), null, Collections.emptyMap()),
-        null);
-  }
-
-  private static Field utf8Child(String name) {
-    return new Field(
-        name, new FieldType(true, ArrowType.Utf8.INSTANCE, null, Collections.emptyMap()), null);
   }
 
   private static StructField field(String name, org.apache.spark.sql.types.DataType dt) {


### PR DESCRIPTION
Blob v2 columns were detected by matching the descriptor struct shape (kind, position, size, etc.). This PR passes through the arrow properties to spark field metadata to act as a flag for blob column detection. This will be used for read operations. 

### Testing

- mvn clean test -pl lance-spark-3.5_2.13 -am
- BlobUtilsTest, LanceArrowColumnVectorTest, BlobV2DescriptorColumnVectorTest