### PR TITLE
fix: keep table-level options out of storage options

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
@@ -82,7 +82,9 @@ public class LanceSparkCatalogConfig {
       if (fullKey.startsWith(STORAGE_PREFIX)) {
         String nativeKey = fullKey.substring(STORAGE_PREFIX.length());
         nativeOptions.put(nativeKey, value);
-      } else {
+      } else if (!TABLE_OPT_ENABLE_STABLE_ROW_IDS.equals(fullKey)
+          && !TABLE_OPT_FILE_FORMAT_VERSION.equals(fullKey)) {
+        // Keep table options out of storageOptions, as writes merge those in.
         nativeOptions.put(fullKey, value);
       }
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
@@ -44,6 +44,21 @@ public class LanceSparkCatalogConfigTest {
   }
 
   @Test
+  public void testFromKeepsTableOptionsOutOfStorageOptions() {
+    Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("file_format_version", "2.0");
+    catalogOptions.put("enable_stable_row_ids", "true");
+    catalogOptions.put("storage.region", "us-west-2");
+
+    LanceSparkCatalogConfig config = LanceSparkCatalogConfig.from(catalogOptions);
+
+    assertFalse(config.getStorageOptions().containsKey("file_format_version"));
+    assertFalse(config.getStorageOptions().containsKey("enable_stable_row_ids"));
+    assertEquals("2.0", config.getFileFormatVersion());
+    assertTrue(config.isEnableStableRowIds());
+  }
+
+  @Test
   public void testFromIgnoresNullKeysOrValues() {
     Map<String, String> catalogOptions = new HashMap<>();
     catalogOptions.put("storage.region", "us-west-2");


### PR DESCRIPTION
Catalog config was putting `file_format_version` and `enable_stable_row_ids` into storage options along with S3 credentials and the like. Storage options get merged into every write. A catalog default like `file_format_version=2.0` would then shadow the version the table was actually created at, so you could append 2.0 fragments into a dataset that started at 2.2.

Those keys stay in `tableOptions` now, and Storage options are for storage.

### TESTING

Added a new test to make sure they don't leak