### PR TITLE
chore: update lance dependency to v8.0.0-beta.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.1</lance-spark.version>
-        <lance.version>8.0.0-beta.9</lance.version>
+        <lance.version>8.0.0-beta.14</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Bump the Lance core dependency from `8.0.0-beta.9` to `8.0.0-beta.14`.
- Verified Docker hardcoded versions against Maven properties: `LANCE_SPARK_VERSION=0.5.1` and `LANCE_NS_IMPL_VERSION=0.3.0` already match, so no Dockerfile change was required.
- Triggering tag: `refs/tags/v8.0.0-beta.14`

## Verification
- `make lint`
- `make install`
