### PR TITLE
ci: bump test-workflow actions to Node 24

### DIFF
--- a/.github/workflows/spark-aws.yml
+++ b/.github/workflows/spark-aws.yml
@@ -61,11 +61,11 @@ jobs:
       TEST_BACKENDS: glue
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -75,9 +75,9 @@ jobs:
         run: |
           make print-docker-build-args SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION} >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build test-base image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker
           file: docker/Dockerfile.test-base

--- a/.github/workflows/spark-search.yml
+++ b/.github/workflows/spark-search.yml
@@ -79,11 +79,11 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -93,9 +93,9 @@ jobs:
         run: |
           make print-docker-build-args SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION} >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build test-base image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker
           file: docker/Dockerfile.test-base

--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -99,9 +99,9 @@ jobs:
           - spark-version: "4.1"
             scala-version: "2.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -132,9 +132,9 @@ jobs:
           - spark-version: "4.1"
             scala-version: "2.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -144,9 +144,9 @@ jobs:
         run: |
           make print-docker-build-args SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }} >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Build test-base image (cached)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: docker
           file: docker/Dockerfile.test-base


### PR DESCRIPTION
Before this PR checkout@v4, setup-java@v4, setup-buildx-action@v3 and build-push-action@v6 run on the deprecated Node 20 runtime. Bump to the current majors, all of which run on Node 24, across the Spark, Spark Search and Spark AWS workflows.

Proof run:

https://github.com/lance-format/lance-spark/actions/runs/27167649332

<img width="1097" height="604" alt="image" src="https://github.com/user-attachments/assets/4eb0459e-59d2-4ae2-8d2b-d1dc7727869d" />
