### PR TITLE
ci: do not cancel main/release Glue runs mid-flight

### DIFF
--- a/.github/workflows/spark-aws.yml
+++ b/.github/workflows/spark-aws.yml
@@ -35,7 +35,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache


### PR DESCRIPTION
Our aws action was set to cancel-in-progress was unconditionally true, so a new push to main could cancel an in-flight Glue run after it had created tables in the shared catalog but before the cleanup step ran, orphaning state that breaks later runs. Only cancel in-progress runs for pull_request events, matching the Spark workflow.

### Testing
- Workflow YAML runs as its a one line change to the `concurrency` block.