### PR TITLE
ci: extract docker build step into action

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -1,0 +1,72 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Docker Build"
+description: "Builds Docker test-base image, Spark bundle, and test image"
+
+inputs:
+  spark-version:
+    description: "Spark major version (e.g. 3.5)"
+    required: true
+  scala-version:
+    description: "Scala version (e.g. 2.13)"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve Docker build args
+      id: docker-args
+      shell: bash
+      run: |
+        make print-docker-build-args \
+          SPARK_VERSION=${{ inputs.spark-version }} \
+          SCALA_VERSION=${{ inputs.scala-version }} \
+          >> $GITHUB_OUTPUT
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build test-base image (cached)
+      uses: docker/build-push-action@v7
+      with:
+        context: docker
+        file: docker/Dockerfile.test-base
+        load: true
+        tags: lance-spark-test-base:${{ inputs.spark-version }}_${{ inputs.scala-version }}
+        build-args: |
+          SPARK_DOWNLOAD_VERSION=${{ steps.docker-args.outputs.spark-download-version }}
+          SPARK_MAJOR_VERSION=${{ inputs.spark-version }}
+          SCALA_VERSION=${{ inputs.scala-version }}
+          PY4J_VERSION=${{ steps.docker-args.outputs.py4j-version }}
+          SPARK_SCALA_SUFFIX=${{ steps.docker-args.outputs.spark-scala-suffix }}
+        cache-from: type=gha,scope=test-base-${{ inputs.spark-version }}_${{ inputs.scala-version }}
+        cache-to: type=gha,mode=max,scope=test-base-${{ inputs.spark-version }}_${{ inputs.scala-version }}
+
+    - name: Build bundle
+      shell: bash
+      run: make bundle SPARK_VERSION=${{ inputs.spark-version }} SCALA_VERSION=${{ inputs.scala-version }}
+
+    - name: Build test image
+      shell: bash
+      run: |
+        NS_VERSION="${{ steps.docker-args.outputs.lance-namespace-impl-version }}"
+        if [ -n "${NS_VERSION}" ]; then
+          make docker-build-test \
+            SPARK_VERSION=${{ inputs.spark-version }} \
+            SCALA_VERSION=${{ inputs.scala-version }} \
+            LANCE_NAMESPACE_IMPL_VERSION="${NS_VERSION}"
+        else
+          make docker-build-test \
+            SPARK_VERSION=${{ inputs.spark-version }} \
+            SCALA_VERSION=${{ inputs.scala-version }}
+        fi

--- a/.github/workflows/spark-aws.yml
+++ b/.github/workflows/spark-aws.yml
@@ -71,35 +71,11 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "maven"
-      - name: Resolve Docker build args
-        id: docker-args
-        run: |
-          make print-docker-build-args SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION} >> $GITHUB_OUTPUT
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Build test-base image (cached)
-        uses: docker/build-push-action@v7
+      - name: Build Docker images
+        uses: ./.github/actions/docker-build
         with:
