### PR TITLE
fix: preserve write options through defaults and overwrite

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -28,7 +28,10 @@ import java.util.Objects;
 /**
  * Write-specific options for Lance Spark connector.
  *
- * <p>These options override catalog-level settings for write operations.
+ * <p>Options supplied via {@link Builder#fromOptions(Map)} override catalog-level settings for
+ * write operations. Typed Builder setters applied before {@link
+ * Builder#withCatalogDefaults(LanceSparkCatalogConfig)} are superseded by catalog values for the
+ * same key (see that method's javadoc).
  *
  * <p>Usage:
  *
@@ -516,14 +519,17 @@ public class LanceSparkWriteOptions implements Serializable {
     }
 
     /**
-     * Merges catalog config options as defaults (write options override).
+     * Merges catalog config options as defaults; options supplied via {@link #fromOptions(Map)}
+     * override catalog values.
      *
      * <p>Re-parses the merged map through {@link #fromOptions(Map)} so that catalog-level write
-     * settings are promoted into their typed Builder fields and stay consistent with the storage
-     * options map. Mirrors {@code LanceSparkReadOptions.Builder#withCatalogDefaults}. Typed values
+     * settings (e.g. {@code spark.sql.catalog.<name>.<key>}) are promoted into their typed Builder
+     * fields and take effect on write paths that do not supply per-write {@code .option(...)}
+     * overrides. Mirrors {@code LanceSparkReadOptions.Builder#withCatalogDefaults}. Typed values
      * previously assigned via Builder setters are re-derived from the merged map, so a catalog
-     * default wins over an earlier setter call for the same key; options supplied via {@link
-     * #fromOptions(Map)} always stay ahead of catalog defaults.
+     * default wins over an earlier setter call for the same key. Call this after {@link
+     * #fromOptions(Map)} / {@link #storageOptions(Map)}: a later {@code fromOptions} call replaces
+     * the storage options map and discards the merged catalog defaults.
      *
      * @param catalogConfig the catalog config
      * @return this builder

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -525,8 +525,7 @@ public class LanceSparkWriteOptions implements Serializable {
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
-      this.storageOptions = merged;
-      return this;
+      return fromOptions(merged);
     }
 
     public LanceSparkWriteOptions build() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -368,6 +368,18 @@ public class LanceSparkWriteOptions implements Serializable {
     private LanceNamespace namespace;
     private List<String> tableId;
     private Long version;
+    private boolean writeModeSet;
+    private boolean maxRowsPerFileSet;
+    private boolean maxRowsPerGroupSet;
+    private boolean maxBytesPerFileSet;
+    private boolean fileFormatVersionSet;
+    private boolean useQueuedWriteBufferSet;
+    private boolean queueDepthSet;
+    private boolean batchSizeSet;
+    private boolean enableStableRowIdsSet;
+    private boolean useLargeVarTypesSet;
+    private boolean maxBatchBytesSet;
+    private boolean blobPackFileSizeThresholdSet;
 
     private Builder() {}
 
@@ -378,57 +390,68 @@ public class LanceSparkWriteOptions implements Serializable {
 
     public Builder writeMode(WriteMode writeMode) {
       this.writeMode = writeMode;
+      this.writeModeSet = true;
       return this;
     }
 
     public Builder maxRowsPerFile(Integer maxRowsPerFile) {
       this.maxRowsPerFile = maxRowsPerFile;
+      this.maxRowsPerFileSet = true;
       return this;
     }
 
     public Builder maxRowsPerGroup(Integer maxRowsPerGroup) {
       this.maxRowsPerGroup = maxRowsPerGroup;
+      this.maxRowsPerGroupSet = true;
       return this;
     }
 
     public Builder maxBytesPerFile(Long maxBytesPerFile) {
       this.maxBytesPerFile = maxBytesPerFile;
+      this.maxBytesPerFileSet = true;
       return this;
     }
 
     public Builder fileFormatVersion(String fileFormatVersion) {
       this.fileFormatVersion = fileFormatVersion;
+      this.fileFormatVersionSet = true;
       return this;
     }
 
     public Builder useQueuedWriteBuffer(boolean useQueuedWriteBuffer) {
       this.useQueuedWriteBuffer = useQueuedWriteBuffer;
+      this.useQueuedWriteBufferSet = true;
       return this;
     }
 
     public Builder queueDepth(int queueDepth) {
       this.queueDepth = queueDepth;
+      this.queueDepthSet = true;
       return this;
     }
 
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
+      this.batchSizeSet = true;
       return this;
     }
 
     public Builder enableStableRowIds(Boolean enableStableRowIds) {
       this.enableStableRowIds = enableStableRowIds;
+      this.enableStableRowIdsSet = true;
       return this;
     }
 
     public Builder useLargeVarTypes(boolean useLargeVarTypes) {
       this.useLargeVarTypes = useLargeVarTypes;
+      this.useLargeVarTypesSet = true;
       return this;
     }
 
     public Builder maxBatchBytes(long maxBatchBytes) {
       Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
       this.maxBatchBytes = maxBatchBytes;
+      this.maxBatchBytesSet = true;
       return this;
     }
 
@@ -437,6 +460,7 @@ public class LanceSparkWriteOptions implements Serializable {
           blobPackFileSizeThreshold == null || blobPackFileSizeThreshold > 0,
           "blobPackFileSizeThreshold must be positive");
       this.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
+      this.blobPackFileSizeThresholdSet = true;
       return this;
     }
 
@@ -471,46 +495,58 @@ public class LanceSparkWriteOptions implements Serializable {
       this.storageOptions = new HashMap<>(options);
       if (options.containsKey(CONFIG_WRITE_MODE)) {
         this.writeMode = WriteMode.valueOf(options.get(CONFIG_WRITE_MODE).toUpperCase());
+        this.writeModeSet = true;
       }
       if (options.containsKey(CONFIG_MAX_ROWS_PER_FILE)) {
         this.maxRowsPerFile = Integer.parseInt(options.get(CONFIG_MAX_ROWS_PER_FILE));
+        this.maxRowsPerFileSet = true;
       }
       if (options.containsKey(CONFIG_MAX_ROWS_PER_GROUP)) {
         this.maxRowsPerGroup = Integer.parseInt(options.get(CONFIG_MAX_ROWS_PER_GROUP));
+        this.maxRowsPerGroupSet = true;
       }
       if (options.containsKey(CONFIG_MAX_BYTES_PER_FILE)) {
         this.maxBytesPerFile = Long.parseLong(options.get(CONFIG_MAX_BYTES_PER_FILE));
+        this.maxBytesPerFileSet = true;
       }
       if (options.containsKey(CONFIG_FILE_FORMAT_VERSION)) {
         this.fileFormatVersion = options.get(CONFIG_FILE_FORMAT_VERSION);
+        this.fileFormatVersionSet = true;
       }
       if (options.containsKey(CONFIG_USE_QUEUED_WRITE_BUFFER)) {
         this.useQueuedWriteBuffer =
             Boolean.parseBoolean(options.get(CONFIG_USE_QUEUED_WRITE_BUFFER));
+        this.useQueuedWriteBufferSet = true;
       }
       if (options.containsKey(CONFIG_QUEUE_DEPTH)) {
         this.queueDepth = Integer.parseInt(options.get(CONFIG_QUEUE_DEPTH));
+        this.queueDepthSet = true;
       }
       if (options.containsKey(CONFIG_BATCH_SIZE)) {
         int parsedBatchSize = Integer.parseInt(options.get(CONFIG_BATCH_SIZE));
         Preconditions.checkArgument(parsedBatchSize > 0, "batch_size must be positive");
         this.batchSize = parsedBatchSize;
+        this.batchSizeSet = true;
       }
       if (options.containsKey(CONFIG_ENABLE_STABLE_ROW_IDS)) {
         this.enableStableRowIds = Boolean.parseBoolean(options.get(CONFIG_ENABLE_STABLE_ROW_IDS));
+        this.enableStableRowIdsSet = true;
       }
       if (options.containsKey(CONFIG_USE_LARGE_VAR_TYPES)) {
         this.useLargeVarTypes = Boolean.parseBoolean(options.get(CONFIG_USE_LARGE_VAR_TYPES));
+        this.useLargeVarTypesSet = true;
       }
       if (options.containsKey(CONFIG_MAX_BATCH_BYTES)) {
         long parsedMaxBatchBytes = Long.parseLong(options.get(CONFIG_MAX_BATCH_BYTES));
         Preconditions.checkArgument(parsedMaxBatchBytes > 0, "max_batch_bytes must be positive");
         this.maxBatchBytes = parsedMaxBatchBytes;
+        this.maxBatchBytesSet = true;
       }
       if (options.containsKey(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD)) {
         long parsed = Long.parseLong(options.get(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD));
         Preconditions.checkArgument(parsed > 0, "blob_pack_file_size_threshold must be positive");
         this.blobPackFileSizeThreshold = parsed;
+        this.blobPackFileSizeThresholdSet = true;
       }
       return this;
     }
@@ -522,10 +558,13 @@ public class LanceSparkWriteOptions implements Serializable {
      * @return this builder
      */
     public Builder withCatalogDefaults(LanceSparkCatalogConfig catalogConfig) {
+      WriteOptionSnapshot current = WriteOptionSnapshot.capture(this);
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
-      return fromOptions(merged);
+      fromOptions(merged);
+      current.restoreExplicitOptions(this);
+      return this;
     }
 
     public LanceSparkWriteOptions build() {
@@ -533,6 +572,103 @@ public class LanceSparkWriteOptions implements Serializable {
         throw new IllegalArgumentException("datasetUri is required");
       }
       return new LanceSparkWriteOptions(this);
+    }
+
+    private static class WriteOptionSnapshot {
+      private final WriteMode writeMode;
+      private final Integer maxRowsPerFile;
+      private final Integer maxRowsPerGroup;
+      private final Long maxBytesPerFile;
+      private final String fileFormatVersion;
+      private final boolean useQueuedWriteBuffer;
+      private final int queueDepth;
+      private final int batchSize;
+      private final Boolean enableStableRowIds;
+      private final boolean useLargeVarTypes;
+      private final long maxBatchBytes;
+      private final Long blobPackFileSizeThreshold;
+      private final boolean writeModeSet;
+      private final boolean maxRowsPerFileSet;
+      private final boolean maxRowsPerGroupSet;
+      private final boolean maxBytesPerFileSet;
+      private final boolean fileFormatVersionSet;
+      private final boolean useQueuedWriteBufferSet;
+      private final boolean queueDepthSet;
+      private final boolean batchSizeSet;
+      private final boolean enableStableRowIdsSet;
+      private final boolean useLargeVarTypesSet;
+      private final boolean maxBatchBytesSet;
+      private final boolean blobPackFileSizeThresholdSet;
+
+      private WriteOptionSnapshot(Builder builder) {
+        this.writeMode = builder.writeMode;
+        this.maxRowsPerFile = builder.maxRowsPerFile;
+        this.maxRowsPerGroup = builder.maxRowsPerGroup;
+        this.maxBytesPerFile = builder.maxBytesPerFile;
+        this.fileFormatVersion = builder.fileFormatVersion;
+        this.useQueuedWriteBuffer = builder.useQueuedWriteBuffer;
+        this.queueDepth = builder.queueDepth;
+        this.batchSize = builder.batchSize;
+        this.enableStableRowIds = builder.enableStableRowIds;
+        this.useLargeVarTypes = builder.useLargeVarTypes;
+        this.maxBatchBytes = builder.maxBatchBytes;
+        this.blobPackFileSizeThreshold = builder.blobPackFileSizeThreshold;
+        this.writeModeSet = builder.writeModeSet;
+        this.maxRowsPerFileSet = builder.maxRowsPerFileSet;
+        this.maxRowsPerGroupSet = builder.maxRowsPerGroupSet;
+        this.maxBytesPerFileSet = builder.maxBytesPerFileSet;
+        this.fileFormatVersionSet = builder.fileFormatVersionSet;
+        this.useQueuedWriteBufferSet = builder.useQueuedWriteBufferSet;
+        this.queueDepthSet = builder.queueDepthSet;
+        this.batchSizeSet = builder.batchSizeSet;
+        this.enableStableRowIdsSet = builder.enableStableRowIdsSet;
+        this.useLargeVarTypesSet = builder.useLargeVarTypesSet;
+        this.maxBatchBytesSet = builder.maxBatchBytesSet;
+        this.blobPackFileSizeThresholdSet = builder.blobPackFileSizeThresholdSet;
+      }
+
+      private static WriteOptionSnapshot capture(Builder builder) {
+        return new WriteOptionSnapshot(builder);
+      }
+
+      private void restoreExplicitOptions(Builder builder) {
+        if (writeModeSet) {
+          builder.writeMode = writeMode;
+        }
+        if (maxRowsPerFileSet) {
+          builder.maxRowsPerFile = maxRowsPerFile;
+        }
+        if (maxRowsPerGroupSet) {
+          builder.maxRowsPerGroup = maxRowsPerGroup;
+        }
+        if (maxBytesPerFileSet) {
+          builder.maxBytesPerFile = maxBytesPerFile;
+        }
+        if (fileFormatVersionSet) {
+          builder.fileFormatVersion = fileFormatVersion;
+        }
+        if (useQueuedWriteBufferSet) {
+          builder.useQueuedWriteBuffer = useQueuedWriteBuffer;
+        }
+        if (queueDepthSet) {
+          builder.queueDepth = queueDepth;
+        }
+        if (batchSizeSet) {
+          builder.batchSize = batchSize;
+        }
+        if (enableStableRowIdsSet) {
+          builder.enableStableRowIds = enableStableRowIds;
+        }
+        if (useLargeVarTypesSet) {
+          builder.useLargeVarTypes = useLargeVarTypes;
+        }
+        if (maxBatchBytesSet) {
+          builder.maxBatchBytes = maxBatchBytes;
+        }
+        if (blobPackFileSizeThresholdSet) {
+          builder.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
+        }
+      }
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -368,18 +368,6 @@ public class LanceSparkWriteOptions implements Serializable {
     private LanceNamespace namespace;
     private List<String> tableId;
     private Long version;
-    private boolean writeModeSet;
-    private boolean maxRowsPerFileSet;
-    private boolean maxRowsPerGroupSet;
-    private boolean maxBytesPerFileSet;
-    private boolean fileFormatVersionSet;
-    private boolean useQueuedWriteBufferSet;
-    private boolean queueDepthSet;
-    private boolean batchSizeSet;
-    private boolean enableStableRowIdsSet;
-    private boolean useLargeVarTypesSet;
-    private boolean maxBatchBytesSet;
-    private boolean blobPackFileSizeThresholdSet;
 
     private Builder() {}
 
@@ -390,68 +378,57 @@ public class LanceSparkWriteOptions implements Serializable {
 
     public Builder writeMode(WriteMode writeMode) {
       this.writeMode = writeMode;
-      this.writeModeSet = true;
       return this;
     }
 
     public Builder maxRowsPerFile(Integer maxRowsPerFile) {
       this.maxRowsPerFile = maxRowsPerFile;
-      this.maxRowsPerFileSet = true;
       return this;
     }
 
     public Builder maxRowsPerGroup(Integer maxRowsPerGroup) {
       this.maxRowsPerGroup = maxRowsPerGroup;
-      this.maxRowsPerGroupSet = true;
       return this;
     }
 
     public Builder maxBytesPerFile(Long maxBytesPerFile) {
       this.maxBytesPerFile = maxBytesPerFile;
-      this.maxBytesPerFileSet = true;
       return this;
     }
 
     public Builder fileFormatVersion(String fileFormatVersion) {
       this.fileFormatVersion = fileFormatVersion;
-      this.fileFormatVersionSet = true;
       return this;
     }
 
     public Builder useQueuedWriteBuffer(boolean useQueuedWriteBuffer) {
       this.useQueuedWriteBuffer = useQueuedWriteBuffer;
-      this.useQueuedWriteBufferSet = true;
       return this;
     }
 
     public Builder queueDepth(int queueDepth) {
       this.queueDepth = queueDepth;
-      this.queueDepthSet = true;
       return this;
     }
 
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
-      this.batchSizeSet = true;
       return this;
     }
 
     public Builder enableStableRowIds(Boolean enableStableRowIds) {
       this.enableStableRowIds = enableStableRowIds;
-      this.enableStableRowIdsSet = true;
       return this;
     }
 
     public Builder useLargeVarTypes(boolean useLargeVarTypes) {
       this.useLargeVarTypes = useLargeVarTypes;
-      this.useLargeVarTypesSet = true;
       return this;
     }
 
     public Builder maxBatchBytes(long maxBatchBytes) {
       Preconditions.checkArgument(maxBatchBytes > 0, "maxBatchBytes must be positive");
       this.maxBatchBytes = maxBatchBytes;
-      this.maxBatchBytesSet = true;
       return this;
     }
 
@@ -460,7 +437,6 @@ public class LanceSparkWriteOptions implements Serializable {
           blobPackFileSizeThreshold == null || blobPackFileSizeThreshold > 0,
           "blobPackFileSizeThreshold must be positive");
       this.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
-      this.blobPackFileSizeThresholdSet = true;
       return this;
     }
 
@@ -495,58 +471,46 @@ public class LanceSparkWriteOptions implements Serializable {
       this.storageOptions = new HashMap<>(options);
       if (options.containsKey(CONFIG_WRITE_MODE)) {
         this.writeMode = WriteMode.valueOf(options.get(CONFIG_WRITE_MODE).toUpperCase());
-        this.writeModeSet = true;
       }
       if (options.containsKey(CONFIG_MAX_ROWS_PER_FILE)) {
         this.maxRowsPerFile = Integer.parseInt(options.get(CONFIG_MAX_ROWS_PER_FILE));
-        this.maxRowsPerFileSet = true;
       }
       if (options.containsKey(CONFIG_MAX_ROWS_PER_GROUP)) {
         this.maxRowsPerGroup = Integer.parseInt(options.get(CONFIG_MAX_ROWS_PER_GROUP));
-        this.maxRowsPerGroupSet = true;
       }
       if (options.containsKey(CONFIG_MAX_BYTES_PER_FILE)) {
         this.maxBytesPerFile = Long.parseLong(options.get(CONFIG_MAX_BYTES_PER_FILE));
-        this.maxBytesPerFileSet = true;
       }
       if (options.containsKey(CONFIG_FILE_FORMAT_VERSION)) {
         this.fileFormatVersion = options.get(CONFIG_FILE_FORMAT_VERSION);
-        this.fileFormatVersionSet = true;
       }
       if (options.containsKey(CONFIG_USE_QUEUED_WRITE_BUFFER)) {
         this.useQueuedWriteBuffer =
             Boolean.parseBoolean(options.get(CONFIG_USE_QUEUED_WRITE_BUFFER));
-        this.useQueuedWriteBufferSet = true;
       }
       if (options.containsKey(CONFIG_QUEUE_DEPTH)) {
         this.queueDepth = Integer.parseInt(options.get(CONFIG_QUEUE_DEPTH));
-        this.queueDepthSet = true;
       }
       if (options.containsKey(CONFIG_BATCH_SIZE)) {
         int parsedBatchSize = Integer.parseInt(options.get(CONFIG_BATCH_SIZE));
         Preconditions.checkArgument(parsedBatchSize > 0, "batch_size must be positive");
         this.batchSize = parsedBatchSize;
-        this.batchSizeSet = true;
       }
       if (options.containsKey(CONFIG_ENABLE_STABLE_ROW_IDS)) {
         this.enableStableRowIds = Boolean.parseBoolean(options.get(CONFIG_ENABLE_STABLE_ROW_IDS));
-        this.enableStableRowIdsSet = true;
       }
       if (options.containsKey(CONFIG_USE_LARGE_VAR_TYPES)) {
         this.useLargeVarTypes = Boolean.parseBoolean(options.get(CONFIG_USE_LARGE_VAR_TYPES));
-        this.useLargeVarTypesSet = true;
       }
       if (options.containsKey(CONFIG_MAX_BATCH_BYTES)) {
         long parsedMaxBatchBytes = Long.parseLong(options.get(CONFIG_MAX_BATCH_BYTES));
         Preconditions.checkArgument(parsedMaxBatchBytes > 0, "max_batch_bytes must be positive");
         this.maxBatchBytes = parsedMaxBatchBytes;
-        this.maxBatchBytesSet = true;
       }
       if (options.containsKey(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD)) {
         long parsed = Long.parseLong(options.get(CONFIG_BLOB_PACK_FILE_SIZE_THRESHOLD));
         Preconditions.checkArgument(parsed > 0, "blob_pack_file_size_threshold must be positive");
         this.blobPackFileSizeThreshold = parsed;
-        this.blobPackFileSizeThresholdSet = true;
       }
       return this;
     }
@@ -554,17 +518,21 @@ public class LanceSparkWriteOptions implements Serializable {
     /**
      * Merges catalog config options as defaults (write options override).
      *
+     * <p>Re-parses the merged map through {@link #fromOptions(Map)} so that catalog-level write
+     * settings are promoted into their typed Builder fields and stay consistent with the storage
+     * options map. Mirrors {@code LanceSparkReadOptions.Builder#withCatalogDefaults}. Typed values
+     * previously assigned via Builder setters are re-derived from the merged map, so a catalog
+     * default wins over an earlier setter call for the same key; options supplied via {@link
+     * #fromOptions(Map)} always stay ahead of catalog defaults.
+     *
      * @param catalogConfig the catalog config
      * @return this builder
      */
     public Builder withCatalogDefaults(LanceSparkCatalogConfig catalogConfig) {
-      WriteOptionSnapshot current = WriteOptionSnapshot.capture(this);
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
-      fromOptions(merged);
-      current.restoreExplicitOptions(this);
-      return this;
+      return fromOptions(merged);
     }
 
     public LanceSparkWriteOptions build() {
@@ -572,103 +540,6 @@ public class LanceSparkWriteOptions implements Serializable {
         throw new IllegalArgumentException("datasetUri is required");
       }
       return new LanceSparkWriteOptions(this);
-    }
-
-    private static class WriteOptionSnapshot {
-      private final WriteMode writeMode;
-      private final Integer maxRowsPerFile;
-      private final Integer maxRowsPerGroup;
-      private final Long maxBytesPerFile;
-      private final String fileFormatVersion;
-      private final boolean useQueuedWriteBuffer;
-      private final int queueDepth;
-      private final int batchSize;
-      private final Boolean enableStableRowIds;
-      private final boolean useLargeVarTypes;
-      private final long maxBatchBytes;
-      private final Long blobPackFileSizeThreshold;
-      private final boolean writeModeSet;
-      private final boolean maxRowsPerFileSet;
-      private final boolean maxRowsPerGroupSet;
-      private final boolean maxBytesPerFileSet;
-      private final boolean fileFormatVersionSet;
-      private final boolean useQueuedWriteBufferSet;
-      private final boolean queueDepthSet;
-      private final boolean batchSizeSet;
-      private final boolean enableStableRowIdsSet;
-      private final boolean useLargeVarTypesSet;
-      private final boolean maxBatchBytesSet;
-      private final boolean blobPackFileSizeThresholdSet;
-
-      private WriteOptionSnapshot(Builder builder) {
-        this.writeMode = builder.writeMode;
-        this.maxRowsPerFile = builder.maxRowsPerFile;
-        this.maxRowsPerGroup = builder.maxRowsPerGroup;
-        this.maxBytesPerFile = builder.maxBytesPerFile;
-        this.fileFormatVersion = builder.fileFormatVersion;
-        this.useQueuedWriteBuffer = builder.useQueuedWriteBuffer;
-        this.queueDepth = builder.queueDepth;
-        this.batchSize = builder.batchSize;
-        this.enableStableRowIds = builder.enableStableRowIds;
-        this.useLargeVarTypes = builder.useLargeVarTypes;
-        this.maxBatchBytes = builder.maxBatchBytes;
-        this.blobPackFileSizeThreshold = builder.blobPackFileSizeThreshold;
-        this.writeModeSet = builder.writeModeSet;
-        this.maxRowsPerFileSet = builder.maxRowsPerFileSet;
-        this.maxRowsPerGroupSet = builder.maxRowsPerGroupSet;
-        this.maxBytesPerFileSet = builder.maxBytesPerFileSet;
-        this.fileFormatVersionSet = builder.fileFormatVersionSet;
-        this.useQueuedWriteBufferSet = builder.useQueuedWriteBufferSet;
-        this.queueDepthSet = builder.queueDepthSet;
-        this.batchSizeSet = builder.batchSizeSet;
-        this.enableStableRowIdsSet = builder.enableStableRowIdsSet;
-        this.useLargeVarTypesSet = builder.useLargeVarTypesSet;
-        this.maxBatchBytesSet = builder.maxBatchBytesSet;
-        this.blobPackFileSizeThresholdSet = builder.blobPackFileSizeThresholdSet;
-      }
-
-      private static WriteOptionSnapshot capture(Builder builder) {
-        return new WriteOptionSnapshot(builder);
-      }
-
-      private void restoreExplicitOptions(Builder builder) {
-        if (writeModeSet) {
-          builder.writeMode = writeMode;
-        }
-        if (maxRowsPerFileSet) {
-          builder.maxRowsPerFile = maxRowsPerFile;
-        }
-        if (maxRowsPerGroupSet) {
-          builder.maxRowsPerGroup = maxRowsPerGroup;
-        }
-        if (maxBytesPerFileSet) {
-          builder.maxBytesPerFile = maxBytesPerFile;
-        }
-        if (fileFormatVersionSet) {
-          builder.fileFormatVersion = fileFormatVersion;
-        }
-        if (useQueuedWriteBufferSet) {
-          builder.useQueuedWriteBuffer = useQueuedWriteBuffer;
-        }
-        if (queueDepthSet) {
-          builder.queueDepth = queueDepth;
-        }
-        if (batchSizeSet) {
-          builder.batchSize = batchSize;
-        }
-        if (enableStableRowIdsSet) {
-          builder.enableStableRowIds = enableStableRowIds;
-        }
-        if (useLargeVarTypesSet) {
-          builder.useLargeVarTypes = useLargeVarTypes;
-        }
-        if (maxBatchBytesSet) {
-          builder.maxBatchBytes = maxBatchBytes;
-        }
-        if (blobPackFileSizeThresholdSet) {
-          builder.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
-        }
-      }
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -242,10 +242,7 @@ public class SparkWrite implements Write, RequiresDistributionAndOrdering {
       LanceSparkWriteOptions options =
           !overwrite
               ? writeOptions
-              : writeOptions
-                  .toBuilder()
-                  .writeMode(WriteParams.WriteMode.OVERWRITE)
-                  .build();
+              : writeOptions.toBuilder().writeMode(WriteParams.WriteMode.OVERWRITE).build();
 
       return new SparkWrite(
           schema,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SparkWrite.java
@@ -242,20 +242,8 @@ public class SparkWrite implements Write, RequiresDistributionAndOrdering {
       LanceSparkWriteOptions options =
           !overwrite
               ? writeOptions
-              : LanceSparkWriteOptions.builder()
-                  .storageOptions(writeOptions.getStorageOptions())
-                  .namespace(writeOptions.getNamespace())
-                  .tableId(writeOptions.getTableId())
-                  .batchSize(writeOptions.getBatchSize())
-                  .datasetUri(writeOptions.getDatasetUri())
-                  .fileFormatVersion(writeOptions.getFileFormatVersion())
-                  .maxBytesPerFile(writeOptions.getMaxBytesPerFile())
-                  .maxRowsPerFile(writeOptions.getMaxRowsPerFile())
-                  .maxRowsPerGroup(writeOptions.getMaxRowsPerGroup())
-                  .queueDepth(writeOptions.getQueueDepth())
-                  .useQueuedWriteBuffer(writeOptions.isUseQueuedWriteBuffer())
-                  .useLargeVarTypes(writeOptions.isUseLargeVarTypes())
-                  .enableStableRowIds(writeOptions.getEnableStableRowIds())
+              : writeOptions
+                  .toBuilder()
                   .writeMode(WriteParams.WriteMode.OVERWRITE)
                   .build();
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -14,15 +14,21 @@
 package org.lance.spark;
 
 import org.lance.WriteParams;
+import org.lance.namespace.LanceNamespace;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link LanceSparkWriteOptions}. */
@@ -172,6 +178,9 @@ public class LanceSparkWriteOptionsTest {
     assertEquals(4, writeOptions.getQueueDepth());
     assertEquals(4096L, writeOptions.getMaxBatchBytes());
     assertEquals(Long.valueOf(8192L), writeOptions.getBlobPackFileSizeThreshold());
+    // Catalog keys are carried into storage options as well as typed fields.
+    assertEquals("512", writeOptions.getStorageOptions().get("batch_size"));
+    assertEquals("8192", writeOptions.getStorageOptions().get("blob_pack_file_size_threshold"));
   }
 
   @Test
@@ -227,6 +236,8 @@ public class LanceSparkWriteOptionsTest {
     // Typed fields and storage options stay consistent: user values win in both.
     assertEquals("1024", writeOptions.getStorageOptions().get("batch_size"));
     assertEquals("16384", writeOptions.getStorageOptions().get("max_batch_bytes"));
+    assertEquals("APPEND", writeOptions.getStorageOptions().get("write_mode"));
+    assertEquals("false", writeOptions.getStorageOptions().get("enable_stable_row_ids"));
   }
 
   @Test
@@ -237,7 +248,8 @@ public class LanceSparkWriteOptionsTest {
     final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
     // Builder setters that pre-date withCatalogDefaults are re-derived from the merged
     // option map (read-path semantics): the catalog value wins for keys it defines, and
-    // the typed field always agrees with the storage option (single source of truth).
+    // the typed field agrees with the storage option for every key present in the merged
+    // map (setter-only values for absent keys live solely in the typed field).
     final LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder()
             .datasetUri(TEMP_URL)
@@ -264,7 +276,79 @@ public class LanceSparkWriteOptionsTest {
             .build();
 
     assertEquals(4, writeOptions.getQueueDepth());
+    assertEquals("4", writeOptions.getStorageOptions().get("queue_depth"));
     assertEquals(1024, writeOptions.getBatchSize());
     assertTrue(writeOptions.getEnableStableRowIds());
+    // Setter-only values are not materialized into storage options (pre-existing builder
+    // behavior): for keys absent from the merged map, the typed field is the only carrier.
+    assertNull(writeOptions.getStorageOptions().get("batch_size"));
+    assertNull(writeOptions.getStorageOptions().get("enable_stable_row_ids"));
+  }
+
+  @Test
+  public void testBuilderDoesNotMutateCallerOptionMaps() {
+    final Map<String, String> userOptions = new HashMap<>();
+    userOptions.put("batch_size", "1024");
+    final Map<String, String> userSnapshot = new HashMap<>(userOptions);
+
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("queue_depth", "4");
+    final Map<String, String> catalogSnapshot = new HashMap<>(catalogOptions);
+    final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
+
+    LanceSparkWriteOptions.builder()
+        .datasetUri(TEMP_URL)
+        .fromOptions(userOptions)
+        .withCatalogDefaults(catalogConfig)
+        .build();
+
+    assertEquals(userSnapshot, userOptions, "fromOptions must not mutate the caller's map");
+    assertEquals(
+        catalogSnapshot,
+        catalogOptions,
+        "withCatalogDefaults must not mutate the catalog config's option map");
+  }
+
+  @Test
+  public void testRebuiltOverwriteOptionsSurviveJavaSerialization() throws Exception {
+    final Map<String, String> options = new HashMap<>();
+    options.put("batch_size", "256");
+    options.put("max_batch_bytes", "4096");
+    // Non-serializable stub: if the transient modifier were ever removed from the
+    // namespace field, writeObject below would throw NotSerializableException.
+    final LanceNamespace stubNamespace = TestUtils.stubNamespace();
+    // Mirror the SparkWrite overwrite rebuild: toBuilder() + writeMode(OVERWRITE).
+    final LanceSparkWriteOptions rebuilt =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .fromOptions(options)
+            .blobPackFileSizeThreshold(8192L)
+            .version(7L)
+            .namespace(stubNamespace)
+            .build()
+            .toBuilder()
+            .writeMode(WriteParams.WriteMode.OVERWRITE)
+            .build();
+    assertSame(stubNamespace, rebuilt.getNamespace());
+
+    final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(rebuilt);
+    }
+    final LanceSparkWriteOptions copy;
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      copy = (LanceSparkWriteOptions) in.readObject();
+    }
+
+    assertEquals(rebuilt, copy);
+    assertEquals(WriteParams.WriteMode.OVERWRITE, copy.getWriteMode());
+    assertEquals(256, copy.getBatchSize());
+    assertEquals(4096L, copy.getMaxBatchBytes());
+    assertEquals(Long.valueOf(8192L), copy.getBlobPackFileSizeThreshold());
+    assertEquals(7L, copy.getVersion());
+    assertNull(
+        copy.getNamespace(),
+        "namespace is transient: the non-null stub set above must not survive serialization");
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -173,4 +173,84 @@ public class LanceSparkWriteOptionsTest {
     assertEquals(4096L, writeOptions.getMaxBatchBytes());
     assertEquals(Long.valueOf(8192L), writeOptions.getBlobPackFileSizeThreshold());
   }
+
+  @Test
+  public void testExplicitWriteSettingsOverrideCatalogDefaults() {
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("write_mode", "OVERWRITE");
+    catalogOptions.put("max_row_per_file", "1000");
+    catalogOptions.put("max_rows_per_group", "500");
+    catalogOptions.put("max_bytes_per_file", "1048576");
+    catalogOptions.put("file_format_version", "2.1");
+    catalogOptions.put("batch_size", "512");
+    catalogOptions.put("use_queued_write_buffer", "true");
+    catalogOptions.put("queue_depth", "4");
+    catalogOptions.put("enable_stable_row_ids", "true");
+    catalogOptions.put("use_large_var_types", "true");
+    catalogOptions.put("max_batch_bytes", "4096");
+    catalogOptions.put("blob_pack_file_size_threshold", "8192");
+
+    final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
+    final LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .writeMode(WriteParams.WriteMode.APPEND)
+            .maxRowsPerFile(2000)
+            .maxRowsPerGroup(1000)
+            .maxBytesPerFile(2097152L)
+            .fileFormatVersion("2.0")
+            .batchSize(1024)
+            .useQueuedWriteBuffer(false)
+            .queueDepth(2)
+            .enableStableRowIds(false)
+            .useLargeVarTypes(false)
+            .maxBatchBytes(16384L)
+            .blobPackFileSizeThreshold(32768L)
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    assertEquals(WriteParams.WriteMode.APPEND, writeOptions.getWriteMode());
+    assertEquals(2000, writeOptions.getMaxRowsPerFile());
+    assertEquals(1000, writeOptions.getMaxRowsPerGroup());
+    assertEquals(2097152L, writeOptions.getMaxBytesPerFile());
+    assertEquals("2.0", writeOptions.getFileFormatVersion());
+    assertEquals(1024, writeOptions.getBatchSize());
+    assertFalse(writeOptions.isUseQueuedWriteBuffer());
+    assertEquals(2, writeOptions.getQueueDepth());
+    assertFalse(writeOptions.getEnableStableRowIds());
+    assertFalse(writeOptions.isUseLargeVarTypes());
+    assertEquals(16384L, writeOptions.getMaxBatchBytes());
+    assertEquals(Long.valueOf(32768L), writeOptions.getBlobPackFileSizeThreshold());
+  }
+
+  @Test
+  public void testFromOptionsOverrideCatalogDefaults() {
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("batch_size", "512");
+    catalogOptions.put("use_queued_write_buffer", "true");
+    catalogOptions.put("queue_depth", "4");
+    catalogOptions.put("max_batch_bytes", "4096");
+    catalogOptions.put("blob_pack_file_size_threshold", "8192");
+
+    final Map<String, String> userOptions = new HashMap<>();
+    userOptions.put("batch_size", "1024");
+    userOptions.put("use_queued_write_buffer", "false");
+    userOptions.put("queue_depth", "2");
+    userOptions.put("max_batch_bytes", "16384");
+    userOptions.put("blob_pack_file_size_threshold", "32768");
+
+    final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
+    final LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .fromOptions(userOptions)
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    assertEquals(1024, writeOptions.getBatchSize());
+    assertFalse(writeOptions.isUseQueuedWriteBuffer());
+    assertEquals(2, writeOptions.getQueueDepth());
+    assertEquals(16384L, writeOptions.getMaxBatchBytes());
+    assertEquals(Long.valueOf(32768L), writeOptions.getBlobPackFileSizeThreshold());
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -175,7 +175,7 @@ public class LanceSparkWriteOptionsTest {
   }
 
   @Test
-  public void testExplicitWriteSettingsOverrideCatalogDefaults() {
+  public void testFromOptionsOverrideCatalogDefaults() {
     final Map<String, String> catalogOptions = new HashMap<>();
     catalogOptions.put("write_mode", "OVERWRITE");
     catalogOptions.put("max_row_per_file", "1000");
@@ -190,22 +190,25 @@ public class LanceSparkWriteOptionsTest {
     catalogOptions.put("max_batch_bytes", "4096");
     catalogOptions.put("blob_pack_file_size_threshold", "8192");
 
+    final Map<String, String> userOptions = new HashMap<>();
+    userOptions.put("write_mode", "APPEND");
+    userOptions.put("max_row_per_file", "2000");
+    userOptions.put("max_rows_per_group", "1000");
+    userOptions.put("max_bytes_per_file", "2097152");
+    userOptions.put("file_format_version", "2.0");
+    userOptions.put("batch_size", "1024");
+    userOptions.put("use_queued_write_buffer", "false");
+    userOptions.put("queue_depth", "2");
+    userOptions.put("enable_stable_row_ids", "false");
+    userOptions.put("use_large_var_types", "false");
+    userOptions.put("max_batch_bytes", "16384");
+    userOptions.put("blob_pack_file_size_threshold", "32768");
+
     final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
     final LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder()
             .datasetUri(TEMP_URL)
-            .writeMode(WriteParams.WriteMode.APPEND)
-            .maxRowsPerFile(2000)
-            .maxRowsPerGroup(1000)
-            .maxBytesPerFile(2097152L)
-            .fileFormatVersion("2.0")
-            .batchSize(1024)
-            .useQueuedWriteBuffer(false)
-            .queueDepth(2)
-            .enableStableRowIds(false)
-            .useLargeVarTypes(false)
-            .maxBatchBytes(16384L)
-            .blobPackFileSizeThreshold(32768L)
+            .fromOptions(userOptions)
             .withCatalogDefaults(catalogConfig)
             .build();
 
@@ -221,36 +224,47 @@ public class LanceSparkWriteOptionsTest {
     assertFalse(writeOptions.isUseLargeVarTypes());
     assertEquals(16384L, writeOptions.getMaxBatchBytes());
     assertEquals(Long.valueOf(32768L), writeOptions.getBlobPackFileSizeThreshold());
+    // Typed fields and storage options stay consistent: user values win in both.
+    assertEquals("1024", writeOptions.getStorageOptions().get("batch_size"));
+    assertEquals("16384", writeOptions.getStorageOptions().get("max_batch_bytes"));
   }
 
   @Test
-  public void testFromOptionsOverrideCatalogDefaults() {
+  public void testCatalogDefaultsKeepTypedFieldsAndStorageOptionsConsistent() {
     final Map<String, String> catalogOptions = new HashMap<>();
     catalogOptions.put("batch_size", "512");
-    catalogOptions.put("use_queued_write_buffer", "true");
-    catalogOptions.put("queue_depth", "4");
-    catalogOptions.put("max_batch_bytes", "4096");
-    catalogOptions.put("blob_pack_file_size_threshold", "8192");
 
-    final Map<String, String> userOptions = new HashMap<>();
-    userOptions.put("batch_size", "1024");
-    userOptions.put("use_queued_write_buffer", "false");
-    userOptions.put("queue_depth", "2");
-    userOptions.put("max_batch_bytes", "16384");
-    userOptions.put("blob_pack_file_size_threshold", "32768");
+    final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
+    // Builder setters that pre-date withCatalogDefaults are re-derived from the merged
+    // option map (read-path semantics): the catalog value wins for keys it defines, and
+    // the typed field always agrees with the storage option (single source of truth).
+    final LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .batchSize(1024)
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    assertEquals(512, writeOptions.getBatchSize());
+    assertEquals("512", writeOptions.getStorageOptions().get("batch_size"));
+  }
+
+  @Test
+  public void testBuilderSettersSurviveCatalogDefaultsForAbsentKeys() {
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("queue_depth", "4");
 
     final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
     final LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder()
             .datasetUri(TEMP_URL)
-            .fromOptions(userOptions)
+            .batchSize(1024)
+            .enableStableRowIds(true)
             .withCatalogDefaults(catalogConfig)
             .build();
 
+    assertEquals(4, writeOptions.getQueueDepth());
     assertEquals(1024, writeOptions.getBatchSize());
-    assertFalse(writeOptions.isUseQueuedWriteBuffer());
-    assertEquals(2, writeOptions.getQueueDepth());
-    assertEquals(16384L, writeOptions.getMaxBatchBytes());
-    assertEquals(Long.valueOf(32768L), writeOptions.getBlobPackFileSizeThreshold());
+    assertTrue(writeOptions.getEnableStableRowIds());
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -150,4 +150,27 @@ public class LanceSparkWriteOptionsTest {
     assertTrue(writeOptions.getEnableStableRowIds());
     assertEquals(Long.valueOf(2147483648L), writeOptions.getBlobPackFileSizeThreshold());
   }
+
+  @Test
+  public void testWithCatalogDefaultsParsesWriteSettings() {
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("batch_size", "512");
+    catalogOptions.put("use_queued_write_buffer", "true");
+    catalogOptions.put("queue_depth", "4");
+    catalogOptions.put("max_batch_bytes", "4096");
+    catalogOptions.put("blob_pack_file_size_threshold", "8192");
+
+    final LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOptions);
+    final LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    assertEquals(512, writeOptions.getBatchSize());
+    assertTrue(writeOptions.isUseQueuedWriteBuffer());
+    assertEquals(4, writeOptions.getQueueDepth());
+    assertEquals(4096L, writeOptions.getMaxBatchBytes());
+    assertEquals(Long.valueOf(8192L), writeOptions.getBlobPackFileSizeThreshold());
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
@@ -13,10 +13,12 @@
  */
 package org.lance.spark;
 
+import org.lance.namespace.LanceNamespace;
 import org.lance.spark.read.LanceInputPartition;
 import org.lance.spark.read.LanceSplit;
 import org.lance.spark.utils.Optional;
 
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -24,6 +26,7 @@ import org.apache.spark.sql.types.StructType;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class TestUtils {
   public static class TestTable1Config {
@@ -104,5 +107,22 @@ public class TestUtils {
       return sb.append(datasetUri).append(".lance").toString();
     }
     return sb.append(datasetUri).toString();
+  }
+
+  /**
+   * A non-functional {@link LanceNamespace} stub for toBuilder identity and serialization tests:
+   * assigned to the transient {@code LanceSparkWriteOptions#namespace} field before serialization,
+   * it must be {@code null} after deserialization.
+   */
+  public static LanceNamespace stubNamespace() {
+    return new LanceNamespace() {
+      @Override
+      public void initialize(Map<String, String> properties, BufferAllocator allocator) {}
+
+      @Override
+      public String namespaceId() {
+        return "stub";
+      }
+    };
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -138,6 +138,8 @@ public class SparkWriteTest {
         LanceSparkWriteOptions.builder()
             .datasetUri(datasetUri)
             .writeMode(WriteParams.WriteMode.APPEND)
+            .maxBatchBytes(4096L)
+            .blobPackFileSizeThreshold(8192L)
             .useLargeVarTypes(true)
             .build();
     SparkWrite.SparkWriteBuilder builder =
@@ -156,6 +158,14 @@ public class SparkWriteTest {
     assertTrue(
         sparkWrite.getWriteOptions().isUseLargeVarTypes(),
         "useLargeVarTypes should be preserved after truncate()");
+    assertEquals(
+        4096L,
+        sparkWrite.getWriteOptions().getMaxBatchBytes(),
+        "maxBatchBytes should be preserved after truncate()");
+    assertEquals(
+        Long.valueOf(8192L),
+        sparkWrite.getWriteOptions().getBlobPackFileSizeThreshold(),
+        "blobPackFileSizeThreshold should be preserved after truncate()");
   }
 
   // --- requiredDistribution / requiredOrdering tests ---

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -132,15 +134,28 @@ public class SparkWriteTest {
   }
 
   @Test
-  public void testTruncatePreservesUseLargeVarTypes(TestInfo testInfo) {
+  public void testTruncatePreservesWriteOptionsAndOverwritesMode(TestInfo testInfo) {
     String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
+    Map<String, String> storageOptions = new HashMap<>();
+    storageOptions.put("region", "us-west-2");
     LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder()
             .datasetUri(datasetUri)
             .writeMode(WriteParams.WriteMode.APPEND)
+            .maxRowsPerFile(1000)
+            .maxRowsPerGroup(500)
+            .maxBytesPerFile(1048576L)
+            .fileFormatVersion("2.0")
+            .useQueuedWriteBuffer(true)
+            .queueDepth(3)
+            .batchSize(256)
+            .enableStableRowIds(true)
+            .useLargeVarTypes(true)
             .maxBatchBytes(4096L)
             .blobPackFileSizeThreshold(8192L)
-            .useLargeVarTypes(true)
+            .storageOptions(storageOptions)
+            .tableId(Arrays.asList("default", "test_table"))
+            .version(7L)
             .build();
     SparkWrite.SparkWriteBuilder builder =
         new SparkWrite.SparkWriteBuilder(
@@ -155,17 +170,32 @@ public class SparkWriteTest {
             Collections.emptyMap());
     builder.truncate();
     SparkWrite sparkWrite = (SparkWrite) builder.build();
+    LanceSparkWriteOptions truncatedOptions = sparkWrite.getWriteOptions();
+
+    assertEquals(WriteParams.WriteMode.OVERWRITE, truncatedOptions.getWriteMode());
+    assertEquals(datasetUri, truncatedOptions.getDatasetUri());
+    assertEquals(1000, truncatedOptions.getMaxRowsPerFile());
+    assertEquals(500, truncatedOptions.getMaxRowsPerGroup());
+    assertEquals(1048576L, truncatedOptions.getMaxBytesPerFile());
+    assertEquals("2.0", truncatedOptions.getFileFormatVersion());
+    assertTrue(truncatedOptions.isUseQueuedWriteBuffer());
+    assertEquals(3, truncatedOptions.getQueueDepth());
+    assertEquals(256, truncatedOptions.getBatchSize());
+    assertTrue(truncatedOptions.getEnableStableRowIds());
     assertTrue(
-        sparkWrite.getWriteOptions().isUseLargeVarTypes(),
+        truncatedOptions.isUseLargeVarTypes(),
         "useLargeVarTypes should be preserved after truncate()");
     assertEquals(
         4096L,
-        sparkWrite.getWriteOptions().getMaxBatchBytes(),
+        truncatedOptions.getMaxBatchBytes(),
         "maxBatchBytes should be preserved after truncate()");
     assertEquals(
         Long.valueOf(8192L),
-        sparkWrite.getWriteOptions().getBlobPackFileSizeThreshold(),
+        truncatedOptions.getBlobPackFileSizeThreshold(),
         "blobPackFileSizeThreshold should be preserved after truncate()");
+    assertEquals(storageOptions, truncatedOptions.getStorageOptions());
+    assertEquals(Arrays.asList("default", "test_table"), truncatedOptions.getTableId());
+    assertEquals(7L, truncatedOptions.getVersion());
   }
 
   // --- requiredDistribution / requiredOrdering tests ---

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SparkWriteTest.java
@@ -16,6 +16,7 @@ package org.lance.spark.write;
 import org.lance.Dataset;
 import org.lance.WriteParams;
 import org.lance.memwal.InitializeMemWalParams;
+import org.lance.namespace.LanceNamespace;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.TestUtils;
 
@@ -138,6 +139,7 @@ public class SparkWriteTest {
     String datasetUri = createDataset(testInfo.getTestMethod().get().getName());
     Map<String, String> storageOptions = new HashMap<>();
     storageOptions.put("region", "us-west-2");
+    LanceNamespace stubNamespace = TestUtils.stubNamespace();
     LanceSparkWriteOptions writeOptions =
         LanceSparkWriteOptions.builder()
             .datasetUri(datasetUri)
@@ -154,6 +156,7 @@ public class SparkWriteTest {
             .maxBatchBytes(4096L)
             .blobPackFileSizeThreshold(8192L)
             .storageOptions(storageOptions)
+            .namespace(stubNamespace)
             .tableId(Arrays.asList("default", "test_table"))
             .version(7L)
             .build();
@@ -194,6 +197,7 @@ public class SparkWriteTest {
         truncatedOptions.getBlobPackFileSizeThreshold(),
         "blobPackFileSizeThreshold should be preserved after truncate()");
     assertEquals(storageOptions, truncatedOptions.getStorageOptions());
+    assertSame(stubNamespace, truncatedOptions.getNamespace());
     assertEquals(Arrays.asList("default", "test_table"), truncatedOptions.getTableId());
     assertEquals(7L, truncatedOptions.getVersion());
   }


### PR DESCRIPTION
## Summary

Two write-option paths were lossy:

- `SparkWriteBuilder.truncate()` rebuilt `LanceSparkWriteOptions` by hand, so newer fields such as `max_batch_bytes`, `blob_pack_file_size_threshold`, and `version` were dropped on overwrite. The overwrite path now uses `writeOptions.toBuilder().writeMode(OVERWRITE)`, which carries every field.
- `LanceSparkWriteOptions.Builder.withCatalogDefaults()` merged catalog storage options but did not promote catalog-level write defaults into the typed fields used by the writer. It now re-parses the merged map through `fromOptions` (mirroring `LanceSparkReadOptions.Builder.withCatalogDefaults`), so typed fields and the storage-options map stay consistent.

Precedence after the re-parse (same semantics as the read path):

- Options supplied via `fromOptions` / per-write `.option(...)` override catalog defaults.
- Typed Builder setters called before `withCatalogDefaults` are re-derived from the merged map, so a catalog default wins for keys it defines; setters for keys absent from the catalog survive.

## Tests

- `LanceSparkWriteOptionsTest`: catalog-default promotion into typed fields, fromOptions-over-catalog precedence (typed fields and storage options asserted consistent), catalog-over-prior-setter semantics, setter survival for catalog-absent keys, no mutation of caller option maps, and a Java-serialization round-trip of the rebuilt overwrite options (including the transient `namespace` invariant via a non-serializable stub).
- `SparkWriteTest#testTruncatePreservesWriteOptionsAndOverwritesMode`: every write-option field (including `namespace`, `tableId`, `version`) survives `truncate()`.
- `./mvnw -pl <module> -Dtest=LanceSparkWriteOptionsTest,SparkWriteTest test` for `lance-spark-3.4_2.12`, `lance-spark-3.5_2.13`, `lance-spark-4.0_2.13`, `lance-spark-4.1_2.13`
- `./mvnw -pl lance-spark-3.5_2.13 test` (818 tests, 0 failures)
- `make lint` and `git diff --check`
