### PR TITLE
feat: Expose native Lance scan descriptor for datafusion-comet integration

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -321,11 +321,11 @@ public class LanceScan
 
   private java.util.Map<String, String> nativeStorageOptions() {
     java.util.Map<String, String> storageOptions = new HashMap<>();
-    if (readOptions.getStorageOptions() != null) {
-      storageOptions.putAll(readOptions.getStorageOptions());
-    }
     if (initialStorageOptions != null) {
       storageOptions.putAll(initialStorageOptions);
+    }
+    if (readOptions.getStorageOptions() != null) {
+      storageOptions.putAll(readOptions.getStorageOptions());
     }
     return storageOptions;
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -17,6 +17,10 @@ import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.read.metric.LanceCustomMetrics;
+import org.lance.spark.read.nativeplan.LanceNativeScanFallbackReason;
+import org.lance.spark.read.nativeplan.LanceNativeScanFallbackReasonCode;
+import org.lance.spark.read.nativeplan.LanceNativeScanPlan;
+import org.lance.spark.read.nativeplan.LanceNativeScanSplit;
 import org.lance.spark.sharding.SparkLanceShardingUtils;
 import org.lance.spark.utils.Optional;
 
@@ -47,8 +51,10 @@ import org.slf4j.LoggerFactory;
 import scala.collection.immutable.Map;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -66,6 +72,7 @@ public class LanceScan
   private static final long serialVersionUID = 947284762748623947L;
   private static final Logger LOG = LoggerFactory.getLogger(LanceScan.class);
 
+  private final StructType sparkReadSchema;
   private final StructType schema;
   private final LanceSparkReadOptions readOptions;
   private final Optional<String> whereConditions;
@@ -144,6 +151,49 @@ public class LanceScan
       java.util.Map<String, String> initialStorageOptions,
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties) {
+    this(
+        schema,
+        schema,
+        readOptions,
+        whereConditions,
+        limit,
+        offset,
+        topNSortOrders,
+        pushedAggregation,
+        pushedPredicates,
+        statistics,
+        zonemapStats,
+        survivingFragmentIds,
+        precomputedSplits,
+        precomputedFragmentRowCounts,
+        activeShardingExpression,
+        fragmentShardingKeys,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties);
+  }
+
+  public LanceScan(
+      StructType sparkReadSchema,
+      StructType schema,
+      LanceSparkReadOptions readOptions,
+      Optional<String> whereConditions,
+      Optional<Integer> limit,
+      Optional<Integer> offset,
+      Optional<List<ColumnOrdering>> topNSortOrders,
+      Optional<Aggregation> pushedAggregation,
+      Predicate[] pushedPredicates,
+      LanceStatistics statistics,
+      java.util.Map<String, List<ZoneStats>> zonemapStats,
+      Set<Integer> survivingFragmentIds,
+      List<LanceSplit> precomputedSplits,
+      java.util.Map<Integer, Long> precomputedFragmentRowCounts,
+      Expression activeShardingExpression,
+      java.util.Map<Integer, Object> fragmentShardingKeys,
+      java.util.Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      java.util.Map<String, String> namespaceProperties) {
+    this.sparkReadSchema = sparkReadSchema;
     this.schema = schema;
     this.readOptions = readOptions;
     this.whereConditions = whereConditions;
@@ -168,6 +218,125 @@ public class LanceScan
     this.initialStorageOptions = initialStorageOptions;
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
+  }
+
+  public java.util.Optional<LanceNativeScanPlan> nativeScanPlan() {
+    if (nativeScanFallbackReason().isPresent()) {
+      return java.util.Optional.empty();
+    }
+    return java.util.Optional.of(
+        new LanceNativeScanPlan(
+            scanId,
+            readOptions.getDatasetUri(),
+            readOptions.getVersion(),
+            sparkReadSchema.json(),
+            schema.json(),
+            optionalValue(whereConditions),
+            optionalValue(limit),
+            optionalValue(offset),
+            readOptions.getBatchSize(),
+            nativeStorageOptions(),
+            namespaceImpl,
+            namespaceProperties,
+            readOptions.getTableId(),
+            readOptions.getCatalogName(),
+            nativeSplits()));
+  }
+
+  public java.util.Optional<LanceNativeScanFallbackReason> nativeScanFallbackReason() {
+    if (pushedAggregation == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE, "pushed aggregation state is missing");
+    }
+    if (pushedAggregation.isPresent()) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.PUSHED_AGGREGATION,
+          "pushed aggregation is not representable in native scan descriptor v1");
+    }
+    if (topNSortOrders == null) {
+      return fallback(LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE, "TopN state is missing");
+    }
+    if (topNSortOrders.isPresent()) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.TOP_N,
+          "pushed TopN is not representable in native scan descriptor v1");
+    }
+    if (readOptions == null || readOptions.getDatasetUri() == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE, "read options are incomplete");
+    }
+    if (readOptions.getVersion() == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.MISSING_RESOLVED_VERSION,
+          "read options are not pinned to a resolved Lance version");
+    }
+    if (precomputedSplits == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.MISSING_SPLIT_STATE,
+          "scan splits were not planned on the driver");
+    }
+    if (sparkReadSchema == null || schema == null || scanId == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE, "schema or scan identity is missing");
+    }
+    if (whereConditions == null || limit == null || offset == null) {
+      return fallback(
+          LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE,
+          "filter, limit, or offset state is missing");
+    }
+    return validateSplitsForNativePlan(precomputedSplits);
+  }
+
+  private java.util.Optional<LanceNativeScanFallbackReason> validateSplitsForNativePlan(
+      List<LanceSplit> splits) {
+    for (int splitIndex = 0; splitIndex < splits.size(); splitIndex++) {
+      LanceSplit split = splits.get(splitIndex);
+      if (split == null || split.getFragments() == null) {
+        return fallback(
+            LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE,
+            "split " + splitIndex + " is missing fragment state");
+      }
+      for (Integer fragmentId : split.getFragments()) {
+        if (fragmentId == null || fragmentId < 0) {
+          return fallback(
+              LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE,
+              "split " + splitIndex + " contains an invalid fragment id");
+        }
+      }
+    }
+    return java.util.Optional.empty();
+  }
+
+  private List<LanceNativeScanSplit> nativeSplits() {
+    List<LanceSplit> prunedSplits = pruneByRowAddrFilters(precomputedSplits);
+    prunedSplits = pruneByZonemapStats(prunedSplits);
+    prunedSplits = pruneByLimit(prunedSplits, precomputedFragmentRowCounts);
+
+    List<LanceNativeScanSplit> nativeSplits = new ArrayList<>(prunedSplits.size());
+    for (int i = 0; i < prunedSplits.size(); i++) {
+      nativeSplits.add(new LanceNativeScanSplit(i, prunedSplits.get(i).getFragments()));
+    }
+    return nativeSplits;
+  }
+
+  private java.util.Map<String, String> nativeStorageOptions() {
+    java.util.Map<String, String> storageOptions = new HashMap<>();
+    if (readOptions.getStorageOptions() != null) {
+      storageOptions.putAll(readOptions.getStorageOptions());
+    }
+    if (initialStorageOptions != null) {
+      storageOptions.putAll(initialStorageOptions);
+    }
+    return storageOptions;
+  }
+
+  private static <T> T optionalValue(Optional<T> optional) {
+    return optional.isPresent() ? optional.get() : null;
+  }
+
+  private static java.util.Optional<LanceNativeScanFallbackReason> fallback(
+      LanceNativeScanFallbackReasonCode code, String message) {
+    return java.util.Optional.of(new LanceNativeScanFallbackReason(code, message));
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -258,6 +258,7 @@ public class LanceScanBuilder
       Optional<String> whereCondition =
           FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);
       return new LanceScan(
+          fullSchema,
           schema,
           resolvedReadOptions,
           whereCondition,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanFallbackReason.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanFallbackReason.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read.nativeplan;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Explicit reason why a {@code LanceScan} cannot be represented as a v1 native scan plan. */
+public final class LanceNativeScanFallbackReason implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final LanceNativeScanFallbackReasonCode code;
+  private final String message;
+
+  public LanceNativeScanFallbackReason(LanceNativeScanFallbackReasonCode code, String message) {
+    this.code = Objects.requireNonNull(code, "code");
+    this.message = Objects.requireNonNull(message, "message");
+  }
+
+  public LanceNativeScanFallbackReasonCode getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  @Override
+  public String toString() {
+    return "LanceNativeScanFallbackReason{" + "code=" + code + ", message='" + message + '\'' + '}';
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanFallbackReasonCode.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanFallbackReasonCode.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read.nativeplan;
+
+/** Stable v1 reason codes for declining native Lance scan descriptors. */
+public enum LanceNativeScanFallbackReasonCode {
+  PUSHED_AGGREGATION,
+  TOP_N,
+  MISSING_RESOLVED_VERSION,
+  MISSING_SPLIT_STATE,
+  UNSAFE_V1_STATE
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanPlan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanPlan.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read.nativeplan;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+/** Immutable v1 native Lance read descriptor for reflection-based consumers. */
+public final class LanceNativeScanPlan implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  public static final int DESCRIPTOR_VERSION = 1;
+
+  private final int descriptorVersion;
+  private final String scanId;
+  private final String datasetUri;
+  private final long resolvedVersion;
+  private final String sparkReadSchemaJson;
+  private final String projectedReadSchemaJson;
+  private final String pushedFilterSql;
+  private final Integer limit;
+  private final Integer offset;
+  private final int batchSize;
+  private final Map<String, String> storageOptions;
+  private final String namespaceImpl;
+  private final Map<String, String> namespaceProperties;
+  private final List<String> tableId;
+  private final String catalogName;
+  private final List<LanceNativeScanSplit> splits;
+
+  public LanceNativeScanPlan(
+      String scanId,
+      String datasetUri,
+      long resolvedVersion,
+      String sparkReadSchemaJson,
+      String projectedReadSchemaJson,
+      String pushedFilterSql,
+      Integer limit,
+      Integer offset,
+      int batchSize,
+      Map<String, String> storageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      List<String> tableId,
+      String catalogName,
+      List<LanceNativeScanSplit> splits) {
+    this.descriptorVersion = DESCRIPTOR_VERSION;
+    this.scanId = Objects.requireNonNull(scanId, "scanId");
+    this.datasetUri = Objects.requireNonNull(datasetUri, "datasetUri");
+    this.resolvedVersion = resolvedVersion;
+    this.sparkReadSchemaJson = Objects.requireNonNull(sparkReadSchemaJson, "sparkReadSchemaJson");
+    this.projectedReadSchemaJson =
+        Objects.requireNonNull(projectedReadSchemaJson, "projectedReadSchemaJson");
+    this.pushedFilterSql = pushedFilterSql;
+    this.limit = limit;
+    this.offset = offset;
+    this.batchSize = batchSize;
+    this.storageOptions = immutableSortedMap(storageOptions);
+    this.namespaceImpl = namespaceImpl;
+    this.namespaceProperties = immutableSortedMap(namespaceProperties);
+    this.tableId = immutableList(tableId);
+    this.catalogName = catalogName;
+    this.splits = immutableList(Objects.requireNonNull(splits, "splits"));
+  }
+
+  public int getDescriptorVersion() {
+    return descriptorVersion;
+  }
+
+  public String getScanId() {
+    return scanId;
+  }
+
+  public String getDatasetUri() {
+    return datasetUri;
+  }
+
+  public long getResolvedVersion() {
+    return resolvedVersion;
+  }
+
+  public String getSparkReadSchemaJson() {
+    return sparkReadSchemaJson;
+  }
+
+  public String getProjectedReadSchemaJson() {
+    return projectedReadSchemaJson;
+  }
+
+  public boolean hasPushedFilterSql() {
+    return pushedFilterSql != null;
+  }
+
+  public String getPushedFilterSql() {
+    return pushedFilterSql;
+  }
+
+  public boolean hasLimit() {
+    return limit != null;
+  }
+
+  public Integer getLimit() {
+    return limit;
+  }
+
+  public boolean hasOffset() {
+    return offset != null;
+  }
+
+  public Integer getOffset() {
+    return offset;
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
+  public boolean hasNamespaceImpl() {
+    return namespaceImpl != null;
+  }
+
+  public String getNamespaceImpl() {
+    return namespaceImpl;
+  }
+
+  public Map<String, String> getNamespaceProperties() {
+    return namespaceProperties;
+  }
+
+  public boolean hasTableId() {
+    return !tableId.isEmpty();
+  }
+
+  public List<String> getTableId() {
+    return tableId;
+  }
+
+  public boolean hasCatalogName() {
+    return catalogName != null;
+  }
+
+  public String getCatalogName() {
+    return catalogName;
+  }
+
+  public List<LanceNativeScanSplit> getSplits() {
+    return splits;
+  }
+
+  private static Map<String, String> immutableSortedMap(Map<String, String> input) {
+    if (input == null || input.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return Collections.unmodifiableMap(new TreeMap<>(input));
+  }
+
+  private static <T> List<T> immutableList(List<T> input) {
+    if (input == null || input.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return Collections.unmodifiableList(new ArrayList<>(input));
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/nativeplan/LanceNativeScanSplit.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read.nativeplan;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Serializable native-read split descriptor containing the Lance fragment IDs in that split. */
+public final class LanceNativeScanSplit implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final int splitIndex;
+  private final List<Integer> fragmentIds;
+
+  public LanceNativeScanSplit(int splitIndex, List<Integer> fragmentIds) {
+    this.splitIndex = splitIndex;
+    this.fragmentIds =
+        Collections.unmodifiableList(new ArrayList<>(Objects.requireNonNull(fragmentIds)));
+  }
+
+  public int getSplitIndex() {
+    return splitIndex;
+  }
+
+  public List<Integer> getFragmentIds() {
+    return fragmentIds;
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -13,12 +13,20 @@
  */
 package org.lance.spark.read;
 
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
+import org.lance.spark.read.nativeplan.LanceNativeScanFallbackReason;
+import org.lance.spark.read.nativeplan.LanceNativeScanFallbackReasonCode;
+import org.lance.spark.read.nativeplan.LanceNativeScanPlan;
+import org.lance.spark.read.nativeplan.LanceNativeScanSplit;
 
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NullOrdering;
+import org.apache.spark.sql.connector.expressions.SortDirection;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.expressions.aggregate.AggregateFunc;
 import org.apache.spark.sql.connector.expressions.aggregate.Aggregation;
 import org.apache.spark.sql.connector.expressions.aggregate.CountStar;
@@ -33,15 +41,31 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class LanceScanTest {
 
   private static final StructType TEST_SCHEMA = TestUtils.TestTable1Config.schema;
+  private static final int NATIVE_BATCH_SIZE = 1234;
+  private static final String CATALOG_NAME = "native_catalog";
+  private static final String NAMESPACE_IMPL = "dir";
+  private static final String NAMESPACE_PROPERTY_KEY = "root";
+  private static final String NAMESPACE_PROPERTY_VALUE = "/tmp/native";
+  private static final String STORAGE_OPTION_KEY = "native.option";
+  private static final String STORAGE_OPTION_VALUE = "driver";
+  private static final String TABLE_NAMESPACE = "default";
+  private static final String TABLE_NAME = "table";
 
   private LanceScan buildScan() {
     return (LanceScan)
@@ -51,6 +75,17 @@ public class LanceScanTest {
                 Collections.emptyMap(),
                 null,
                 Collections.emptyMap())
+            .build();
+  }
+
+  private LanceScan buildScan(
+      LanceSparkReadOptions readOptions,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties) {
+    return (LanceScan)
+        new LanceScanBuilder(
+                TEST_SCHEMA, readOptions, initialStorageOptions, namespaceImpl, namespaceProperties)
             .build();
   }
 
@@ -118,6 +153,119 @@ public class LanceScanTest {
     LanceInputPartition partition = (LanceInputPartition) scan.planInputPartitions()[0];
     assertTrue(partition.getLimit().isPresent());
     assertEquals(2, partition.getLimit().get());
+  }
+
+  @Test
+  public void testNativeScanPlanForEligibleOrdinaryRead() throws Exception {
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri(TestUtils.TestTable1Config.datasetUri)
+            .batchSize(NATIVE_BATCH_SIZE)
+            .tableId(Arrays.asList(TABLE_NAMESPACE, TABLE_NAME))
+            .catalogName(CATALOG_NAME)
+            .build();
+    LanceScan scan =
+        buildScan(
+            readOptions,
+            Collections.singletonMap(STORAGE_OPTION_KEY, STORAGE_OPTION_VALUE),
+            NAMESPACE_IMPL,
+            Collections.singletonMap(NAMESPACE_PROPERTY_KEY, NAMESPACE_PROPERTY_VALUE));
+
+    java.util.Optional<LanceNativeScanPlan> maybePlan = scan.nativeScanPlan();
+    assertTrue(maybePlan.isPresent());
+    assertFalse(scan.nativeScanFallbackReason().isPresent());
+    LanceNativeScanPlan plan = maybePlan.get();
+
+    assertEquals(LanceNativeScanPlan.DESCRIPTOR_VERSION, plan.getDescriptorVersion());
+    assertNotNull(plan.getScanId());
+    assertEquals(TestUtils.TestTable1Config.datasetUri, plan.getDatasetUri());
+    assertTrue(plan.getResolvedVersion() > 0);
+    assertEquals(TEST_SCHEMA.json(), plan.getSparkReadSchemaJson());
+    assertEquals(TEST_SCHEMA.json(), plan.getProjectedReadSchemaJson());
+    assertFalse(plan.hasPushedFilterSql());
+    assertFalse(plan.hasLimit());
+    assertFalse(plan.hasOffset());
+    assertEquals(NATIVE_BATCH_SIZE, plan.getBatchSize());
+    assertEquals(STORAGE_OPTION_VALUE, plan.getStorageOptions().get(STORAGE_OPTION_KEY));
+    assertEquals(NAMESPACE_IMPL, plan.getNamespaceImpl());
+    assertEquals(
+        NAMESPACE_PROPERTY_VALUE, plan.getNamespaceProperties().get(NAMESPACE_PROPERTY_KEY));
+    assertEquals(Arrays.asList(TABLE_NAMESPACE, TABLE_NAME), plan.getTableId());
+    assertEquals(CATALOG_NAME, plan.getCatalogName());
+    assertFalse(plan.getSplits().isEmpty());
+    for (LanceNativeScanSplit split : plan.getSplits()) {
+      assertFalse(split.getFragmentIds().isEmpty());
+    }
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> plan.getStorageOptions().put(STORAGE_OPTION_KEY, STORAGE_OPTION_VALUE));
+    assertThrows(UnsupportedOperationException.class, () -> plan.getTableId().add(TABLE_NAME));
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> plan.getSplits().add(new LanceNativeScanSplit(0, Collections.singletonList(0))));
+
+    LanceNativeScanPlan roundTripped = roundTrip(plan);
+    assertEquals(plan.getDatasetUri(), roundTripped.getDatasetUri());
+    assertEquals(plan.getSplits().size(), roundTripped.getSplits().size());
+  }
+
+  @Test
+  public void testNativeScanPlanIncludesProjectedSchemaAndPushedOptions() {
+    StructType projectedSchema = new StructType().add("x", DataTypes.LongType);
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            TEST_SCHEMA,
+            TestUtils.TestTable1Config.readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap());
+    builder.pruneColumns(projectedSchema);
+    builder.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
+    builder.pushLimit(2);
+
+    LanceScan scan = (LanceScan) builder.build();
+    java.util.Optional<LanceNativeScanPlan> maybePlan = scan.nativeScanPlan();
+    assertTrue(maybePlan.isPresent());
+    LanceNativeScanPlan plan = maybePlan.get();
+
+    assertEquals(TEST_SCHEMA.json(), plan.getSparkReadSchemaJson());
+    assertEquals(projectedSchema.json(), plan.getProjectedReadSchemaJson());
+    assertTrue(plan.hasPushedFilterSql());
+    assertNotNull(plan.getPushedFilterSql());
+    assertEquals(Integer.valueOf(2), plan.getLimit());
+    assertFalse(plan.hasOffset());
+  }
+
+  @Test
+  public void testNativeScanFallbackReasons() {
+    FallbackCase[] cases =
+        new FallbackCase[] {
+          new FallbackCase(
+              "aggregation",
+              this::buildPushedAggregationScan,
+              LanceNativeScanFallbackReasonCode.PUSHED_AGGREGATION),
+          new FallbackCase("topN", this::buildTopNScan, LanceNativeScanFallbackReasonCode.TOP_N),
+          new FallbackCase(
+              "missing version",
+              this::buildMissingResolvedVersionScan,
+              LanceNativeScanFallbackReasonCode.MISSING_RESOLVED_VERSION),
+          new FallbackCase(
+              "missing splits",
+              this::buildMissingSplitStateScan,
+              LanceNativeScanFallbackReasonCode.MISSING_SPLIT_STATE),
+          new FallbackCase(
+              "unsafe split",
+              this::buildUnsafeSplitStateScan,
+              LanceNativeScanFallbackReasonCode.UNSAFE_V1_STATE)
+        };
+
+    for (FallbackCase testCase : cases) {
+      LanceScan scan = testCase.scanSupplier.get();
+      java.util.Optional<LanceNativeScanFallbackReason> reason = scan.nativeScanFallbackReason();
+      assertTrue(reason.isPresent(), testCase.name);
+      assertEquals(testCase.expectedCode, reason.get().getCode(), testCase.name);
+      assertFalse(scan.nativeScanPlan().isPresent(), testCase.name);
+    }
   }
 
   @Test
@@ -327,5 +475,113 @@ public class LanceScanTest {
                 .build();
 
     assertNotEquals(scan1, scan2, "Scans with different schemas should not be equal");
+  }
+
+  private LanceScan buildPushedAggregationScan() {
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            TEST_SCHEMA,
+            TestUtils.TestTable1Config.readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap());
+    builder.pushPredicates(new Predicate[] {TestPredicates.gt("x", 0L)});
+    builder.pushAggregation(
+        new Aggregation(new AggregateFunc[] {new CountStar()}, new Expression[] {}));
+    return (LanceScan) builder.build();
+  }
+
+  private LanceScan buildTopNScan() {
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            TEST_SCHEMA,
+            TestUtils.TestTable1Config.readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap());
+    assertTrue(
+        builder.pushTopN(
+            new SortOrder[] {
+              Expressions.sort(
+                  Expressions.column("x"), SortDirection.ASCENDING, NullOrdering.NULLS_FIRST)
+            },
+            10));
+    return (LanceScan) builder.build();
+  }
+
+  private LanceScan buildMissingResolvedVersionScan() {
+    LanceSplit.ScanPlanResult plan = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
+    return directScan(
+        TestUtils.TestTable1Config.readOptions, plan.getSplits(), plan.getFragmentRowCounts());
+  }
+
+  private LanceScan buildMissingSplitStateScan() {
+    LanceSparkReadOptions resolvedReadOptions = resolvedReadOptions();
+    return directScan(resolvedReadOptions, null, Collections.emptyMap());
+  }
+
+  private LanceScan buildUnsafeSplitStateScan() {
+    LanceSparkReadOptions resolvedReadOptions = resolvedReadOptions();
+    return directScan(
+        resolvedReadOptions,
+        Collections.singletonList(new LanceSplit(Collections.singletonList(-1))),
+        Collections.emptyMap());
+  }
+
+  private LanceScan directScan(
+      LanceSparkReadOptions readOptions,
+      List<LanceSplit> splits,
+      Map<Integer, Long> fragmentRowCounts) {
+    return new LanceScan(
+        TEST_SCHEMA,
+        readOptions,
+        org.lance.spark.utils.Optional.empty(),
+        org.lance.spark.utils.Optional.empty(),
+        org.lance.spark.utils.Optional.empty(),
+        org.lance.spark.utils.Optional.empty(),
+        org.lance.spark.utils.Optional.empty(),
+        new Predicate[0],
+        null,
+        Collections.emptyMap(),
+        null,
+        splits,
+        fragmentRowCounts,
+        null,
+        null,
+        Collections.emptyMap(),
+        null,
+        Collections.emptyMap());
+  }
+
+  private LanceSparkReadOptions resolvedReadOptions() {
+    LanceSplit.ScanPlanResult plan = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
+    return TestUtils.TestTable1Config.readOptions.withVersion(plan.getResolvedVersion());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(value);
+    }
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) in.readObject();
+    }
+  }
+
+  private static class FallbackCase {
+    private final String name;
+    private final Supplier<LanceScan> scanSupplier;
+    private final LanceNativeScanFallbackReasonCode expectedCode;
+
+    private FallbackCase(
+        String name,
+        Supplier<LanceScan> scanSupplier,
+        LanceNativeScanFallbackReasonCode expectedCode) {
+      this.name = name;
+      this.scanSupplier = scanSupplier;
+      this.expectedCode = expectedCode;
+    }
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -63,7 +63,10 @@ public class LanceScanTest {
   private static final String NAMESPACE_PROPERTY_KEY = "root";
   private static final String NAMESPACE_PROPERTY_VALUE = "/tmp/native";
   private static final String STORAGE_OPTION_KEY = "native.option";
-  private static final String STORAGE_OPTION_VALUE = "driver";
+  private static final String STORAGE_OPTION_INITIAL_VALUE = "initial";
+  private static final String STORAGE_OPTION_READ_VALUE = "read";
+  private static final String STORAGE_OPTION_INITIAL_ONLY_KEY = "native.initial.only";
+  private static final String STORAGE_OPTION_INITIAL_ONLY_VALUE = "driver";
   private static final String TABLE_NAMESPACE = "default";
   private static final String TABLE_NAME = "table";
 
@@ -161,13 +164,17 @@ public class LanceScanTest {
         LanceSparkReadOptions.builder()
             .datasetUri(TestUtils.TestTable1Config.datasetUri)
             .batchSize(NATIVE_BATCH_SIZE)
+            .storageOptions(Collections.singletonMap(STORAGE_OPTION_KEY, STORAGE_OPTION_READ_VALUE))
             .tableId(Arrays.asList(TABLE_NAMESPACE, TABLE_NAME))
             .catalogName(CATALOG_NAME)
             .build();
+    Map<String, String> initialStorageOptions = new HashMap<>();
+    initialStorageOptions.put(STORAGE_OPTION_KEY, STORAGE_OPTION_INITIAL_VALUE);
+    initialStorageOptions.put(STORAGE_OPTION_INITIAL_ONLY_KEY, STORAGE_OPTION_INITIAL_ONLY_VALUE);
     LanceScan scan =
         buildScan(
             readOptions,
-            Collections.singletonMap(STORAGE_OPTION_KEY, STORAGE_OPTION_VALUE),
+            initialStorageOptions,
             NAMESPACE_IMPL,
             Collections.singletonMap(NAMESPACE_PROPERTY_KEY, NAMESPACE_PROPERTY_VALUE));
 
@@ -186,7 +193,10 @@ public class LanceScanTest {
     assertFalse(plan.hasLimit());
     assertFalse(plan.hasOffset());
     assertEquals(NATIVE_BATCH_SIZE, plan.getBatchSize());
-    assertEquals(STORAGE_OPTION_VALUE, plan.getStorageOptions().get(STORAGE_OPTION_KEY));
+    assertEquals(STORAGE_OPTION_READ_VALUE, plan.getStorageOptions().get(STORAGE_OPTION_KEY));
+    assertEquals(
+        STORAGE_OPTION_INITIAL_ONLY_VALUE,
+        plan.getStorageOptions().get(STORAGE_OPTION_INITIAL_ONLY_KEY));
     assertEquals(NAMESPACE_IMPL, plan.getNamespaceImpl());
     assertEquals(
         NAMESPACE_PROPERTY_VALUE, plan.getNamespaceProperties().get(NAMESPACE_PROPERTY_KEY));
@@ -198,7 +208,7 @@ public class LanceScanTest {
     }
     assertThrows(
         UnsupportedOperationException.class,
-        () -> plan.getStorageOptions().put(STORAGE_OPTION_KEY, STORAGE_OPTION_VALUE));
+        () -> plan.getStorageOptions().put(STORAGE_OPTION_KEY, STORAGE_OPTION_READ_VALUE));
     assertThrows(UnsupportedOperationException.class, () -> plan.getTableId().add(TABLE_NAME));
     assertThrows(
         UnsupportedOperationException.class,


### PR DESCRIPTION
Closes #623.

## Summary

This adds a stable native-read descriptor for ordinary Lance Spark scans so native engines can consume Spark-planned Lance reads without depending on Lance Spark internals.

The descriptor captures:

- Dataset URI and resolved dataset version.
- Spark read schema JSON and projected read schema JSON.
- Projected columns, pushed filter SQL, limit/offset, batch size, and storage options.
- Per-partition native splits with Lance fragment IDs.
- Explicit fallback reasons when a scan cannot be represented by the minimal v1 descriptor.

The v1 scope is ordinary table reads only. Search/hybrid search, index-backed execution descriptors, aggregation pushdown, metadata/version columns, and namespace-backed credential refresh remain fallback/future work.

## Why LanceScan carries the descriptor state

This PR adds several parameters to the `LanceScan` constructor because `LanceScan` is the object Spark keeps inside `BatchScanExec` after planning. A native consumer such as Comet sees that final `BatchScanExec(scan = LanceScan)` object, not the earlier `LanceScanBuilder` or catalog planning context. Therefore `nativeScanPlan()` needs the complete, already-resolved scan snapshot on `LanceScan` itself.

The goal is not to make the constructor a broad public API. The goal is to avoid asking native consumers to infer or recompute Lance Spark planning semantics from partial state. Re-planning later would be risky because it could reopen a different dataset version, use different storage options, produce different fragments, or miss fallback-only state such as pushed TopN/aggregation.

The added state is the minimum needed to describe or reject the native v1 scan accurately:

- `sparkReadSchema` and `schema` keep the Spark-visible schema and projected read schema separate, which matters when Spark-facing fields differ from the physical/projection schema.
- `readOptions` provides dataset URI, resolved version, batch size, table/catalog identifiers, and user storage options. The resolved version is required so native execution cannot drift to a newer Lance snapshot.
- `whereConditions`, `limit`, and `offset` are serialized into the descriptor when v1 supports them.
- `topNSortOrders` and `pushedAggregation` are carried even though v1 falls back for them, because the descriptor must reject those scans explicitly instead of silently dropping semantics.
- `pushedPredicates`, zonemap stats, surviving fragment IDs, precomputed splits, and fragment row counts preserve the fragment-pruning and limit-pruning decisions Lance Spark already made on the driver.
- `activeShardingExpression` and `fragmentShardingKeys` preserve the existing partitioning/reporting contract used by Lance Spark planning.
- `initialStorageOptions`, `namespaceImpl`, and `namespaceProperties` preserve storage option precedence and the namespace context that workers/native readers need for the same dataset access path.

A follow-up cleanup could wrap this constructor state into an internal immutable scan-state object if reviewers prefer that shape. This PR keeps the change direct so the descriptor contract and tests are easy to review first.

## Testing

- `./mvnw -pl lance-spark-base_2.12 -Dtest=LanceScanTest -Dspotless.skip=true test`
- `./mvnw -pl lance-spark-4.1_2.13 -am -Dtest=LanceScanTest -Dspotless.skip=true -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl lance-spark-base_2.12 spotless:check`
