### PR TITLE
ci: skip Glue/S3 job on Dependabot PRs

### DIFF
--- a/.github/workflows/spark-aws.yml
+++ b/.github/workflows/spark-aws.yml
@@ -50,8 +50,9 @@ env:
 jobs:
   glue-s3-integration-test:
     if: >
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     name: Glue/S3 Docker Test Spark 4.1 / Scala 2.13
     runs-on: ubuntu-24.04
     timeout-minutes: 60


### PR DESCRIPTION
Dependabot branches live in the base repo, so they pass the fork guard and the Glue/S3 job runs instead of skipping. But Dependabot-triggered runs don't receive the repository's Actions secrets, and adding secrets to the updates doesn't really buy us anything for the actions so I'll exclude by default for now. 