### PR TITLE
test: drop blob v2 tables in cleanup_tables fixture

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -444,6 +444,8 @@ def cleanup_tables(spark):
     spark.sql("DROP TABLE IF EXISTS default.test_table_renamed PURGE")
     spark.sql("DROP TABLE IF EXISTS default.test_table_new PURGE")
     spark.sql("DROP TABLE IF EXISTS default.employees PURGE")
+    spark.sql("DROP TABLE IF EXISTS default.test_blob_v2 PURGE")
+    spark.sql("DROP TABLE IF EXISTS default.test_blob_v2_bad_insert PURGE")
     # TODO - reenable once `tableExists` works on Spark 4.0
     #spark.catalog.dropTempView("source") if spark.catalog.tableExists("source") else None
     #spark.catalog.dropTempView("tmp_view") if spark.catalog.tableExists("tmp_view") else None
@@ -454,6 +456,8 @@ def cleanup_tables(spark):
     spark.sql("DROP TABLE IF EXISTS default.test_table_renamed PURGE")
     spark.sql("DROP TABLE IF EXISTS default.test_table_new PURGE")
     spark.sql("DROP TABLE IF EXISTS default.employees PURGE")
+    spark.sql("DROP TABLE IF EXISTS default.test_blob_v2 PURGE")
+    spark.sql("DROP TABLE IF EXISTS default.test_blob_v2_bad_insert PURGE")
     # TODO - reenable once `tableExists` works on Spark 4.0
     #spark.catalog.dropTempView("source") if spark.catalog.tableExists("source") else None
     #spark.catalog.dropTempView("tmp_view") if spark.catalog.tableExists("tmp_view") else None


### PR DESCRIPTION
The cleanup_tables fixture in `integration-tests/conftest.py` drops a fixed set of tables before and after each test. It did not include `test_blob_v2` or `test_blob_v2_bad_insert`.

On local, MinIO, and Azurite that was fine: storage is empty each session. Glue keeps the catalog across runs. If a blob v2 test created its table and teardown never ran, the table stayed in the shared default database and the next run failed on `CREATE TABLE` with `TABLE_OR_VIEW_ALREADY_EXISTS`.

We added both tables to the drop list. The pre-test drop clears leftovers from earlier runs, so no manual Glue cleanup is needed.