### PR TITLE
fix: close dataset when add-index job fails

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -183,9 +183,10 @@ case class AddIndexExec(
     val dataset = Utils.openDatasetBuilder(readOptions).build()
 
     // The finally closes the dataset on every exit path, including a failure of the
-    // index-build job or the commit below. Partial per-fragment metadata that workers
-    // already wrote under this uuid stays uncommitted: unreferenced by the manifest, so
-    // invisible to readers and reclaimable by VACUUM with delete_unverified = true.
+    // index-build job or the commit below. If the build or commit fails, partial index files
+    // written under this uuid (per-fragment partials and any merged root) stay uncommitted:
+    // unreferenced by the manifest, so invisible to readers, and eventually reclaimable by
+    // VACUUM with delete_unverified = true.
     try {
       val indexBuildResult =
         new FragmentBasedIndexJob(

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -182,11 +182,10 @@ case class AddIndexExec(
     val uuid = UUID.randomUUID()
     val dataset = Utils.openDatasetBuilder(readOptions).build()
 
-    // The finally closes the dataset on every exit path, including a failure of the
-    // index-build job or the commit below. If the build or commit fails, partial index files
-    // written under this uuid (per-fragment partials and any merged root) stay uncommitted:
-    // unreferenced by the manifest, so invisible to readers, and eventually reclaimable by
-    // VACUUM with delete_unverified = true.
+    // The finally closes the dataset on every exit path. If the index-build job or the commit
+    // below fails, partial index files written under this uuid (per-fragment partials and any
+    // merged root) stay uncommitted: unreferenced by the manifest, so invisible to readers, and
+    // eventually reclaimable by VACUUM with delete_unverified = true.
     try {
       val indexBuildResult =
         new FragmentBasedIndexJob(

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -182,18 +182,22 @@ case class AddIndexExec(
     val uuid = UUID.randomUUID()
     val dataset = Utils.openDatasetBuilder(readOptions).build()
 
-    val indexBuildResult =
-      new FragmentBasedIndexJob(
-        this.copy(columns = canonicalColumns),
-        readOptions,
-        uuid.toString,
-        fragmentIds,
-        nsImpl,
-        nsProps,
-        tableId,
-        initialStorageOpts).run()
-
+    // The finally closes the dataset on every exit path, including a failure of the
+    // index-build job or the commit below. Partial per-fragment metadata that workers
+    // already wrote under this uuid stays uncommitted: unreferenced by the manifest, so
+    // invisible to readers and reclaimable by VACUUM with delete_unverified = true.
     try {
+      val indexBuildResult =
+        new FragmentBasedIndexJob(
+          this.copy(columns = canonicalColumns),
+          readOptions,
+          uuid.toString,
+          fragmentIds,
+          nsImpl,
+          nsProps,
+          tableId,
+          initialStorageOpts).run()
+
       // Merge index metadata after all fragments are indexed
       dataset.mergeIndexMetadata(uuid.toString, indexType, Optional.empty())
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -710,8 +710,8 @@ public abstract class BaseAddIndexTest {
     Dataset<Row> all = spark.sql(String.format("select * from %s", fullTable));
     Assertions.assertEquals(20, all.collectAsList().size());
 
-    // Nothing was committed to the manifest: at this point the table should have no index at
-    // all (stronger than checking for the failed name, and robust to unnamed segment entries).
+    // Nothing was committed to the manifest: the table should have no index at all. (A check
+    // for the failed name alone would miss unnamed segment entries.)
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
     try {
       Assertions.assertTrue(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -674,6 +674,52 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateIndexFailureLeavesTableUsable() {
+    prepareDataset();
+
+    // An FTS index on a non-text column (id is int) resolves the column fine but fails inside
+    // AddIndexExec.run()'s FTS path, after the driver-side dataset is opened — the path the
+    // close-on-failure fix guards. We assert the publicly observable contract: the failed index
+    // is not committed, the table stays queryable, and a later valid CREATE INDEX succeeds. (On
+    // POSIX a leaked read handle would not surface, so this guards reusability/cleanliness, not
+    // handle-closure directly.)
+    Exception failure =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql(
+                        String.format(
+                            "alter table %s create index bad_idx using fts (id)", fullTable))
+                    .collect());
+
+    // The failure must come from the index-build path (after the driver-side dataset is opened),
+    // not from query analysis — otherwise this test would no longer exercise the close-on-failure
+    // path it exists to guard.
+    Assertions.assertFalse(
+        failure instanceof org.apache.spark.sql.AnalysisException,
+        "Expected a build-time failure after dataset open, not an analysis error: " + failure);
+
+    // The table is still fully queryable after the failed CREATE INDEX.
+    Dataset<Row> all = spark.sql(String.format("select * from %s", fullTable));
+    Assertions.assertEquals(20L, all.count());
+
+    // The failed index was never committed to the manifest.
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      boolean hasBadIdx =
+          lanceDataset.getIndexes().stream().anyMatch(i -> "bad_idx".equals(i.name()));
+      Assertions.assertFalse(hasBadIdx, "Failed index should not be committed to the manifest");
+    } finally {
+      lanceDataset.close();
+    }
+
+    // The dataset is reusable: a subsequent valid CREATE INDEX still succeeds.
+    spark.sql(String.format("alter table %s create index good_idx using btree (id)", fullTable));
+    checkIndex("good_idx");
+  }
+
+  @Test
   public void testCreateFtsIndex() {
     prepareDataset();
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -19,6 +19,7 @@ import org.lance.index.IndexDescription;
 import org.lance.index.IndexType;
 import org.lance.spark.utils.FieldPathUtils;
 
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -693,23 +694,30 @@ public abstract class BaseAddIndexTest {
                             "alter table %s create index bad_idx using fts (id)", fullTable))
                     .collect());
 
-    // The failure must come from the index-build path (after the driver-side dataset is opened),
-    // not from query analysis — otherwise this test would no longer exercise the close-on-failure
-    // path it exists to guard.
-    Assertions.assertFalse(
-        failure instanceof org.apache.spark.sql.AnalysisException,
-        "Expected a build-time failure after dataset open, not an analysis error: " + failure);
+    // The failure must come from the distributed index-build job, which runs only after the
+    // driver-side dataset is opened. A SparkException in the cause chain indicates a job failure;
+    // earlier failures (analysis, driver-side validation) surface unwrapped and would mean this
+    // test no longer exercises the close-on-failure path it exists to guard.
+    boolean fromBuildJob = false;
+    for (Throwable t = failure; t != null && !fromBuildJob; t = t.getCause()) {
+      fromBuildJob = t instanceof SparkException;
+    }
+    Assertions.assertTrue(
+        fromBuildJob, "Expected a build-job failure after dataset open, got: " + failure);
 
-    // The table is still fully queryable after the failed CREATE INDEX.
+    // The table is still fully queryable after the failed CREATE INDEX. collectAsList (not
+    // count, which is answered from manifest metadata) forces a real scan of the data pages.
     Dataset<Row> all = spark.sql(String.format("select * from %s", fullTable));
-    Assertions.assertEquals(20L, all.count());
+    Assertions.assertEquals(20, all.collectAsList().size());
 
-    // The failed index was never committed to the manifest.
+    // Nothing was committed to the manifest: at this point the table should have no index at
+    // all (stronger than checking for the failed name, and robust to unnamed segment entries).
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
     try {
-      boolean hasBadIdx =
-          lanceDataset.getIndexes().stream().anyMatch(i -> "bad_idx".equals(i.name()));
-      Assertions.assertFalse(hasBadIdx, "Failed index should not be committed to the manifest");
+      Assertions.assertTrue(
+          lanceDataset.getIndexes().isEmpty(),
+          "Failed CREATE INDEX should not commit any index to the manifest, found: "
+              + lanceDataset.getIndexes());
     } finally {
       lanceDataset.close();
     }


### PR DESCRIPTION
`AddIndexExec.run()`'s FTS/INVERTED path opens a driver-side Lance `Dataset` (a native handle), then runs `FragmentBasedIndexJob` outside the `try/finally` that closes it. A failure during the build or the commit leaks the handle on every failed `CREATE INDEX`, and since the handle is native it stays leaked until the driver exits. Moving the job inside the `try` lets the `finally` close it on all paths.

The BTREE and ZONEMAP paths commit via segments and don't hold a driver dataset across the job, so they're unaffected — #612's segment-commit rework already removed the same pattern from the BTREE path.

### TESTING

New test `testCreateIndexFailureLeavesTableUsable`: an FTS index on a non-text column fails inside the distributed build, after the driver dataset is opened. A `SparkException` in the cause chain pins the failure to the build job, so the test turns red if the failure ever moves before the dataset open. It then checks the manifest holds no index, a full scan still returns every row, and a later valid `CREATE INDEX` succeeds.

`AddIndexTest` passes on Spark 3.5/Scala 2.12 (26 tests) and Spark 4.0/Scala 2.13 (53 tests); spotless and checkstyle clean.
