### PR TITLE
feat: resolve blob v2 file format version at table creation

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -40,7 +40,6 @@ import org.lance.spark.function.LanceBucketFunction;
 import org.lance.spark.function.LanceFragmentIdWithDefaultFunction;
 import org.lance.spark.sharding.SparkLanceShardingUtils;
 import org.lance.spark.utils.Optional;
-import org.lance.spark.utils.SchemaConverter;
 import org.lance.spark.utils.Utils;
 import org.lance.spark.write.StagedCommit;
 import org.lance.spark.write.StagedCommitOptions;
@@ -142,6 +141,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
         || name.startsWith("abfss://")
         || name.startsWith("file://")
         || name.startsWith("hdfs://");
+  }
+
+  /** Create-time schema and file format version resolution for every catalog create path. */
+  private CreateTableSpec resolveCreateSpec(StructType schema, Map<String, String> properties) {
+    return CreateTableSpec.resolve(schema, properties, catalogConfig.getFileFormatVersion());
   }
 
   /**
@@ -607,9 +611,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
     // Build the table ID for credential vending
     List<String> tableIdList = buildTableId(actualIdent);
 
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     // Create dataset using namespace - WriteDatasetBuilder handles declareTable internally
     // and properly leverages namespace client for credential vending
@@ -683,7 +687,8 @@ public abstract class BaseLanceNamespaceSparkCatalog
       ShardingSpec shardingSpec) {
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
-    StructType processedSchema = SchemaConverter.processSchemaWithProperties(schema, properties);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
     Map<String, String> tableProperties = copyUserTableProperties(properties);
 
     if (lanceDatasetExists(userLocation)) {
@@ -702,7 +707,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     String location = declareResponse.getLocation();
     Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
     boolean managedVersioning = Boolean.TRUE.equals(declareResponse.getManagedVersioning());
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
+    String fileFormatVersion = spec.fileFormatVersion();
 
     try {
       Map<String, String> merged =
@@ -767,9 +772,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       throws TableAlreadyExistsException {
     String datasetUri = getDatasetUri(ident);
 
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
     LanceSparkReadOptions readOptions =
         createReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
@@ -1067,9 +1072,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     DeclareTableRequest declareRequest = new DeclareTableRequest();
     tableIdList.forEach(declareRequest::addIdItem);
@@ -1122,9 +1127,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> properties,
       ShardingSpec shardingSpec) {
     String datasetUri = getDatasetUri(ident);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     LanceSparkReadOptions readOptions =
         createReadOptions(
@@ -1163,9 +1168,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     ResolvedTable resolved = resolveIdentifier(ident);
     DescribeTableResponse describeResponse = resolved.describeResponse;
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
     Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
     boolean managedVersioning = Boolean.TRUE.equals(describeResponse.getManagedVersioning());
 
@@ -1207,9 +1212,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       ShardingSpec shardingSpec)
       throws NoSuchTableException {
     String datasetUri = getDatasetUri(ident);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     LanceSparkReadOptions readOptions =
         createReadOptions(
@@ -1267,9 +1272,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     Identifier actualIdent = transformIdentifierForApi(ident);
     List<String> tableIdList = buildTableId(actualIdent);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     boolean exists = tableExists(ident);
     String location;
@@ -1346,9 +1351,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Map<String, String> properties,
       ShardingSpec shardingSpec) {
     String datasetUri = getDatasetUri(ident);
-    String fileFormatVersion = catalogConfig.getFileFormatVersion(properties);
-    StructType processedSchema =
-        SchemaConverter.processSchemaWithProperties(schema, properties, fileFormatVersion);
+    CreateTableSpec spec = resolveCreateSpec(schema, properties);
+    StructType processedSchema = spec.schema();
+    String fileFormatVersion = spec.fileFormatVersion();
 
     LanceSparkReadOptions readOptions =
         createReadOptions(

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/CreateTableSpec.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/CreateTableSpec.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.BlobUtils;
+import org.lance.spark.utils.SchemaConverter;
+
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Resolved schema and Lance file format version for CREATE TABLE.
+ *
+ * <p>If the incoming schema already contains blob v2 metadata, the create version must support blob
+ * v2. A table-level {@code file_format_version} is explicit user intent and is rejected when
+ * incompatible. A catalog default is upgraded with a warning because it may not have been chosen
+ * for this table's schema.
+ *
+ * <p>After the version resolves, property-driven blob encodings are applied once against the final
+ * version.
+ */
+public final class CreateTableSpec {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CreateTableSpec.class);
+
+  private final StructType schema;
+  private final String fileFormatVersion;
+
+  private CreateTableSpec(StructType schema, String fileFormatVersion) {
+    this.schema = schema;
+    this.fileFormatVersion = fileFormatVersion;
+  }
+
+  /**
+   * Resolves the create-time schema and file format version.
+   *
+   * @param sparkSchema the Spark schema requested for the new table
+   * @param tableProperties TBLPROPERTIES from CREATE TABLE (may request blob encodings and a
+   *     per-table {@code file_format_version})
+   * @param catalogDefaultVersion the catalog-level {@code file_format_version} default, or null
+   * @throws IllegalArgumentException when the table-level properties request a version that cannot
+   *     store the table's blob v2 columns
+   */
+  public static CreateTableSpec resolve(
+      StructType sparkSchema, Map<String, String> tableProperties, String catalogDefaultVersion) {
+    String tableVersion =
+        tableProperties.get(LanceSparkCatalogConfig.TABLE_OPT_FILE_FORMAT_VERSION);
+    String resolved = resolveVersion(sparkSchema, tableVersion, catalogDefaultVersion);
+    StructType schema =
+        SchemaConverter.processSchemaWithProperties(sparkSchema, tableProperties, resolved);
+    return new CreateTableSpec(schema, resolved);
+  }
+
+  private static String resolveVersion(
+      StructType schema, String tableVersion, String catalogDefaultVersion) {
+    if (!BlobUtils.hasBlobV2Fields(schema)) {
+      return tableVersion != null ? tableVersion : catalogDefaultVersion;
+    }
+
+    if (tableVersion != null) {
+      if (!BlobUtils.fileFormatSupportsBlobV2(tableVersion)) {
+        throw new IllegalArgumentException(
+            "Blob v2 columns require Lance file_format_version "
+                + BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION
+                + " or newer. Requested file_format_version '"
+                + tableVersion
+                + "' cannot store blob v2 columns.");
+      }
+      return tableVersion;
+    }
+
+    if (catalogDefaultVersion == null) {
+      return BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION;
+    }
+
+    if (BlobUtils.fileFormatSupportsBlobV2(catalogDefaultVersion)) {
+      return catalogDefaultVersion;
+    }
+
+    LOG.warn(
+        "Catalog default file_format_version '{}' cannot store this table's blob v2 columns."
+            + " Creating the table with version {} instead",
+        catalogDefaultVersion,
+        BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION);
+    return BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION;
+  }
+
+  public StructType schema() {
+    return schema;
+  }
+
+  /** The file format version to create the dataset with, or null to let Lance pick its default. */
+  public String fileFormatVersion() {
+    return fileFormatVersion;
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
@@ -154,21 +154,6 @@ public class LanceSparkCatalogConfig {
     return tableOptions.get(TABLE_OPT_FILE_FORMAT_VERSION);
   }
 
-  /**
-   * Returns the file format version, allowing per-table TBLPROPERTIES to override the catalog-level
-   * default.
-   *
-   * @param tableProperties the TBLPROPERTIES from CREATE TABLE
-   * @return the file format version string, or null if not specified
-   */
-  public String getFileFormatVersion(Map<String, String> tableProperties) {
-    String override = tableProperties.get(TABLE_OPT_FILE_FORMAT_VERSION);
-    if (override != null) {
-      return override;
-    }
-    return getFileFormatVersion();
-  }
-
   @Override
   public boolean equals(Object o) {
     if (o == null || getClass() != o.getClass()) return false;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
@@ -29,6 +29,9 @@ public class BlobUtils {
   public static final String ARROW_EXTENSION_NAME_KEY = "ARROW:extension:name";
   public static final String ARROW_EXTENSION_BLOB_V2 = "lance.blob.v2";
 
+  /** Lowest Lance file format version that can store blob v2 columns. */
+  public static final String MIN_BLOB_V2_FILE_FORMAT_VERSION = "2.2";
+
   /**
    * Spark struct type for a Lance blob v2 descriptor: {@code kind, position, size, blob_id,
    * blob_uri}.
@@ -143,5 +146,30 @@ public class BlobUtils {
     }
 
     return changed ? new StructType(fields) : schema;
+  }
+
+  /**
+   * True when {@code fileFormatVersion} is numeric {@code major[.minor]} of {@value
+   * #MIN_BLOB_V2_FILE_FORMAT_VERSION} or newer.
+   *
+   * <p>Null, named aliases like {@code stable}, and malformed strings return false. Lance validates
+   * version strings at dataset creation.
+   *
+   * <p>TODO: delegate to {@code LanceFileFormatVersion.isAtLeast()} in lance-core once version
+   * aliases are exposed to Java. Local parsing is conservative while {@code stable} resolves below
+   * 2.2.
+   */
+  public static boolean fileFormatSupportsBlobV2(String fileFormatVersion) {
+    if (fileFormatVersion == null) {
+      return false;
+    }
+    String[] parts = fileFormatVersion.trim().split("\\.");
+    try {
+      int major = Integer.parseInt(parts.length > 0 ? parts[0] : "");
+      int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+      return major > 2 || (major == 2 && minor >= 2);
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/SchemaConverter.java
@@ -223,7 +223,7 @@ public class SchemaConverter {
         if ("blob".equalsIgnoreCase(encodingValue)) {
           if (field.dataType() instanceof BinaryType) {
             // Add metadata for blob encoding
-            boolean useV2 = enablesBlobV2(fileFormatVersion);
+            boolean useV2 = BlobUtils.fileFormatSupportsBlobV2(fileFormatVersion);
             String metaKey = useV2 ? ARROW_EXTENSION_NAME_KEY : LANCE_ENCODING_BLOB_KEY;
             String metaVal = useV2 ? ARROW_EXTENSION_BLOB_V2 : LANCE_ENCODING_BLOB_VALUE;
             Metadata newMetadata =
@@ -251,26 +251,6 @@ public class SchemaConverter {
     }
 
     return new StructType(newFields);
-  }
-
-  private static boolean enablesBlobV2(String fileFormatVersion) {
-    if (fileFormatVersion == null) {
-      return false;
-    }
-
-    String[] parts = fileFormatVersion.split("\\.");
-    try {
-      int major = Integer.parseInt(parts[0]);
-      int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
-
-      return major > 2 || (major == 2 && minor >= 2);
-    } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Blob columns require a numeric file_format_version like '2.2'. Got: '%s'.",
-              fileFormatVersion),
-          e);
-    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobCreateTableTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobCreateTableTest.java
@@ -898,6 +898,26 @@ public abstract class BaseBlobCreateTableTest {
     spark.sql("DROP TABLE IF EXISTS " + catalogName + ".default." + tableName);
   }
 
+  @Test
+  public void testMalformedFileFormatVersionRejectedAtCreate() {
+    String tableName = "blob_badversion_" + System.currentTimeMillis();
+    Exception ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark.sql(
+                    "CREATE TABLE "
+                        + catalogName
+                        + ".default."
+                        + tableName
+                        + " (id INT, data BINARY) USING lance TBLPROPERTIES ("
+                        + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.x')"));
+    assertTrue(
+        ex.getMessage() != null && ex.getMessage().toLowerCase().contains("version"),
+        "creating with a malformed file_format_version must fail mentioning the version, but got "
+            + ex.getMessage());
+  }
+
   private static String bytesToHex(byte[] bytes) {
     StringBuilder hexString = new StringBuilder();
     for (byte b : bytes) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/CreateTableSpecTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/CreateTableSpecTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.BlobUtils;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CreateTableSpecTest {
+
+  private static final StructType SCHEMA =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+            new StructField("data", DataTypes.BinaryType, true, Metadata.empty()),
+          });
+
+  @Test
+  public void noBlobColumnsPassesVersionThrough() {
+    CreateTableSpec spec = CreateTableSpec.resolve(SCHEMA, Collections.emptyMap(), "2.0");
+    assertEquals("2.0", spec.fileFormatVersion());
+    assertFalse(BlobUtils.hasBlobV2Fields(spec.schema()));
+  }
+
+  @Test
+  public void noBlobColumnsAndNoVersionStaysUnset() {
+    CreateTableSpec spec = CreateTableSpec.resolve(SCHEMA, Collections.emptyMap(), null);
+    assertNull(spec.fileFormatVersion());
+  }
+
+  @Test
+  public void tablePropertyVersionOverridesCatalogDefault() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(SCHEMA, props("file_format_version", "stable"), "legacy");
+    assertEquals("stable", spec.fileFormatVersion());
+  }
+
+  @Test
+  public void blobV2SchemaWithNoVersionUsesMinimumBlobV2Version() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(blobV2QuerySchema(), Collections.emptyMap(), null);
+    assertEquals(BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION, spec.fileFormatVersion());
+    assertTrue(BlobUtils.hasBlobV2Fields(spec.schema()));
+  }
+
+  @Test
+  public void blobV2SchemaHonorsTableVersionThatSupportsIt() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(blobV2QuerySchema(), props("file_format_version", "2.3"), null);
+    assertEquals("2.3", spec.fileFormatVersion());
+  }
+
+  @Test
+  public void blobV2SchemaRejectsExplicitTableVersionBelowMinimum() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                CreateTableSpec.resolve(
+                    blobV2QuerySchema(), props("file_format_version", "2.0"), null));
+    assertTrue(ex.getMessage().contains("2.0"), ex.getMessage());
+  }
+
+  @Test
+  public void blobV2SchemaUpgradesCatalogDefaultBelowMinimum() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(blobV2QuerySchema(), Collections.emptyMap(), "2.0");
+    assertEquals(BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION, spec.fileFormatVersion());
+  }
+
+  @Test
+  public void blobV2SchemaUpgradesNamedCatalogDefault() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(blobV2QuerySchema(), Collections.emptyMap(), "stable");
+    assertEquals(BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION, spec.fileFormatVersion());
+  }
+
+  @Test
+  public void blobV2SchemaKeepsCatalogDefaultThatSupportsIt() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(blobV2QuerySchema(), Collections.emptyMap(), "2.4");
+    assertEquals("2.4", spec.fileFormatVersion());
+  }
+
+  @Test
+  public void blobPropertyAtSupportedVersionResolvesToBlobV2Metadata() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(
+            SCHEMA, props("data.lance.encoding", "blob", "file_format_version", "2.2"), null);
+    assertEquals("2.2", spec.fileFormatVersion());
+    assertTrue(BlobUtils.isBlobV2SparkField(spec.schema().apply("data")));
+  }
+
+  @Test
+  public void blobPropertyAtOlderVersionStaysBlobV1() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(
+            SCHEMA, props("data.lance.encoding", "blob", "file_format_version", "2.0"), null);
+    assertEquals("2.0", spec.fileFormatVersion());
+    assertTrue(BlobUtils.isBlobSparkField(spec.schema().apply("data")));
+    assertFalse(BlobUtils.isBlobV2SparkField(spec.schema().apply("data")));
+  }
+
+  @Test
+  public void blobPropertyAtNamedCatalogDefaultStaysBlobV1() {
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(SCHEMA, props("data.lance.encoding", "blob"), "stable");
+    assertEquals("stable", spec.fileFormatVersion());
+    assertTrue(BlobUtils.isBlobSparkField(spec.schema().apply("data")));
+    assertFalse(BlobUtils.isBlobV2SparkField(spec.schema().apply("data")));
+  }
+
+  @Test
+  public void blobV2SchemaRejectsExplicitNamedTableVersion() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                CreateTableSpec.resolve(
+                    blobV2QuerySchema(), props("file_format_version", "stable"), null));
+    assertTrue(ex.getMessage().contains("stable"), ex.getMessage());
+  }
+
+  @Test
+  public void versionUpgradeReResolvesPropertyDrivenBlobColumns() {
+    Metadata v2 =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
+    StructType mixed =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+              new StructField("copied", DataTypes.BinaryType, true, v2),
+              new StructField("fresh", DataTypes.BinaryType, true, Metadata.empty()),
+            });
+    CreateTableSpec spec =
+        CreateTableSpec.resolve(mixed, props("fresh.lance.encoding", "blob"), "2.0");
+    assertEquals(BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION, spec.fileFormatVersion());
+    assertTrue(BlobUtils.isBlobV2SparkField(spec.schema().apply("fresh")));
+    assertFalse(BlobUtils.isBlobSparkField(spec.schema().apply("fresh")));
+  }
+
+  private static StructType blobV2QuerySchema() {
+    Metadata v2 =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
+    return new StructType(
+        new StructField[] {
+          new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
+          new StructField("data", DataTypes.BinaryType, true, v2),
+        });
+  }
+
+  private static Map<String, String> props(String... keyValues) {
+    Map<String, String> map = new HashMap<>();
+    for (int i = 0; i < keyValues.length; i += 2) {
+      map.put(keyValues[i], keyValues[i + 1]);
+    }
+    return map;
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
@@ -174,28 +174,4 @@ public class LanceSparkCatalogConfigTest {
 
     assertEquals("LEGACY", config.getFileFormatVersion());
   }
-
-  @Test
-  public void testFileFormatVersionTablePropertiesOverrideCatalogDefault() {
-    Map<String, String> catalogOptions = new HashMap<>();
-    catalogOptions.put("file_format_version", "LEGACY");
-    LanceSparkCatalogConfig config = LanceSparkCatalogConfig.from(catalogOptions);
-
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put("file_format_version", "STABLE");
-
-    assertEquals("LEGACY", config.getFileFormatVersion());
-    assertEquals("STABLE", config.getFileFormatVersion(tableProperties));
-  }
-
-  @Test
-  public void testFileFormatVersionTablePropertiesFallsThroughToCatalogDefault() {
-    Map<String, String> catalogOptions = new HashMap<>();
-    catalogOptions.put("file_format_version", "LEGACY");
-    LanceSparkCatalogConfig config = LanceSparkCatalogConfig.from(catalogOptions);
-
-    Map<String, String> tableProperties = new HashMap<>();
-
-    assertEquals("LEGACY", config.getFileFormatVersion(tableProperties));
-  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -114,6 +114,31 @@ public class BlobUtilsTest {
     assertEquals(DataTypes.BinaryType, rewritten.apply("payload").dataType());
   }
 
+  @Test
+  public void fileFormatSupportsBlobV2AcceptsTwoTwoAndNewer() {
+    assertTrue(BlobUtils.fileFormatSupportsBlobV2("2.2"));
+    assertTrue(BlobUtils.fileFormatSupportsBlobV2("2.10"));
+    assertTrue(BlobUtils.fileFormatSupportsBlobV2("3.0"));
+    assertTrue(BlobUtils.fileFormatSupportsBlobV2(" 2.2 "));
+  }
+
+  @Test
+  public void fileFormatSupportsBlobV2RejectsOlderAndNull() {
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2(null));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("2.0"));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("2.1"));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("2"));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("2."));
+  }
+
+  @Test
+  public void fileFormatSupportsBlobV2RejectsNamedAndMalformedVersions() {
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("stable"));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2(""));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("."));
+    assertFalse(BlobUtils.fileFormatSupportsBlobV2("2.x"));
+  }
+
   private static StructField field(String name, org.apache.spark.sql.types.DataType dt) {
     return new StructField(name, dt, true, Metadata.empty());
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/SchemaConverterTest.java
@@ -607,7 +607,6 @@ public class SchemaConverterTest {
 
   @Test
   public void testBlobV1WithUnsupportedVersion() {
-    // v2 only supported on 2.2 or higher
     assertBlobV1Field(blobSchemaWithVersion("2.1").apply("data"));
   }
 
@@ -632,31 +631,13 @@ public class SchemaConverterTest {
   }
 
   @Test
-  public void testBlobEncodingRejectsUnknownFileFormatVersion() {
-    StructType schema =
-        new StructType(
-            new StructField[] {
-              DataTypes.createStructField("data", DataTypes.BinaryType, true),
-            });
-    Map<String, String> properties = ImmutableMap.of("data.lance.encoding", "blob");
-
-    assertValidationFailure(
-        "Blob columns require a numeric file_format_version like '2.2'. Got: 'stable'.",
-        () -> SchemaConverter.processSchemaWithProperties(schema, properties, "stable"));
+  public void testBlobEncodingAtNamedFileFormatVersionResolvesToBlobV1() {
+    assertBlobV1Field(blobSchemaWithVersion("stable").apply("data"));
   }
 
   @Test
-  public void testBlobEncodingRejectsMalformedFileFormatVersion() {
-    StructType schema =
-        new StructType(
-            new StructField[] {
-              DataTypes.createStructField("data", DataTypes.BinaryType, true),
-            });
-    Map<String, String> properties = ImmutableMap.of("data.lance.encoding", "blob");
-
-    assertValidationFailure(
-        "numeric file_format_version",
-        () -> SchemaConverter.processSchemaWithProperties(schema, properties, "2.x"));
+  public void testBlobEncodingAtMalformedFileFormatVersionResolvesToBlobV1() {
+    assertBlobV1Field(blobSchemaWithVersion("2.x").apply("data"));
   }
 
   private static StructType blobSchemaWithVersion(String fileFormatVersion) {


### PR DESCRIPTION
A schema from CTAS can already carry blob v2 metadata, but we were not reconciling that with the file format version on create. Blob v2 needs `file_format_version` 2.2+.

`CreateTableSpec` is the single entry point for this on every catalog create path. The catalog funnels all nine through `resolveCreateSpec().

If the schema has blob v2 and nothing requested a version, we use 2.2. If you set `file_format_version` on the table and it cannot store blob v2, we error. If only the catalog default is too old (or something like stable), we bump to 2.2 and warn.

Version resolves first, then blob property encoding runs once against that final version.

`BlobUtils.fileFormatSupportsBlobV2()` handles numeric parsing for now. Named and malformed strings return false at blob-tag time. Lance still rejects bad version strings at dataset creation. 

### Notes
- A TODO tracks delegating alias resolution to lance-core once that API exists.
- Create-time version policy may tighten later. Table-level `file_format_version` is always honored or rejected. Catalog defaults that cannot store blob v2 may error instead of upgrading.

### Testing
- `CreateTableSpecTest`, `BlobUtilsTest`
- `BaseBlobCreateTableTest.testMalformedFileFormatVersionRejectedAtCreate()`


