### PR TITLE
chore: update lance dependency to v8.0.0-beta.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.0-beta.1</lance-spark.version>
-        <lance.version>7.0.0-rc.1</lance.version>
+        <lance.version>8.0.0-beta.7</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump `lance.version` from `7.0.0-rc.1` to `8.0.0-beta.7`.
- Checked Docker image version pins against Maven properties:
  - `LANCE_SPARK_VERSION=0.5.0-beta.1` matches `lance-spark.version`.
  - `LANCE_NS_IMPL_VERSION=0.3.0` matches `lance-namespace-impl.version`.
- Triggered by tag `refs/tags/v8.0.0-beta.7`.

## Verification
- `make lint` passed.
- `make install` was run, but Maven could not resolve `org.lance:lance-core:8.0.0-beta.7` from Maven Central. Maven Central metadata currently lists `8.0.0-beta.6` as the newest published `lance-core` version, and the direct `8.0.0-beta.7` artifact URL returns 404.