-          context: docker
-          file: docker/Dockerfile.test-base
-          load: true
-          tags: lance-spark-test-base:${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-          build-args: |
-            SPARK_DOWNLOAD_VERSION=${{ steps.docker-args.outputs.spark-download-version }}
-            SPARK_MAJOR_VERSION=${{ env.SPARK_VERSION }}
-            SCALA_VERSION=${{ env.SCALA_VERSION }}
-            PY4J_VERSION=${{ steps.docker-args.outputs.py4j-version }}
-            SPARK_SCALA_SUFFIX=${{ steps.docker-args.outputs.spark-scala-suffix }}
-          cache-from: type=gha,scope=test-base-${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-          cache-to: type=gha,mode=max,scope=test-base-${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-      - name: Build bundle
-        run: make bundle SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION}
-      - name: Build Glue/S3 test image
-        run: |
-          make docker-build-test \
-            SPARK_VERSION=${SPARK_VERSION} \
-            SCALA_VERSION=${SCALA_VERSION} \
-            LANCE_NAMESPACE_IMPL_VERSION=${{ steps.docker-args.outputs.lance-namespace-impl-version }}
+          spark-version: ${{ env.SPARK_VERSION }}
+          scala-version: ${{ env.SCALA_VERSION }}
       - name: Verify AWS Glue/S3 targets
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/spark-search.yml
+++ b/.github/workflows/spark-search.yml
@@ -88,35 +88,11 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "maven"
-      - name: Resolve Docker build args
-        id: docker-args
-        run: |
-          make print-docker-build-args SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION} >> $GITHUB_OUTPUT
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Build test-base image (cached)
-        uses: docker/build-push-action@v7
+      - name: Build Docker images
+        uses: ./.github/actions/docker-build
         with:
-          context: docker
-          file: docker/Dockerfile.test-base
-          load: true
-          tags: lance-spark-test-base:${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-          build-args: |
-            SPARK_DOWNLOAD_VERSION=${{ steps.docker-args.outputs.spark-download-version }}
-            SPARK_MAJOR_VERSION=${{ env.SPARK_VERSION }}
-            SCALA_VERSION=${{ env.SCALA_VERSION }}
-            PY4J_VERSION=${{ steps.docker-args.outputs.py4j-version }}
-            SPARK_SCALA_SUFFIX=${{ steps.docker-args.outputs.spark-scala-suffix }}
-          cache-from: type=gha,scope=search-test-base-${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-          cache-to: type=gha,mode=max,scope=search-test-base-${{ env.SPARK_VERSION }}_${{ env.SCALA_VERSION }}
-      - name: Build bundle
-        run: make bundle SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION}
-      - name: Build test image
-        run: |
-          make docker-build-test \
-            SPARK_VERSION=${SPARK_VERSION} \
-            SCALA_VERSION=${SCALA_VERSION} \
-            LANCE_NAMESPACE_IMPL_VERSION=${{ steps.docker-args.outputs.lance-namespace-impl-version }}
+          spark-version: ${{ env.SPARK_VERSION }}
+          scala-version: ${{ env.SCALA_VERSION }}
       - name: Run directory namespace search tests
         if: ${{ contains(env.SEARCH_TEST_BACKENDS, 'local') }}
         run: |

--- a/.github/workflows/spark.yml
+++ b/.github/workflows/spark.yml
@@ -139,30 +139,10 @@ jobs:
           distribution: temurin
           java-version: 17
           cache: "maven"
-      - name: Resolve Docker build args
-        id: docker-args
-        run: |
-          make print-docker-build-args SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }} >> $GITHUB_OUTPUT
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Build test-base image (cached)
-        uses: docker/build-push-action@v7
+      - name: Build Docker images
+        uses: ./.github/actions/docker-build
         with:
-          context: docker
-          file: docker/Dockerfile.test-base
-          load: true
-          tags: lance-spark-test-base:${{ matrix.spark-version }}_${{ matrix.scala-version }}
-          build-args: |
-            SPARK_DOWNLOAD_VERSION=${{ steps.docker-args.outputs.spark-download-version }}
-            SPARK_MAJOR_VERSION=${{ matrix.spark-version }}
-            SCALA_VERSION=${{ matrix.scala-version }}
-            PY4J_VERSION=${{ steps.docker-args.outputs.py4j-version }}
-            SPARK_SCALA_SUFFIX=${{ steps.docker-args.outputs.spark-scala-suffix }}
-          cache-from: type=gha,scope=test-base-${{ matrix.spark-version }}_${{ matrix.scala-version }}
-          cache-to: type=gha,mode=max,scope=test-base-${{ matrix.spark-version }}_${{ matrix.scala-version }}
-      - name: Build bundle
-        run: make bundle SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }}
-      - name: Build test image
-        run: make docker-build-test SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }}
+          spark-version: ${{ matrix.spark-version }}
+          scala-version: ${{ matrix.scala-version }}
       - name: Run Docker integration tests
         run: make docker-test SPARK_VERSION=${{ matrix.spark-version }} SCALA_VERSION=${{ matrix.scala-version }}


### PR DESCRIPTION
Our spark actions all have a duplicated docker setup with some incorrect caching logic in `spark-search.yml` using it's own docker cache scope. So I extracted to a separate file to maintain parity.

