### PR TITLE
chore: update lance dependency to v8.0.0-beta.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.1</lance-spark.version>
-        <lance.version>8.0.0-beta.9</lance.version>
+        <lance.version>8.0.0-beta.12</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Bump `lance.version` from `8.0.0-beta.9` to `8.0.0-beta.12`.
- Verified Docker hardcoded versions against Maven properties:
  - `LANCE_SPARK_VERSION=0.5.1` matches `lance-spark.version`.
  - `LANCE_NS_IMPL_VERSION=0.3.0` matches `lance-namespace-impl.version`.
- Triggering tag: `refs/tags/v8.0.0-beta.12`.

## Verification

- `make lint` passed.
- `make install` was run, but Maven could not resolve `org.lance:lance-core:8.0.0-beta.12` from Maven Central. Maven Central metadata currently lists `8.0.0-beta.11` as latest and does not include `8.0.0-beta.12`.
