### PR TITLE
ci: stop running lance release job on fork

### DIFF
--- a/.github/workflows/lance-release-timer.yml
+++ b/.github/workflows/lance-release-timer.yml
@@ -27,6 +27,7 @@ concurrency:
 
 jobs:
   trigger-update:
+    if: github.repository == 'lance-format/lance-spark'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The Lance Release Timer CI job is running on my fork, this PR gates it to the main repo :)

- github.com/geruh/lance-spark/actions/runs/27381558709