### PR TITLE
ci: improve Docker test-image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ docker-build-test-base:
 docker-build-test:
 	@ls $(BUNDLE_MODULE)/target/$(BUNDLE_MODULE)-*.jar >/dev/null 2>&1 || \
 		(echo "Error: Bundle jar not found. Run 'make bundle' first." && exit 1)
-	docker build --no-cache \
+	docker build \
 		--build-arg SPARK_MAJOR_VERSION=$(SPARK_VERSION) \
 		--build-arg SCALA_VERSION=$(SCALA_VERSION) \
 		--build-arg LANCE_NAMESPACE_IMPL_VERSION=$(LANCE_NAMESPACE_IMPL_VERSION) \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1
 FROM ubuntu:24.04
 
 RUN apt-get update && \

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-#
 # Test image for running lance-spark integration tests.
 # Builds on top of the test-base image (from make docker-build-test-base)
 # to produce the same result as the minimal image.
@@ -14,10 +12,7 @@ ARG SPARK_MAJOR_VERSION=4.0
 ARG SCALA_VERSION=2.13
 ARG LANCE_NAMESPACE_IMPL_VERSION=0.3.0
 
-# --- Uncached layers: bundle JAR ---
-
-# Add a random query as a cache buster
-ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
+# --- Bundle JAR (layer cache invalidates when the jar content changes) ---
 
 COPY lance-spark-bundle-${SPARK_MAJOR_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-${SPARK_MAJOR_VERSION}_${SCALA_VERSION}-*.jar ${SPARK_HOME}/jars/
 RUN curl -fL \

--- a/docker/Dockerfile.test-base
+++ b/docker/Dockerfile.test-base
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 FROM ubuntu:24.04
 
 RUN apt-get update && \


### PR DESCRIPTION
The Glue/S3 job failed before running any test when Docker Hub returned a 504 resolving the frontend image. This PR removes some of the logic causing the failures:

1.  The header `# syntax=docker/dockerfile:1` across a few files that was forcing the buildkit to fetch frontend images from docker on every build. 
2. `docker-build-test` ran build without cache and the we are busting a cache in the image so it shouldnt be needed. Especailly with the copy operation since it's invalidating on operation.


### Testing

Run the tests here, and we have only removals