### PR TITLE
feat(sql): copy through blob v2 columns in Lance writes

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -506,30 +506,24 @@ For details on how caching works and tuning recommendations, see [Performance Tu
 
 ## Blob v2 Reads
 
-Lance datasets that contain a blob v2 column expose that column to Spark as the native 5-field descriptor struct: `struct<kind:short, position:long, size:long, blob_id:long, blob_uri:string>`. Querying the descriptor never fetches the blob bytes, so `SELECT payload.size` and `SELECT payload.blob_uri` are cheap.
+Lance exposes blob v2 columns as `struct<kind:short, position:long, size:long, blob_id:long, blob_uri:string>`. Descriptor queries do not fetch bytes.
 
 ```sql
--- Query metadata only (no byte fetch):
 SELECT id, payload.size, payload.kind FROM lance.ns.tbl;
 ```
 
-A column is treated as blob v2 when the Arrow field carries `ARROW:extension:name = lance.blob.v2`, matching lance-core's blob v2 extension type.
+A column is blob v2 when the Arrow field has `ARROW:extension:name = lance.blob.v2`.
 
-Filter pushdown for SQL `WHERE` is disabled on blob v2 tables; Spark evaluates predicates after the scan. Zonemap-based fragment pruning still runs.
-
-The connector does not materialize blob bytes on read; queries against descriptor fields fetch metadata only. See [Blob v2 Writes](#blob-v2-writes) below for the write path.
+SQL filter pushdown is disabled on blob v2 tables; zonemap fragment pruning still runs. See [Blob v2 Writes](#blob-v2-writes) for copying blobs between tables.
 
 ## Blob v2 Writes
 
-To write blob v2 columns, set `file_format_version` to `2.2` or higher and set
+To write blob v2 columns, set `file_format_version` to `2.2` or higher and
 `<column>.lance.encoding = blob` in `TBLPROPERTIES`.
 
-Spark still sees the column as `BINARY` when writing. The connector converts that binary
-value into the Arrow blob write struct during encoding.
+Spark accepts `BINARY` on write. The connector maps that to the Arrow blob write struct at encode time. On read the same columns come back as descriptor structs ([Blob v2 Reads](#blob-v2-reads)).
 
-On reads, blob v2 columns are exposed as descriptor structs. See
-[Blob v2 Reads](#blob-v2-reads). For writes, `INSERT` and DataFrame append still take
-`BINARY`.
+Copy blobs between Lance tables with a direct column select in `INSERT ... SELECT` or CTAS. See [INSERT INTO](operations/dml/insert-into.md#copying-blob-v2-columns) and [CREATE TABLE](operations/ddl/create-table.md#blob-v2-columns).
 
 ```sql
 CREATE TABLE lance.mydb.users (

--- a/docs/src/operations/ddl/create-table.md
+++ b/docs/src/operations/ddl/create-table.md
@@ -342,8 +342,7 @@ To create a table with blob columns, use the table property pattern `<column_nam
 
 To create blob v2 columns, set the blob encoding property and use `file_format_version = '2.2'` or higher.
 
-Spark writes blob v2 columns as `BINARY`. On reads, the same columns are exposed as
-descriptor structs. See [Blob v2 Reads](../../config.md#blob-v2-reads).
+Spark writes blob v2 columns as `BINARY` and reads expose descriptor structs ([Blob v2 Reads](../../config.md#blob-v2-reads)).
 
 === "SQL"
     ```sql
@@ -364,6 +363,18 @@ descriptor structs. See [Blob v2 Reads](../../config.md#blob-v2-reads).
         .tableProperty("file_format_version", "2.2") \
         .createOrReplace()
     ```
+
+
+#### CTAS from a blob v2 source
+
+```sql
+CREATE TABLE documents_copy USING lance
+AS SELECT id, content FROM documents;
+```
+
+The new table picks up `file_format_version = '2.2'` when the query includes blob v2 columns. A lower explicit version is rejected.
+
+Same rules as [INSERT INTO](../dml/insert-into.md#copying-blob-v2-columns).
 
 ## Large String Columns
 

--- a/docs/src/operations/dml/insert-into.md
+++ b/docs/src/operations/dml/insert-into.md
@@ -200,6 +200,22 @@ subsequent writes will automatically use blob encoding. No additional configurat
     df.writeTo("documents").append();
     ```
 
+
+### Copying blob v2 columns
+
+Blob v2 columns [read as descriptor structs](../../config.md#blob-v2-reads). Copy them with a direct select:
+
+```sql
+INSERT INTO documents_copy SELECT id, content FROM documents;
+```
+
+`writeTo().append()` and `.overwrite()` work the same way. Joins and filters are fine if the blob column stays a direct select or alias.
+
+**Limitations**
+
+- Do not transform the blob column (`CASE`, `content.size`, `GROUP BY`, `UNION`, `DISTINCT` fail the write).
+- `MERGE`, `UPDATE`, and dynamic partition overwrite are not supported.
+
 ## Writing Large String Data
 
 If you created a table with the `arrow.large_var_char` property (see [CREATE TABLE](../ddl/create-table.md#large-string-columns)), 

--- a/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -26,6 +26,9 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     // parser extensions
     extensions.injectParser { case (_, parser) => new LanceSparkSqlExtensionsParser(parser) }
+
+    // blob v2 copy-through for CTAS/INSERT (resolution rule)
+    extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2CopyFailureTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2CopyFailureTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2CopyFailureTest extends BaseBlobV2CopyFailureTest {}

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2CopyTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2CopyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2CopyTest extends BaseBlobV2CopyTest {}

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2PlanShapeTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2PlanShapeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2PlanShapeTest extends BaseBlobV2PlanShapeTest {}

--- a/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -26,6 +26,9 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     // parser extensions
     extensions.injectParser { case (_, parser) => new LanceSparkSqlExtensionsParser(parser) }
+
+    // blob v2 copy-through for CTAS/INSERT (resolution rule)
+    extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2CopyFailureTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2CopyFailureTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2CopyFailureTest extends BaseBlobV2CopyFailureTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2CopyTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2CopyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2CopyTest extends BaseBlobV2CopyTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2PlanShapeTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2PlanShapeTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2PlanShapeTest extends BaseBlobV2PlanShapeTest {}

--- a/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -26,6 +26,9 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     // parser extensions
     extensions.injectParser { case (_, parser) => new LanceSparkSqlExtensionsParser(parser) }
+
+    // blob v2 copy-through for CTAS/INSERT (resolution rule)
+    extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -26,6 +26,9 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     // parser extensions
     extensions.injectParser { case (_, parser) => new LanceSparkSqlExtensionsParser(parser) }
+
+    // blob v2 copy-through for CTAS/INSERT (resolution rule)
+    extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -170,6 +170,14 @@ public class LanceScan
     this.namespaceProperties = namespaceProperties;
   }
 
+  /**
+   * The read options this scan executes with, already pinned to the resolved dataset version by
+   * {@link LanceScanBuilder} for snapshot isolation.
+   */
+  public LanceSparkReadOptions readOptions() {
+    return readOptions;
+  }
+
   @Override
   public Batch toBatch() {
     return this;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
@@ -13,10 +13,12 @@
  */
 package org.lance.spark.utils;
 
+import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -43,6 +45,45 @@ public class BlobUtils {
           .add("size", DataTypes.LongType)
           .add("blob_id", DataTypes.LongType)
           .add("blob_uri", DataTypes.StringType);
+
+  /** Ordinal of the {@code size} field within {@link #BLOB_DESCRIPTOR_STRUCT}. */
+  public static final int BLOB_DESCRIPTOR_SIZE_ORDINAL = BLOB_DESCRIPTOR_STRUCT.fieldIndex("size");
+
+  private static final int BLOB_DESCRIPTOR_KIND_ORDINAL = BLOB_DESCRIPTOR_STRUCT.fieldIndex("kind");
+  private static final int BLOB_DESCRIPTOR_POSITION_ORDINAL =
+      BLOB_DESCRIPTOR_STRUCT.fieldIndex("position");
+  private static final int BLOB_DESCRIPTOR_BLOB_ID_ORDINAL =
+      BLOB_DESCRIPTOR_STRUCT.fieldIndex("blob_id");
+  private static final int BLOB_DESCRIPTOR_BLOB_URI_ORDINAL =
+      BLOB_DESCRIPTOR_STRUCT.fieldIndex("blob_uri");
+
+  /**
+   * True when a blob v2 descriptor row is Lance's null sentinel: inline kind with zero
+   * position/size, zero blob_id, and empty uri. Matches lance-core {@code collect_blob_entries_v2}
+   * and Python {@code _is_null_blob_description}. A SQL-null descriptor also counts as null.
+   */
+  public static boolean isNullBlobV2Descriptor(InternalRow descriptor) {
+    if (descriptor == null) {
+      return true;
+    }
+    if (descriptor.getShort(BLOB_DESCRIPTOR_KIND_ORDINAL) != 0) {
+      return false;
+    }
+    if (descriptor.getLong(BLOB_DESCRIPTOR_POSITION_ORDINAL) != 0L) {
+      return false;
+    }
+    if (descriptor.getLong(BLOB_DESCRIPTOR_SIZE_ORDINAL) != 0L) {
+      return false;
+    }
+    if (descriptor.getLong(BLOB_DESCRIPTOR_BLOB_ID_ORDINAL) != 0L) {
+      return false;
+    }
+    if (descriptor.isNullAt(BLOB_DESCRIPTOR_BLOB_URI_ORDINAL)) {
+      return true;
+    }
+    UTF8String uri = descriptor.getUTF8String(BLOB_DESCRIPTOR_BLOB_URI_ORDINAL);
+    return uri == null || uri.numBytes() == 0;
+  }
 
   /**
    * Check if a Spark field is a blob field based on its metadata.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/expressions/LanceBlobV2CopyRef.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/expressions/LanceBlobV2CopyRef.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.{BinaryType, DataType}
+import org.lance.spark.utils.{BlobReference, BlobUtils}
+
+/**
+ * [[LanceBlobV2CopyRef]] turns a blob v2 descriptor struct into a [[org.lance.spark.utils.BlobReference]]
+ * BINARY token for the write path.
+ */
+case class LanceBlobV2CopyRef(
+    blobDescriptor: Expression,
+    rowAddress: Expression,
+    datasetUri: String,
+    columnName: String)
+  extends Expression
+  with CodegenFallback {
+
+  override def children: Seq[Expression] = Seq(blobDescriptor, rowAddress)
+
+  override def dataType: DataType = BinaryType
+
+  override def nullable: Boolean = true
+
+  // datasetUri and columnName are constant for the whole scan, so encode the reference prefix once.
+  @transient private lazy val prefix: Array[Byte] =
+    BlobReference.serializePrefix(datasetUri, columnName)
+
+  override def eval(input: InternalRow): Any = {
+    val descriptor = blobDescriptor.eval(input)
+    if (descriptor == null) {
+      null
+    } else {
+      val desc = descriptor.asInstanceOf[InternalRow]
+      if (BlobUtils.isNullBlobV2Descriptor(desc)) {
+        null
+      } else {
+        val size = desc.getLong(BlobUtils.BLOB_DESCRIPTOR_SIZE_ORDINAL)
+        val rowAddr = rowAddress.eval(input)
+        // A null row address would unbox to 0L and silently copy row 0's blob into this row.
+        if (rowAddr == null) {
+          throw new IllegalStateException(
+            s"Row address is null while copying blob column '$columnName' from $datasetUri. " +
+              "Cannot locate the source blob")
+        }
+        BlobReference.appendRowAddressAndSize(prefix, rowAddr.asInstanceOf[Long], size)
+      }
+    }
+  }
+
+  override protected def withNewChildrenInternal(
+      newChildren: IndexedSeq[Expression]): LanceBlobV2CopyRef =
+    copy(blobDescriptor = newChildren(0), rowAddress = newChildren(1))
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/BlobPlanUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/BlobPlanUtils.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.NamedRelation
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, OverwriteByExpression}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.lance.spark.LanceDataset
+
+private[optimizer] object BlobPlanUtils {
+
+  final class V2BlobWrite private[BlobPlanUtils] (
+      val table: NamedRelation,
+      val query: LogicalPlan,
+      val writeOptions: Map[String, String],
+      command: LogicalPlan) {
+
+    def withQuery(newQuery: LogicalPlan): LogicalPlan = command match {
+      case a: AppendData => a.copy(query = newQuery)
+      case o: OverwriteByExpression => o.copy(query = newQuery)
+    }
+
+    def withTableAndOptions(
+        newTable: NamedRelation,
+        newWriteOptions: Map[String, String]): LogicalPlan = command match {
+      case a: AppendData => a.copy(table = newTable, writeOptions = newWriteOptions)
+      case o: OverwriteByExpression => o.copy(table = newTable, writeOptions = newWriteOptions)
+    }
+  }
+
+  object V2BlobWrite {
+    def unapply(plan: LogicalPlan): Option[V2BlobWrite] = plan match {
+      case a: AppendData => Some(new V2BlobWrite(a.table, a.query, a.writeOptions, a))
+      case o: OverwriteByExpression => Some(new V2BlobWrite(o.table, o.query, o.writeOptions, o))
+      case _ => None
+    }
+  }
+
+  object LanceRelation {
+    def unapply(plan: LogicalPlan): Option[(DataSourceV2Relation, LanceDataset)] = plan match {
+      case relation: DataSourceV2Relation =>
+        relation.table match {
+          case ds: LanceDataset => Some((relation, ds))
+          case _ => None
+        }
+      case _ => None
+    }
+  }
+
+  def collectLanceRelationsWithSubqueries(
+      plan: LogicalPlan): Seq[(DataSourceV2Relation, LanceDataset)] =
+    plan.collectWithSubqueries { case LanceRelation(relation, ds) => (relation, ds) }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRule.scala
@@ -13,92 +13,147 @@
  */
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.analysis.NamedRelation
+import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation}
-import org.apache.spark.sql.types.StructField
-import org.apache.spark.sql.util.LanceSerializeUtil
-import org.lance.spark.{LanceConstant, LanceDataset}
-import org.lance.spark.utils.{BlobSourceContext, BlobUtils}
+import org.apache.spark.sql.util.{CaseInsensitiveStringMap, LanceSerializeUtil}
+import org.lance.spark.{LanceConstant, LanceDataset, LanceSparkReadOptions}
+import org.lance.spark.read.LanceScan
+import org.lance.spark.utils.{BlobSourceContext, BlobUtils, Utils}
+
+import scala.util.control.NonFatal
 
 /**
- * Optimizer rule that propagates blob source credentials to the write side.
- *
- * When a Lance table with blob columns is read and its blob columns flow through a shuffle into a
- * write (e.g. `INSERT INTO target SELECT ... [JOIN ...]`), the blob bytes are not materialized: a
- * compact reference carrying the source dataset URI travels instead. To resolve those references the
- * write executors must reopen the source dataset — but Spark's DSv2 write is never handed the read
- * plan, so it has no way to learn the source's credentials.
- *
- * This rule bridges that gap on the driver, where both the write command and its source query are
- * visible: it collects each blob source's [[BlobSourceContext]] (read options + namespace config for
- * credential refresh), encodes them keyed by source URI, and stashes the result in the write
- * command's options under [[LanceConstant.BLOB_SOURCE_CONTEXTS_KEY]]. `LanceDataset.newWriteBuilder`
- * decodes it and threads it down to the per-task blob resolver. This keeps the credential context
- * query-scoped (no global state) and rides the write's own options channel rather than bloating
- * every shuffled row.
- *
- * No-op when the target is not a Lance table or the source query has no Lance blob tables.
+ * Encodes blob source credentials into Lance write options so write tasks can reopen source
+ * datasets for [[org.lance.spark.utils.BlobReference]] copy-through.
  */
 case class LanceBlobSourceContextRule() extends Rule[LogicalPlan] {
 
-  private val key = LanceConstant.BLOB_SOURCE_CONTEXTS_KEY
+  import LanceBlobSourceContextRule._
 
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
-    case a: AppendData if shouldAnnotate(a.table, a.writeOptions) =>
-      annotate(a.query) match {
-        case Some(v) => a.copy(writeOptions = a.writeOptions + (key -> v))
-        case None => a
-      }
-    case o: OverwriteByExpression if shouldAnnotate(o.table, o.writeOptions) =>
-      annotate(o.query) match {
-        case Some(v) => o.copy(writeOptions = o.writeOptions + (key -> v))
-        case None => o
-      }
-    case o: OverwritePartitionsDynamic if shouldAnnotate(o.table, o.writeOptions) =>
-      annotate(o.query) match {
-        case Some(v) => o.copy(writeOptions = o.writeOptions + (key -> v))
-        case None => o
-      }
+    case V2BlobWrite(write) if shouldAnnotate(write.table, write.writeOptions) =>
+      val (table, writeOptions) = annotate(write.query, write.table, write.writeOptions)
+      write.withTableAndOptions(table, writeOptions)
   }
 
-  private def shouldAnnotate(table: NamedRelation, writeOptions: Map[String, String]): Boolean =
-    !writeOptions.contains(key) && isLanceTarget(table)
+  // Spark 4.x V2Writes.mergeOptions requires command and relation options to match or one side empty.
+  private def annotate(
+      query: LogicalPlan,
+      table: NamedRelation,
+      writeOptions: Map[String, String]): (NamedRelation, Map[String, String]) =
+    encodeBlobSourceContexts(query) match {
+      case None => (table, writeOptions)
+      case Some(encoded) =>
+        val relationCarriesOptions = table match {
+          case relation: DataSourceV2Relation => !relation.options.isEmpty
+          case _ => false
+        }
+        val annotatedTable = table match {
+          case relation: DataSourceV2Relation if relationCarriesOptions =>
+            val merged = new java.util.HashMap[String, String](relation.options)
+            merged.put(key, encoded)
+            relation.copy(options = new CaseInsensitiveStringMap(merged))
+          case other => other
+        }
+        val annotatedWriteOptions =
+          if (writeOptions.nonEmpty || !relationCarriesOptions) writeOptions + (key -> encoded)
+          else writeOptions
+        (annotatedTable, annotatedWriteOptions)
+    }
 
-  private def isLanceTarget(table: NamedRelation): Boolean = table match {
-    case r: DataSourceV2Relation => r.table.isInstanceOf[LanceDataset]
+  private def shouldAnnotate(table: NamedRelation, writeOptions: Map[String, String]): Boolean =
+    !writeOptions.contains(key) && !annotatedOnRelation(table) && isLanceTarget(table)
+
+  private def annotatedOnRelation(table: NamedRelation): Boolean = table match {
+    case relation: DataSourceV2Relation => relation.options.containsKey(key)
     case _ => false
   }
 
-  /** Encodes {sourceUri -> context} for the query's blob sources, or None if there are none. */
-  private def annotate(query: LogicalPlan): Option[String] = {
-    val contexts = new java.util.HashMap[String, BlobSourceContext]()
-    query.foreach { node =>
-      lanceTableWithBlobs(node).foreach { ds =>
-        contexts.put(
-          ds.readOptions().getDatasetUri,
-          new BlobSourceContext(
-            ds.readOptions(),
-            ds.getInitialStorageOptions(),
-            ds.getNamespaceImpl(),
-            ds.getNamespaceProperties()))
+  private def isLanceTarget(table: NamedRelation): Boolean = table match {
+    case LanceRelation(_, _) => true
+    case _ => false
+  }
+}
+
+object LanceBlobSourceContextRule extends Logging {
+
+  val key: String = LanceConstant.BLOB_SOURCE_CONTEXTS_KEY
+
+  /** Adds the encoded blob source contexts for {@code query} to {@code writeOptions}, if any. */
+  def annotateWriteOptions(
+      query: LogicalPlan,
+      writeOptions: Map[String, String]): Map[String, String] =
+    encodeBlobSourceContexts(query) match {
+      case Some(encoded) => writeOptions + (key -> encoded)
+      case None => writeOptions
+    }
+
+  def encodeBlobSourceContexts(query: LogicalPlan): Option[String] = {
+    // Last relation per URI wins; pinning runs after dedup.
+    val sources =
+      new java.util.LinkedHashMap[String, (LanceDataset, Option[LanceSparkReadOptions])]()
+    (query +: query.subqueriesAll).foreach { plan =>
+      plan.foreach { node =>
+        blobSource(node).foreach { case source @ (ds, _) =>
+          sources.put(ds.readOptions().getDatasetUri, source)
+        }
       }
     }
-    if (contexts.isEmpty) None else Some(LanceSerializeUtil.encode(contexts))
+    if (sources.isEmpty) {
+      return None
+    }
+    val contexts = new java.util.HashMap[String, BlobSourceContext]()
+    sources.forEach { (uri, source) =>
+      val (ds, scanPinned) = source
+      contexts.put(
+        uri,
+        new BlobSourceContext(
+          scanPinned.getOrElse(pinToCurrentVersion(ds)),
+          ds.getInitialStorageOptions(),
+          ds.getNamespaceImpl(),
+          ds.getNamespaceProperties()))
+    }
+    Some(LanceSerializeUtil.encode(contexts))
   }
 
-  /** Returns the Lance table backing a relation iff it has blob columns (pre- or post-pushdown). */
-  private def lanceTableWithBlobs(node: LogicalPlan): Option[LanceDataset] = {
-    val table: Option[Table] = node match {
-      case r: DataSourceV2Relation => Some(r.table)
-      case sr: DataSourceV2ScanRelation => Some(sr.relation.table)
-      case _ => None
+  private def blobSource(
+      node: LogicalPlan): Option[(LanceDataset, Option[LanceSparkReadOptions])] = node match {
+    case LanceRelation(_, ds) if hasBlobColumns(ds) =>
+      Some((ds, None))
+    case sr: DataSourceV2ScanRelation =>
+      LanceRelation.unapply(sr.relation).collect {
+        case (_, ds) if hasBlobColumns(ds) =>
+          sr.scan match {
+            case scan: LanceScan => (ds, Some(scan.readOptions()))
+            case _ => (ds, None)
+          }
+      }
+    case _ => None
+  }
+
+  // Pin to the driver-visible version when time travel is not set; fall back on open failure.
+  private def pinToCurrentVersion(ds: LanceDataset): LanceSparkReadOptions = {
+    val opts = ds.readOptions()
+    if (opts.getVersion != null) {
+      return opts
     }
-    table.collect { case ds: LanceDataset if hasBlobColumns(ds) => ds }
+    try {
+      val dataset = Utils.openDatasetBuilder(opts).build()
+      try opts.withVersion(dataset.version())
+      finally dataset.close()
+    } catch {
+      case NonFatal(e) =>
+        logWarning(
+          s"Could not pin a dataset version for blob source '${opts.getDatasetUri}'; " +
+            s"blob references will resolve at the latest version: ${e.getMessage}")
+        opts
+    }
   }
 
   private def hasBlobColumns(ds: LanceDataset): Boolean =
-    ds.schema().fields.exists((f: StructField) => BlobUtils.isBlobSparkField(f))
+    ds.schema().fields.exists(f => BlobUtils.isBlobReadColumn(f))
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -1,0 +1,234 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.Metadata
+import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceConstant}
+import org.lance.spark.utils.BlobUtils
+
+/**
+ * Rewrites direct blob v2 reads in Lance writes into [[LanceBlobV2CopyRef]] tokens so writes see
+ * BINARY instead of descriptor structs.
+ *
+ * Note that the rule stands down on DISTINCT/GROUP BY/UNION, ORDER BY blob, transformed
+ * descriptors, and when the same source URI appears under different read identities.
+ */
+case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+    case c: CreateTableAsSelect if c.query.resolved && isLanceCatalog(c.name) =>
+      rewriteGuarded(c.query, None) match {
+        case Some(q) =>
+          c.copy(query = q, writeOptions = withBlobSourceContexts(c.query, c.writeOptions))
+        case None => c
+      }
+    case r: ReplaceTableAsSelect if r.query.resolved && isLanceCatalog(r.name) =>
+      rewriteGuarded(r.query, None) match {
+        case Some(q) =>
+          r.copy(query = q, writeOptions = withBlobSourceContexts(r.query, r.writeOptions))
+        case None => r
+      }
+    case command @ V2BlobWrite(write) if write.query.resolved =>
+      rewriteForExistingTarget(write.table, write.query).map(write.withQuery).getOrElse(command)
+  }
+
+  private def rewriteGuarded(
+      query: LogicalPlan,
+      targetBlobColumns: Option[Set[String]]): Option[LogicalPlan] =
+    rewriteQuery(query, targetBlobColumns)
+      .filterNot(rewritten => hasAmbiguousSource(query, copyTokenUris(rewritten)))
+
+  private def copyTokenUris(rewritten: LogicalPlan): Set[String] =
+    rewritten.collect { case p: Project =>
+      p.projectList.collect { case Alias(ref: LanceBlobV2CopyRef, _) => ref.datasetUri }
+    }.flatten.toSet
+
+  private def hasAmbiguousSource(query: LogicalPlan, tokenUris: Set[String]): Boolean =
+    BlobPlanUtils
+      .collectLanceRelationsWithSubqueries(query)
+      .filter { case (_, ds) => tokenUris.contains(ds.readOptions().getDatasetUri) }
+      .groupBy { case (_, ds) => ds.readOptions().getDatasetUri }
+      .exists { case (_, sameUri) =>
+        sameUri.map { case (relation, ds) =>
+          (ds.readOptions(), relation.options.asCaseSensitiveMap)
+        }.distinct.size > 1
+      }
+
+  // The optimizer-phase LanceBlobSourceContextRule cannot see a CTAS query (an AnalysisOnlyCommand),
+  // so inject the source context here. INSERT goes through that rule instead.
+  private def withBlobSourceContexts(
+      query: LogicalPlan,
+      writeOptions: Map[String, String]): Map[String, String] =
+    LanceBlobSourceContextRule.annotateWriteOptions(query, writeOptions)
+
+  private def rewriteForExistingTarget(
+      table: NamedRelation,
+      query: LogicalPlan): Option[LogicalPlan] =
+    targetBlobV2Columns(table).flatMap(names => rewriteGuarded(query, Some(names)))
+
+  private def targetBlobV2Columns(table: NamedRelation): Option[Set[String]] = table match {
+    case LanceRelation(_, ds) =>
+      val names =
+        ds.schema().fields.collect { case f if BlobUtils.isBlobV2SparkField(f) => f.name }.toSet
+      if (names.isEmpty) None else Some(names)
+    case _ => None
+  }
+
+  private def rewriteQuery(
+      query: LogicalPlan,
+      targetBlobColumns: Option[Set[String]]): Option[LogicalPlan] = query match {
+    case p: Project => rewriteProject(p, targetBlobColumns)
+    // Use field accessors rather than positional patterns. Sort gained a field in Spark 4.1 and a
+    // positional pattern would break when the case class grows.
+    case s: Sort =>
+      rewriteQuery(s.child, targetBlobColumns)
+        .filterNot(rewritten => ordersByRewrittenColumn(s.order, rewritten))
+        .map(rewritten => s.copy(child = rewritten))
+    case l: GlobalLimit =>
+      rewriteQuery(l.child, targetBlobColumns).map(rewritten => l.copy(child = rewritten))
+    case l: LocalLimit =>
+      rewriteQuery(l.child, targetBlobColumns).map(rewritten => l.copy(child = rewritten))
+    case o: Offset =>
+      rewriteQuery(o.child, targetBlobColumns).map(rewritten => o.copy(child = rewritten))
+    case a: SubqueryAlias =>
+      rewriteQuery(a.child, targetBlobColumns).map(rewritten => a.copy(child = rewritten))
+    // A bare table read (e.g. spark.table(...).writeTo(...).append()) has no projection to
+    // rewrite. Synthesize the identity projection so the DataFrame API matches the SQL path.
+    case LanceRelation(relation, _) =>
+      rewriteProject(Project(relation.output, relation), targetBlobColumns)
+    case _ => None
+  }
+
+  private def ordersByRewrittenColumn(order: Seq[SortOrder], rewritten: LogicalPlan): Boolean = {
+    val tokenIds = rewritten.collect { case Project(projectList, _) =>
+      projectList.collect { case a @ Alias(_: LanceBlobV2CopyRef, _) => a.exprId }
+    }.flatten.toSet
+    order.exists(_.references.exists(attr => tokenIds.contains(attr.exprId)))
+  }
+
+  private def rewriteProject(
+      project: Project,
+      targetBlobColumns: Option[Set[String]]): Option[LogicalPlan] = {
+    val Project(projectList, child) = project
+    val lanceRelations = child.collect { case LanceRelation(relation, ds) => relation -> ds }
+    if (lanceRelations.isEmpty) {
+      return None
+    }
+    val datasetByRelation = lanceRelations.toMap
+    val blobColumns: Map[ExprId, DataSourceV2Relation] = lanceRelations.flatMap {
+      case (relation, _) =>
+        relation.output.collect {
+          case a: AttributeReference if BlobUtils.isBlobV2SparkMetadata(a.metadata) =>
+            a.exprId -> relation
+        }
+    }.toMap
+    val rewrittenIds =
+      projectList.flatMap(e => admittedSourceId(e, blobColumns.contains, targetBlobColumns)).toSet
+    if (rewrittenIds.isEmpty) {
+      return None
+    }
+    val contributingRelations =
+      rewrittenIds.map(blobColumns).toSeq.distinct
+    val bindingByRelation: Map[DataSourceV2Relation, SourceBlobBinding] =
+      contributingRelations.map { relation =>
+        // markAsAllowAnyAccess lets AddMetadataColumns thread _rowaddr through nested SELECTs.
+        val rowAddress = relation.metadataOutput
+          .find(_.name == LanceConstant.ROW_ADDRESS)
+          .map(_.markAsAllowAnyAccess())
+          .getOrElse(throw new IllegalStateException(
+            s"blob v2 copy-through requires the '${LanceConstant.ROW_ADDRESS}' metadata column " +
+              s"on '${relation.table.name()}', but the Lance relation did not expose it"))
+        val datasetUri = datasetByRelation(relation).readOptions().getDatasetUri
+        relation -> SourceBlobBinding(rowAddress, datasetUri)
+      }.toMap
+    val bindingById: Map[ExprId, SourceBlobBinding] =
+      rewrittenIds.map(id => id -> bindingByRelation(blobColumns(id))).toMap
+    val newChild = child.resolveOperatorsDown {
+      case r: DataSourceV2Relation if bindingByRelation.contains(r) => r.withMetadataColumns()
+    }
+    val newProjectList =
+      projectList.map(e => rewriteProjection(e, bindingById, targetBlobColumns))
+    Some(Project(newProjectList, newChild))
+  }
+
+  private case class SourceBlobBinding(rowAddress: Expression, datasetUri: String)
+
+  private def admittedSourceId(
+      e: NamedExpression,
+      admittedColumn: ExprId => Boolean,
+      targetBlobColumns: Option[Set[String]]): Option[ExprId] =
+    sourceColumnId(e).filter(id =>
+      admittedColumn(id) && targetBlobColumns.forall(_.contains(e.name)))
+
+  private def sourceColumnId(e: NamedExpression): Option[ExprId] = e match {
+    case a: AttributeReference => Some(a.exprId)
+    case Alias(a: AttributeReference, _) => Some(a.exprId)
+    case _ => None
+  }
+
+  private def rewriteProjection(
+      e: NamedExpression,
+      bindingById: Map[ExprId, SourceBlobBinding],
+      targetBlobColumns: Option[Set[String]]): NamedExpression = {
+    if (admittedSourceId(e, bindingById.contains, targetBlobColumns).isEmpty) {
+      return e
+    }
+    e match {
+      case a: AttributeReference =>
+        copyRefAlias(
+          a,
+          a.name,
+          a.exprId,
+          a.qualifier,
+          a.metadata,
+          bindingById(a.exprId).rowAddress,
+          bindingById(a.exprId).datasetUri)
+      case alias @ Alias(a: AttributeReference, name) =>
+        copyRefAlias(
+          a,
+          name,
+          alias.exprId,
+          alias.qualifier,
+          a.metadata,
+          bindingById(a.exprId).rowAddress,
+          bindingById(a.exprId).datasetUri)
+      case other => other
+    }
+  }
+
+  private def copyRefAlias(
+      source: AttributeReference,
+      outputName: String,
+      exprId: ExprId,
+      qualifier: Seq[String],
+      metadata: Metadata,
+      rowAddress: Expression,
+      datasetUri: String): Alias =
+    Alias(LanceBlobV2CopyRef(source, rowAddress, datasetUri, source.name), outputName)(
+      exprId = exprId,
+      qualifier = qualifier,
+      explicitMetadata = Some(metadata))
+
+  private def isLanceCatalog(name: LogicalPlan): Boolean = name match {
+    case ResolvedIdentifier(catalog, _) => catalog.isInstanceOf[BaseLanceNamespaceSparkCatalog]
+    case _ => false
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -128,7 +128,9 @@ object LanceArrowWriter {
           resolver)
         new MapWriter(vector, structVector, keyWriter, valueWriter)
       case (BinaryType, vector: StructVector) if BlobUtils.isBlobV2SparkMetadata(metadata) =>
-        new BlobV2StructWriter(vector, createFieldWriter(vector.getChild("data"), BinaryType))
+        new BlobV2StructWriter(
+          vector,
+          createFieldWriter(vector.getChild("data"), BinaryType, null, resolver))
       case (StructType(fields), vector: StructVector) =>
         val children = fields.zipWithIndex.map { case (field, ordinal) =>
           createFieldWriter(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/AbstractBlobV2CopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/AbstractBlobV2CopyTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class AbstractBlobV2CopyTest {
+
+  protected static final String CATALOG_NAME = "lance_blob_v2";
+
+  protected SparkSession spark;
+
+  @TempDir protected Path tempDir;
+
+  @BeforeEach
+  void baseSetup() {
+    spark =
+        SparkSession.builder()
+            .appName("blob-v2-late-materialization")
+            .master("local[2]")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config(
+                "spark.sql.catalog." + CATALOG_NAME, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".impl", "dir")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".root", tempDir.toString())
+            .getOrCreate();
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS " + CATALOG_NAME + ".default");
+  }
+
+  @AfterEach
+  void baseTearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  protected String fq(String table) {
+    return CATALOG_NAME + ".default." + table;
+  }
+
+  protected static StructType idDataBinarySchema() {
+    return new StructType(
+        new StructField[] {
+          DataTypes.createStructField("id", DataTypes.IntegerType, false),
+          DataTypes.createStructField("data", DataTypes.BinaryType, true)
+        });
+  }
+
+  protected void createV2BlobTable(String fqTable, String... extraProps) {
+    StringBuilder props =
+        new StringBuilder("'data.lance.encoding' = 'blob', 'file_format_version' = '2.2'");
+    for (String p : extraProps) {
+      props.append(", ").append(p);
+    }
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTable
+            + " (id INT NOT NULL, data BINARY) USING lance TBLPROPERTIES ("
+            + props
+            + ")");
+  }
+
+  protected void createV2BlobSource(String fqTable, Row... rows) throws Exception {
+    createV2BlobTable(fqTable);
+    spark
+        .createDataFrame(Arrays.asList(rows), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqTable)
+        .append();
+  }
+
+  protected static StructType tagSchema() {
+    return new StructType(
+        new StructField[] {
+          DataTypes.createStructField("id", DataTypes.IntegerType, false),
+          DataTypes.createStructField("tag", DataTypes.StringType, true)
+        });
+  }
+
+  protected void createTwoBlobTarget(String fqTable) {
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTable
+            + " (id INT NOT NULL, data_a BINARY, data_b BINARY) USING lance TBLPROPERTIES ("
+            + "'data_a.lance.encoding' = 'blob', 'data_b.lance.encoding' = 'blob', "
+            + "'file_format_version' = '2.2')");
+  }
+
+  protected void createV2BlobTagTarget(String fqTable) {
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTable
+            + " (id INT NOT NULL, data BINARY, tag STRING) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.2')");
+  }
+
+  protected void createBlobAndPlainBinaryTarget(String fqTable) {
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTable
+            + " (id INT NOT NULL, data BINARY, note BINARY) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.2')");
+  }
+
+  protected void createV1BlobSource(String fqTable, Row... rows) throws Exception {
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTable
+            + " (id INT NOT NULL, data BINARY) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.0')");
+    spark
+        .createDataFrame(Arrays.asList(rows), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqTable)
+        .append();
+  }
+
+  protected static byte[] deterministicBlob(long seed, int length) {
+    byte[] bytes = new byte[length];
+    new Random(seed).nextBytes(bytes);
+    return bytes;
+  }
+
+  protected LogicalPlan analyzePlan(String sql) throws Exception {
+    return spark.sessionState().analyzer().execute(spark.sessionState().sqlParser().parsePlan(sql));
+  }
+
+  protected int countCopyRefs(LogicalPlan plan) {
+    return BlobPlanProbe.countCopyRefs(plan);
+  }
+
+  protected List<String> rowAddressColumnNames(LogicalPlan plan) {
+    return BlobPlanProbe.rowAddressColumnNames(plan);
+  }
+
+  protected long datasetVersionOf(String table) throws Exception {
+    try (org.lance.Dataset ds =
+        org.lance.Dataset.open()
+            .allocator(LanceRuntime.allocator())
+            .uri(datasetUriOf(table))
+            .build()) {
+      return ds.version();
+    }
+  }
+
+  protected String datasetUriOf(String table) throws Exception {
+    return ((LanceDataset)
+            ((TableCatalog) spark.sessionState().catalogManager().catalog(CATALOG_NAME))
+                .loadTable(Identifier.of(new String[] {"default"}, table)))
+        .readOptions()
+        .getDatasetUri();
+  }
+
+  protected List<Long> rowAddressesOf(String fqTable) {
+    List<Row> addrRows =
+        spark
+            .sql("SELECT " + LanceConstant.ROW_ADDRESS + " FROM " + fqTable + " ORDER BY id")
+            .collectAsList();
+    List<Long> addrs = new ArrayList<>();
+    for (Row r : addrRows) {
+      addrs.add(r.getLong(0));
+    }
+    return addrs;
+  }
+
+  protected void assertTargetBlobBytes(String datasetUri, List<Long> rowAddrs, byte[][] expected)
+      throws Exception {
+    assertTargetBlobBytes(datasetUri, rowAddrs, "data", expected);
+  }
+
+  protected void assertTargetBlobBytes(
+      String datasetUri, List<Long> rowAddrs, String column, byte[][] expected) throws Exception {
+    try (org.lance.Dataset ds =
+        org.lance.Dataset.open().allocator(LanceRuntime.allocator()).uri(datasetUri).build()) {
+      List<org.lance.BlobFile> blobs = ds.takeBlobs(rowAddrs, column);
+      assertEquals(expected.length, blobs.size(), "blob count mismatch");
+      for (int i = 0; i < expected.length; i++) {
+        try (org.lance.BlobFile bf = blobs.get(i)) {
+          assertArrayEquals(expected[i], bf.read(), "blob bytes mismatch at row " + i);
+        }
+      }
+    }
+  }
+
+  protected static Row row(int id, byte[] data) {
+    return RowFactory.create(id, data);
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyFailureTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyFailureTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseBlobV2CopyFailureTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void dynamicOverwrite_rejectedAsUnsupported() throws Exception {
+    String src = "v2_fail_dynover_src_" + System.currentTimeMillis();
+    String tgt = "v2_fail_dynover_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(140, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class, () -> spark.table(fqSrc).writeTo(fqTgt).overwritePartitions());
+      assertTrue(
+          ex.getMessage().contains("dynamic overwrite"),
+          "expected the connector's dynamic-overwrite rejection, got: " + ex.getMessage());
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void mergeIntoBlobV2Table_failsLoudly() throws Exception {
+    String src = "v2_fail_merge_src_" + System.currentTimeMillis();
+    String tgt = "v2_fail_merge_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(141, 16)));
+    createV2BlobSource(fqTgt, row(1, deterministicBlob(142, 16)));
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                      "MERGE INTO "
+                          + fqTgt
+                          + " t USING "
+                          + fqSrc
+                          + " s ON t.id = s.id"
+                          + " WHEN MATCHED THEN UPDATE SET t.data = s.data"));
+      assertTrue(
+          ex.getMessage() != null && !ex.getMessage().isEmpty(),
+          "MERGE must fail with a message, got: " + ex);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void updateBlobV2Table_failsLoudly() throws Exception {
+    String tgt = "v2_fail_update_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqTgt, row(1, deterministicBlob(143, 16)));
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () -> spark.sql("UPDATE " + fqTgt + " SET data = X'00' WHERE id = 1"));
+      assertTrue(
+          ex.getMessage() != null && !ex.getMessage().isEmpty(),
+          "UPDATE must fail with a message, got: " + ex);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void unionAllInsert_failsAtWriteValidationNotSilently() throws Exception {
+    String srcA = "v2_fail_union_a_" + System.currentTimeMillis();
+    String srcB = "v2_fail_union_b_" + System.currentTimeMillis();
+    String tgt = "v2_fail_union_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqA, row(1, deterministicBlob(145, 16)));
+    createV2BlobSource(fqB, row(2, deterministicBlob(146, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                      "INSERT INTO "
+                          + fqTgt
+                          + " SELECT id, data FROM "
+                          + fqA
+                          + " UNION ALL SELECT id, data FROM "
+                          + fqB));
+      assertTrue(
+          ex.getMessage().contains("binary"),
+          "expected the write validator's descriptor rejection, got: " + ex.getMessage());
+      assertEquals(0, spark.sql("SELECT * FROM " + fqTgt).count());
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
@@ -1,0 +1,876 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.BlobUtils;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseBlobV2CopyTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void insertSelect_copiesNullBlobAsNull() throws Exception {
+    String src = "v2_e2e_null_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_null_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] blob = deterministicBlob(147, 16);
+    createV2BlobSource(fqSrc, row(1, blob), row(2, null));
+    createV2BlobTable(fqTgt);
+    try {
+      Row nullDesc =
+          spark
+              .sql(
+                  "SELECT data.kind, data.position, data.size, data.blob_id, data.blob_uri "
+                      + "FROM "
+                      + fqSrc
+                      + " WHERE id = 2")
+              .first();
+      assertEquals((short) 0, nullDesc.getShort(0));
+      assertEquals(0L, nullDesc.getLong(1));
+      assertEquals(0L, nullDesc.getLong(2));
+      assertEquals(0L, nullDesc.getLong(3));
+      assertEquals("", nullDesc.getString(4));
+
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+
+      List<Row> rows = spark.sql("SELECT id, data FROM " + fqTgt + " ORDER BY id").collectAsList();
+      assertEquals(2, rows.size());
+      assertFalse(rows.get(0).isNullAt(1));
+
+      Row tgtNullDesc =
+          spark
+              .sql(
+                  "SELECT data.kind, data.position, data.size, data.blob_id, data.blob_uri "
+                      + "FROM "
+                      + fqTgt
+                      + " WHERE id = 2")
+              .first();
+      assertEquals((short) 0, tgtNullDesc.getShort(0));
+      assertEquals(0L, tgtNullDesc.getLong(1));
+      assertEquals(0L, tgtNullDesc.getLong(2));
+      assertEquals(0L, tgtNullDesc.getLong(3));
+      assertEquals("", tgtNullDesc.getString(4));
+
+      List<Long> tgtAddrs = rowAddressesOf(fqTgt);
+      assertEquals(2, tgtAddrs.size());
+      try (org.lance.Dataset ds =
+          org.lance.Dataset.open()
+              .allocator(LanceRuntime.allocator())
+              .uri(datasetUriOf(tgt))
+              .build()) {
+        assertEquals(1, ds.takeBlobs(tgtAddrs, "data").size(), "v2 takeBlobs skips null rows");
+      }
+
+      assertTargetBlobBytes(
+          datasetUriOf(tgt),
+          Collections.singletonList(rowAddressesOf(fqTgt).get(0)),
+          new byte[][] {blob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertSelect_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_insert_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_insert_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(11, 64), deterministicBlob(12, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void ctas_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_ctas_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_ctas_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(13, 64), deterministicBlob(14, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    try {
+      spark.sql("CREATE TABLE " + fqTgt + " USING lance AS SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void joinAndInsert_copiesBothSidesBlobBytes() throws Exception {
+    String srcA = "v2_e2e_join_a_" + System.currentTimeMillis();
+    String srcB = "v2_e2e_join_b_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_join_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    byte[][] blobsA = {deterministicBlob(41, 1000), deterministicBlob(42, 1000)};
+    byte[][] blobsB = {deterministicBlob(43, 2000), deterministicBlob(44, 2000)};
+    createV2BlobSource(fqA, row(1, blobsA[0]), row(2, blobsA[1]));
+    createV2BlobSource(fqB, row(1, blobsB[0]), row(2, blobsB[1]));
+    createTwoBlobTarget(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data AS data_a, b.data AS data_b FROM "
+              + fqA
+              + " a JOIN "
+              + fqB
+              + " b ON a.id = b.id");
+      List<Long> rowAddrs = rowAddressesOf(fqTgt);
+      String tgtUri = datasetUriOf(tgt);
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_a", blobsA);
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_b", blobsB);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void oneToManyJoin_copiesBlobBytesForEveryFannedRow() throws Exception {
+    String blobTbl = "v2_e2e_o2m_blob_" + System.currentTimeMillis();
+    String tagTbl = "v2_e2e_o2m_tag_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_o2m_tgt_" + System.currentTimeMillis();
+    String fqBlob = fq(blobTbl);
+    String fqTag = fq(tagTbl);
+    String fqTgt = fq(tgt);
+    byte[] blob1 = deterministicBlob(51, 512);
+    byte[] blob2 = deterministicBlob(52, 512);
+    createV2BlobSource(fqBlob, row(1, blob1), row(2, blob2));
+    spark.sql("CREATE TABLE " + fqTag + " (id INT NOT NULL, tag STRING) USING lance");
+    List<Row> tagRows = new ArrayList<>();
+    tagRows.add(RowFactory.create(1, "a"));
+    tagRows.add(RowFactory.create(1, "b"));
+    tagRows.add(RowFactory.create(1, "c"));
+    tagRows.add(RowFactory.create(2, "d"));
+    spark.createDataFrame(tagRows, tagSchema()).coalesce(1).writeTo(fqTag).append();
+    createV2BlobTagTarget(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data, b.tag FROM "
+              + fqBlob
+              + " a JOIN "
+              + fqTag
+              + " b ON a.id = b.id");
+      List<Row> ordered =
+          spark
+              .sql(
+                  "SELECT "
+                      + LanceConstant.ROW_ADDRESS
+                      + ", id, tag FROM "
+                      + fqTgt
+                      + " ORDER BY id, tag")
+              .collectAsList();
+      assertEquals(4, ordered.size(), "one-to-many join should produce 4 rows");
+      List<Long> rowAddrs = new ArrayList<>();
+      byte[][] expected = new byte[ordered.size()][];
+      for (int i = 0; i < ordered.size(); i++) {
+        rowAddrs.add(ordered.get(i).getLong(0));
+        expected[i] = ordered.get(i).getInt(1) == 1 ? blob1 : blob2;
+      }
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddrs, "data", expected);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqBlob);
+      spark.sql("DROP TABLE IF EXISTS " + fqTag);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void selfJoin_injectsCopyRefBoundToSelectedSide() throws Exception {
+    String src = "v2_e2e_self_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_self_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(7, 128), deterministicBlob(8, 128)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data FROM "
+              + fqSrc
+              + " a JOIN "
+              + fqSrc
+              + " b ON a.id = b.id";
+      int copyRefs = countCopyRefs(analyzePlan(sql));
+      assertEquals(1, copyRefs, "expected 1 CopyRef for self-join selecting one side");
+      spark.sql(sql);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertSelectWithOrderBy_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_order_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_order_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(31, 64), deterministicBlob(32, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " ORDER BY id DESC");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertSelectWithOrderByLimit_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_limit_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_limit_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(33, 64), deterministicBlob(34, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " ORDER BY id LIMIT 1");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blobs[0]});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertSelectWithOffset_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_offset_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_offset_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(93, 64), deterministicBlob(94, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM "
+              + fqSrc
+              + " ORDER BY id LIMIT 1"
+              + " OFFSET 1");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blobs[1]});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertOverwrite_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_overwrite_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_overwrite_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(68, 64), deterministicBlob(69, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobSource(fqTgt, row(99, deterministicBlob(70, 16)));
+    try {
+      spark.sql("INSERT OVERWRITE " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertEquals(
+          2,
+          spark.sql("SELECT * FROM " + fqTgt).count(),
+          "overwrite must replace the previous row");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void ctasFromJoin_copiesBothSidesBlobBytes() throws Exception {
+    String srcA = "v2_e2e_ctasjoin_a_" + System.currentTimeMillis();
+    String srcB = "v2_e2e_ctasjoin_b_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_ctasjoin_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    byte[] blobA = deterministicBlob(73, 128);
+    byte[] blobB = deterministicBlob(74, 128);
+    createV2BlobSource(fqA, row(1, blobA));
+    createV2BlobSource(fqB, row(1, blobB));
+    try {
+      spark.sql(
+          "CREATE TABLE "
+              + fqTgt
+              + " USING lance AS SELECT a.id, a.data AS data_a, b.data AS data_b FROM "
+              + fqA
+              + " a JOIN "
+              + fqB
+              + " b ON a.id = b.id");
+      List<Long> rowAddrs = rowAddressesOf(fqTgt);
+      String tgtUri = datasetUriOf(tgt);
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_a", new byte[][] {blobA});
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_b", new byte[][] {blobB});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void ctasIntoCatalogWithPre22Default_upgradesToBlobV2() throws Exception {
+    String oldCatalog = "lance_v20_default";
+    spark
+        .conf()
+        .set("spark.sql.catalog." + oldCatalog, "org.lance.spark.LanceNamespaceSparkCatalog");
+    spark.conf().set("spark.sql.catalog." + oldCatalog + ".impl", "dir");
+    spark
+        .conf()
+        .set("spark.sql.catalog." + oldCatalog + ".root", tempDir.resolve("v20root").toString());
+    spark.conf().set("spark.sql.catalog." + oldCatalog + ".file_format_version", "2.0");
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS " + oldCatalog + ".default");
+
+    String src = "v2_e2e_catdef_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_catdef_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = oldCatalog + ".default." + tgt;
+    byte[][] blobs = {deterministicBlob(37, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    try {
+      spark.sql("CREATE TABLE " + fqTgt + " USING lance AS SELECT id, data FROM " + fqSrc);
+      LanceDataset target =
+          (LanceDataset)
+              ((TableCatalog) spark.sessionState().catalogManager().catalog(oldCatalog))
+                  .loadTable(Identifier.of(new String[] {"default"}, tgt));
+      assertTrue(
+          BlobUtils.hasBlobV2Fields(target.schema()),
+          "target should have been created with blob v2 columns, schema: " + target.schema());
+      assertTargetBlobBytes(target.readOptions().getDatasetUri(), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void replaceTableAsSelect_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_rtas_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_rtas_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(65, 64), deterministicBlob(66, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobSource(fqTgt, row(99, deterministicBlob(67, 16)));
+    try {
+      spark.sql(
+          "CREATE OR REPLACE TABLE " + fqTgt + " USING lance AS SELECT id, data FROM " + fqSrc);
+      assertEquals(
+          2, spark.sql("SELECT * FROM " + fqTgt).count(), "replace must drop the previous row");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void appendIntoNonEmptyTarget_copiesBytesAndKeepsExistingRows() throws Exception {
+    String src = "v2_e2e_append_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_append_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] existing = deterministicBlob(71, 64);
+    byte[] appended = deterministicBlob(72, 256);
+    createV2BlobSource(fqTgt, row(1, existing));
+    createV2BlobSource(fqSrc, row(2, appended));
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertEquals(2, spark.sql("SELECT * FROM " + fqTgt).count(), "append must add a row");
+      assertTargetBlobBytes(
+          datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {existing, appended});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void sameSourceBlobUnderTwoNames_copiesBytesToBothColumns() throws Exception {
+    String src = "v2_e2e_dupname_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dupname_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] blob = deterministicBlob(75, 512);
+    createV2BlobSource(fqSrc, row(1, blob));
+    createTwoBlobTarget(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO " + fqTgt + " SELECT id, data AS data_a, data AS data_b FROM " + fqSrc);
+      List<Long> rowAddrs = rowAddressesOf(fqTgt);
+      String tgtUri = datasetUriOf(tgt);
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_a", new byte[][] {blob});
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_b", new byte[][] {blob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void timeTravelSingleSource_copiesPinnedVersionBytes() throws Exception {
+    String src = "v2_e2e_ttsingle_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_ttsingle_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] oldBytes = deterministicBlob(85, 64);
+    byte[] newBytes = deterministicBlob(86, 96);
+    createV2BlobSource(fqSrc, row(1, oldBytes));
+    long oldVersion = datasetVersionOf(src);
+    spark
+        .createDataFrame(Collections.singletonList(row(1, newBytes)), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .overwrite(org.apache.spark.sql.functions.lit(true));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM "
+              + fqSrc
+              + " VERSION AS OF "
+              + oldVersion);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {oldBytes});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void insertValuesLiteral_storesLiteralBytes() throws Exception {
+    String tgt = "v2_e2e_values_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " VALUES (1, X'CAFEBABE')");
+      assertTargetBlobBytes(
+          datasetUriOf(tgt),
+          rowAddressesOf(fqTgt),
+          new byte[][] {{(byte) 0xCA, (byte) 0xFE, (byte) 0xBA, (byte) 0xBE}});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void dataframeAppend_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_dfappend_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dfappend_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(111, 64), deterministicBlob(112, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.table(fqSrc).writeTo(fqTgt).append();
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void dataframeOverwrite_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_dfover_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dfover_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(113, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    createV2BlobSource(fqTgt, row(9, deterministicBlob(114, 16)));
+    try {
+      spark.table(fqSrc).writeTo(fqTgt).overwrite(org.apache.spark.sql.functions.lit(true));
+      assertEquals(1, spark.sql("SELECT * FROM " + fqTgt).count());
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void dataframeCreateOrReplace_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_dfcor_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dfcor_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(115, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    try {
+      spark.table(fqSrc).writeTo(fqTgt).using("lance").createOrReplace();
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void selfJoinBothSides_copiesBothSidesBlobBytes() throws Exception {
+    String src = "v2_e2e_selfboth_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_selfboth_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] blob = deterministicBlob(116, 128);
+    createV2BlobSource(fqSrc, row(1, blob));
+    createTwoBlobTarget(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data AS data_a, b.data AS data_b FROM "
+              + fqSrc
+              + " a JOIN "
+              + fqSrc
+              + " b ON a.id = b.id");
+      List<Long> rowAddrs = rowAddressesOf(fqTgt);
+      String tgtUri = datasetUriOf(tgt);
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_a", new byte[][] {blob});
+      assertTargetBlobBytes(tgtUri, rowAddrs, "data_b", new byte[][] {blob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void whereFilter_copiesOnlyMatchingRows() throws Exception {
+    String src = "v2_e2e_where_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_where_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(117, 64), deterministicBlob(118, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " WHERE id = 2");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blobs[1]});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void largeBlob_copiesAllBytes() throws Exception {
+    String src = "v2_e2e_large_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_large_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(119, 4 * 1024 * 1024)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void multiPartitionSource_copiesEveryRow() throws Exception {
+    String src = "v2_e2e_multipart_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_multipart_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobTable(fqSrc);
+    byte[][] blobs = new byte[8][];
+    List<Row> rows = new ArrayList<>();
+    for (int i = 0; i < 8; i++) {
+      blobs[i] = deterministicBlob(120 + i, 64 + i);
+      rows.add(row(i + 1, blobs[i]));
+    }
+    spark.createDataFrame(rows, idDataBinarySchema()).repartition(3).writeTo(fqSrc).append();
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void duplicateBlobBytesAcrossRows_copiesEachRow() throws Exception {
+    String src = "v2_e2e_dupbytes_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dupbytes_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] same = deterministicBlob(130, 64);
+    createV2BlobSource(fqSrc, row(1, same), row(2, same));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {same, same});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void emptyBlob_roundTrips() throws Exception {
+    String src = "v2_e2e_empty_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_empty_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(131, 64), new byte[0]};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void v1BlobSourceIntoV2Target_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_v1src_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_v1src_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(132, 64), deterministicBlob(133, 4096)};
+    createV1BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void crossCatalogCopy_copiesBlobBytes() throws Exception {
+    String otherCatalog = "lance_blob_v2_other";
+    spark
+        .conf()
+        .set("spark.sql.catalog." + otherCatalog, "org.lance.spark.LanceNamespaceSparkCatalog");
+    spark.conf().set("spark.sql.catalog." + otherCatalog + ".impl", "dir");
+    spark
+        .conf()
+        .set("spark.sql.catalog." + otherCatalog + ".root", tempDir.resolve("othercat").toString());
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS " + otherCatalog + ".default");
+    String src = "v2_e2e_xcat_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_xcat_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = otherCatalog + ".default." + tgt;
+    byte[][] blobs = {deterministicBlob(134, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTgt
+            + " (id INT NOT NULL, data BINARY) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.2')");
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      org.apache.spark.sql.connector.catalog.TableCatalog cat =
+          (org.apache.spark.sql.connector.catalog.TableCatalog)
+              spark.sessionState().catalogManager().catalog(otherCatalog);
+      LanceDataset target =
+          (LanceDataset)
+              cat.loadTable(
+                  org.apache.spark.sql.connector.catalog.Identifier.of(
+                      new String[] {"default"}, tgt));
+      List<Row> addrRows =
+          spark
+              .sql("SELECT " + LanceConstant.ROW_ADDRESS + " FROM " + fqTgt + " ORDER BY id")
+              .collectAsList();
+      List<Long> addrs = new ArrayList<>();
+      for (Row r : addrRows) {
+        addrs.add(r.getLong(0));
+      }
+      assertTargetBlobBytes(target.readOptions().getDatasetUri(), addrs, blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void cteInsert_copiesOnSpark3FailsLoudlyOnSpark4() throws Exception {
+    String src = "v2_e2e_cte_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_cte_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(150, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "WITH x AS (SELECT id, data FROM "
+              + fqSrc
+              + ") INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM x";
+      if (spark.version().startsWith("4")) {
+        Exception ex = assertThrows(IllegalArgumentException.class, () -> spark.sql(sql));
+        assertTrue(ex.getMessage().contains("binary"), ex.getMessage());
+        assertEquals(0, spark.sql("SELECT * FROM " + fqTgt).count());
+      } else {
+        spark.sql(sql);
+        assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+      }
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void windowFunctionInQuery_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_window_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_window_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(151, 64), deterministicBlob(152, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTgt
+            + " (id INT NOT NULL, data BINARY, rn INT) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.2')");
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data, CAST(row_number() OVER (ORDER BY id) AS INT) AS rn FROM "
+              + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void directPathSave_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_dpath_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_dpath_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(160, 64)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]));
+    createV2BlobTable(fqTgt);
+    String tgtUri = datasetUriOf(tgt);
+    try {
+      spark
+          .table(fqSrc)
+          .write()
+          .format("lance")
+          .option(LanceSparkReadOptions.CONFIG_DATASET_URI, tgtUri)
+          .mode("append")
+          .save();
+      assertTargetBlobBytes(tgtUri, rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void namedVersionSourceIntoV2Target_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_namedver_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_namedver_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(161, 64)};
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqSrc
+            + " (id INT NOT NULL, data BINARY) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = 'stable')");
+    spark
+        .createDataFrame(java.util.Arrays.asList(row(1, blobs[0])), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .append();
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql("INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void tablesample_copiesSurvivingRowsBytes() throws Exception {
+    String src = "v2_e2e_sample_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_sample_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(171, 64), deterministicBlob(172, 256)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " TABLESAMPLE (100 PERCENT)");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
@@ -1,0 +1,684 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseBlobV2PlanShapeTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void directColumnRef_injectsCopyRef() throws Exception {
+    String src = "v2_plan_direct_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_direct_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(1, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      List<String> rowAddrs = rowAddressColumnNames(plan);
+      assertEquals(1, copyRefs, "expected 1 CopyRef, got " + copyRefs + "\nplan:\n" + plan);
+      assertTrue(
+          rowAddrs.contains("_rowaddr"),
+          "row address should reference _rowaddr, got " + rowAddrs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void aliasOfRef_injectsCopyRef() throws Exception {
+    String src = "v2_plan_alias_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_alias_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(2, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data AS data FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      List<String> rowAddrs = rowAddressColumnNames(plan);
+      assertEquals(1, copyRefs, "expected 1 CopyRef, got " + copyRefs + "\nplan:\n" + plan);
+      assertTrue(
+          rowAddrs.contains("_rowaddr"),
+          "row address should reference _rowaddr, got " + rowAddrs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void ctas_injectsCopyRef() throws Exception {
+    String src = "v2_plan_ctas_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_ctas_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(3, 16)));
+    try {
+      String sql = "CREATE TABLE " + fqTgt + " USING lance AS SELECT id, data FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      List<String> rowAddrs = rowAddressColumnNames(plan);
+      assertEquals(1, copyRefs, "expected 1 CopyRef, got " + copyRefs + "\nplan:\n" + plan);
+      assertTrue(
+          rowAddrs.contains("_rowaddr"),
+          "row address should reference _rowaddr, got " + rowAddrs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+    }
+  }
+
+  @Test
+  public void transformedDescriptor_noCopyRef() throws Exception {
+    String src = "v2_plan_xform_src_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(4, 16)));
+    try {
+      String sql = "SELECT id, data.size AS sz FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          0,
+          copyRefs,
+          "expected 0 CopyRef for transformed descriptor, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+    }
+  }
+
+  @Test
+  public void singleSourceBlobInJoin_injectsOneCopyRef() throws Exception {
+    String srcA = "v2_plan_multi_a_" + System.currentTimeMillis();
+    String srcB = "v2_plan_multi_b_" + System.currentTimeMillis();
+    String tgt = "v2_plan_multi_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqA, row(1, deterministicBlob(5, 16)));
+    spark.sql("CREATE TABLE " + fqB + " (id INT NOT NULL, tag STRING) USING lance");
+    spark
+        .createDataFrame(Collections.singletonList(RowFactory.create(1, "x")), tagSchema())
+        .coalesce(1)
+        .writeTo(fqB)
+        .append();
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data FROM "
+              + fqA
+              + " a JOIN "
+              + fqB
+              + " b ON a.id = b.id";
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          1,
+          copyRefs,
+          "expected 1 CopyRef for blob from one join side, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void twoBlobSourcesInJoin_injectsTwoCopyRefs() throws Exception {
+    String srcA = "v2_plan_two_a_" + System.currentTimeMillis();
+    String srcB = "v2_plan_two_b_" + System.currentTimeMillis();
+    String tgt = "v2_plan_two_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqA, row(1, deterministicBlob(5, 16)));
+    createV2BlobSource(fqB, row(1, deterministicBlob(6, 16)));
+    createTwoBlobTarget(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data AS data_a, b.data AS data_b FROM "
+              + fqA
+              + " a JOIN "
+              + fqB
+              + " b ON a.id = b.id";
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          2,
+          copyRefs,
+          "expected 2 CopyRefs for two blob join sides, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void orderByBlobColumn_noCopyRef() throws Exception {
+    String src = "v2_plan_orderblob_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_orderblob_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(35, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " ORDER BY data";
+      int copyRefs = countCopyRefs(analyzePlan(sql));
+      assertEquals(0, copyRefs, "expected 0 CopyRef when ordering by the blob column itself");
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void distinctSelect_noCopyRef() throws Exception {
+    String src = "v2_plan_distinct_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_distinct_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(36, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT DISTINCT id, data FROM " + fqSrc;
+      int copyRefs = countCopyRefs(analyzePlan(sql));
+      assertEquals(0, copyRefs, "expected 0 CopyRef under DISTINCT");
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void nonLanceCatalogCtas_noCopyRef() throws Exception {
+    String src = "v2_plan_noncat_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_noncat_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(8, 16)));
+    try {
+      String sql = "CREATE TABLE " + tgt + " USING parquet AS SELECT id, data FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          0,
+          copyRefs,
+          "expected 0 CopyRef for non-Lance catalog CTAS, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+    }
+  }
+
+  @Test
+  public void timeTravelJoinOneSideCopied_noCopyRef() throws Exception {
+    String src = "v2_plan_ttjoin_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_ttjoin_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] oldBytes = deterministicBlob(81, 64);
+    byte[] newBytes = deterministicBlob(82, 96);
+    createV2BlobSource(fqSrc, row(1, oldBytes));
+    long oldVersion = datasetVersionOf(src);
+    spark
+        .createDataFrame(Collections.singletonList(row(1, newBytes)), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .overwrite(org.apache.spark.sql.functions.lit(true));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT o.id, o.data FROM "
+              + fqSrc
+              + " VERSION AS OF "
+              + oldVersion
+              + " o JOIN "
+              + fqSrc
+              + " c ON o.id = c.id";
+      LogicalPlan plan = analyzePlan(sql);
+      assertEquals(
+          0,
+          countCopyRefs(plan),
+          "same URI at two versions is ambiguous; no CopyRef may be injected\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void timeTravelJoinBothSidesCopied_noCopyRef() throws Exception {
+    String src = "v2_plan_ttjoin2_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_ttjoin2_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(83, 64)));
+    long oldVersion = datasetVersionOf(src);
+    spark
+        .createDataFrame(
+            Collections.singletonList(row(1, deterministicBlob(84, 96))), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .overwrite(org.apache.spark.sql.functions.lit(true));
+    createTwoBlobTarget(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT o.id, o.data AS data_a, c.data AS data_b FROM "
+              + fqSrc
+              + " VERSION AS OF "
+              + oldVersion
+              + " o JOIN "
+              + fqSrc
+              + " c ON o.id = c.id";
+      LogicalPlan plan = analyzePlan(sql);
+      assertEquals(
+          0,
+          countCopyRefs(plan),
+          "same URI at two versions is ambiguous; no CopyRef may be injected\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void timeTravelInSubqueryFilter_noCopyRef() throws Exception {
+    String src = "v2_plan_ttsubq_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_ttsubq_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(87, 64)));
+    long oldVersion = datasetVersionOf(src);
+    spark
+        .createDataFrame(
+            Collections.singletonList(row(1, deterministicBlob(88, 96))), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .overwrite(org.apache.spark.sql.functions.lit(true));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM "
+              + fqSrc
+              + " WHERE id IN (SELECT id FROM "
+              + fqSrc
+              + " VERSION AS OF "
+              + oldVersion
+              + ")";
+      LogicalPlan plan = analyzePlan(sql);
+      assertEquals(
+          0,
+          countCopyRefs(plan),
+          "a subquery reading the same URI at another version is ambiguous; no CopyRef may be"
+              + " injected\nplan:\n"
+              + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void timeTravelInSelectListSubquery_noCopyRef() throws Exception {
+    String src = "v2_plan_ttscalar_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_ttscalar_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(90, 64)));
+    long oldVersion = datasetVersionOf(src);
+    spark
+        .createDataFrame(
+            Collections.singletonList(row(1, deterministicBlob(91, 96))), idDataBinarySchema())
+        .coalesce(1)
+        .writeTo(fqSrc)
+        .overwrite(org.apache.spark.sql.functions.lit(true));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT (SELECT MIN(id) FROM "
+              + fqSrc
+              + " VERSION AS OF "
+              + oldVersion
+              + ") AS id, data FROM "
+              + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      assertEquals(
+          0,
+          countCopyRefs(plan),
+          "a SELECT-list subquery reading the same URI at another version is ambiguous; no"
+              + " CopyRef may be injected\nplan:\n"
+              + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void blobIntoNonBlobTargetColumn_noCopyRefForThatColumn() throws Exception {
+    String src = "v2_plan_gate_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_gate_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(61, 16)));
+    createBlobAndPlainBinaryTarget(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data AS data, data AS note FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          1,
+          copyRefs,
+          "only the blob-column projection may be tokenized, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void sameSourceBlobUnderTwoNames_injectsTwoCopyRefs() throws Exception {
+    String src = "v2_plan_dupname_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_dupname_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(62, 16)));
+    createTwoBlobTarget(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO " + fqTgt + " SELECT id, data AS data_a, data AS data_b FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          2,
+          copyRefs,
+          "the same blob under two names should yield two CopyRefs, got "
+              + copyRefs
+              + "\nplan:\n"
+              + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void replaceTableAsSelect_injectsCopyRef() throws Exception {
+    String src = "v2_plan_rtas_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_rtas_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(63, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "CREATE OR REPLACE TABLE " + fqTgt + " USING lance AS SELECT id, data FROM " + fqSrc;
+      LogicalPlan plan = analyzePlan(sql);
+      int copyRefs = countCopyRefs(plan);
+      assertEquals(
+          1, copyRefs, "expected 1 CopyRef for RTAS, got " + copyRefs + "\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void blobSourceContext_pinsScanVersion() throws Exception {
+    String src = "v2_plan_ctxpin_src_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(89, 64)));
+    long version = datasetVersionOf(src);
+    try {
+      LogicalPlan query = analyzePlan("SELECT id, data FROM " + fqSrc);
+      java.util.Map<String, Long> versions = BlobPlanProbe.blobSourceContextVersions(query);
+      assertEquals(1, versions.size(), "expected one blob source context");
+      assertEquals(
+          version,
+          versions.values().iterator().next(),
+          "the context must pin the version the query reads, not float to latest");
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+    }
+  }
+
+  @Test
+  public void caseOverDescriptor_noCopyRef() throws Exception {
+    String src = "v2_plan_case_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_case_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(101, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, CASE WHEN id > 0 THEN data ELSE data END AS data FROM "
+              + fqSrc;
+      assertEquals(0, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void unionAll_noCopyRef() throws Exception {
+    String srcA = "v2_plan_union_a_" + System.currentTimeMillis();
+    String srcB = "v2_plan_union_b_" + System.currentTimeMillis();
+    String tgt = "v2_plan_union_tgt_" + System.currentTimeMillis();
+    String fqA = fq(srcA);
+    String fqB = fq(srcB);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqA, row(1, deterministicBlob(102, 16)));
+    createV2BlobSource(fqB, row(2, deterministicBlob(103, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM "
+              + fqA
+              + " UNION ALL SELECT id, data FROM "
+              + fqB;
+      assertEquals(0, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqA);
+      spark.sql("DROP TABLE IF EXISTS " + fqB);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void groupByFirstBlob_noCopyRef() throws Exception {
+    String src = "v2_plan_group_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_group_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(104, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO " + fqTgt + " SELECT id, first(data) AS data FROM " + fqSrc + " GROUP BY id";
+      assertEquals(0, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void windowFunctionInQuery_injectsCopyRef() throws Exception {
+    String src = "v2_plan_window_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_window_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(105, 16)));
+    spark.sql(
+        "CREATE TABLE IF NOT EXISTS "
+            + fqTgt
+            + " (id INT NOT NULL, data BINARY, rn INT) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.2')");
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, data, CAST(row_number() OVER (ORDER BY id) AS INT) AS rn FROM "
+              + fqSrc;
+      assertEquals(1, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void cteInsert_injectsCopyRefOnSpark3() throws Exception {
+    String src = "v2_plan_cte_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_cte_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(106, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "WITH x AS (SELECT id, data FROM "
+              + fqSrc
+              + ") INSERT INTO "
+              + fqTgt
+              + " SELECT id, data FROM x";
+      int expected = spark.version().startsWith("4") ? 0 : 1;
+      assertEquals(expected, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void v1BlobSource_noCopyRef() throws Exception {
+    String src = "v2_plan_v1src_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_v1src_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV1BlobSource(fqSrc, row(1, deterministicBlob(107, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc;
+      assertEquals(0, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void selfJoinBothSides_injectsTwoCopyRefs() throws Exception {
+    String src = "v2_plan_selfboth_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_selfboth_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(108, 16)));
+    createTwoBlobTarget(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT a.id, a.data AS data_a, b.data AS data_b FROM "
+              + fqSrc
+              + " a JOIN "
+              + fqSrc
+              + " b ON a.id = b.id";
+      assertEquals(2, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void whereFilter_injectsCopyRef() throws Exception {
+    String src = "v2_plan_where_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_where_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(109, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql = "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " WHERE id > 0";
+      assertEquals(1, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void blobSourceContext_carriesNamespaceImpl() throws Exception {
+    String src = "v2_plan_ctxns_src_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(110, 16)));
+    try {
+      java.util.Map<String, String> impls =
+          BlobPlanProbe.blobSourceContextNamespaceImpls(
+              analyzePlan("SELECT id, data FROM " + fqSrc));
+      assertEquals(1, impls.size());
+      assertEquals("dir", impls.values().iterator().next());
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+    }
+  }
+
+  @Test
+  public void tablesample_injectsCopyRef() throws Exception {
+    String src = "v2_plan_sample_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_sample_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(170, 16)));
+    createV2BlobTable(fqTgt);
+    try {
+      String sql =
+          "INSERT INTO " + fqTgt + " SELECT id, data FROM " + fqSrc + " TABLESAMPLE (50 PERCENT)";
+      assertEquals(1, countCopyRefs(analyzePlan(sql)));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceBlobV2CopyRefTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceBlobV2CopyRefTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.BlobReference;
+import org.lance.spark.utils.BlobUtils;
+
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.LanceBlobV2CopyRef;
+import org.apache.spark.sql.catalyst.expressions.Literal;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class LanceBlobV2CopyRefTest {
+
+  private static final String DATASET_URI = "file:///tmp/source_dataset";
+  private static final String COLUMN = "data";
+  private static final long BLOB_SIZE = 42L;
+
+  private static Literal descriptorLiteral() {
+    Object[] descriptor = new Object[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fields().length];
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("kind")] = (short) 0;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("position")] = 0L;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_SIZE_ORDINAL] = BLOB_SIZE;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("blob_id")] = 7L;
+    return new Literal(new GenericInternalRow(descriptor), BlobUtils.BLOB_DESCRIPTOR_STRUCT);
+  }
+
+  private static Literal nullSentinelDescriptorLiteral() {
+    Object[] descriptor = new Object[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fields().length];
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("kind")] = (short) 0;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("position")] = 0L;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_SIZE_ORDINAL] = 0L;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("blob_id")] = 0L;
+    descriptor[BlobUtils.BLOB_DESCRIPTOR_STRUCT.fieldIndex("blob_uri")] = UTF8String.fromString("");
+    return new Literal(new GenericInternalRow(descriptor), BlobUtils.BLOB_DESCRIPTOR_STRUCT);
+  }
+
+  @Test
+  public void encodesRowAddressAndSizeIntoBlobReferenceToken() {
+    LanceBlobV2CopyRef ref =
+        new LanceBlobV2CopyRef(
+            descriptorLiteral(), new Literal(123L, DataTypes.LongType), DATASET_URI, COLUMN);
+    byte[] expected =
+        BlobReference.appendRowAddressAndSize(
+            BlobReference.serializePrefix(DATASET_URI, COLUMN), 123L, BLOB_SIZE);
+    assertArrayEquals(expected, (byte[]) ref.eval(null));
+  }
+
+  @Test
+  public void nullDescriptorYieldsNull() {
+    LanceBlobV2CopyRef ref =
+        new LanceBlobV2CopyRef(
+            new Literal(null, BlobUtils.BLOB_DESCRIPTOR_STRUCT),
+            new Literal(123L, DataTypes.LongType),
+            DATASET_URI,
+            COLUMN);
+    assertNull(ref.eval(null));
+  }
+
+  @Test
+  public void nullSentinelDescriptorYieldsNull() {
+    LanceBlobV2CopyRef ref =
+        new LanceBlobV2CopyRef(
+            nullSentinelDescriptorLiteral(),
+            new Literal(123L, DataTypes.LongType),
+            DATASET_URI,
+            COLUMN);
+    assertNull(ref.eval(null));
+  }
+
+  @Test
+  public void nullRowAddressFailsInsteadOfCopyingRowZero() {
+    LanceBlobV2CopyRef ref =
+        new LanceBlobV2CopyRef(
+            descriptorLiteral(), new Literal(null, DataTypes.LongType), DATASET_URI, COLUMN);
+    assertThrows(IllegalStateException.class, () -> ref.eval(null));
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -13,11 +13,13 @@
  */
 package org.lance.spark.utils;
 
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -78,6 +80,27 @@ public class BlobUtilsTest {
     assertTrue(BlobUtils.isBlobReadColumn(new StructField("v1", DataTypes.BinaryType, true, v1)));
     assertTrue(BlobUtils.isBlobReadColumn(blobV2Field()));
     assertFalse(BlobUtils.isBlobReadColumn(field("id", DataTypes.IntegerType)));
+  }
+
+  @Test
+  public void testNullBlobV2DescriptorSentinel() {
+    // The sentinel is ALL five fields zero/empty; any single non-zero field means a real blob,
+    // so each field must participate in the detection (size == 0 alone is not enough).
+    Object[] sentinel = {(short) 0, 0L, 0L, 0L, UTF8String.fromString("")};
+    assertTrue(BlobUtils.isNullBlobV2Descriptor(new GenericInternalRow(sentinel)));
+    Object[][] realBlobs = {
+      {(short) 1, 0L, 0L, 0L, UTF8String.fromString("")},
+      {(short) 0, 8L, 0L, 0L, UTF8String.fromString("")},
+      {(short) 0, 0L, 16L, 0L, UTF8String.fromString("")},
+      {(short) 0, 0L, 0L, 7L, UTF8String.fromString("")},
+      {(short) 0, 0L, 0L, 0L, UTF8String.fromString("file:///b.blob")},
+    };
+    for (Object[] fields : realBlobs) {
+      assertFalse(
+          BlobUtils.isNullBlobV2Descriptor(new GenericInternalRow(fields)),
+          "must not classify a real descriptor as the null sentinel: "
+              + java.util.Arrays.toString(fields));
+    }
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceWriteSchemaValidatorTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceWriteSchemaValidatorTest.java
@@ -26,6 +26,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+/**
+ * The name+order contract pinned here is load-bearing for blob v2 copy-through:
+ * LanceBlobV2CopyThroughRule gates rewrites by output column NAME, which is only sound because this
+ * validator admits exclusively projections matching the target columns in name and order. Weakening
+ * these rejections requires changing that gating first.
+ */
 public class LanceWriteSchemaValidatorTest {
 
   @Test

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRuleTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRuleTest.scala
@@ -13,14 +13,18 @@
  */
 package org.apache.spark.sql.catalyst.optimizer
 
-import org.apache.spark.sql.catalyst.plans.logical.AppendData
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, OverwriteByExpression, OverwritePartitionsDynamic}
 import org.apache.spark.sql.connector.catalog.{Table, TableCapability}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.{BinaryType, DoubleType, IntegerType, MetadataBuilder, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
 import org.lance.spark.{LanceConstant, LanceDataset, LanceSparkReadOptions}
 import org.lance.spark.utils.BlobUtils
+
+import scala.collection.JavaConverters._
 
 /**
  * Unit tests for [[LanceBlobSourceContextRule]]'s application logic, exercised directly on logical
@@ -122,5 +126,62 @@ class LanceBlobSourceContextRuleTest {
     val twice = rule(once).asInstanceOf[AppendData]
     assertTrue(once.writeOptions.contains(key))
     assertEquals(once, twice)
+  }
+
+  @Test
+  def annotationPreservesV2WritesMergeInvariant(): Unit = {
+    // V2Writes.mergeOptions (Spark 4.x) asserts commandOptions == dsOptions or one side empty,
+    // reflecting the three writer APIs: SQL puts options on the relation, DataFrameWriterV2 on
+    // the command, and the V1 save() path on both, equal. Annotation must keep the invariant in
+    // every (command, relation) configuration.
+    val target = lanceTable("file:///target.lance", blobSchema)
+    val source = lanceTable("file:///src.lance", blobSchema)
+    val carried = Map("dataset_uri" -> "file:///target.lance")
+    val configs = Seq(
+      (Map.empty[String, String], Map.empty[String, String]), // SQL / writeTo without options
+      (carried, carried), // V1 save(): both channels, equal
+      (carried, Map.empty[String, String]), // DataFrameWriterV2 with command options
+      (Map.empty[String, String], carried)
+    ) // relation as the sole carrier
+    configs.foreach { case (commandOptions, relationOptions) =>
+      val targetRelation = DataSourceV2Relation.create(
+        target,
+        None,
+        None,
+        new CaseInsensitiveStringMap(relationOptions.asJava))
+      val plan = AppendData.byName(targetRelation, relation(source), commandOptions)
+      val result = rule(plan).asInstanceOf[AppendData]
+      val command = result.writeOptions
+      val ds = result.table.asInstanceOf[DataSourceV2Relation].options.asScala.toMap
+      assertTrue(
+        command.contains(key) || ds.contains(key),
+        s"context not attached for command=$commandOptions relation=$relationOptions")
+      assertTrue(
+        command == ds || command.isEmpty || ds.isEmpty,
+        s"V2Writes.mergeOptions invariant violated: command=$command ds=$ds")
+    }
+  }
+
+  @Test
+  def annotatesExactlyTheSupportedWriteCommands(): Unit = {
+    // The blob-write command matrix (single source of truth: BlobPlanUtils.V2BlobWrite):
+    //   AppendData                 -> context here, copy rewrite in LanceBlobV2CopyThroughRule
+    //   OverwriteByExpression      -> context here, copy rewrite in LanceBlobV2CopyThroughRule
+    //   CTAS / RTAS                -> both handled inside LanceBlobV2CopyThroughRule
+    //   OverwritePartitionsDynamic -> rejected at the capability check before any rule runs,
+    //                                 so this rule must not pretend to support it
+    val target = relation(lanceTable("file:///target.lance", blobSchema))
+    val source = relation(lanceTable("file:///src.lance", blobSchema))
+
+    val append = rule(AppendData.byName(target, source, Map.empty)).asInstanceOf[AppendData]
+    assertTrue(append.writeOptions.contains(key))
+
+    val overwrite = rule(
+      OverwriteByExpression.byName(target, source, Literal.TrueLiteral, Map.empty))
+      .asInstanceOf[OverwriteByExpression]
+    assertTrue(overwrite.writeOptions.contains(key))
+
+    val dynamic = OverwritePartitionsDynamic.byName(target, source, Map.empty)
+    assertEquals(dynamic, rule(dynamic))
   }
 }

--- a/lance-spark-base_2.12/src/test/scala/org/lance/spark/BlobPlanProbe.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/lance/spark/BlobPlanProbe.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark
+
+import org.apache.spark.sql.catalyst.expressions.{Expression, LanceBlobV2CopyRef}
+import org.apache.spark.sql.catalyst.optimizer.LanceBlobSourceContextRule
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.util.LanceSerializeUtil
+import org.lance.spark.utils.BlobSourceContext
+
+object BlobPlanProbe {
+
+  def countCopyRefs(plan: LogicalPlan): Int =
+    allExpressions(plan).flatMap(copyRefsInExpr).size
+
+  def rowAddressColumnNames(plan: LogicalPlan): java.util.List[String] = {
+    val names = new java.util.ArrayList[String]()
+    allExpressions(plan).flatMap(copyRefsInExpr).foreach { ref =>
+      ref.rowAddress.references.foreach(attr => names.add(attr.name))
+    }
+    names
+  }
+
+  /** The dataset version each encoded blob source context would resolve against; null = latest. */
+  def blobSourceContextVersions(plan: LogicalPlan): java.util.Map[String, java.lang.Long] = {
+    val versions = new java.util.HashMap[String, java.lang.Long]()
+    decodedContexts(plan).forEach((uri, ctx) => versions.put(uri, ctx.getReadOptions.getVersion))
+    versions
+  }
+
+  /** The namespace impl each encoded blob source context would reopen its dataset through. */
+  def blobSourceContextNamespaceImpls(plan: LogicalPlan): java.util.Map[String, String] = {
+    val impls = new java.util.HashMap[String, String]()
+    decodedContexts(plan).forEach((uri, ctx) => impls.put(uri, ctx.getNamespaceImpl))
+    impls
+  }
+
+  private def decodedContexts(plan: LogicalPlan): java.util.Map[String, BlobSourceContext] =
+    LanceBlobSourceContextRule
+      .encodeBlobSourceContexts(plan)
+      .map(encoded =>
+        LanceSerializeUtil.decode[java.util.HashMap[String, BlobSourceContext]](encoded))
+      .getOrElse(new java.util.HashMap[String, BlobSourceContext]())
+
+  private def allExpressions(plan: LogicalPlan): Seq[Expression] =
+    allNodes(plan).flatMap(_.expressions)
+
+  // CTAS/RTAS are AnalysisOnlyCommands: their rewritten query lives in innerChildren, not children,
+  // so a plain children walk misses the injected copyref. Traverse both.
+  private def allNodes(plan: LogicalPlan): Seq[LogicalPlan] = {
+    val inner = plan.innerChildren.collect { case child: LogicalPlan => child }
+    plan +: (plan.children ++ inner).flatMap(allNodes)
+  }
+
+  private def copyRefsInExpr(e: Expression): Seq[LanceBlobV2CopyRef] = {
+    val self = e match {
+      case ref: LanceBlobV2CopyRef => Seq(ref)
+      case _ => Seq.empty
+    }
+    self ++ e.children.flatMap(copyRefsInExpr)
+  }
+}


### PR DESCRIPTION
Blob v2 columns read as descriptor structs but writes expect BINARY. Before this, `INSERT INTO tgt SELECT blob FROM src` would hit the write validator and error out.

This PR adds a resolution rule that rewrites direct blob selects into copy tokens. The write path resolves them via `takeBlobs` and actually copies the bytes.

### What works

Direct blob copies, including joins (both sides, self-join, fan-out):

```sql
INSERT INTO out SELECT a.id, a.data, b.data
FROM docs_a a JOIN docs_b b ON a.id = b.id;
```

Plain single-table copy:

```sql
INSERT INTO documents_copy SELECT id, content FROM documents;
```

CTAS / RTAS (picks up file_format_version = '2.2' when the query has blob v2 columns):

```sql
CREATE TABLE documents_copy USING lance
AS SELECT id, content FROM documents;
```

Also: `writeTo().append(), .overwrite()`, path writes, cross-catalog copies when source creds differ.
Filters, limits, windows are fine too, as long as each blob column is a direct ref or alias (`SELECT data, SELECT data AS x`). Not `CASE`, not `GROUP BY`, not `UNION`, not `ORDER BY data`.


### Logic

This PR adds 2 new rules:

- `LanceBlobV2CopyThroughRule` (resolution): finds blob v2 columns in the write query, swaps them for `LanceBlobV2CopyRef` tokens bound to `_rowaddr` + source `URI`. On joins, each side gets its own token tied to that relation's row address.
- `LanceBlobSourceContextRule` (optimizer): stashes source dataset creds/version on write options so tasks can reopen the source for `takeBlobs`. `CTAS` gets context injected in the copy rule since optimizer can't see the `CTAS` query.

Stands down when the same URI is read twice with different identities (time travel in a subquery, etc.). otherwise the per-URI context map lies about which snapshot you're copying from.







