### PR TITLE
ci: defer lance dependency bump until the artifact is on Maven Central

### DIFF
--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -21,6 +21,8 @@ import os
 import re
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -31,6 +33,13 @@ except ImportError:
     import xml.etree.ElementTree as etree
 
 LANCE_REPO = "lance-format/lance"
+
+# Lance's Java artifacts are published to Maven Central by a separate, slower
+# pipeline than the GitHub release/tag the timer watches. These point at the
+# lance-core jar so we can confirm a tagged version is actually resolvable
+# before opening a dependency-bump PR.
+MAVEN_CENTRAL_BASE = "https://repo1.maven.org/maven2"
+LANCE_CORE_PATH = "org/lance/lance-core"
 
 SEMVER_RE = re.compile(
     r"^\s*(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
@@ -172,6 +181,38 @@ def determine_latest_tag(tags: Iterable[TagInfo]) -> TagInfo:
     return max(tags, key=lambda tag: tag.semver)
 
 
+def maven_artifact_published(version: str) -> bool:
+    """Return True if lance-core ``version`` is resolvable on Maven Central.
+
+    The release timer keys off Lance's GitHub tags, but the Java artifacts are
+    pushed to Maven Central by a separate, slower pipeline. Opening the bump PR
+    before the jar lands only produces a guaranteed-red build (the dependency
+    cannot be resolved), so we defer until the artifact actually exists. Any
+    ambiguity (404, network error, unexpected status) is treated as
+    "not yet published" so the next scheduled run simply retries.
+    """
+    jar_url = f"{MAVEN_CENTRAL_BASE}/{LANCE_CORE_PATH}/{version}/lance-core-{version}.jar"
+    request = urllib.request.Request(jar_url, method="HEAD")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return 200 <= response.status < 300
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            print(
+                f"Unexpected HTTP {exc.code} probing Maven Central for "
+                f"lance-core {version}; treating as not yet published.",
+                file=sys.stderr,
+            )
+        return False
+    except urllib.error.URLError as exc:
+        print(
+            f"Network error probing Maven Central for lance-core {version} "
+            f"({exc.reason}); treating as not yet published.",
+            file=sys.stderr,
+        )
+        return False
+
+
 def write_outputs(args: argparse.Namespace, payload: dict) -> None:
     target = getattr(args, "github_output", None)
     if not target:
@@ -202,13 +243,26 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     tags = fetch_remote_tags()
     latest = determine_latest_tag(tags)
-    needs_update = latest.semver > current_semver
+    newer_tag_available = latest.semver > current_semver
+
+    # A newer tag alone is not enough: only proceed once the artifact is on
+    # Maven Central, otherwise the bump PR's build cannot resolve the dependency.
+    artifact_published = newer_tag_available and maven_artifact_published(latest.version)
+    if newer_tag_available and not artifact_published:
+        print(
+            f"Lance {latest.version} is tagged but its artifact is not yet on "
+            "Maven Central; deferring the dependency update until it is published.",
+            file=sys.stderr,
+        )
+
+    needs_update = newer_tag_available and artifact_published
 
     payload = {
         "current_version": current_version,
         "current_tag": f"v{current_version}",
         "latest_version": latest.version,
         "latest_tag": latest.tag,
+        "artifact_published": "true" if artifact_published else "false",
         "needs_update": "true" if needs_update else "false",
     }
 


### PR DESCRIPTION
## Problem

The Lance release timer (`lance-release-timer.yml` → `ci/check_lance_release.py`)
decides whether to open a dependency-bump PR by polling Lance's **GitHub
tags** (`repos/lance-format/lance/git/refs/tags`). It does not check Maven
Central at all.

Lance's Java artifacts (`org.lance:lance-core`) are published to Maven
Central by a **separate, slower pipeline** than the GitHub release/tag.
So the codex bot opens the bump PR — and triggers full CI — within ~10 min
of a tag appearing, while the artifact is often not yet resolvable. The
build then fails with `Could not find artifact org.lance:lance-core:jar:<v>
in central` until the jar lands.

Concrete example: **#619** bumped to `v8.0.0-beta.12`. The Lance GitHub
release was published at `18:01Z`, the PR opened `18:16Z`, but
`lance-core-8.0.0-beta.12.jar` was still 404 on Maven Central (latest
published was `beta.11`, which itself only synced ~1h after its tag). Same
root cause as the first failure on #604.

## Fix

Gate `needs_update` on artifact availability: a newer tag is necessary but
no longer sufficient — `ci/check_lance_release.py` now also does a `HEAD`
probe of `lance-core-<version>.jar` on Maven Central and only sets
`needs_update=true` when the jar is actually resolvable.

When the tag is ahead but the artifact is missing, the run logs the reason
and **defers**; since the timer runs every 10 minutes, the next run retries
and opens the PR once the jar is published. Any ambiguity (404, network
error, unexpected status) is treated as "not yet published" so we never
open a guaranteed-red PR. A new `artifact_published` output is exposed for
visibility. No workflow change is needed — the timer already gates every
downstream step on `needs_update`.

## Testing

Run locally against the current live state (pom at `8.0.0-beta.9`, latest
Lance tag `v8.0.0-beta.12`):

- `maven_artifact_published`: `beta.9`→true, `beta.11`→true, **`beta.12`→false**, `beta.99`→false
- Full script output: `latest_version=8.0.0-beta.12`, `artifact_published=false`, **`needs_update=false`**, with a deferral message on stderr — i.e. it would *not* have opened #619; it will open once beta.12's jar lands.
- `python3 -m py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)