### PR TITLE
ci: add Dependabot for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# github-actions only: Maven and the lance dependency are maintained by the
+# auto-bump and codex-update-lance-dependency workflows.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # "ci" prefix so Dependabot PR titles pass the pr-title.yml commitlint check.
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
This PR Adds `.github/dependabot.yml` so GitHub Actions runtime deprecations to avoid issues like #596 and show up as routine weekly PRs and will avoid errors.

I also scoped to the `github-actions` ecosystem only. Maven and the lance dependency stay with the existing `auto-bump` and `codex-update-lance-dependency` workflows, so Dependabot does not collide with them. Lastly, uses a `ci` commit prefix so the generated PR titles pass `pr-title.yml`'s conventional-commit check.