### PR TITLE
fix: define blob v2 descriptor scan contract

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -103,21 +103,20 @@ public class LanceFragmentScanner implements AutoCloseable {
       }
       ScanOptions.Builder scanOptions = new ScanOptions.Builder();
 
-      // Detect blob columns in the schema
-      Set<String> blobColumnNames = getBlobColumnNames(inputPartition.getSchema());
+      StructType scanSchema = inputPartition.getSchema();
+      Set<String> blobColumnNames = getBlobColumnNames(scanSchema);
       boolean hasBlobColumns = !blobColumnNames.isEmpty();
 
-      List<String> projectedColumns = getColumnNames(inputPartition.getSchema());
-      if (projectedColumns.isEmpty() && inputPartition.getSchema().isEmpty()) {
+      List<String> projectedColumns = getColumnNames(scanSchema);
+      if (projectedColumns.isEmpty() && scanSchema.isEmpty()) {
         scanOptions.withRowId(true);
       }
-      if (hasField(inputPartition.getSchema(), LanceConstant.ROW_ID)) {
+      if (hasField(scanSchema, LanceConstant.ROW_ID)) {
         scanOptions.withRowId(true);
       }
 
       // Request _rowaddr when blob columns are present so we can build blob references.
-      boolean userRequestedRowAddr =
-          hasField(inputPartition.getSchema(), LanceConstant.ROW_ADDRESS);
+      boolean userRequestedRowAddr = hasField(scanSchema, LanceConstant.ROW_ADDRESS);
       boolean withRowAddrForBlobs = hasBlobColumns && !userRequestedRowAddr;
       if (hasBlobColumns || userRequestedRowAddr) {
         scanOptions.withRowAddress(true);
@@ -137,8 +136,7 @@ public class LanceFragmentScanner implements AutoCloseable {
       if (inputPartition.getTopNSortOrders().isPresent()) {
         scanOptions.setColumnOrderings(inputPartition.getTopNSortOrders().get());
       }
-      boolean withFragmentId =
-          inputPartition.getSchema().getFieldIndex(LanceConstant.FRAGMENT_ID).nonEmpty();
+      boolean withFragmentId = scanSchema.getFieldIndex(LanceConstant.FRAGMENT_ID).nonEmpty();
       long scanCreateStart = System.nanoTime();
       lanceScanner = fragment.newScan(scanOptions.build());
       long scanCreateTimeNs = System.nanoTime() - scanCreateStart;
@@ -251,7 +249,7 @@ public class LanceFragmentScanner implements AutoCloseable {
   private static Set<String> getBlobColumnNames(StructType schema) {
     Set<String> blobColumns = new HashSet<>();
     for (StructField field : schema.fields()) {
-      if (BlobUtils.isBlobSparkField(field)) {
+      if (BlobUtils.isBlobReadColumn(field)) {
         blobColumns.add(field.name());
       }
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -29,6 +29,7 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FilterPushDown {
@@ -54,25 +55,18 @@ public class FilterPushDown {
     return Optional.of(whereClause);
   }
 
-  /**
-   * @param predicates predicates to check for Lance push-down support
-   * @return accepted push-down predicates (row 0) and rejected post-scan predicates (row 1)
-   */
-  public static Predicate[][] processPredicates(Predicate[] predicates) {
-    List<Predicate> accepted = new ArrayList<>();
-    List<Predicate> rejected = new ArrayList<>();
-
-    for (Predicate predicate : predicates) {
-      if (isPredicateSupported(predicate)) {
-        accepted.add(predicate);
-      } else {
-        rejected.add(predicate);
+  /** Returns true if {@code predicate} references any of the given top-level columns. */
+  public static boolean referencesAny(Predicate predicate, Set<String> columns) {
+    if (columns.isEmpty()) {
+      return false;
+    }
+    for (NamedReference ref : predicate.references()) {
+      String[] names = ref.fieldNames();
+      if (names.length > 0 && columns.contains(names[0])) {
+        return true;
       }
     }
-
-    return new Predicate[][] {
-      accepted.toArray(new Predicate[0]), rejected.toArray(new Predicate[0])
-    };
+    return false;
   }
 
   public static boolean isPredicateSupported(Predicate predicate) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -77,9 +77,16 @@ public class LanceScanBuilder
   /** Full table schema before column pruning; used to widen nested structs for vectorized reads. */
   private final StructType fullSchema;
 
+  /** Blob v2 column names in the read schema. Filters on these cannot push to Lance. */
+  private final Set<String> blobV2Columns;
+
   private StructType schema;
 
   private Predicate[] pushedPredicates = new Predicate[0];
+
+  // Set when pushPredicates leaves filters for Spark. pushLimit and friends read this after
+  // pushPredicates because Spark pushes filters before those operators.
+  private boolean hasResidualPredicates = false;
   private Optional<Integer> limit = Optional.empty();
   private Optional<Integer> offset = Optional.empty();
   private Optional<List<ColumnOrdering>> topNSortOrders = Optional.empty();
@@ -119,6 +126,7 @@ public class LanceScanBuilder
       java.util.Map<String, String> namespaceProperties,
       ShardingSpec shardingSpec) {
     this.fullSchema = BlobUtils.applyBlobV2DescriptorSchema(schema);
+    this.blobV2Columns = BlobUtils.blobV2ColumnNames(this.fullSchema);
     this.schema = this.fullSchema;
     this.readOptions = readOptions;
     this.initialStorageOptions = initialStorageOptions;
@@ -280,12 +288,30 @@ public class LanceScanBuilder
 
   @Override
   public Predicate[] pushPredicates(Predicate[] predicates) {
+    Predicate[] pushed;
+    Predicate[] residual;
     if (!readOptions.isPushDownFilters()) {
-      return predicates;
+      pushed = new Predicate[0];
+      residual = predicates;
+    } else {
+      List<Predicate> pushedList = new ArrayList<>();
+      List<Predicate> residualList = new ArrayList<>();
+      // Push supported predicates unless they touch a blob v2 column. Those read back as descriptor
+      // structs, so Lance cannot evaluate filters on them. Normal-column filters still prune.
+      for (Predicate predicate : predicates) {
+        if (FilterPushDown.isPredicateSupported(predicate)
+            && !FilterPushDown.referencesAny(predicate, blobV2Columns)) {
+          pushedList.add(predicate);
+        } else {
+          residualList.add(predicate);
+        }
+      }
+      pushed = pushedList.toArray(new Predicate[0]);
+      residual = residualList.toArray(new Predicate[0]);
     }
-    Predicate[][] processed = FilterPushDown.processPredicates(predicates);
-    pushedPredicates = processed[0];
-    return processed[1];
+    this.pushedPredicates = pushed;
+    this.hasResidualPredicates = residual.length > 0;
+    return residual;
   }
 
   @Override
@@ -295,12 +321,18 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushLimit(int limit) {
+    if (hasResidualPredicates) {
+      return false;
+    }
     this.limit = Optional.of(limit);
     return true;
   }
 
   @Override
   public boolean pushOffset(int offset) {
+    if (hasResidualPredicates) {
+      return false;
+    }
     // Only one data file can be pushed down the offset.
     List<Integer> fragmentIds =
         getOrOpenDataset().getFragments().stream()
@@ -323,7 +355,7 @@ public class LanceScanBuilder
   public boolean pushTopN(SortOrder[] orders, int limit) {
     // The Order by operator will use compute thread in lance.
     // So it's better to have an option to enable it.
-    if (!readOptions.isTopNPushDown()) {
+    if (!readOptions.isTopNPushDown() || hasResidualPredicates) {
       return false;
     }
     this.limit = Optional.of(limit);
@@ -345,6 +377,9 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushAggregation(Aggregation aggregation) {
+    if (hasResidualPredicates) {
+      return false;
+    }
     AggregateFunc[] funcs = aggregation.aggregateExpressions();
     if (aggregation.groupByExpressions().length > 0) {
       return false;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
@@ -18,6 +18,9 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class BlobUtils {
 
   public static final String LANCE_ENCODING_BLOB_KEY = "lance-encoding:blob";
@@ -99,15 +102,28 @@ public class BlobUtils {
         && ARROW_EXTENSION_BLOB_V2.equals(metadata.getString(ARROW_EXTENSION_NAME_KEY));
   }
 
-  /** Returns true if any field in {@code schema} is a blob v2 column. */
-  public static boolean hasBlobV2Fields(StructType schema) {
+  /** Names of the blob v2 columns in {@code schema}, identified by the lance.blob.v2 extension. */
+  public static Set<String> blobV2ColumnNames(StructType schema) {
+    Set<String> names = new HashSet<>();
     for (StructField field : schema.fields()) {
       if (isBlobV2SparkField(field)) {
-        return true;
+        names.add(field.name());
       }
     }
+    return names;
+  }
 
-    return false;
+  /** Returns true if any field in {@code schema} is a blob v2 column. */
+  public static boolean hasBlobV2Fields(StructType schema) {
+    return !blobV2ColumnNames(schema).isEmpty();
+  }
+
+  /**
+   * Returns true for blob columns in the Spark read schema, v1 or v2. Drives {@code _rowaddr} and
+   * the unloaded-blob read path in the scan.
+   */
+  public static boolean isBlobReadColumn(StructField field) {
+    return isBlobSparkField(field) || isBlobV2SparkField(field);
   }
 
   /** Rewrites blob v2 columns to the descriptor struct returned by Lance. */

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
@@ -17,10 +17,12 @@ import org.lance.namespace.LanceNamespace;
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.read.LanceInputPartition;
+import org.lance.spark.utils.BlobUtils;
 import org.lance.spark.utils.Optional;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
@@ -256,6 +258,31 @@ public class LanceFragmentScannerTest {
         0,
         RecordingNamespace.INITIALIZE_CALLS.get(),
         "executor_credential_refresh=false must not load or initialize the namespace impl");
+  }
+
+  @Test
+  public void getBlobColumnNamesIncludesBlobV2ReadColumns() throws Exception {
+    Method method =
+        LanceFragmentScanner.class.getDeclaredMethod("getBlobColumnNames", StructType.class);
+    method.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    java.util.Set<String> names =
+        (java.util.Set<String>)
+            method.invoke(
+                null,
+                new StructType(
+                    new StructField[] {
+                      new StructField(
+                          "payload",
+                          BlobUtils.BLOB_DESCRIPTOR_STRUCT,
+                          true,
+                          new MetadataBuilder()
+                              .putString(
+                                  BlobUtils.ARROW_EXTENSION_NAME_KEY,
+                                  BlobUtils.ARROW_EXTENSION_BLOB_V2)
+                              .build())
+                    }));
+    assertEquals(java.util.Collections.singleton("payload"), names);
   }
 
   /**

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -244,10 +245,13 @@ public class FilterPushDownTest {
     assertFalse(FilterPushDown.isPredicateSupported(timeGt));
 
     Predicate intGt = TestPredicates.gt("age", 30);
-    Predicate[][] processed = FilterPushDown.processPredicates(new Predicate[] {timeGt, intGt});
-    assertEquals(1, processed[0].length);
-    assertEquals(1, processed[1].length);
-    assertEquals(intGt, processed[0][0]);
-    assertEquals(timeGt, processed[1][0]);
+    assertTrue(FilterPushDown.isPredicateSupported(intGt));
+  }
+
+  @Test
+  public void testReferencesAnyMatchesTopLevelColumn() {
+    Predicate onPayload = TestPredicates.gt("payload", 1L);
+    assertTrue(FilterPushDown.referencesAny(onPayload, Collections.singleton("payload")));
+    assertFalse(FilterPushDown.referencesAny(onPayload, Collections.singleton("id")));
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
@@ -15,6 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
+import org.lance.spark.utils.BlobUtils;
 
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.FieldReference;
@@ -29,6 +30,8 @@ import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
@@ -122,6 +125,46 @@ public class LanceScanBuilderTest {
   }
 
   @Test
+  public void testBlobV2FilterStaysResidualWhileOtherColumnsPushDown() {
+    Metadata blobV2Metadata =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.LongType, true),
+              new StructField("payload", DataTypes.BinaryType, true, blobV2Metadata)
+            });
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            schema,
+            TestUtils.TestTable1Config.readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap());
+
+    Predicate onId = TestPredicates.gt("id", 1L);
+    Predicate onBlob = TestPredicates.gt("payload", 1L);
+    Predicate[] postScan = builder.pushPredicates(new Predicate[] {onId, onBlob});
+
+    // Blob v2 filters stay in Spark. Normal-column filters still push to Lance.
+    assertArrayEquals(new Predicate[] {onBlob}, postScan);
+    assertArrayEquals(new Predicate[] {onId}, builder.pushedPredicates());
+    assertFalse(builder.pushLimit(10));
+  }
+
+  @Test
+  public void testResidualPredicateBlocksLimitPushdownWithoutBlobColumn() {
+    LanceScanBuilder builder = createBuilder();
+    // Unsupported CONTAINS stays in Spark even on a table with no blob columns.
+    Predicate[] postScan =
+        builder.pushPredicates(new Predicate[] {TestPredicates.contains("b", "x")});
+    assertEquals(1, postScan.length);
+    assertFalse(builder.pushLimit(10));
+  }
+
+  @Test
   public void testPushPredicatesWithNestedArrayOfStruct() {
     // Filters on non-Array<Struct> columns should be pushed down normally.
     StructType nestedSchema =
@@ -154,7 +197,7 @@ public class LanceScanBuilderTest {
   // --- pushLimit ---
 
   @Test
-  public void testPushLimitAlwaysSucceeds() {
+  public void testPushLimitWhenNoResidualPredicates() {
     LanceScanBuilder builder = createBuilder();
     assertTrue(builder.pushLimit(100));
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -20,6 +20,8 @@ import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,6 +51,33 @@ public class BlobUtilsTest {
               field("id", DataTypes.IntegerType), blobV2Field(),
             });
     assertTrue(BlobUtils.hasBlobV2Fields(schema));
+  }
+
+  @Test
+  public void testBlobV2ColumnNamesExcludesNonBlobAndV1() {
+    Metadata v1 =
+        new MetadataBuilder()
+            .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
+            .build();
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              field("id", DataTypes.IntegerType),
+              new StructField("attachment", DataTypes.BinaryType, true, v1),
+              blobV2Field(),
+            });
+    assertEquals(Collections.singleton("payload"), BlobUtils.blobV2ColumnNames(schema));
+  }
+
+  @Test
+  public void testIsBlobReadColumnCoversV1AndV2() {
+    Metadata v1 =
+        new MetadataBuilder()
+            .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
+            .build();
+    assertTrue(BlobUtils.isBlobReadColumn(new StructField("v1", DataTypes.BinaryType, true, v1)));
+    assertTrue(BlobUtils.isBlobReadColumn(blobV2Field()));
+    assertFalse(BlobUtils.isBlobReadColumn(field("id", DataTypes.IntegerType)));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Follow-up to #539. 

Wires blob v2 into the read scan path and fixes pushdown so we don't get wrong results.

- Rewrite blob v2 columns to descriptor structs in the scan schema (what lance-core already returns)
- Filters that reference a blob v2 column stay in Spark. Spark reads those columns as descriptor structs, and we don't have a safe way to translate those filters into Lance SQL yet.
- Route v2 blobs through the same read path as v1 `_rowaddr`, blob refs via `isBlobReadColumn`

No ScanOptions hook (yet lol). lance-core returns descriptor structs by default and we rely on that.

## Test plan

- `./mvnw test -pl lance-spark-3.5_2.13 -am -Dtest='LanceScanBuilderTest,FilterPushDownTest,BlobUtilsTest,LanceFragmentScannerTest'`
- Non-blob filters still push on tables with blob columns
- Limit still pushes when no residuals
- Blob v2 filter stays in Spark, limit blocked when it does