### PR TITLE
feat(cbo): add ANALYZE TABLE persistent column statistics

### DIFF
--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
@@ -75,13 +75,26 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
   }
 
   /**
-   * Parse a string to a LogicalPlan.
+   * Parse a string to a LogicalPlan. Delegate to Spark's built-in parser first; only fall through
+   * to the Lance extension grammar (index / optimize / vacuum / column-backfill / primary-key
+   * commands) when Spark rejects the statement. ANALYZE TABLE is intentionally NOT handled here —
+   * Spark parses it natively, and `LanceAnalyzeTableResolution` rewrites it for Lance tables during
+   * analysis, so non-Lance ANALYZE is left to Spark untouched (no hijack).
    */
   override def parsePlan(sqlText: String): LogicalPlan = {
     try {
       delegate.parsePlan(sqlText)
     } catch {
-      case _: ParseException => parse(sqlText)
+      case e: ParseException =>
+        // Spark rejected it; try the Lance extension grammar. If Lance can't parse it either (the
+        // input is neither valid Spark SQL nor a Lance command), surface Spark's original
+        // positioned ParseException rather than the raw ANTLR ParseCancellationException that the
+        // fail-fast parse() throws.
+        try {
+          parse(sqlText)
+        } catch {
+          case _: Exception => throw e
+        }
     }
   }
 
@@ -97,6 +110,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new LanceSqlExtensionsParser(tokenStream)
     parser.removeErrorListeners()
+    // Fail fast on any token mismatch instead of silently recovering to a partial plan. parse() is
+    // only reached after Spark's delegate already rejected the statement, so a failure here means
+    // it is neither valid Spark SQL nor a Lance extension command; throwing lets parsePlan surface
+    // Spark's original positioned ParseException rather than the raw ANTLR ParseCancellationException.
+    parser.setErrorHandler(new BailErrorStrategy())
 
     try {
       // first, try parsing with potentially faster SLL mode
@@ -107,6 +125,7 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
         // if we fail, parse with LL mode
         tokenStream.seek(0) // rewind input stream
         parser.reset()
+        parser.setErrorHandler(new BailErrorStrategy())
 
         // Try Again.
         parser.getInterpreter.setPredictionMode(PredictionMode.LL)

--- a/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.apache.spark.sql.execution.datasources.v2.{LanceAnalyzeTableResolution, LanceDataSourceV2Strategy}
 import org.lance.spark.search.LanceSearchTableFunctions
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
@@ -29,6 +29,11 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // blob v2 copy-through for CTAS/INSERT (resolution rule)
     extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
+
+    // Rewrite Spark's native ANALYZE TABLE plans (AnalyzeColumn / AnalyzeTable) into
+    // LanceAnalyzeTable for Lance tables. There is no custom ANALYZE grammar; non-Lance ANALYZE is
+    // left untouched for Spark to handle.
+    extensions.injectResolutionRule(_ => LanceAnalyzeTableResolution)
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/AnalyzeTableTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/AnalyzeTableTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class AnalyzeTableTest extends BaseAnalyzeTableTest {}

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
@@ -75,13 +75,26 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
   }
 
   /**
-   * Parse a string to a LogicalPlan.
+   * Parse a string to a LogicalPlan. Delegate to Spark's built-in parser first; only fall through
+   * to the Lance extension grammar (index / optimize / vacuum / column-backfill / primary-key
+   * commands) when Spark rejects the statement. ANALYZE TABLE is intentionally NOT handled here —
+   * Spark parses it natively, and `LanceAnalyzeTableResolution` rewrites it for Lance tables during
+   * analysis, so non-Lance ANALYZE is left to Spark untouched (no hijack).
    */
   override def parsePlan(sqlText: String): LogicalPlan = {
     try {
       delegate.parsePlan(sqlText)
     } catch {
-      case _: ParseException => parse(sqlText)
+      case e: ParseException =>
+        // Spark rejected it; try the Lance extension grammar. If Lance can't parse it either (the
+        // input is neither valid Spark SQL nor a Lance command), surface Spark's original
+        // positioned ParseException rather than the raw ANTLR ParseCancellationException that the
+        // fail-fast parse() throws.
+        try {
+          parse(sqlText)
+        } catch {
+          case _: Exception => throw e
+        }
     }
   }
 
@@ -97,6 +110,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new LanceSqlExtensionsParser(tokenStream)
     parser.removeErrorListeners()
+    // Fail fast on any token mismatch instead of silently recovering to a partial plan. parse() is
+    // only reached after Spark's delegate already rejected the statement, so a failure here means
+    // it is neither valid Spark SQL nor a Lance extension command; throwing lets parsePlan surface
+    // Spark's original positioned ParseException rather than the raw ANTLR ParseCancellationException.
+    parser.setErrorHandler(new BailErrorStrategy())
 
     try {
       // first, try parsing with potentially faster SLL mode
@@ -107,6 +125,7 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
         // if we fail, parse with LL mode
         tokenStream.seek(0) // rewind input stream
         parser.reset()
+        parser.setErrorHandler(new BailErrorStrategy())
 
         // Try Again.
         parser.getInterpreter.setPredictionMode(PredictionMode.LL)

--- a/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.apache.spark.sql.execution.datasources.v2.{LanceAnalyzeTableResolution, LanceDataSourceV2Strategy}
 import org.lance.spark.search.LanceSearchTableFunctions
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
@@ -33,6 +33,11 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
 
     extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
+
+    // Rewrite Spark's native ANALYZE TABLE plans (AnalyzeColumn / AnalyzeTable) into
+    // LanceAnalyzeTable for Lance tables. There is no custom ANALYZE grammar; non-Lance ANALYZE is
+    // left untouched for Spark to handle.
+    extensions.injectResolutionRule(_ => LanceAnalyzeTableResolution)
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/AnalyzeTableTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/AnalyzeTableTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+public class AnalyzeTableTest extends BaseAnalyzeTableTest {}

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
@@ -75,7 +75,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
   }
 
   /**
-   * Parse a string to a LogicalPlan.
+   * Parse a string to a LogicalPlan. Delegate to Spark's built-in parser first; only fall through
+   * to the Lance extension grammar (index / optimize / vacuum / column-backfill / primary-key
+   * commands) when Spark rejects the statement. ANALYZE TABLE is intentionally NOT handled here —
+   * Spark parses it natively, and `LanceAnalyzeTableResolution` rewrites it for Lance tables during
+   * analysis, so non-Lance ANALYZE is left to Spark untouched (no hijack).
    */
   override def parsePlan(sqlText: String): LogicalPlan = {
     if (sqlText.trim.toUpperCase.startsWith("CREATE INDEX")) {
@@ -86,7 +90,16 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     try {
       delegate.parsePlan(sqlText)
     } catch {
-      case _: ParseException => parse(sqlText)
+      case e: ParseException =>
+        // Spark rejected it; try the Lance extension grammar. If Lance can't parse it either (the
+        // input is neither valid Spark SQL nor a Lance command), surface Spark's original
+        // positioned ParseException rather than the raw ANTLR ParseCancellationException that the
+        // fail-fast parse() throws.
+        try {
+          parse(sqlText)
+        } catch {
+          case _: Exception => throw e
+        }
     }
   }
 
@@ -105,6 +118,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new LanceSqlExtensionsParser(tokenStream)
     parser.removeErrorListeners()
+    // Fail fast on any token mismatch instead of silently recovering to a partial plan. parse() is
+    // only reached after Spark's delegate already rejected the statement, so a failure here means
+    // it is neither valid Spark SQL nor a Lance extension command; throwing lets parsePlan surface
+    // Spark's original positioned ParseException rather than the raw ANTLR ParseCancellationException.
+    parser.setErrorHandler(new BailErrorStrategy())
 
     try {
       // first, try parsing with potentially faster SLL mode
@@ -115,6 +133,7 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
         // if we fail, parse with LL mode
         tokenStream.seek(0) // rewind input stream
         parser.reset()
+        parser.setErrorHandler(new BailErrorStrategy())
 
         // Try Again.
         parser.getInterpreter.setPredictionMode(PredictionMode.LL)

--- a/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.apache.spark.sql.execution.datasources.v2.{LanceAnalyzeTableResolution, LanceDataSourceV2Strategy}
 import org.lance.spark.search.LanceSearchTableFunctions
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
@@ -33,6 +33,11 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
 
     extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
+
+    // Rewrite Spark's native ANALYZE TABLE plans (AnalyzeColumn / AnalyzeTable) into
+    // LanceAnalyzeTable for Lance tables. There is no custom ANALYZE grammar; non-Lance ANALYZE is
+    // left untouched for Spark to handle.
+    extensions.injectResolutionRule(_ => LanceAnalyzeTableResolution)
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSparkSqlExtensionsParser.scala
@@ -75,7 +75,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
   }
 
   /**
-   * Parse a string to a LogicalPlan.
+   * Parse a string to a LogicalPlan. Delegate to Spark's built-in parser first; only fall through
+   * to the Lance extension grammar (index / optimize / vacuum / column-backfill / primary-key
+   * commands) when Spark rejects the statement. ANALYZE TABLE is intentionally NOT handled here —
+   * Spark parses it natively, and `LanceAnalyzeTableResolution` rewrites it for Lance tables during
+   * analysis, so non-Lance ANALYZE is left to Spark untouched (no hijack).
    */
   override def parsePlan(sqlText: String): LogicalPlan = {
     if (sqlText.trim.toUpperCase.startsWith("CREATE INDEX")) {
@@ -86,7 +90,16 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     try {
       delegate.parsePlan(sqlText)
     } catch {
-      case _: ParseException => parse(sqlText)
+      case e: ParseException =>
+        // Spark rejected it; try the Lance extension grammar. If Lance can't parse it either (the
+        // input is neither valid Spark SQL nor a Lance command), surface Spark's original
+        // positioned ParseException rather than the raw ANTLR ParseCancellationException that the
+        // fail-fast parse() throws.
+        try {
+          parse(sqlText)
+        } catch {
+          case _: Exception => throw e
+        }
     }
   }
 
@@ -105,6 +118,11 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
     val tokenStream = new CommonTokenStream(lexer)
     val parser = new LanceSqlExtensionsParser(tokenStream)
     parser.removeErrorListeners()
+    // Fail fast on any token mismatch instead of silently recovering to a partial plan. parse() is
+    // only reached after Spark's delegate already rejected the statement, so a failure here means
+    // it is neither valid Spark SQL nor a Lance extension command; throwing lets parsePlan surface
+    // Spark's original positioned ParseException rather than the raw ANTLR ParseCancellationException.
+    parser.setErrorHandler(new BailErrorStrategy())
 
     try {
       // first, try parsing with potentially faster SLL mode
@@ -115,6 +133,7 @@ class LanceSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserInt
         // if we fail, parse with LL mode
         tokenStream.seek(0) // rewind input stream
         parser.reset()
+        parser.setErrorHandler(new BailErrorStrategy())
 
         // Try Again.
         parser.getInterpreter.setPredictionMode(PredictionMode.LL)

--- a/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
+import org.apache.spark.sql.execution.datasources.v2.{LanceAnalyzeTableResolution, LanceDataSourceV2Strategy}
 import org.lance.spark.search.LanceSearchTableFunctions
 
 class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
@@ -33,6 +33,11 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
 
     extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
+
+    // Rewrite Spark's native ANALYZE TABLE plans (AnalyzeColumn / AnalyzeTable) into
+    // LanceAnalyzeTable for Lance tables. There is no custom ANALYZE grammar; non-Lance ANALYZE is
+    // left untouched for Spark to handle.
+    extensions.injectResolutionRule(_ => LanceAnalyzeTableResolution)
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -54,6 +54,9 @@ public class LanceSparkReadOptions implements Serializable {
   public static final String CONFIG_TOP_N_PUSH_DOWN = "topN_push_down";
   private static final String DEPRECATED_CONFIG_NEAREST = "nearest";
 
+  /** Per-scan kill-switch for CBO column-stats reporting (persisted ANALYZE TABLE stats). */
+  public static final String CONFIG_CBO_COLUMN_STATS_ENABLED = "cbo.column.stats.enabled";
+
   /**
    * Whether executors should rebuild the namespace client and re-fetch storage options via {@code
    * namespace.describeTable()} when opening a dataset for fragment scans.
@@ -94,6 +97,7 @@ public class LanceSparkReadOptions implements Serializable {
   // Changed from 512 to 8192 for better OLAP scan performance (33x improvement)
   private static final int DEFAULT_BATCH_SIZE = 8192;
   private static final boolean DEFAULT_TOP_N_PUSH_DOWN = true;
+  private static final boolean DEFAULT_CBO_COLUMN_STATS_ENABLED = true;
   private static final boolean DEFAULT_EXECUTOR_CREDENTIAL_REFRESH = true;
 
   private final String datasetUri;
@@ -106,6 +110,7 @@ public class LanceSparkReadOptions implements Serializable {
   private final Integer metadataCacheSize;
   private final int batchSize;
   private final boolean topNPushDown;
+  private final boolean cboColumnStatsEnabled;
   private final Map<String, String> storageOptions;
 
   /** The namespace for credential vending. Transient as LanceNamespace is not serializable. */
@@ -135,6 +140,7 @@ public class LanceSparkReadOptions implements Serializable {
     this.metadataCacheSize = builder.metadataCacheSize;
     this.batchSize = builder.batchSize;
     this.topNPushDown = builder.topNPushDown;
+    this.cboColumnStatsEnabled = builder.cboColumnStatsEnabled;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
@@ -250,6 +256,10 @@ public class LanceSparkReadOptions implements Serializable {
     return topNPushDown;
   }
 
+  public boolean isCboColumnStatsEnabled() {
+    return cboColumnStatsEnabled;
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -306,6 +316,7 @@ public class LanceSparkReadOptions implements Serializable {
         .metadataCacheSize(this.metadataCacheSize)
         .batchSize(this.batchSize)
         .topNPushDown(this.topNPushDown)
+        .cboColumnStatsEnabled(this.cboColumnStatsEnabled)
         .storageOptions(this.storageOptions)
         .namespace(this.namespace)
         .tableId(this.tableId)
@@ -349,6 +360,7 @@ public class LanceSparkReadOptions implements Serializable {
     return pushDownFilters == that.pushDownFilters
         && batchSize == that.batchSize
         && topNPushDown == that.topNPushDown
+        && cboColumnStatsEnabled == that.cboColumnStatsEnabled
         && executorCredentialRefresh == that.executorCredentialRefresh
         && Objects.equals(datasetUri, that.datasetUri)
         && Objects.equals(blockSize, that.blockSize)
@@ -370,6 +382,7 @@ public class LanceSparkReadOptions implements Serializable {
         metadataCacheSize,
         batchSize,
         topNPushDown,
+        cboColumnStatsEnabled,
         storageOptions,
         tableId,
         executorCredentialRefresh);
@@ -385,6 +398,7 @@ public class LanceSparkReadOptions implements Serializable {
     private Integer metadataCacheSize;
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean topNPushDown = DEFAULT_TOP_N_PUSH_DOWN;
+    private boolean cboColumnStatsEnabled = DEFAULT_CBO_COLUMN_STATS_ENABLED;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
     private List<String> tableId;
@@ -430,6 +444,11 @@ public class LanceSparkReadOptions implements Serializable {
 
     public Builder topNPushDown(boolean topNPushDown) {
       this.topNPushDown = topNPushDown;
+      return this;
+    }
+
+    public Builder cboColumnStatsEnabled(boolean cboColumnStatsEnabled) {
+      this.cboColumnStatsEnabled = cboColumnStatsEnabled;
       return this;
     }
 
@@ -519,6 +538,10 @@ public class LanceSparkReadOptions implements Serializable {
       }
       if (opts.containsKey(CONFIG_TOP_N_PUSH_DOWN)) {
         this.topNPushDown = Boolean.parseBoolean(opts.get(CONFIG_TOP_N_PUSH_DOWN));
+      }
+      if (opts.containsKey(CONFIG_CBO_COLUMN_STATS_ENABLED)) {
+        this.cboColumnStatsEnabled =
+            Boolean.parseBoolean(opts.get(CONFIG_CBO_COLUMN_STATS_ENABLED));
       }
       if (opts.containsKey(CONFIG_EXECUTOR_CREDENTIAL_REFRESH)) {
         this.executorCredentialRefresh =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -30,6 +30,7 @@ import org.lance.spark.utils.BlobUtils;
 import org.lance.spark.utils.Optional;
 import org.lance.spark.utils.Utils;
 
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.expressions.Expression;
@@ -49,6 +50,7 @@ import org.apache.spark.sql.connector.read.SupportsPushDownOffset;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.connector.read.SupportsPushDownTopN;
 import org.apache.spark.sql.connector.read.SupportsPushDownV2Filters;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
@@ -58,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -166,7 +169,8 @@ public class LanceScanBuilder
       }
 
       // Get statistics from manifest summary before closing dataset
-      ManifestSummary summary = getOrOpenDataset().getVersion().getManifestSummary();
+      org.lance.Version datasetVersion = getOrOpenDataset().getVersion();
+      ManifestSummary summary = datasetVersion.getManifestSummary();
 
       // Collect all columns that need zonemap stats: filter columns + sharding columns.
       Set<String> columnsToLoad = extractReferencedColumns(pushedPredicates);
@@ -232,8 +236,37 @@ public class LanceScanBuilder
         projectedRows = (long) (projectedRows * ratio);
         projectedFullSize = (long) (projectedFullSize * ratio);
       }
+      // CBO column statistics: when ANALYZE TABLE has persisted lance.stats.* into the manifest
+      // config and the manifest version + schema fingerprint still match, surface them to Spark's
+      // optimizer via Statistics.columnStats(). There is intentionally NO zonemap-derived fallback
+      // here — when persisted stats are absent or stale we report none and let Spark fall back to
+      // its own row-count heuristics, exactly as native ANALYZE TABLE behaves.
+      //
+      // Skip the persisted stats entirely when zonemap fragment pruning has shrunk the reported row
+      // count below the live total: the persisted stats describe the FULL table, so pairing their
+      // full-table distinctCount / nullCount / min / max with a pruned (smaller) numRows would be
+      // internally inconsistent — e.g. distinctCount could exceed numRows — and mislead Spark's
+      // join/filter estimation worse than having no column stats. The full-table stats simply do
+      // not describe the pruned subset, so we drop them and let the (accurate) pruned row count
+      // drive estimation.
+      SparkSession session = activeSparkSessionOrNull();
+      Map<NamedReference, ColumnStatistics> columnStats = Collections.emptyMap();
+      boolean fragmentPruningReducedRows = projectedRows < summary.getTotalRows();
+      if (!fragmentPruningReducedRows && resolveCboColumnStatsEnabled(session, readOptions)) {
+        Map<String, String> tableProperties = getOrOpenDataset().getConfig();
+        Map<NamedReference, ColumnStatistics> persisted =
+            loadPersistedColumnStats(
+                session, tableProperties, fullSchema, schema, datasetVersion.getId());
+        if (persisted != null) {
+          columnStats = persisted;
+          LOG.info(
+              "Using persisted column stats (ANALYZE TABLE fast path) for {} columns",
+              persisted.size());
+        }
+      }
       LanceStatistics statistics =
-          LanceStatistics.estimateProjected(projectedRows, projectedFullSize, fullSchema, schema);
+          LanceStatistics.estimateProjected(
+              projectedRows, projectedFullSize, fullSchema, schema, columnStats);
       if (survivingFragmentIds != null) {
         LOG.debug(
             "Scan statistics after pruning: {} of {} fragments survive,"
@@ -485,5 +518,181 @@ public class LanceScanBuilder
       }
     }
     return columns;
+  }
+
+  private static SparkSession activeSparkSessionOrNull() {
+    try {
+      return SparkSession.active();
+    } catch (Exception ignored) {
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the column-stats kill-switch using two-level lookup. The SparkConf key {@link
+   * LanceStatsKeys#SPARK_CONF_CBO_COLUMN_STATS_ENABLED} acts as a global kill-switch: when set, it
+   * overrides the per-scan {@link LanceSparkReadOptions#isCboColumnStatsEnabled()} value. When
+   * unset, the per-scan option (default {@code true}) wins. This makes a single session-level
+   * config able to disable the feature everywhere for safe rollback.
+   */
+  private static boolean resolveCboColumnStatsEnabled(
+      SparkSession session, LanceSparkReadOptions readOptions) {
+    if (session != null) {
+      try {
+        String key = LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ENABLED;
+        if (session.conf().contains(key)) {
+          return Boolean.parseBoolean(session.conf().get(key));
+        }
+      } catch (Exception ignored) {
+        // Conf access can throw if the session was closed mid-scan — fall through.
+      }
+    }
+    return readOptions.isCboColumnStatsEnabled();
+  }
+
+  /**
+   * Read ANALYZE-TABLE-persisted column statistics from the Lance manifest config ({@code
+   * lance.stats.*} keys), or {@code null} when none are usable. The returned map feeds Spark's CBO
+   * via {@link LanceStatistics#columnStats()}. This path is fully decoupled from zonemap indexes —
+   * it reads only persisted properties. When it returns {@code null}, the caller reports no column
+   * stats (it does NOT fall back to zonemap aggregation), matching native ANALYZE TABLE semantics.
+   */
+  static Map<NamedReference, ColumnStatistics> loadPersistedColumnStats(
+      SparkSession session,
+      java.util.Map<String, String> tableProperties,
+      StructType fullSchema,
+      StructType projectedSchema,
+      long currentManifestVersion) {
+    if (tableProperties == null || tableProperties.isEmpty()) {
+      return null;
+    }
+    // No completeness sentinel is consulted: ANALYZE commits the entire stats payload in one atomic
+    // alterTable (BaseLanceNamespaceSparkCatalog issues a single Dataset.updateConfig), so a reader
+    // never observes a half-written set. Validity is gated below by the format version,
+    // computedAtVersion, and schemaHash tags instead.
+    // Format-version gate: only consume payloads we know how to decode. Missing version is
+    // fail-safe (skip); unrecognized version warns and skips so a future v2 writer can ship
+    // before the readers catch up.
+    String formatVersion = tableProperties.get(LanceStatsKeys.VERSION);
+    if (formatVersion == null) {
+      LOG.debug(
+          "lance.stats.version key absent — reporting no column stats (no ANALYZE-written "
+              + "stats payload present, or a hand-edited / partially-written payload)");
+      return null;
+    }
+    if (!LanceStatsKeys.SUPPORTED_VERSION.equals(formatVersion.trim())) {
+      // Sanitize: TBLPROPERTIES values are user-controllable; SLF4J's {} passes CR/LF verbatim.
+      LOG.warn(
+          "Unrecognized lance.stats.version='{}' — reporting no column stats. "
+              + "This usually means the table was analyzed with a newer connector; upgrade the "
+              + "connector or re-run ANALYZE TABLE with the current connector to restore the fast "
+              + "path.",
+          sanitizeForLog(formatVersion));
+      return null;
+    }
+    String versionStr = tableProperties.get(LanceStatsKeys.COMPUTED_AT_VERSION);
+    if (versionStr == null) {
+      return null;
+    }
+    long computedAtVersion;
+    try {
+      computedAtVersion = Long.parseLong(versionStr.trim());
+    } catch (NumberFormatException e) {
+      LOG.warn(
+          "Malformed lance.stats.computedAtVersion='{}' — ignoring persisted stats",
+          sanitizeForLog(versionStr));
+      return null;
+    }
+    if (computedAtVersion < 0) {
+      LOG.warn(
+          "Negative lance.stats.computedAtVersion={} — ignoring persisted stats",
+          computedAtVersion);
+      return null;
+    }
+    boolean allowStale = false;
+    if (session != null) {
+      try {
+        String key = LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE;
+        if (session.conf().contains(key)) {
+          allowStale = Boolean.parseBoolean(session.conf().get(key));
+        }
+      } catch (Exception ignored) {
+        // Conf access can throw if the session was closed mid-scan — keep allowStale=false.
+      }
+    }
+    // Schema fingerprint guard: a hash mismatch means columns were renamed/retyped/dropped/
+    // reordered, and persisted stats may attribute values to the wrong column. Missing hash is
+    // also fail-safe — a hand-edited or pre-hash payload can't be verified.
+    String recordedSchemaHash = tableProperties.get(LanceStatsKeys.SCHEMA_HASH);
+    if (recordedSchemaHash == null) {
+      LOG.debug(
+          "lance.stats.schemaHash key absent — reporting no column stats. Persisted stats "
+              + "predate the schema-drift guard; re-run ANALYZE TABLE to populate the hash.");
+      return null;
+    }
+    String currentSchemaHash = LanceStatsKeys.computeSchemaHash(fullSchema);
+    if (!recordedSchemaHash.equals(currentSchemaHash)) {
+      // Sanitize the recorded hash — a poisoned property could violate the SHA-256-hex shape.
+      LOG.info(
+          "lance.stats.schemaHash mismatch (recorded={}, current={}); schema has changed since "
+              + "ANALYZE — reporting no column stats. Re-run ANALYZE TABLE to refresh.",
+          sanitizeForLog(recordedSchemaHash.substring(0, Math.min(8, recordedSchemaHash.length()))),
+          currentSchemaHash.substring(0, Math.min(8, currentSchemaHash.length())));
+      return null;
+    }
+    if (computedAtVersion != currentManifestVersion && !allowStale) {
+      LOG.debug(
+          "Persisted column stats are stale (computedAtVersion={}, currentVersion={}); "
+              + "reporting no column stats. Re-run ANALYZE TABLE to refresh, or set {}=true.",
+          computedAtVersion,
+          currentManifestVersion,
+          LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE);
+      return null;
+    }
+
+    Map<NamedReference, ColumnStatistics> result = new LinkedHashMap<>();
+    for (org.apache.spark.sql.types.StructField f : projectedSchema.fields()) {
+      // Spark matches V2 column stats via AttributeReference.name().equals(ref.describe()).
+      // FieldReference.describe() backtick-quotes any name needing SQL quoting, so a stat for such
+      // a column would be reported but never matched/used by the optimizer. Skip it so
+      // columnStats() advertises only stats Spark can actually consume.
+      if (!FieldReference.column(f.name()).describe().equals(f.name())) {
+        LOG.debug(
+            "Skipping persisted stats for column {} — its name requires SQL quoting, so Spark's "
+                + "optimizer cannot match it to a plan attribute.",
+            sanitizeForLog(f.name()));
+        continue;
+      }
+      // TimestampNTZ min/max crash Spark's CBO FilterEstimation (no toDouble case → MatchError).
+      // ANALYZE never writes them, but defend against a hand-edited/poisoned payload too.
+      if (org.apache.spark.sql.types.DataTypes.TimestampNTZType.equals(f.dataType())) {
+        continue;
+      }
+      // Decode this column's persisted keys via Spark's own CatalogColumnStat codec (see
+      // LanceColumnStatCodec): fromMap + toPlanStat yields min/max in the internal catalyst
+      // representation that DataSourceV2Relation.transformV2Stats copies verbatim into a catalyst
+      // ColumnStat (no CatalystTypeConverters round-trip on the V2 min/max path). Every decode
+      // failure — absent keys, Spark codec rejection, or a poisoned min/max that fromExternalString
+      // can't parse — is fail-safe (empty), so the column is simply omitted from the stats map.
+      java.util.Optional<ColumnStatistics> decoded =
+          org.apache.spark.sql.execution.datasources.v2.LanceColumnStatCodec.decode(
+              STATS_DECODE_TABLE_LABEL, f.name(), f.dataType(), tableProperties);
+      if (decoded.isPresent()) {
+        result.put(FieldReference.column(f.name()), decoded.get());
+      }
+    }
+    return result.isEmpty() ? null : result;
+  }
+
+  /**
+   * Placeholder table label passed to {@link
+   * org.apache.spark.sql.execution.datasources.v2.LanceColumnStatCodec#decode}. Spark's {@code
+   * CatalogColumnStat.fromMap} uses it only in an internal warn message on malformed input; no real
+   * table identifier is in scope here, so a constant suffices.
+   */
+  private static final String STATS_DECODE_TABLE_LABEL = "lance";
+
+  private static String sanitizeForLog(String value) {
+    return LanceStatsKeys.sanitizeForLog(value);
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatistics.java
@@ -15,11 +15,15 @@ package org.lance.spark.read;
 
 import org.lance.ManifestSummary;
 
+import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.Statistics;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 import java.util.OptionalLong;
 
 /**
@@ -33,18 +37,35 @@ public class LanceStatistics implements Statistics, Serializable {
   private final long sizeInBytes;
 
   /**
+   * Per-column stats reported via {@link Statistics#columnStats}. Always non-null but typically
+   * empty when ANALYZE TABLE has not persisted stats for the projected columns — kept as a
+   * defensive copy so callers cannot mutate state visible to Spark's CBO.
+   */
+  private final Map<NamedReference, ColumnStatistics> columnStats;
+
+  /**
    * Create statistics from a ManifestSummary.
    *
    * @param summary the manifest summary containing pre-computed statistics
    */
   public LanceStatistics(ManifestSummary summary) {
-    this(summary.getTotalRows(), summary.getTotalFilesSize());
+    this(summary.getTotalRows(), summary.getTotalFilesSize(), Collections.emptyMap());
   }
 
   /** Create statistics with explicit values (e.g., after scaling for pruned fragments). */
   public LanceStatistics(long numRows, long sizeInBytes) {
+    this(numRows, sizeInBytes, Collections.emptyMap());
+  }
+
+  /** Create statistics with explicit values and per-column statistics for CBO. */
+  public LanceStatistics(
+      long numRows, long sizeInBytes, Map<NamedReference, ColumnStatistics> columnStats) {
     this.numRows = numRows;
     this.sizeInBytes = sizeInBytes;
+    this.columnStats =
+        columnStats == null || columnStats.isEmpty()
+            ? Collections.emptyMap()
+            : Collections.unmodifiableMap(new java.util.LinkedHashMap<>(columnStats));
   }
 
   /**
@@ -88,6 +109,23 @@ public class LanceStatistics implements Statistics, Serializable {
    */
   public static LanceStatistics estimateProjected(
       long numRows, long fullSizeInBytes, StructType fullSchema, StructType projectedSchema) {
+    return estimateProjected(
+        numRows, fullSizeInBytes, fullSchema, projectedSchema, Collections.emptyMap());
+  }
+
+  /**
+   * Same as {@link #estimateProjected(long, long, StructType, StructType)} but additionally carries
+   * an aggregated {@code columnStats} map so Spark's CBO can read per-column min/max/null counts
+   * via {@link Statistics#columnStats()}. Map keys must be top-level {@link NamedReference}s
+   * matching the projected schema's field names; entries for non-projected columns are dropped
+   * silently (Spark would ignore them anyway).
+   */
+  public static LanceStatistics estimateProjected(
+      long numRows,
+      long fullSizeInBytes,
+      StructType fullSchema,
+      StructType projectedSchema,
+      Map<NamedReference, ColumnStatistics> columnStats) {
     long projWidth = sumWidths(projectedSchema);
     long fullWidth = sumWidths(fullSchema);
     long sizeInBytes;
@@ -99,7 +137,40 @@ public class LanceStatistics implements Statistics, Serializable {
     }
     // Clamp to 1: integer truncation can round very small scaled sizes to 0, which
     // JoinSelection reads as "below threshold" and would unintentionally force a broadcast.
-    return new LanceStatistics(numRows, Math.max(sizeInBytes, 1L));
+    return new LanceStatistics(
+        numRows, Math.max(sizeInBytes, 1L), filterToProjected(columnStats, projectedSchema));
+  }
+
+  /**
+   * Strip stats entries whose column name is not in the projected schema. The persisted-stats path
+   * can carry stats for columns the user didn't project. Spark's CBO would silently ignore them
+   * anyway; filtering here preserves the invariant "stats keys ⊆ projected schema field names" for
+   * downstream code that reads {@link #columnStats()} directly.
+   *
+   * <p>Nested-path entries (where {@code fieldNames().length > 1}) are also dropped. Spark's CBO
+   * resolves stats by exact {@link NamedReference} match against the leaf attribute referenced in
+   * the optimized plan, and our scan exposes only top-level columns through the projected schema —
+   * so a {@code FieldReference("a", "b")} entry would never match a planner lookup against {@code
+   * AttributeReference("a")} even if "a" is in the projected schema. Dropping the entry up front
+   * avoids carrying ballast through serialization and into executor-side reads.
+   */
+  private static Map<NamedReference, ColumnStatistics> filterToProjected(
+      Map<NamedReference, ColumnStatistics> input, StructType projectedSchema) {
+    if (input == null || input.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    java.util.Set<String> projected = new java.util.HashSet<>();
+    for (StructField f : projectedSchema.fields()) {
+      projected.add(f.name());
+    }
+    Map<NamedReference, ColumnStatistics> filtered = new java.util.LinkedHashMap<>();
+    for (Map.Entry<NamedReference, ColumnStatistics> e : input.entrySet()) {
+      String[] parts = e.getKey().fieldNames();
+      if (parts.length == 1 && projected.contains(parts[0])) {
+        filtered.put(e.getKey(), e.getValue());
+      }
+    }
+    return filtered;
   }
 
   private static long sumWidths(StructType schema) {
@@ -121,5 +192,10 @@ public class LanceStatistics implements Statistics, Serializable {
   @Override
   public OptionalLong numRows() {
     return OptionalLong.of(numRows);
+  }
+
+  @Override
+  public Map<NamedReference, ColumnStatistics> columnStats() {
+    return columnStats;
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatsKeys.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceStatsKeys.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Constants and helpers that define the on-disk wire format of {@code ANALYZE TABLE} persisted
+ * column statistics in TBLPROPERTIES. Centralizing these in one base-package utility keeps the
+ * ANALYZE writer (in {@code org.apache.spark.sql.execution.datasources.v2}) and the scan-time
+ * reader (in {@code org.lance.spark.read}) on the same source of truth without forcing the read
+ * path to depend on a class inside Spark's internal package namespace.
+ *
+ * <h2>Wire format (lance.stats.version = 1)</h2>
+ *
+ * <ul>
+ *   <li>{@code lance.stats.version} = "1" — bumping this invalidates older readers.
+ *   <li>{@code lance.stats.computedAtVersion} = decimal Lance manifest version stats reflect.
+ *   <li>{@code lance.stats.computedAt} = ISO-8601 instant.
+ *   <li>{@code lance.stats.numRows} = decimal row count at ANALYZE time.
+ *   <li>{@code lance.stats.schemaHash} = SHA-256 hex of the (name, dataType, nullable) tuple
+ *       stream.
+ *   <li>{@code lance.stats.column.<name>.{version,min,max,nullCount,distinctCount,avgLen,maxLen}} —
+ *       per-column stats. The suffix set and string encoding are Spark's own {@code
+ *       CatalogColumnStat} map form (written by {@code CatalogColumnStat.toMap}, read by {@code
+ *       CatalogColumnStat.fromMap}); {@code <name>} is a top-level column name and the format does
+ *       not currently support nested-leaf paths (see {@link #validateColumnName} below). The
+ *       per-column {@code .version} is Spark's CatalogColumnStat serialization version, distinct
+ *       from the table-level {@link #VERSION}. {@code distinctCount} is HLL-approximate (Spark's
+ *       native ANALYZE behavior). No {@code histogram} entry is ever written: the ANALYZE writer
+ *       forces {@code spark.sql.statistics.histogram.enabled} off for the aggregation, so {@code
+ *       toMap} never produces one (the read path discards histograms anyway — the V2 {@code
+ *       ColumnStatistics} histogram type differs from catalyst's).
+ * </ul>
+ *
+ * <p>The format is a stability contract: existing tags must keep their semantics across connector
+ * versions. New stats tags may be added at the same {@code lance.stats.version}; format-breaking
+ * changes (existing tag's encoding altered, key prefix renamed) require bumping {@code
+ * lance.stats.version} so older readers report no column stats rather than silently misinterpret
+ * the payload.
+ *
+ * <h2>Design choices and known gaps vs. upstream conventions</h2>
+ *
+ * <ul>
+ *   <li><b>Storage medium:</b> stats live in TBLPROPERTIES on the Lance manifest, not in a Puffin
+ *       sidecar (Iceberg's choice) or a separate stats table (Delta's choice). The Lance manifest
+ *       is the single source of truth; sidecar files would require a second read path and add a
+ *       Puffin dependency. The trade-off is that very large per-column stats (histograms, sketches)
+ *       are awkward — but at v1 we only persist scalar bounds and counts, which fit.
+ *   <li><b>Per-column only, not table-level:</b> Spark's native {@code ANALYZE TABLE … COMPUTE
+ *       STATISTICS} updates both row-count and on-disk-size. This implementation persists row count
+ *       under {@code lance.stats.numRows} for human / tooling inspection only — the read path
+ *       always takes BOTH {@code numRows} and {@code sizeInBytes} from {@link
+ *       org.lance.ManifestSummary} (live), never from the persisted payload, so {@code
+ *       lance.stats.numRows} never feeds the table-size or row-count estimate, regardless of the
+ *       FOR clause.
+ *   <li><b>{@code avgLen} / {@code maxLen} persisted:</b> Spark's CBO uses these for join size
+ *       estimation on string/binary columns. They come for free from {@code
+ *       CommandUtils.computeColumnStats} and are surfaced to the CBO via the read path's {@code
+ *       ColumnStatistics}.
+ *   <li><b>Output row deviates from native ANALYZE TABLE:</b> Spark's {@code AnalyzeTableCommand}
+ *       returns zero rows; this command returns one row of {@code (columns_analyzed, rows_scanned,
+ *       manifest_version)} for tooling and operator diagnostics.
+ * </ul>
+ */
+public final class LanceStatsKeys {
+
+  /** Top-level table-property keys. */
+  public static final String VERSION = "lance.stats.version";
+
+  public static final String COMPUTED_AT_VERSION = "lance.stats.computedAtVersion";
+  public static final String COMPUTED_AT = "lance.stats.computedAt";
+  public static final String NUM_ROWS = "lance.stats.numRows";
+  public static final String SCHEMA_HASH = "lance.stats.schemaHash";
+
+  /**
+   * Per-column key prefix; a full key is {@code COLUMN_PREFIX + name + <suffix>}, where {@code
+   * <suffix>} (e.g. {@code .min}, {@code .distinctCount}) is whatever Spark's own {@code
+   * CatalogColumnStat.toMap} emits — the writer serializes each stat with {@code toMap} and the
+   * reader deserializes with {@code CatalogColumnStat.fromMap}, so the per-column payload IS
+   * Spark's native string form, prefixed with {@link #COLUMN_PREFIX}. Lance code never enumerates
+   * the suffixes (the format is delegated to Spark); only tests assert the concrete key shape, via
+   * {@code LanceStatsTestKeys}.
+   */
+  public static final String COLUMN_PREFIX = "lance.stats.column.";
+
+  /** Format version this connector knows how to read and write. */
+  public static final String SUPPORTED_VERSION = "1";
+
+  // SparkConf keys below are part of the operator-facing configuration contract — once a
+  // release ships, renaming requires a deprecation cycle. All share the prefix
+  // `spark.lance.cbo.column.stats.` for namespace introspection.
+
+  /**
+   * Master kill-switch for the column-stats fast path. Overrides per-scan {@code
+   * lance.cbo.column.stats.enabled}. Default: {@code true}.
+   */
+  public static final String SPARK_CONF_CBO_COLUMN_STATS_ENABLED =
+      "spark.lance.cbo.column.stats.enabled";
+
+  /**
+   * If {@code true}, accept persisted stats whose {@code computedAtVersion} differs from the
+   * current Lance manifest version. Default: {@code false}. Trades CBO correctness for fast-path
+   * hit rate; only enable when stale estimates are acceptable.
+   */
+  public static final String SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE =
+      "spark.lance.cbo.column.stats.allow.stale";
+
+  private LanceStatsKeys() {}
+
+  /** Maximum length of a column name surfaced in error messages, to bound exception size. */
+  private static final int MAX_NAME_IN_ERROR = 256;
+
+  /**
+   * True when {@code name} produces a non-ambiguous TBLPROPERTIES key under {@link #COLUMN_PREFIX}.
+   * Ambiguity sources today: dots in the name (collide with future nested-leaf paths) and the empty
+   * string (would emit a key like {@code lance.stats.column..min} that orphan-cleanup would later
+   * misattribute).
+   */
+  public static boolean isStatsCompatibleColumnName(String name) {
+    return name != null && !name.isEmpty() && name.indexOf('.') < 0;
+  }
+
+  /**
+   * Reject column names that would produce ambiguous TBLPROPERTIES keys: dotted names collide with
+   * future nested-leaf paths (and would mis-attribute under the prefix-based orphan-cleanup sweep,
+   * which splits the column segment on the first '.'), empty names produce a malformed {@code
+   * lance.stats.column..<suffix>} key. Forbidding at write time is more conservative than
+   * introducing wire-format escaping.
+   *
+   * @throws IllegalArgumentException if the name is null, empty, or contains a dot.
+   */
+  public static void validateColumnName(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("Column name must not be null");
+    }
+    if (name.isEmpty()) {
+      throw new IllegalArgumentException(
+          "ANALYZE TABLE does not support empty column names. Persisted-stats keys would be "
+              + "malformed (lance.stats.column..<suffix>).");
+    }
+    if (!isStatsCompatibleColumnName(name)) {
+      // Cap the echoed name in the message to bound exception size — a hostile or accidental
+      // 10MB column name should not produce a 10MB error string that flows back to the driver.
+      String shown =
+          name.length() > MAX_NAME_IN_ERROR ? name.substring(0, MAX_NAME_IN_ERROR) + "…" : name;
+      throw new IllegalArgumentException(
+          "ANALYZE TABLE does not support column names containing '.': '"
+              + shown
+              + "'. Persisted-stats keys would be ambiguous with future nested-leaf paths. "
+              + "Rename the column or omit it from FOR COLUMNS.");
+    }
+  }
+
+  private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+
+  /**
+   * Per-thread {@link MessageDigest} so {@link #computeSchemaHash} avoids the JCE provider lookup
+   * on every call; reset() before reuse keeps it thread-safe.
+   */
+  private static final ThreadLocal<MessageDigest> SHA256 =
+      ThreadLocal.withInitial(
+          () -> {
+            try {
+              return MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException e) {
+              throw new IllegalStateException("SHA-256 not available", e);
+            }
+          });
+
+  /**
+   * SHA-256 fingerprint of the schema's "field name + data-type + nullable" triples in declared
+   * order. Lets the read path detect schema drift between ANALYZE and a subsequent scan: if any
+   * column was renamed, retyped, had its nullability flipped, dropped, or reordered in a way that
+   * changes resolution, the hash diverges and persisted stats are rejected.
+   *
+   * <p><b>Schema-mutation monotonicity (intentional):</b> the hash covers ALL fields, so adding,
+   * dropping, retyping, reordering, or flipping nullability of any single column invalidates the
+   * persisted stats for ALL columns — not just the one that changed. This is the safe direction:
+   * the read path reports no column stats, never reports stats it cannot prove still apply.
+   * Operators must re-run ANALYZE TABLE after any {@code ALTER TABLE} that changes the schema, even
+   * if only one column was touched.
+   *
+   * <p>Stable across JVM instances because we hash a deterministic UTF-8 byte stream rather than
+   * relying on Scala or Java's hashCode (which is salted in some implementations).
+   */
+  public static String computeSchemaHash(StructType schema) {
+    MessageDigest md = SHA256.get();
+    md.reset();
+    for (StructField f : schema.fields()) {
+      md.update(f.name().getBytes(StandardCharsets.UTF_8));
+      md.update((byte) 0);
+      md.update(f.dataType().catalogString().getBytes(StandardCharsets.UTF_8));
+      md.update((byte) 0);
+      md.update(f.nullable() ? (byte) 1 : (byte) 0);
+      md.update((byte) 0);
+    }
+    byte[] digest = md.digest();
+    char[] hex = new char[digest.length * 2];
+    for (int i = 0; i < digest.length; i++) {
+      int b = digest[i] & 0xff;
+      hex[i * 2] = HEX_CHARS[b >>> 4];
+      hex[i * 2 + 1] = HEX_CHARS[b & 0x0f];
+    }
+    return new String(hex);
+  }
+
+  /**
+   * CR/LF/tab-strip and length-cap a user-controllable value before embedding it in a log line.
+   * TBLPROPERTIES values and SQL text flow into SLF4J {@code {}} interpolation, which does not
+   * strip control characters; capping at 256 chars bounds log-line size. Shared by the codec and
+   * the read path so the control-character set lives in one place.
+   */
+  public static String sanitizeForLog(String value) {
+    if (value == null) {
+      return null;
+    }
+    String capped = value.length() > 256 ? value.substring(0, 256) + "…" : value;
+    return capped.replace('\r', '_').replace('\n', '_').replace('\t', '_');
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceAnalyzeTable.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/LanceAnalyzeTable.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
+/**
+ * Logical plan for `ANALYZE TABLE <t> COMPUTE STATISTICS [FOR ALL COLUMNS | FOR COLUMNS c1, ...]`.
+ * The executor computes per-column min/max/nullCount/distinctCount (+ avgLen/maxLen) via Spark's
+ * own `CommandUtils.computeColumnStats` and persists them into Lance table properties under
+ * `lance.stats.*` keys, tagged with the expected post-write manifest version (read version + 1).
+ *
+ * <p>This plan is produced by [[org.apache.spark.sql.execution.datasources.v2.LanceAnalyzeTableResolution]],
+ * which rewrites Spark's native `AnalyzeColumn` / `AnalyzeTable` into it when the target is a Lance
+ * table — there is no custom ANALYZE grammar. {@code columns} is empty when the user specified
+ * {@code FOR ALL COLUMNS} (or omitted the clause entirely); the executor expands it to the full
+ * table schema. NDV is always HLL-approximate (Spark's native ANALYZE behavior).
+ */
+case class LanceAnalyzeTable(
+    table: LogicalPlan,
+    columns: Seq[String],
+    forAllColumns: Boolean) extends Command {
+
+  override def children: Seq[LogicalPlan] = Seq(table)
+
+  override def output: Seq[Attribute] = LanceAnalyzeTableOutputType.SCHEMA
+
+  override def simpleString(maxFields: Int): String = {
+    val target = if (forAllColumns) "ALL COLUMNS" else columns.mkString(", ")
+    s"AnalyzeLanceTable [for $target]"
+  }
+
+  override protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan])
+      : LanceAnalyzeTable = {
+    copy(table = newChildren(0))
+  }
+}
+
+object LanceAnalyzeTableOutputType {
+  val SCHEMA = StructType(
+    Array(
+      StructField("columns_analyzed", DataTypes.IntegerType, nullable = false),
+      StructField("rows_scanned", DataTypes.LongType, nullable = false),
+      StructField("manifest_version", DataTypes.LongType, nullable = false)))
+    .map(field => AttributeReference(field.name, field.dataType, field.nullable, field.metadata)())
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceAnalyzeTableExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceAnalyzeTableExec.scala
@@ -1,0 +1,379 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, GenericInternalRow}
+import org.apache.spark.sql.catalyst.plans.logical.LanceAnalyzeTableOutputType
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog, TableChange}
+import org.apache.spark.sql.types.{AnsiIntervalType, ArrayType, CalendarIntervalType, DataType, MapType, NullType, StructField, StructType, UserDefinedType}
+import org.lance.spark.LanceDataset
+import org.lance.spark.read.LanceStatsKeys
+
+import scala.collection.JavaConverters._
+
+/**
+ * Executor for `ANALYZE TABLE`. Delegates the per-column computation to Spark's own
+ * {@code CommandUtils.computeColumnStats} (via {@link LanceNativeColumnStats}), which runs a single
+ * aggregation job producing min / max / nullCount / HLL-approximate distinctCount / avgLen / maxLen
+ * as internal-representation {@code ColumnStat}s. Each is serialized with Spark's {@code
+ * CatalogColumnStat.toMap} (minus the histogram — see the persist loop) and written to the Lance
+ * table's properties under {@code lance.stats.column.<name>.<suffix>}, plus the table-level
+ * {@code lance.stats.computedAtVersion} = Lance manifest version. {@link LanceScanBuilder} reads these
+ * back via {@code CatalogColumnStat.fromMap} / {@code toPlanStat} and surfaces them to Spark's CBO
+ * directly — no per-scan re-aggregation.
+ *
+ * <p>NDV is always HLL-approximate (Spark's native ANALYZE behavior). This exec is produced by
+ * {@link LanceAnalyzeTableResolution}, which rewrites Spark's native ANALYZE plans for Lance tables;
+ * there is no custom ANALYZE grammar.
+ */
+case class LanceAnalyzeTableExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    columns: Seq[String],
+    forAllColumns: Boolean) extends LeafV2CommandExec with Logging {
+
+  override def output: Seq[Attribute] = LanceAnalyzeTableOutputType.SCHEMA
+
+  /**
+   * Returns true when Spark's column-stat computation supports this type and the resulting stat is
+   * safe for the CBO. Complex containers (StructType, ArrayType, MapType, UserDefinedType, NullType)
+   * and interval types (CalendarIntervalType, AnsiIntervalType — the parent of YearMonthIntervalType
+   * / DayTimeIntervalType) are not analyzable by Spark's `computeColumnStats` and are skipped up
+   * front with a log line rather than allowed to fail mid-job. TimestampNTZType is also excluded
+   * (the final `case` below) for a different reason: its min/max would crash Spark's CBO
+   * FilterEstimation, not because the stat can't be computed.
+   */
+  private def isStatSupported(dt: DataType): Boolean = dt match {
+    case _: StructType | _: ArrayType | _: MapType | _: UserDefinedType[_] | _: NullType => false
+    case _: CalendarIntervalType | _: AnsiIntervalType => false
+    // TimestampNTZ min/max would reach Spark's CBO FilterEstimation.toDouble, which (through at
+    // least Spark 4.x) has no TimestampNTZType case and throws a scala.MatchError at query-planning
+    // time whenever a filter references the column. Skip it so ANALYZE never turns a previously
+    // working query into a hard planning failure under spark.sql.cbo.enabled=true.
+    case _ if dt == org.apache.spark.sql.types.DataTypes.TimestampNTZType => false
+    case _ => true
+  }
+
+  override protected def run(): Seq[InternalRow] = {
+    // Sanitized table name for all subsequent error / log lines (CR/LF stripped, length capped).
+    val tableName = LanceAnalyzeTableExec.sanitizeForLog(ident.toString)
+
+    // The persisted-stats payload requires single-manifest atomicity: BaseLanceNamespace-
+    // SparkCatalog issues one Dataset.updateConfig per alterTable call. Other catalogs may
+    // batch the change list across multiple commits, leaving a half-written stats set visible to
+    // readers between commits — reject up front.
+    if (!catalog.isInstanceOf[org.lance.spark.BaseLanceNamespaceSparkCatalog]) {
+      throw new UnsupportedOperationException(
+        s"ANALYZE TABLE $tableName: the Lance SQL extension intercepts ANALYZE TABLE and supports " +
+          "only Lance tables (this table is on " + catalog.getClass.getName + ", not a " +
+          "BaseLanceNamespaceSparkCatalog). The persisted-stats wire format requires the catalog " +
+          "to commit the change list as a single atomic manifest write, which other catalogs do " +
+          "not guarantee. To run Spark's native ANALYZE TABLE on a non-Lance table, use a session " +
+          "without the Lance SQL extension enabled.")
+    }
+    val lanceDataset = catalog.loadTable(ident) match {
+      case ds: LanceDataset => ds
+      case other =>
+        throw new UnsupportedOperationException(
+          s"ANALYZE TABLE $tableName: only LanceDataset tables are supported; got " +
+            other.getClass.getName)
+    }
+
+    val schema: StructType = lanceDataset.schema()
+    // Reject duplicate field names BEFORE type/name-shape filters: persisted-stats keys would
+    // collide regardless of column type, so this is the most fundamental constraint and should
+    // surface first.
+    val duplicateNames = schema.fields.groupBy(_.name).collect {
+      case (name, fields) if fields.length > 1 => name
+    }
+    if (duplicateNames.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"ANALYZE TABLE $tableName: schema has duplicate field names: " +
+          duplicateNames.toSeq.sorted.map(LanceAnalyzeTableExec.sanitizeForLog).mkString(", ") +
+          ". Persisted-stats keys would collide; rename the conflicting columns first.")
+    }
+    val requestedCols: Seq[StructField] =
+      if (forAllColumns) schema.fields.toSeq
+      else {
+        // Resolve FOR COLUMNS names honoring spark.sql.caseSensitive (default false) to match
+        // Spark's native column resolution; map to the canonical StructField so the persisted key
+        // uses the table's stored column case.
+        val caseSensitive = org.apache.spark.sql.internal.SQLConf.get.caseSensitiveAnalysis
+        val byName =
+          if (caseSensitive) schema.fields.map(f => f.name -> f).toMap
+          else schema.fields.map(f => f.name.toLowerCase(java.util.Locale.ROOT) -> f).toMap
+        // distinct: a duplicate column in the FOR COLUMNS list would otherwise be aggregated twice
+        // (wasted compute).
+        columns.distinct.map { c =>
+          val key = if (caseSensitive) c else c.toLowerCase(java.util.Locale.ROOT)
+          byName.getOrElse(
+            key,
+            throw new IllegalArgumentException(
+              s"ANALYZE TABLE $tableName: column not found: " +
+                LanceAnalyzeTableExec.sanitizeForLog(c)))
+        }
+      }
+    // Filter complex types (Struct/Array/Map/UDT/Null) and interval types: df.agg(min(col))
+    // raises AnalysisException at planning time on these. FOR ALL COLUMNS skips silently to
+    // avoid crashing ANALYZE on tables that happen to contain one. FOR COLUMNS fails fast.
+    val (typeSupported, complexSkipped) = requestedCols.partition(f => isStatSupported(f.dataType))
+    if (complexSkipped.nonEmpty) {
+      // Sanitize per-name BEFORE mkString so the per-name length cap is honored and a hostile
+      // name can't inject CR/LF into either log lines or the driver query-error response.
+      val sanitizedSkippedNames =
+        complexSkipped.map(f => LanceAnalyzeTableExec.sanitizeForLog(f.name)).mkString(", ")
+      if (forAllColumns) {
+        log.info(
+          s"ANALYZE TABLE $tableName skipping unsupported-type columns: $sanitizedSkippedNames")
+      } else {
+        throw new IllegalArgumentException(
+          s"ANALYZE TABLE $tableName FOR COLUMNS: unsupported column type(s). Stats are not " +
+            "collected for complex types (StructType / ArrayType / MapType / UserDefinedType / " +
+            "NullType), interval types (CalendarIntervalType / AnsiIntervalType), or " +
+            "TimestampNTZType (its min/max would crash Spark's CBO FilterEstimation). Unsupported " +
+            "columns: " + sanitizedSkippedNames)
+      }
+    }
+
+    // Reject names that would produce ambiguous stats keys: empty (yields a malformed
+    // `lance.stats.column..<suffix>` key) or containing '.' (collides with future nested-leaf paths
+    // and mis-attributes under the prefix-based orphan-cleanup sweep). FOR-ALL skips and logs
+    // (separately for empty vs dotted, so operators see the actual cause); FOR-COLUMNS delegates to
+    // validateColumnName for a fail-fast exception with the canonical message.
+    val (targetCols, nameSkipped) =
+      typeSupported.partition(f => LanceStatsKeys.isStatsCompatibleColumnName(f.name))
+    if (nameSkipped.nonEmpty) {
+      if (forAllColumns) {
+        val (emptyNames, dottedNames) = nameSkipped.partition(_.name.isEmpty)
+        if (emptyNames.nonEmpty) {
+          log.info(s"ANALYZE TABLE skipping ${emptyNames.size} column(s) with empty names " +
+            "(persisted-stats keys would be malformed: lance.stats.column..<suffix>).")
+        }
+        if (dottedNames.nonEmpty) {
+          // Per-name sanitize before join (see complexSkipped path above for rationale).
+          val sanitizedNames =
+            dottedNames.map(f => LanceAnalyzeTableExec.sanitizeForLog(f.name)).mkString(", ")
+          log.info("ANALYZE TABLE skipping columns whose names contain '.' (key ambiguity " +
+            "with nested-leaf paths): " + sanitizedNames)
+        }
+      } else {
+        // FOR COLUMNS must fail fast. Use the first bad name as the exception's example;
+        // validateColumnName picks the right message for empty vs dotted.
+        LanceStatsKeys.validateColumnName(nameSkipped.head.name)
+      }
+    }
+
+    // SparkSession.active reads a ThreadLocal; under AQE re-plan the calling thread may have
+    // no session bound. Wrap the generic IllegalStateException with a command-specific message.
+    val spark =
+      try {
+        SparkSession.active
+      } catch {
+        case _: IllegalStateException =>
+          throw new IllegalStateException(
+            "ANALYZE TABLE requires an active SparkSession on the calling thread; ensure the " +
+              "command runs from the driver query thread (AQE re-plan threads may not have a " +
+              "session bound).")
+      }
+    // If every requested column is unsupported (e.g., a struct-only table under FOR ALL COLUMNS),
+    // there is nothing to analyze. Return an empty result rather than write a stats payload of
+    // just version / numRows / hash with no per-column entries. This branch issues no alterTable at
+    // all, so any pre-existing valid stats are preserved untouched.
+    //
+    // Output-row contract for this branch: columns_analyzed=0, rows_scanned=0, manifest_version=0.
+    // The manifest_version=0 here is a sentinel meaning "no write occurred"; the table's actual
+    // manifest version is unchanged. Tooling that reads the command output should use
+    // columns_analyzed==0 as the signal that no stats were persisted, not the manifest_version value.
+    if (targetCols.isEmpty) {
+      log.info(
+        s"ANALYZE TABLE $tableName: no analyzable columns " +
+          s"(${requestedCols.size} requested, all unsupported types) — skipping write.")
+      return Seq(new GenericInternalRow(Array[Any](
+        0.asInstanceOf[java.lang.Integer],
+        0L.asInstanceOf[java.lang.Long],
+        0L.asInstanceOf[java.lang.Long])))
+    }
+
+    // Pass the per-table storage options (cloud credentials / endpoint config the namespace
+    // catalog injects into readOptions) to the aggregation read. Without them, ANALYZE fails to
+    // authenticate against cloud-hosted tables. On local-FS tables this map is empty (no-op). The
+    // native dataset opened below for the version capture already receives them via readOptions.
+    val df = spark.read
+      .format("lance")
+      .options(lanceDataset.readOptions().getStorageOptions())
+      .load(lanceDataset.readOptions().getDatasetUri)
+
+    // Capture the manifest version BEFORE the aggregation read. A concurrent writer between
+    // this line and alterTable means the stats reflect a version the table never directly
+    // held; the read path's exact-equality check then rejects them and falls back to live
+    // aggregation. Safer-stale-than-wrong.
+    val readVersion = {
+      val ds = org.lance.spark.utils.Utils.openDatasetBuilder(lanceDataset.readOptions()).build()
+      try {
+        ds.getVersion.getId
+      } finally {
+        ds.close()
+      }
+    }
+
+    // Reuse Spark's own column-stat computation (single job): min / max / nullCount /
+    // HLL-approximate distinctCount / avgLen / maxLen (+ histogram when
+    // spark.sql.statistics.histogram.enabled), in the internal catalyst representation that
+    // CatalogColumnStat.toMap serializes and the CBO consumes. NDV is always HLL-approximate
+    // (Spark's native ANALYZE behavior).
+    val analyzed = df.queryExecution.analyzed
+    val targetColNames: Set[String] = targetCols.map(_.name).toSet
+    val targetAttrs = analyzed.output.filter(a => targetColNames.contains(a.name))
+    val (rowCount, columnStats) =
+      LanceNativeColumnStats.computeColumnStats(spark, analyzed, targetAttrs)
+
+    // Tag stats with the expected post-write manifest version (readVersion + 1, since Lance
+    // increments by 1 per write). If a concurrent writer interleaves, the actual version will
+    // be readVersion + N (N >= 2) and the read path's exact-equality check rejects these stats
+    // as stale — reporting no column stats rather than feeding inconsistent values to CBO.
+    // Safer-stale-than-wrong.
+    val manifestVersion = readVersion + 1
+
+    // Build the change array. Step 1: GC orphan keys for dropped/omitted columns. Step 2:
+    // table-level tags (version / computedAtVersion / numRows / schemaHash). Step 3: fresh
+    // per-column stats. The whole array is committed as one atomic manifest write (see the
+    // alterTable comment below), so there is no partial-write window to guard against — the
+    // payload's own version / computedAtVersion / schemaHash tags are what the read path validates.
+    val changes = scala.collection.mutable.ArrayBuffer[TableChange]()
+
+    // Step 1: GC orphan column stats. A partial ANALYZE (FOR COLUMNS subset) REPLACES the persisted
+    // stat set: remove every `lance.stats.column.<col>.*` key for a column NOT analyzed in this run
+    // (dropped from the schema, or simply omitted from FOR COLUMNS). This keeps the single
+    // table-level computedAtVersion an accurate freshness tag for EVERY surviving column — without
+    // it, a column analyzed earlier whose data later changed would retain stats the reader wrongly
+    // accepts as fresh once this run re-advances computedAtVersion to the current manifest version.
+    //
+    // The sweep is prefix-based (the column-name segment up to the first '.'), NOT a fixed suffix
+    // list: the per-column payload format is delegated to Spark's CatalogColumnStat, so a key shape
+    // we don't enumerate — a split-large-prop histogram's `.histogram.part.N`, or any suffix a
+    // future Spark adds — is still swept. Column names are dot-free (validateColumnName), so the
+    // first '.' after the prefix always terminates the column segment.
+    val columnPrefixLen = LanceStatsKeys.COLUMN_PREFIX.length
+    // Reuse the loadTable snapshot already in scope; avoids a redundant catalog round-trip.
+    val existingProps: Map[String, String] =
+      try {
+        Option(lanceDataset.properties()).map(_.asScala.toMap).getOrElse(Map.empty)
+      } catch {
+        case _: Exception => Map.empty[String, String]
+      }
+    val staleKeys = existingProps.keys.filter { k =>
+      k.startsWith(LanceStatsKeys.COLUMN_PREFIX) && {
+        val rest = k.substring(columnPrefixLen)
+        val dot = rest.indexOf('.')
+        val colName = if (dot < 0) rest else rest.substring(0, dot)
+        !targetColNames.contains(colName)
+      }
+    }.toSeq
+    staleKeys.foreach(k => changes += TableChange.removeProperty(k))
+    if (staleKeys.nonEmpty) {
+      log.info(
+        s"ANALYZE TABLE $tableName: removing ${staleKeys.size} stale column-stats key(s) for " +
+          s"columns not analyzed in this run")
+    }
+
+    // Step 2: write table-level tags for this run.
+    changes += TableChange.setProperty(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION)
+    changes += TableChange.setProperty(
+      LanceStatsKeys.COMPUTED_AT_VERSION,
+      manifestVersion.toString)
+    // numRows captures the count at ANALYZE time; the read path uses ManifestSummary's count
+    // (always live) for sizeInBytes/numRows, but we persist it here for human inspection and
+    // for future use cases that may want a "count at last ANALYZE" reference.
+    changes += TableChange.setProperty(LanceStatsKeys.NUM_ROWS, rowCount.toString)
+    val computedAt = java.time.Instant.now().toString
+    changes += TableChange.setProperty(LanceStatsKeys.COMPUTED_AT, computedAt)
+
+    // Schema fingerprint guards against schema drift (column rename or type change between
+    // ANALYZE and read). Read path verifies hash equality before trusting any persisted stat.
+    val schemaHash = LanceStatsKeys.computeSchemaHash(schema)
+    changes += TableChange.setProperty(LanceStatsKeys.SCHEMA_HASH, schemaHash)
+
+    // Step 3: per-column stats via Spark's CatalogColumnStat codec: serialize each ColumnStat
+    // (internal catalyst rep) to Spark's `<col>.{version,distinctCount,min,max,nullCount,avgLen,maxLen}`
+    // string map, under our column prefix. Re-ANALYZE correctness: write exactly the keys this run
+    // produced and REMOVE any prior key for the column this run did NOT produce (e.g. min/max gone
+    // after the column became all-NULL), so the reader can't serve a stale value under the fresh
+    // manifest version. (Columns not analyzed at all are cleared by staleKeys.)
+    //
+    // No histogram appears in the map: LanceNativeColumnStats forces
+    // spark.sql.statistics.histogram.enabled off for the aggregation, so toMap never emits a
+    // `<col>.histogram[.partN]` payload (the read path discards histograms anyway — the V2
+    // ColumnStatistics histogram type differs from catalyst's). The per-column removal below still
+    // clears any histogram key a prior run, written before this change, may have left behind.
+    val byName: Map[String, org.apache.spark.sql.catalyst.plans.logical.ColumnStat] =
+      columnStats.map { case (a, s) => a.name -> s }
+    targetCols.foreach { f =>
+      val keyPrefix = LanceStatsKeys.COLUMN_PREFIX + f.name + "."
+      val produced: Map[String, String] =
+        byName
+          .get(f.name)
+          .map { stat =>
+            try {
+              stat
+                .toCatalogColumnStat(f.name, f.dataType)
+                .toMap(f.name)
+                .map { case (k, v) => (LanceStatsKeys.COLUMN_PREFIX + k) -> v }
+            } catch {
+              // A type Spark's codec can't externalize: skip this column's stats rather than fail
+              // ANALYZE (graceful degradation, matching the old null-skip behavior).
+              case _: Exception => Map.empty[String, String]
+            }
+          }
+          .getOrElse(Map.empty[String, String])
+      produced.foreach { case (k, v) => changes += TableChange.setProperty(k, v) }
+      existingProps.keys
+        .filter(k => k.startsWith(keyPrefix) && !produced.contains(k))
+        .foreach(k => changes += TableChange.removeProperty(k))
+    }
+
+    // Atomicity: BaseLanceNamespaceSparkCatalog merges the entire `changes` array into one
+    // property map and issues a single Dataset.updateConfig — the manifest commits atomically, so a
+    // reader never observes a half-written stats set. The catalog instanceof check above enforces
+    // this single-commit contract; because the write is atomic there is no separate completeness
+    // sentinel to maintain — the payload's version / computedAtVersion / schemaHash tags fully gate
+    // validity on the read side.
+    catalog.alterTable(ident, changes.toArray: _*)
+    // Include computedAt + numRows so cron operators can grep logs to answer "when did this table's
+    // stats last refresh?".
+    log.info(
+      s"ANALYZE TABLE $tableName: stats persisted for ${targetCols.size} columns at " +
+        s"manifest version $manifestVersion (rows_scanned=$rowCount, " +
+        s"computedAt=$computedAt, schemaHash=${schemaHash.take(8)}…)")
+
+    Seq(new GenericInternalRow(Array[Any](
+      targetCols.size.asInstanceOf[java.lang.Integer],
+      rowCount.asInstanceOf[java.lang.Long],
+      manifestVersion.asInstanceOf[java.lang.Long])))
+  }
+}
+
+object LanceAnalyzeTableExec {
+
+  /**
+   * Strip CR/LF/tab from a value before interpolating into a log message or exception message, and
+   * bound length. Delegates to {@link LanceStatsKeys#sanitizeForLog} so the writer-side (Scala),
+   * codec, and reader-side (Java) paths share one canonical control-character/cap definition. Used
+   * for any user-controllable input flowing into a Scala s-string (table identifier, column name).
+   */
+  private[v2] def sanitizeForLog(value: String): String =
+    LanceStatsKeys.sanitizeForLog(value)
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceAnalyzeTableResolution.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceAnalyzeTableResolution.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.analysis.{ResolvedIdentifier, ResolvedTable}
+import org.apache.spark.sql.catalyst.plans.logical.{AnalyzeColumn, AnalyzeTable, LanceAnalyzeTable, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.lance.spark.LanceDataset
+
+/**
+ * Analyzer resolution rule that rewrites Spark's native `ANALYZE TABLE … COMPUTE STATISTICS` plans
+ * into [[LanceAnalyzeTable]] when — and only when — the target resolves to a Lance table. This
+ * removes the need for a custom ANALYZE grammar rule: Spark parses ANALYZE natively into
+ * `AnalyzeColumn` / `AnalyzeTable`, and this rule intercepts the Lance ones during resolution.
+ *
+ * <p>Why a resolution rule works: `ResolveSessionCatalog` only rewrites ANALYZE for V1 (session-
+ * catalog) tables; a V2 Lance table leaves `AnalyzeColumn(ResolvedTable, …)` unhandled, which would
+ * otherwise fail in `CheckAnalysis` with NOT_SUPPORTED_COMMAND_FOR_V2_TABLE. `CheckAnalysis` runs
+ * after the analyzer's fixed-point resolution batches, so converting the node here pre-empts the
+ * rejection. Keying on `ResolvedTable.table instanceof LanceDataset` means ANALYZE on a non-Lance
+ * table is left untouched for Spark to handle natively (no hijack).
+ *
+ * <p>Uses `transformDown` rather than `resolveOperators` deliberately: once `AnalyzeColumn`'s child
+ * resolves to a `ResolvedTable`, the node is itself "analyzed", and `resolveOperators` would skip it
+ * before this rule could fire. `transformDown` ignores the analyzed flag; the rewrite is idempotent
+ * because the resulting `LanceAnalyzeTable` no longer matches either case.
+ *
+ * <p>Scope: `AnalyzeColumn` covers `FOR ALL COLUMNS` / `FOR COLUMNS …`. `AnalyzeTable` covers the
+ * bare `COMPUTE STATISTICS` (no FOR clause) form, treated as FOR ALL COLUMNS — but only when it
+ * carries no partition spec and no `NOSCAN`; those forms fall through to Spark (which rejects ANALYZE
+ * for V2 tables), preserving the prior behavior that Lance does not support NOSCAN / partition-level
+ * ANALYZE. NDV is always HLL-approximate (Spark's native ANALYZE behavior).
+ */
+object LanceAnalyzeTableResolution extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
+    // FOR [ALL] COLUMNS. columnNames is None for FOR ALL COLUMNS (allColumns=true) and
+    // Some(cols) for FOR COLUMNS … (allColumns=false).
+    case AnalyzeColumn(rt @ ResolvedTable(_, _, _: LanceDataset, _), columnNames, allColumns) =>
+      LanceAnalyzeTable(
+        ResolvedIdentifier(rt.catalog, rt.identifier),
+        columnNames.getOrElse(Nil),
+        allColumns)
+
+    // Bare COMPUTE STATISTICS (no FOR clause) → FOR ALL COLUMNS. NOSCAN (noScan=true) and
+    // partition-scoped ANALYZE are intentionally NOT intercepted; they fall through to Spark's
+    // native (V2-rejecting) handling.
+    case AnalyzeTable(rt @ ResolvedTable(_, _, _: LanceDataset, _), partitionSpec, noScan)
+        if partitionSpec.isEmpty && !noScan =>
+      LanceAnalyzeTable(ResolvedIdentifier(rt.catalog, rt.identifier), Nil, forAllColumns = true)
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceColumnStatCodec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceColumnStatCodec.scala
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.catalog.CatalogColumnStat
+import org.apache.spark.sql.catalyst.plans.logical.ColumnStat
+import org.apache.spark.sql.connector.read.colstats.{ColumnStatistics, Histogram}
+import org.apache.spark.sql.types.DataType
+import org.lance.spark.read.LanceStatsKeys
+
+import java.util.{Optional, OptionalLong}
+
+import scala.collection.JavaConverters._
+
+/**
+ * Reader-side bridge from persisted `lance.stats.column.<col>.<suffix>` table properties back into a
+ * V2 [[ColumnStatistics]], reusing Spark's own [[CatalogColumnStat#fromMap]] + [[CatalogColumnStat#toPlanStat]].
+ *
+ * <p>The writer ([[LanceAnalyzeTableExec]]) serializes each internal-representation [[ColumnStat]]
+ * with [[org.apache.spark.sql.catalyst.plans.logical.ColumnStat#toCatalogColumnStat]] →
+ * [[CatalogColumnStat#toMap]], producing Spark's canonical `<col>.{version,distinctCount,min,max,
+ * nullCount,avgLen,maxLen}` string keys (prefixed here with `lance.stats.column.`; `toMap` can also
+ * emit a `histogram` key, but the writer disables histogram computation so none is produced, and
+ * this codec defensively drops any it sees in a legacy/hand-edited payload — see below). This codec
+ * strips the prefix, feeds the sub-map to `fromMap`, and `toPlanStat` returns min/max in the
+ * internal catalyst representation — exactly what Spark's CBO {@code FilterEstimation} expects and
+ * what {@code DataSourceV2Relation.transformV2Stats} copies verbatim into a catalyst {@code ColumnStat}
+ * (across Spark 3.4–4.1 that path performs no {@code CatalystTypeConverters} round-trip on the V2
+ * min/max, so the internal rep is what reaches the optimizer unchanged).
+ *
+ * <p>Java-friendly: returns {@link java.util.Optional} so the Java {@code LanceScanBuilder} reader can
+ * call it directly. Every decode failure (absent keys, Spark codec rejection, poisoned min/max that
+ * {@code fromExternalString} can't parse) is fail-safe → {@code Optional.empty} so the scan simply
+ * reports no stats for that column rather than feeding the optimizer a degenerate value.
+ */
+object LanceColumnStatCodec {
+
+  /**
+   * Hard cap on the length of a single per-column stat value accepted from TBLPROPERTIES. Every
+   * legitimate value is short (a Decimal(38,x) min/max is ~40 chars; counts / lengths / version are
+   * small integers), so this never rejects a real value — it only bounds the cost of parsing a
+   * poisoned, oversized min/max (see the BigDecimal note in {@link #decode}).
+   */
+  private val MAX_STAT_VALUE_LEN = 256
+
+  /**
+   * Decode persisted stats for a single column.
+   *
+   * @param tableName  table identifier, used only in Spark's internal warn logging on bad input
+   * @param colName    the (top-level, unquoted, dot-free) column name
+   * @param dataType   the column's current Spark type (drives `fromExternalString` parsing)
+   * @param props      the full table-properties map (all `lance.stats.*` keys)
+   * @return a V2 ColumnStatistics, or empty if no decodable stats exist for the column
+   */
+  def decode(
+      tableName: String,
+      colName: String,
+      dataType: DataType,
+      props: java.util.Map[String, String]): Optional[ColumnStatistics] = {
+    if (props == null || props.isEmpty) {
+      return Optional.empty()
+    }
+    val keyPrefix = LanceStatsKeys.COLUMN_PREFIX + colName + "."
+    val histogramPrefix = keyPrefix + "histogram"
+    val envelopeLen = LanceStatsKeys.COLUMN_PREFIX.length
+    // Strip the `lance.stats.column.` envelope so keys read as `<col>.<suffix>` — the exact shape
+    // CatalogColumnStat.fromMap consumes. The trailing '.' in keyPrefix prevents a column whose
+    // name is a prefix of another (e.g. "id" vs "id2") from capturing the sibling's keys.
+    //
+    // Drop any `<col>.histogram[.partN]` key: the writer no longer persists histograms, and we
+    // discard them on read anyway. Excluding them here also closes a DoS vector — fromMap eagerly
+    // calls HistogramSerializer.deserialize, which allocates arrays sized by an int read from the
+    // (user-editable) payload before any bin data, so a poisoned/legacy histogram value could force
+    // a multi-GB driver allocation at planning time.
+    //
+    // Also drop any value longer than MAX_STAT_VALUE_LEN. Every legitimate per-column value here is
+    // short (a Decimal(38,x) min/max is ~40 chars; counts/lengths/version are small integers), so
+    // this is a no-op in practice. It bounds a second poisoned-payload cost: toPlanStat parses a
+    // DecimalType min/max via `new BigDecimal(String)`, whose construction is O(n^2) in digit count
+    // and runs to completion before any validation — a multi-MB digit string would stall the driver
+    // at plan time, re-incurred on every scan. Dropping the oversized key degrades to "no stats" for
+    // that bound (fail-safe), consistent with the rest of this codec.
+    val subMap: Map[String, String] = props.asScala.iterator.collect {
+      case (k, v)
+          if k != null && v != null && k.startsWith(keyPrefix) &&
+            !k.startsWith(histogramPrefix) &&
+            v.length <= LanceColumnStatCodec.MAX_STAT_VALUE_LEN =>
+        k.substring(envelopeLen) -> v
+    }.toMap
+    if (subMap.isEmpty) {
+      return Optional.empty()
+    }
+    val catalogStat: Option[CatalogColumnStat] =
+      try {
+        CatalogColumnStat.fromMap(tableName, colName, subMap)
+      } catch {
+        // fromMap already swallows NonFatal internally and returns None, but guard defensively so
+        // a future Spark that throws here still degrades to "no stats" rather than failing the scan.
+        case _: Throwable => None
+      }
+    catalogStat match {
+      case Some(ccs) =>
+        // Forward-compat guard: the per-column `<col>.version` is Spark's own CatalogColumnStat
+        // serialization version, NOT gated by the envelope `lance.stats.version`. If a payload was
+        // written by a newer Spark whose CatalogColumnStat format we don't understand, skip it
+        // rather than risk toPlanStat silently mis-parsing a reformatted min/max into a
+        // plausible-but-wrong bound that would mislead the CBO. (Cross-version reads only; within a
+        // deployment the Spark version is fixed, so this never fires.)
+        if (ccs.version > CatalogColumnStat.VERSION) {
+          return Optional.empty()
+        }
+        val stat: ColumnStat =
+          try {
+            ccs.toPlanStat(colName, dataType)
+          } catch {
+            // toPlanStat calls fromExternalString, which throws on a poisoned min/max that doesn't
+            // parse for the column's type. Skip the column rather than surface a planning failure.
+            case _: Throwable => return Optional.empty()
+          }
+        // CBO contract: a negative nullCount or distinctCount is corrupt — skip the whole column.
+        // distinctCount == 0 (e.g. an all-null column whose NDV is 0) is legitimate: the wrapper
+        // drops it to empty but still surfaces the column for its nullCount, which feeds
+        // null-fraction selectivity.
+        if (stat.nullCount.exists(_ < 0) || stat.distinctCount.exists(_ < 0)) {
+          return Optional.empty()
+        }
+        Optional.of(new LanceV2ColumnStatistics(stat))
+      case None => Optional.empty()
+    }
+  }
+}
+
+/**
+ * Trivial [[ColumnStatistics]] view over a catalyst [[ColumnStat]]. min/max are surfaced in the
+ * internal catalyst representation (e.g. UTF8String, Decimal, days-as-Int, micros-as-Long) that
+ * {@code transformV2Stats} copies straight into a catalyst {@code ColumnStat}. distinctCount is
+ * suppressed when non-positive (CBO requires > 0). Histogram is intentionally dropped — the catalyst
+ * {@code Histogram} type differs from the V2 {@code Histogram}, and uniform-within-range selectivity
+ * is an acceptable fallback.
+ */
+final class LanceV2ColumnStatistics(stat: ColumnStat)
+  extends ColumnStatistics
+  with java.io.Serializable {
+
+  override def distinctCount(): OptionalLong =
+    stat.distinctCount.filter(_ > 0).map(b => OptionalLong.of(b.toLong)).getOrElse(
+      OptionalLong.empty())
+
+  // Optional.ofNullable, not Optional.of: fromExternalString returns null (not a throw) for
+  // String/Binary, so a poisoned `<col>.min`/`.max` on such a column yields Some(null) here; of()
+  // would NPE at plan time, breaking the fail-safe contract. ofNullable surfaces it as empty.
+  override def min(): Optional[Object] =
+    Optional.ofNullable(stat.min.map(_.asInstanceOf[Object]).orNull)
+
+  override def max(): Optional[Object] =
+    Optional.ofNullable(stat.max.map(_.asInstanceOf[Object]).orNull)
+
+  override def nullCount(): OptionalLong =
+    stat.nullCount.map(b => OptionalLong.of(b.toLong)).getOrElse(OptionalLong.empty())
+
+  override def avgLen(): OptionalLong =
+    stat.avgLen.map(l => OptionalLong.of(l)).getOrElse(OptionalLong.empty())
+
+  override def maxLen(): OptionalLong =
+    stat.maxLen.map(l => OptionalLong.of(l)).getOrElse(OptionalLong.empty())
+
+  override def histogram(): Optional[Histogram] = Optional.empty()
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDataSourceV2Strategy.scala
@@ -63,6 +63,9 @@ case class LanceDataSourceV2Strategy(session: SparkSession) extends SparkStrateg
     case SetUnenforcedPrimaryKey(ResolvedIdentifier(catalog, ident), columns) =>
       SetUnenforcedPrimaryKeyExec(asTableCatalog(catalog), ident, columns) :: Nil
 
+    case LanceAnalyzeTable(ResolvedIdentifier(catalog, ident), columns, forAllColumns) =>
+      LanceAnalyzeTableExec(asTableCatalog(catalog), ident, columns, forAllColumns) :: Nil
+
     case _ => Nil
   }
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceNativeColumnStats.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceNativeColumnStats.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.plans.logical.{ColumnStat, LogicalPlan}
+
+/**
+ * Reflective bridge to Spark's internal `CommandUtils.computeColumnStats`, which computes
+ * min / max / nullCount / (HLL-approximate) distinctCount / avgLen / maxLen for the given
+ * attributes in a single aggregation job — the exact computation Spark's own
+ * `ANALYZE TABLE ... COMPUTE STATISTICS FOR COLUMNS` runs. Reusing it (instead of a hand-rolled
+ * `df.agg(...)`) guarantees the produced `ColumnStat` values are in the internal catalyst
+ * representation that `CatalogColumnStat.toMap` expects and that Spark's CBO consumes.
+ *
+ * <p>Histogram computation is force-disabled for the duration of the call (see below): Lance
+ * ANALYZE never persists histograms, so spending a percentile-sketch pass to build one we would
+ * immediately discard is pure waste.
+ *
+ * <p>Reflection is required: `computeColumnStats`'s session parameter is
+ * `org.apache.spark.sql.SparkSession` in Spark 3.x but `org.apache.spark.sql.classic.SparkSession`
+ * in Spark 4.x (the Connect/Classic split). The shared `lance-spark-base_2.12` source compiles
+ * standalone and against every supported Spark version, so it cannot name the 4.x `classic` type
+ * to call the method statically. The lookup is by name + arity and fails loudly if Spark's
+ * internal signature ever changes, so a Spark upgrade that breaks it surfaces immediately rather
+ * than silently misbehaving.
+ */
+object LanceNativeColumnStats {
+
+  /**
+   * @return (rowCount, perColumnStats) — distinctCount is HLL-approximate, matching Spark's
+   *         native ANALYZE; avgLen/maxLen are always populated. No histogram is ever produced:
+   *         `spark.sql.statistics.histogram.enabled` is forced off for the duration of the call.
+   */
+  def computeColumnStats(
+      spark: SparkSession,
+      relation: LogicalPlan,
+      attributes: Seq[Attribute]): (Long, Map[Attribute, ColumnStat]) = {
+    // CommandUtils.computeColumnStats reads sparkSession.sessionState.conf.histogramEnabled to
+    // decide whether to add the percentile-sketch aggregation that builds a histogram. Lance
+    // ANALYZE never persists histograms (the read path discards them — the V2 ColumnStatistics
+    // histogram type differs from catalyst's), so force the flag off here rather than computing a
+    // histogram and stripping it from the serialized output afterward. Save/restore so we don't
+    // disturb the user's session setting for unrelated queries.
+    val histogramKey = "spark.sql.statistics.histogram.enabled"
+    val runtimeConf = spark.conf
+    val previousHistogram: Option[String] =
+      if (runtimeConf.contains(histogramKey)) Some(runtimeConf.get(histogramKey)) else None
+    runtimeConf.set(histogramKey, "false")
+    try {
+      val module =
+        Class
+          .forName("org.apache.spark.sql.execution.command.CommandUtils$")
+          .getField("MODULE$")
+          .get(null)
+      val method = module.getClass.getMethods
+        .find(m => m.getName == "computeColumnStats" && m.getParameterCount == 3)
+        .getOrElse(
+          throw new IllegalStateException(
+            "Spark CommandUtils.computeColumnStats(session, relation, Seq[Attribute]) was not "
+              + "found via reflection. A Spark upgrade likely changed this internal API; update "
+              + "LanceNativeColumnStats to match."))
+      val raw =
+        try {
+          method.invoke(module, spark, relation, attributes)
+        } catch {
+          case e: java.lang.reflect.InvocationTargetException if e.getCause != null =>
+            throw e.getCause
+        }
+      val tuple = raw.asInstanceOf[scala.Tuple2[Any, Map[Attribute, ColumnStat]]]
+      val rowCount = tuple._1 match {
+        case n: java.lang.Number => n.longValue()
+        case b: scala.math.BigInt => b.toLong
+        case other => other.toString.toLong
+      }
+      (rowCount, tuple._2)
+    } finally {
+      previousHistogram match {
+        case Some(v) => runtimeConf.set(histogramKey, v)
+        case None => runtimeConf.unset(histogramKey)
+      }
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceAnalyzeTableSchemaHashTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceAnalyzeTableSchemaHashTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Unit tests for {@link LanceStatsKeys#computeSchemaHash}. The hash is the sole guard against
+ * schema drift between {@code ANALYZE TABLE} and a subsequent scan, so a regression in its
+ * sensitivity to column changes silently feeds stale stats to Spark's CBO.
+ */
+class LanceAnalyzeTableSchemaHashTest {
+
+  private static StructType schema(StructField... fields) {
+    return new StructType(fields);
+  }
+
+  @Test
+  @DisplayName("identical schemas produce identical hashes (deterministic)")
+  void sameSchemaSameHash() {
+    StructType a =
+        schema(
+            new StructField("id", DataTypes.LongType, false, null),
+            new StructField("name", DataTypes.StringType, true, null));
+    StructType b =
+        schema(
+            new StructField("id", DataTypes.LongType, false, null),
+            new StructField("name", DataTypes.StringType, true, null));
+    assertEquals(LanceStatsKeys.computeSchemaHash(a), LanceStatsKeys.computeSchemaHash(b));
+  }
+
+  @Test
+  @DisplayName("hash is stable across repeated calls on same schema (no JVM-salted hashCode reuse)")
+  void hashIsStableAcrossCalls() {
+    StructType s = schema(new StructField("c", DataTypes.IntegerType, true, null));
+    String h1 = LanceStatsKeys.computeSchemaHash(s);
+    String h2 = LanceStatsKeys.computeSchemaHash(s);
+    assertEquals(h1, h2);
+  }
+
+  @Test
+  @DisplayName("different field order produces different hash")
+  void fieldOrderChangeDifferentHash() {
+    StructType ordered =
+        schema(
+            new StructField("a", DataTypes.LongType, true, null),
+            new StructField("b", DataTypes.StringType, true, null));
+    StructType reordered =
+        schema(
+            new StructField("b", DataTypes.StringType, true, null),
+            new StructField("a", DataTypes.LongType, true, null));
+    assertNotEquals(
+        LanceStatsKeys.computeSchemaHash(ordered), LanceStatsKeys.computeSchemaHash(reordered));
+  }
+
+  @Test
+  @DisplayName("renaming a column produces different hash")
+  void renameDifferentHash() {
+    StructType before = schema(new StructField("foo", DataTypes.IntegerType, true, null));
+    StructType after = schema(new StructField("bar", DataTypes.IntegerType, true, null));
+    assertNotEquals(
+        LanceStatsKeys.computeSchemaHash(before), LanceStatsKeys.computeSchemaHash(after));
+  }
+
+  @Test
+  @DisplayName("retyping a column produces different hash")
+  void retypeDifferentHash() {
+    StructType before = schema(new StructField("c", DataTypes.IntegerType, true, null));
+    StructType after = schema(new StructField("c", DataTypes.LongType, true, null));
+    assertNotEquals(
+        LanceStatsKeys.computeSchemaHash(before), LanceStatsKeys.computeSchemaHash(after));
+  }
+
+  @Test
+  @DisplayName("flipping nullable produces different hash")
+  void nullabilityFlipDifferentHash() {
+    StructType nullable = schema(new StructField("c", DataTypes.IntegerType, true, null));
+    StructType notNull = schema(new StructField("c", DataTypes.IntegerType, false, null));
+    assertNotEquals(
+        LanceStatsKeys.computeSchemaHash(nullable), LanceStatsKeys.computeSchemaHash(notNull));
+  }
+
+  @Test
+  @DisplayName("empty schema produces a stable, non-empty hash")
+  void emptySchemaProducesHash() {
+    String empty = LanceStatsKeys.computeSchemaHash(new StructType());
+    // SHA-256 hex is 64 chars; an empty schema produces SHA-256(""), the well-known constant.
+    assertEquals(64, empty.length());
+    assertEquals("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", empty);
+  }
+
+  @Test
+  @DisplayName("hash is 64 hex characters (SHA-256)")
+  void hashIsSha256Hex() {
+    String h =
+        LanceStatsKeys.computeSchemaHash(
+            schema(new StructField("c", DataTypes.IntegerType, true, null)));
+    assertEquals(64, h.length());
+    for (char ch : h.toCharArray()) {
+      boolean isHex = (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f');
+      org.junit.jupiter.api.Assertions.assertTrue(isHex, "Expected hex char, got: " + ch);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatsKeysTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatsKeysTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Unit tests for {@link LanceStatsKeys} key constants and validators. */
+class LanceStatsKeysTest {
+
+  @Test
+  @DisplayName("validateColumnName accepts plain names")
+  void validateColumnNameAccepts() {
+    LanceStatsKeys.validateColumnName("foo");
+    LanceStatsKeys.validateColumnName("foo_bar");
+    LanceStatsKeys.validateColumnName("Mixed-Case");
+    LanceStatsKeys.validateColumnName("with spaces");
+    // No assertion needed — passing without throwing is the contract.
+  }
+
+  @Test
+  @DisplayName("validateColumnName rejects dotted names (key ambiguity with nested-leaf paths)")
+  void validateColumnNameRejectsDots() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> LanceStatsKeys.validateColumnName("a.b"));
+    assertTrue(ex.getMessage().contains("'.'"));
+  }
+
+  @Test
+  @DisplayName("validateColumnName rejects null")
+  void validateColumnNameRejectsNull() {
+    assertThrows(IllegalArgumentException.class, () -> LanceStatsKeys.validateColumnName(null));
+  }
+
+  @Test
+  @DisplayName("validateColumnName rejects empty string (orphan-cleanup ambiguity)")
+  void validateColumnNameRejectsEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> LanceStatsKeys.validateColumnName(""));
+  }
+
+  @Test
+  @DisplayName("isStatsCompatibleColumnName: empty / null / dotted all reject")
+  void isStatsCompatibleColumnNameRejectsBadInputs() {
+    assertFalse(LanceStatsKeys.isStatsCompatibleColumnName(null));
+    assertFalse(LanceStatsKeys.isStatsCompatibleColumnName(""));
+    assertFalse(LanceStatsKeys.isStatsCompatibleColumnName("a.b"));
+    assertTrue(LanceStatsKeys.isStatsCompatibleColumnName("a"));
+  }
+
+  @Test
+  @DisplayName("Concatenated keys equal top-level constants")
+  void keyConstantsConsistency() {
+    assertEquals(
+        "lance.stats.column.foo.min",
+        LanceStatsKeys.COLUMN_PREFIX + "foo" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN);
+    assertEquals(
+        "lance.stats.column.foo.distinctCount",
+        LanceStatsKeys.COLUMN_PREFIX + "foo" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT);
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatsTestKeys.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceStatsTestKeys.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+/**
+ * Per-column TBLPROPERTIES key suffixes used only by ANALYZE-stats tests to assemble and assert the
+ * on-disk key shape. Production code never references these: the ANALYZE writer serializes each
+ * column stat with Spark's {@code CatalogColumnStat.toMap} and the read path deserializes with
+ * {@code CatalogColumnStat.fromMap}, so the suffix naming is Spark's own, prefixed with {@link
+ * LanceStatsKeys#COLUMN_PREFIX}. These constants live in the test sources rather than in {@link
+ * LanceStatsKeys} so the production wire-format class carries only the keys production actually
+ * reads or writes.
+ */
+public final class LanceStatsTestKeys {
+
+  private LanceStatsTestKeys() {}
+
+  public static final String COLUMN_SUFFIX_VERSION = ".version";
+  public static final String COLUMN_SUFFIX_MIN = ".min";
+  public static final String COLUMN_SUFFIX_MAX = ".max";
+  public static final String COLUMN_SUFFIX_NULL_COUNT = ".nullCount";
+  public static final String COLUMN_SUFFIX_DISTINCT_COUNT = ".distinctCount";
+  public static final String COLUMN_SUFFIX_AVG_LEN = ".avgLen";
+  public static final String COLUMN_SUFFIX_MAX_LEN = ".maxLen";
+
+  /**
+   * The suffix Spark's {@code toMap} uses for a histogram. Lance ANALYZE never persists one (it
+   * forces {@code spark.sql.statistics.histogram.enabled} off during computation), so tests use
+   * this only to assert the histogram key's absence.
+   */
+  public static final String COLUMN_SUFFIX_HISTOGRAM = ".histogram";
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LoadPersistedColumnStatsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LoadPersistedColumnStatsTest.java
@@ -1,0 +1,481 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link LanceScanBuilder#loadPersistedColumnStats} fast-path branches. The fast
+ * path is the entire premise of ANALYZE TABLE persistent stats; a regression in any branch silently
+ * degrades CBO without a failing test, so we test each guard independently rather than relying on
+ * end-to-end coverage alone.
+ *
+ * <p>The per-column payload is Spark's own {@code CatalogColumnStat} map form (written by {@code
+ * CatalogColumnStat.toMap}, read by {@code CatalogColumnStat.fromMap}) under the {@code
+ * lance.stats.column.} prefix: each column needs a {@code .version} key (Spark's serialization
+ * version, required by {@code fromMap}) plus any of {@code .min/.max/.nullCount/.distinctCount/
+ * .avgLen/.maxLen}. min/max are plain external strings (decimal for Long, the raw text for String).
+ *
+ * <p>Tests pass {@code session = null} since the only session use is the {@code allowStale}
+ * SparkConf lookup, which gracefully falls through to {@code allowStale=false} when no session is
+ * bound.
+ */
+class LoadPersistedColumnStatsTest {
+
+  /**
+   * Spark's {@code CatalogColumnStat} serialization version (the value of {@code
+   * CatalogColumnStat.VERSION}). Stable at 2 since histogram support landed; {@code fromMap}
+   * requires the per-column {@code .version} key to be present and integer-parseable.
+   */
+  private static final String CATALOG_STAT_VERSION = "2";
+
+  /**
+   * Local SparkSession used by the {@code allowStale} branch tests. Built once for the class so the
+   * per-test cost stays low; the rest of the tests pass {@code session = null} since they don't
+   * exercise SparkConf.
+   */
+  private static SparkSession spark;
+
+  @BeforeAll
+  static void setUpSession() {
+    spark =
+        SparkSession.builder()
+            .appName("LoadPersistedColumnStatsTest")
+            .master("local")
+            .getOrCreate();
+  }
+
+  @AfterAll
+  static void tearDownSession() {
+    if (spark != null) {
+      // Clear active+default refs: SparkSession.builder().getOrCreate() in a sibling test class
+      // returns this thread's active session if one is still bound, silently inheriting our
+      // (non-catalog-configured) builder.
+      SparkSession.clearActiveSession();
+      SparkSession.clearDefaultSession();
+      spark.stop();
+      spark = null;
+    }
+  }
+
+  private static final StructType SCHEMA =
+      new StructType(
+          new StructField[] {
+            new StructField("id", DataTypes.LongType, true, null),
+            new StructField("name", DataTypes.StringType, true, null)
+          });
+
+  /** Put the per-column {@code .version} key Spark's {@code fromMap} requires. */
+  private static void putVersion(Map<String, String> p, String col) {
+    p.put(
+        LanceStatsKeys.COLUMN_PREFIX + col + LanceStatsTestKeys.COLUMN_SUFFIX_VERSION,
+        CATALOG_STAT_VERSION);
+  }
+
+  /** Build a properties map representing a fully-valid stats payload at version=42. */
+  private static Map<String, String> validProps() {
+    Map<String, String> p = new HashMap<>();
+    p.put(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION);
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "42");
+    p.put(LanceStatsKeys.SCHEMA_HASH, LanceStatsKeys.computeSchemaHash(SCHEMA));
+    putVersion(p, "id");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "1");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX, "100");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT, "5");
+    p.put(
+        LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT,
+        "95");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_AVG_LEN, "8");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX_LEN, "8");
+    return p;
+  }
+
+  @Test
+  @DisplayName("Valid payload returns ColumnStatistics for analyzed column")
+  void validPayloadReturnsStats() {
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, validProps(), SCHEMA, SCHEMA, 42L);
+    assertNotNull(result);
+    NamedReference idRef = FieldReference.column("id");
+    assertTrue(result.containsKey(idRef));
+    ColumnStatistics idStats = result.get(idRef);
+    // LongType internal rep == external long, so min/max surface as java.lang.Long.
+    assertEquals(1L, idStats.min().get());
+    assertEquals(100L, idStats.max().get());
+    assertEquals(5L, idStats.nullCount().getAsLong());
+    assertEquals(95L, idStats.distinctCount().getAsLong());
+    // avgLen/maxLen must round-trip too (they feed Spark's join-size estimation).
+    assertEquals(8L, idStats.avgLen().getAsLong());
+    assertEquals(8L, idStats.maxLen().getAsLong());
+  }
+
+  @Test
+  @DisplayName("formatVersion absent → fall back (fail-safe gate)")
+  void formatVersionAbsentRejected() {
+    Map<String, String> p = validProps();
+    p.remove(LanceStatsKeys.VERSION);
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("formatVersion=2 (unrecognized) → fall back")
+  void formatVersionUnrecognizedRejected() {
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.VERSION, "2");
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("computedAtVersion mismatch + allowStale unset → fall back")
+  void staleVersionRejected() {
+    // currentManifestVersion=43 but stats are tagged at version=42 — must reject without an
+    // active session bound (so allowStale defaults to false).
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, validProps(), SCHEMA, SCHEMA, 43L));
+  }
+
+  @Test
+  @DisplayName("computedAtVersion malformed → fall back")
+  void computedAtVersionMalformedRejected() {
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "not-a-number");
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("computedAtVersion negative → fall back")
+  void computedAtVersionNegativeRejected() {
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "-1");
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("schemaHash mismatch → fall back (drift guard)")
+  void schemaHashMismatchRejected() {
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.SCHEMA_HASH, "0".repeat(64)); // not the SCHEMA's hash
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("schemaHash absent → fall back (fail-safe)")
+  void schemaHashAbsentRejected() {
+    Map<String, String> p = validProps();
+    p.remove(LanceStatsKeys.SCHEMA_HASH);
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Empty properties → null (no stats to consume)")
+  void emptyPropsReturnsNull() {
+    assertNull(
+        LanceScanBuilder.loadPersistedColumnStats(null, new HashMap<>(), SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Null properties → null")
+  void nullPropsReturnsNull() {
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, null, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Poisoned min that does not parse for the type → whole column dropped (fail-safe)")
+  void poisonedMinDropsColumn() {
+    // With Spark's CatalogColumnStat codec, a min that won't parse for the column's type
+    // (here a non-numeric string for a Long column) makes toPlanStat → fromExternalString throw.
+    // The reader degrades the WHOLE column to "no stats" rather than surfacing a partial stat.
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "not-a-long");
+    // id is the only analyzed column, so dropping it yields a null result map.
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Missing per-column .version → column dropped (fromMap requires it)")
+  void missingVersionDropsColumn() {
+    Map<String, String> p = validProps();
+    p.remove(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_VERSION);
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Projected schema is a subset → only projected columns appear")
+  void projectionFiltersStats() {
+    // Add full stats for "name" too, then project only "id".
+    Map<String, String> p = validProps();
+    putVersion(p, "name");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "alice");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX, "zach");
+    StructType projected = new StructType(new StructField[] {SCHEMA.fields()[0]});
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, projected, 42L);
+    assertNotNull(result);
+    assertTrue(result.containsKey(FieldReference.column("id")));
+    assertEquals(1, result.size(), "name should not appear in projected result");
+  }
+
+  @Test
+  @DisplayName("Projected schema with no analyzed columns → null (caller falls back)")
+  void projectedSchemaWithNoStatsReturnsNull() {
+    // ANALYZE wrote stats for "id" only; project only "name". All sentinels pass but no
+    // per-column entries match the projection, so the method returns null and the caller
+    // falls back to live aggregation.
+    StructType nameOnly = new StructType(new StructField[] {SCHEMA.fields()[1]});
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, validProps(), SCHEMA, nameOnly, 42L);
+    assertNull(result);
+  }
+
+  @Test
+  @DisplayName("Column with no stats keys at all is skipped (not a malformed-decode case)")
+  void columnWithoutAnalyzeIsSkipped() {
+    // "name" never had ANALYZE stats written; only "id" did. result should contain only "id".
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, validProps(), SCHEMA, SCHEMA, 42L);
+    assertNotNull(result);
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey(FieldReference.column("id")));
+  }
+
+  @Test
+  @DisplayName("allowStale=true → accept stats whose computedAtVersion lags currentManifestVersion")
+  void allowStaleAcceptsStaleVersion() {
+    try {
+      spark.conf().set(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE, "true");
+      // computedAtVersion=42, currentManifestVersion=43 — stale, but allowStale=true accepts.
+      Map<NamedReference, ColumnStatistics> result =
+          LanceScanBuilder.loadPersistedColumnStats(spark, validProps(), SCHEMA, SCHEMA, 43L);
+      assertNotNull(result, "allowStale=true should accept stale stats");
+      assertTrue(result.containsKey(FieldReference.column("id")));
+    } finally {
+      spark.conf().unset(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE);
+    }
+  }
+
+  @Test
+  @DisplayName("allowStale=false (explicit) → still reject stale version")
+  void allowStaleFalseStillRejectsStale() {
+    try {
+      spark.conf().set(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE, "false");
+      Map<NamedReference, ColumnStatistics> result =
+          LanceScanBuilder.loadPersistedColumnStats(spark, validProps(), SCHEMA, SCHEMA, 43L);
+      assertNull(result, "allowStale=false must reject stale stats");
+    } finally {
+      spark.conf().unset(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ALLOW_STALE);
+    }
+  }
+
+  @Test
+  @DisplayName("allowStale unset + session present → defaults to false (rejects stale)")
+  void allowStaleUnsetDefaultsToFalse() {
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(spark, validProps(), SCHEMA, SCHEMA, 43L);
+    assertNull(result);
+  }
+
+  @Test
+  @DisplayName("Negative nullCount is treated as corrupt → whole column dropped (range guard)")
+  void negativeNullCountRejected() {
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT, "-1");
+    // id was the only analyzed column; negative nullCount drops it → result map is empty → null.
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("distinctCount=0 keeps the column but omits NDV; negative drops the column")
+  void distinctCountZeroKeepsColumnNegativeDrops() {
+    // distinctCount == 0 is legitimate (e.g. an all-null column): keep min/max/nullCount, drop NDV.
+    Map<String, String> zero = validProps();
+    zero.put(
+        LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT, "0");
+    Map<NamedReference, ColumnStatistics> zeroResult =
+        LanceScanBuilder.loadPersistedColumnStats(null, zero, SCHEMA, SCHEMA, 42L);
+    assertNotNull(zeroResult);
+    ColumnStatistics idStats = zeroResult.get(FieldReference.column("id"));
+    assertNotNull(idStats);
+    assertTrue(idStats.distinctCount().isEmpty(), "distinctCount=0 → empty NDV");
+    assertEquals(1L, idStats.min().get(), "min still surfaced");
+    assertEquals(5L, idStats.nullCount().getAsLong(), "nullCount still surfaced");
+
+    // A negative distinctCount is corrupt → whole column dropped (fail-safe).
+    Map<String, String> negative = validProps();
+    negative.put(
+        LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT,
+        "-5");
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, negative, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("All-null column: nullCount present, no min/max/distinctCount → kept with empty NDV")
+  void allNullColumnKeepsNullCountWithoutDistinctCount() {
+    // Mirrors what the writer persists for an all-NULL column: only version + nullCount, no
+    // min/max/distinctCount. The reader must KEEP the column (surfacing nullCount), not drop it.
+    Map<String, String> p = new HashMap<>();
+    p.put(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION);
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "42");
+    p.put(LanceStatsKeys.SCHEMA_HASH, LanceStatsKeys.computeSchemaHash(SCHEMA));
+    putVersion(p, "id");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT, "7");
+
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L);
+    assertNotNull(result);
+    ColumnStatistics idStats = result.get(FieldReference.column("id"));
+    assertNotNull(idStats, "all-null column must be reported, not dropped");
+    assertEquals(7L, idStats.nullCount().getAsLong());
+    assertTrue(idStats.distinctCount().isEmpty(), "no distinctCount persisted → empty");
+    assertTrue(idStats.min().isEmpty(), "no min persisted → empty");
+    assertTrue(idStats.max().isEmpty(), "no max persisted → empty");
+  }
+
+  @Test
+  @DisplayName("Column name needing SQL quoting is excluded (Spark CBO can't match describe())")
+  void quotingNeededColumnNameExcluded() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("ok_col", DataTypes.LongType, true, null),
+              new StructField("weird name", DataTypes.LongType, true, null)
+            });
+    Map<String, String> p = new HashMap<>();
+    p.put(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION);
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "42");
+    p.put(LanceStatsKeys.SCHEMA_HASH, LanceStatsKeys.computeSchemaHash(schema));
+    putVersion(p, "ok_col");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "ok_col" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "1");
+    putVersion(p, "weird name");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "weird name" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "5");
+
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, schema, schema, 42L);
+    assertNotNull(result);
+    assertTrue(
+        result.containsKey(FieldReference.column("ok_col")), "plain identifier column is included");
+    assertNull(
+        result.get(FieldReference.column("weird name")),
+        "quoting-needed column must be excluded — Spark's CBO cannot match its describe()");
+  }
+
+  @Test
+  @DisplayName(
+      "Per-column .version newer than this Spark's CatalogColumnStat.VERSION → column dropped")
+  void perColumnVersionNewerThanSparkIsDropped() {
+    // Simulate a payload written by a newer Spark whose CatalogColumnStat serialization format we
+    // don't understand: the per-column version exceeds the connector's CatalogColumnStat.VERSION.
+    // The reader skips it rather than risk mis-parsing a reformatted min/max into a wrong CBO
+    // bound.
+    Map<String, String> p = validProps();
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_VERSION, "999");
+    // id is the only analyzed column, so dropping it yields a null result map.
+    assertNull(LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L));
+  }
+
+  @Test
+  @DisplayName("Poisoned min on a String column surfaces as empty (no NPE — fail-safe)")
+  void poisonedStringMinSurfacesAsEmpty() {
+    // Spark's fromExternalString returns null (not a throw) for String/Binary, so a hand-edited
+    // name.min yields a Some(null) bound internally. The V2 ColumnStatistics must surface it as an
+    // empty min rather than NPE at plan time (Spark never computes min/max for string columns).
+    Map<String, String> p = new HashMap<>();
+    p.put(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION);
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "42");
+    p.put(LanceStatsKeys.SCHEMA_HASH, LanceStatsKeys.computeSchemaHash(SCHEMA));
+    putVersion(p, "name");
+    p.put(
+        LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN,
+        "hand-edited");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT, "3");
+
+    StructType nameOnly = new StructType(new StructField[] {SCHEMA.fields()[1]});
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, nameOnly, 42L);
+    assertNotNull(result);
+    ColumnStatistics nameStats = result.get(FieldReference.column("name"));
+    assertNotNull(nameStats);
+    assertTrue(nameStats.min().isEmpty(), "String min must surface as empty, not throw");
+    assertEquals(3L, nameStats.nullCount().getAsLong());
+  }
+
+  @Test
+  @DisplayName("Oversized stat value is dropped (length cap), not handed to the parser")
+  void oversizedStatValueIsDropped() {
+    // A poisoned, very long min would otherwise reach Spark's parser (e.g. an O(n^2) BigDecimal
+    // construction for a DecimalType). The length cap drops the oversized key, so the column still
+    // decodes with its remaining stats and an empty min — fail-safe, no expensive parse.
+    Map<String, String> p = validProps();
+    StringBuilder huge = new StringBuilder();
+    for (int i = 0; i < 300; i++) {
+      huge.append('9');
+    }
+    p.put(
+        LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN,
+        huge.toString());
+
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, SCHEMA, SCHEMA, 42L);
+    assertNotNull(result);
+    ColumnStatistics idStats = result.get(FieldReference.column("id"));
+    assertNotNull(idStats);
+    assertTrue(idStats.min().isEmpty(), "oversized min must be dropped, leaving an empty min");
+    assertEquals(100L, idStats.max().get(), "other stats still decode");
+  }
+
+  @Test
+  @DisplayName(
+      "TimestampNTZ column is skipped on read (its min/max would crash CBO FilterEstimation)")
+  void timestampNtzColumnSkippedOnRead() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              new StructField("id", DataTypes.LongType, true, null),
+              new StructField("ts", DataTypes.TimestampNTZType, true, null)
+            });
+    Map<String, String> p = new HashMap<>();
+    p.put(LanceStatsKeys.VERSION, LanceStatsKeys.SUPPORTED_VERSION);
+    p.put(LanceStatsKeys.COMPUTED_AT_VERSION, "42");
+    p.put(LanceStatsKeys.SCHEMA_HASH, LanceStatsKeys.computeSchemaHash(schema));
+    putVersion(p, "id");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "1");
+    // A hand-poisoned ts stat: the read path must skip TimestampNTZ entirely so its min/max never
+    // reach Spark's CBO FilterEstimation (no toDouble case → MatchError on a filtered query).
+    putVersion(p, "ts");
+    p.put(LanceStatsKeys.COLUMN_PREFIX + "ts" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN, "1000000");
+
+    Map<NamedReference, ColumnStatistics> result =
+        LanceScanBuilder.loadPersistedColumnStats(null, p, schema, schema, 42L);
+    assertNotNull(result);
+    assertTrue(result.containsKey(FieldReference.column("id")), "id stats present");
+    assertNull(
+        result.get(FieldReference.column("ts")), "TimestampNTZ column must be skipped on read");
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAnalyzeTableTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAnalyzeTableTest.java
@@ -1,0 +1,734 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.update;
+
+import org.lance.spark.read.LanceStatsKeys;
+import org.lance.spark.read.LanceStatsTestKeys;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end tests for {@code ANALYZE TABLE … COMPUTE STATISTICS}. Exercises the full stack:
+ * grammar → AST → logical plan → {@code LanceAnalyzeTableExec} → {@code catalog.alterTable} →
+ * manifest write → {@code LanceScanBuilder.loadPersistedColumnStats}. Asserts (a) the TBLPROPERTIES
+ * write happens with the expected wire-format keys, (b) the persisted payload round-trips through
+ * the read path back into Spark's {@code Statistics.columnStats()}, and (c) staleness invalidates
+ * the cached stats so a subsequent INSERT correctly forces fallback.
+ *
+ * <p>Sub-classed per Spark major version so each module's parser-strategy wiring is exercised.
+ */
+public abstract class BaseAnalyzeTableTest {
+
+  protected final String catalogName = "lance_test";
+
+  protected SparkSession spark;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    spark =
+        SparkSession.builder()
+            .appName("lance-analyze-table-test")
+            .master("local[2]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + catalogName + ".impl", "dir")
+            .config("spark.sql.catalog." + catalogName + ".root", tempDir.toString())
+            .getOrCreate();
+    spark.sql("CREATE NAMESPACE IF NOT EXISTS " + catalogName + ".default");
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException {
+    if (spark != null) {
+      // Clear active+default session refs so that a follow-up test class calling
+      // SparkSession.builder().getOrCreate() builds a fresh session with its own catalog config.
+      // Without this, the next test inherits this class's catalog wiring and silently
+      // mis-routes ANALYZE TABLE / SELECT to the wrong namespace.
+      SparkSession.clearActiveSession();
+      SparkSession.clearDefaultSession();
+      spark.close();
+      spark = null;
+    }
+  }
+
+  private TableCatalog catalog() {
+    return (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+  }
+
+  private java.util.Map<String, String> properties(String tableName) throws Exception {
+    Table table = catalog().loadTable(Identifier.of(new String[] {"default"}, tableName));
+    return table.properties();
+  }
+
+  /**
+   * Build a fresh scan for the table and return the per-column statistics it reports to Spark's
+   * CBO. A fresh scan re-reads the current manifest version, so this reflects the read path's
+   * staleness/gate decisions at call time.
+   */
+  private java.util.Map<
+          org.apache.spark.sql.connector.expressions.NamedReference,
+          org.apache.spark.sql.connector.read.colstats.ColumnStatistics>
+      scanColumnStats(String tableName) throws Exception {
+    Table table = catalog().loadTable(Identifier.of(new String[] {"default"}, tableName));
+    org.apache.spark.sql.connector.read.Scan scan =
+        ((org.apache.spark.sql.connector.catalog.SupportsRead) table)
+            .newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap.empty())
+            .build();
+    return ((org.apache.spark.sql.connector.read.SupportsReportStatistics) scan)
+        .estimateStatistics()
+        .columnStats();
+  }
+
+  /**
+   * Build a scan with a pushed {@code id >= lowerBound} predicate (so zonemap fragment pruning can
+   * engage) and return its reported statistics.
+   */
+  private org.apache.spark.sql.connector.read.Statistics prunedScanStats(
+      String tableName, long lowerBound) throws Exception {
+    Table table = catalog().loadTable(Identifier.of(new String[] {"default"}, tableName));
+    org.apache.spark.sql.connector.read.ScanBuilder sb =
+        ((org.apache.spark.sql.connector.catalog.SupportsRead) table)
+            .newScanBuilder(org.apache.spark.sql.util.CaseInsensitiveStringMap.empty());
+    org.apache.spark.sql.connector.expressions.filter.Predicate ge =
+        new org.apache.spark.sql.connector.expressions.filter.Predicate(
+            ">=",
+            new org.apache.spark.sql.connector.expressions.Expression[] {
+              org.apache.spark.sql.connector.expressions.FieldReference.column("id"),
+              new org.apache.spark.sql.connector.expressions.LiteralValue<>(
+                  lowerBound, org.apache.spark.sql.types.DataTypes.LongType)
+            });
+    ((org.apache.spark.sql.connector.read.SupportsPushDownV2Filters) sb)
+        .pushPredicates(new org.apache.spark.sql.connector.expressions.filter.Predicate[] {ge});
+    return ((org.apache.spark.sql.connector.read.SupportsReportStatistics) sb.build())
+        .estimateStatistics();
+  }
+
+  @Test
+  public void analyzeForAllColumnsPersistsExpectedKeys() throws Exception {
+    String tableName = "t_for_all_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'alice'), (2, 'bob'), (3, 'carol')");
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    // Top-level wire-format tags must be present.
+    assertEquals(LanceStatsKeys.SUPPORTED_VERSION, props.get(LanceStatsKeys.VERSION));
+    assertEquals("3", props.get(LanceStatsKeys.NUM_ROWS));
+    assertNotNull(props.get(LanceStatsKeys.COMPUTED_AT_VERSION));
+    assertNotNull(props.get(LanceStatsKeys.SCHEMA_HASH));
+    assertNotNull(props.get(LanceStatsKeys.COMPUTED_AT));
+
+    // Per-column stats use Spark's CatalogColumnStat string form. For a BIGINT column, min/max are
+    // plain decimal external strings, and a per-column .version key is always present.
+    String idMinKey = LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN;
+    String idMaxKey = LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX;
+    assertEquals("1", props.get(idMinKey));
+    assertEquals("3", props.get(idMaxKey));
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_VERSION),
+        "per-column .version key (required by CatalogColumnStat.fromMap) must be present");
+    assertNotNull(
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT),
+        "distinctCount must be persisted");
+
+    // String columns: Spark's computeColumnStats does NOT compute min/max for StringType (matching
+    // native ANALYZE), but DOES compute nullCount / distinctCount / avgLen / maxLen.
+    assertNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN),
+        "Spark does not compute min/max for string columns");
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX_LEN),
+        "string column maxLen must be persisted");
+    assertNotNull(
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX
+                + "name"
+                + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT),
+        "string column distinctCount must be persisted");
+  }
+
+  @Test
+  public void analyzeForColumnsSubsetOnlyPersistsRequestedColumns() throws Exception {
+    String tableName = "t_subset_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id INT, payload STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'x'), (2, 'y')");
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR COLUMNS id");
+
+    java.util.Map<String, String> props = properties(tableName);
+    // id stats present.
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    // payload stats absent (subset).
+    assertNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "payload" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+  }
+
+  @Test
+  public void analyzeComputesApproximateDistinctCount() throws Exception {
+    String tableName = "t_ndv_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2), (3), (1), (2)");
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    // NDV is always HLL-approximate (Spark's native computeColumnStats behavior); the APPROX
+    // keyword was removed with the custom grammar. distinctCount must be persisted and positive
+    // (3 distinct values → HLL returns 3 for this tiny cardinality).
+    java.util.Map<String, String> props = properties(tableName);
+    String ndv =
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT);
+    assertNotNull(ndv, "distinctCount must be persisted");
+    assertTrue(Long.parseLong(ndv) > 0, "distinctCount must be positive, got: " + ndv);
+  }
+
+  @Test
+  public void subsequentInsertInvalidatesPersistedStats() throws Exception {
+    String tableName = "t_invalidate_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2)");
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    long taggedVersion = Long.parseLong(props.get(LanceStatsKeys.COMPUTED_AT_VERSION));
+
+    // A subsequent INSERT bumps the manifest version; the persisted-stats version-equality
+    // check on the read path should now reject these stats and fall back to live aggregation.
+    spark.sql("INSERT INTO " + fullName + " VALUES (3)");
+
+    // Stats keys are still on disk (we don't proactively delete); the reader's exact-equality
+    // check is what protects correctness. Sanity-check the key still exists with the OLD value
+    // — the read path's protection is logical, not physical.
+    java.util.Map<String, String> after = properties(tableName);
+    assertEquals(
+        Long.toString(taggedVersion),
+        after.get(LanceStatsKeys.COMPUTED_AT_VERSION),
+        "INSERT should not modify persisted-stats keys; the read path detects staleness");
+  }
+
+  @Test
+  public void analyzeReturnsResultRowWithAnalyzedCount() throws Exception {
+    String tableName = "t_result_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (a INT, b STRING, c DOUBLE) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'x', 1.5)");
+
+    List<Row> rows =
+        spark
+            .sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS")
+            .collectAsList();
+    assertEquals(1, rows.size());
+    Row r = rows.get(0);
+    // Per LanceAnalyzeTableOutputType.SCHEMA: (columns_analyzed, rows_scanned, manifest_version).
+    assertEquals(3, r.getInt(0)); // 3 columns analyzed
+    assertEquals(1L, r.getLong(1)); // 1 row
+    assertTrue(r.getLong(2) > 0); // manifest_version > 0
+  }
+
+  @Test
+  public void reAnalyzeOnUnchangedSchemaIsIdempotent() throws Exception {
+    // Idempotency check: running ANALYZE twice on an unchanged table produces the same per-
+    // column stats keys AND the same schemaHash. The orphan-cleanup pass during the second run
+    // sees no orphans (every key belongs to a still-present column) and the per-column writes
+    // overwrite with identical values. Only computedAt (ISO timestamp) is allowed to differ.
+    String tableName = "t_idempotent_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'a'), (2, 'b')");
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+    java.util.Map<String, String> first = new java.util.HashMap<>(properties(tableName));
+
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+    java.util.Map<String, String> second = properties(tableName);
+
+    // Per-column key stability.
+    for (String key : first.keySet()) {
+      if (!key.startsWith(LanceStatsKeys.COLUMN_PREFIX)) {
+        continue;
+      }
+      assertEquals(first.get(key), second.get(key), "Stat key '" + key + "' should be stable");
+    }
+    // Schema hash must be deterministic — a regression here would invalidate persisted stats
+    // on every read.
+    assertEquals(
+        first.get(LanceStatsKeys.SCHEMA_HASH),
+        second.get(LanceStatsKeys.SCHEMA_HASH),
+        "schemaHash must be stable across re-ANALYZE on unchanged schema");
+    // Numeric counts must also be identical.
+    assertEquals(first.get(LanceStatsKeys.NUM_ROWS), second.get(LanceStatsKeys.NUM_ROWS));
+    assertEquals(first.get(LanceStatsKeys.VERSION), second.get(LanceStatsKeys.VERSION));
+  }
+
+  @Test
+  public void analyzeTableMalformedSyntaxSurfacesParseError() throws Exception {
+    // A malformed ANALYZE TABLE must surface a parse error, NOT Spark's confusing
+    // NOT_SUPPORTED_COMMAND_FOR_V2_TABLE. `FOR COLUMNS` with no column list is a syntax error in
+    // Spark's native grammar, raised at parse time — before resolution and the resolution-rule
+    // interception — so the user sees a positioned parse error, never the V2-table rejection.
+    String tableName = "t_malformed_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+
+    Exception ex =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            Exception.class,
+            () -> spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR COLUMNS"));
+    String msg = ex.getMessage() == null ? "" : ex.getMessage();
+    assertFalse(
+        msg.contains("NOT_SUPPORTED_COMMAND_FOR_V2_TABLE"),
+        "Lance parse error should surface, not Spark's V2 rejection. Got: " + msg);
+  }
+
+  @Test
+  public void analyzeTableWithLeadingCommentIsHandled() throws Exception {
+    // ANALYZE TABLE with leading SQL comments must still reach the resolution-rule interception.
+    // Spark's native parser skips leading comments natively, parses AnalyzeColumn, and
+    // LanceAnalyzeTableResolution rewrites it for the Lance table — so stats are persisted rather
+    // than the analyzer rejecting it with NOT_SUPPORTED_COMMAND_FOR_V2_TABLE.
+    String tableName = "t_comment_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1)");
+
+    // Block comment + line comment + extra whitespace before the keyword.
+    spark.sql(
+        "/* hint */\n-- another\n  ANALYZE TABLE "
+            + fullName
+            + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    // ANALYZE persisted a stats payload — the version tag is the read path's "stats present" gate,
+    // and the id column carries a min/max — so interception happened past the leading comments.
+    assertEquals(LanceStatsKeys.SUPPORTED_VERSION, props.get(LanceStatsKeys.VERSION));
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+  }
+
+  @Test
+  public void killSwitchSuppressesPersistedStatsConsumption() throws Exception {
+    // R19: spark.lance.cbo.column.stats.enabled=false is the production rollback path. Must
+    // suppress persisted-stats consumption end-to-end. Hard to assert "no stats consumed"
+    // directly (no driver-side metric); assert that scans complete successfully and produce
+    // correct rows even with the kill-switch on, AND that the persisted TBLPROPERTIES are
+    // unchanged (the writer path is unaffected by the read-side kill-switch).
+    String tableName = "t_killswitch_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2), (3)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> propsBefore = properties(tableName);
+    String hashBefore = propsBefore.get(LanceStatsKeys.SCHEMA_HASH);
+    assertNotNull(hashBefore, "ANALYZE should have written stats");
+
+    try {
+      spark.conf().set(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ENABLED, "false");
+      // Scan must succeed and return correct rows. With the kill-switch on, the read path's
+      // CBO column-stats fast path is skipped entirely (no persisted-stats consumption, no
+      // zonemap aggregation). Underlying scan correctness is unaffected.
+      long count = spark.sql("SELECT COUNT(*) FROM " + fullName).collectAsList().get(0).getLong(0);
+      assertEquals(3L, count);
+      long selected = spark.sql("SELECT * FROM " + fullName).count();
+      assertEquals(3L, selected);
+    } finally {
+      spark.conf().unset(LanceStatsKeys.SPARK_CONF_CBO_COLUMN_STATS_ENABLED);
+    }
+
+    // Persisted-stats keys are untouched by the kill-switch — re-flipping enabled=true should
+    // bring back the fast path without re-running ANALYZE.
+    java.util.Map<String, String> propsAfter = properties(tableName);
+    assertEquals(hashBefore, propsAfter.get(LanceStatsKeys.SCHEMA_HASH));
+  }
+
+  @Test
+  public void readPathRejectsStaleStatsAfterInsert() throws Exception {
+    // Prove the read-path staleness check fires at runtime by inspecting the stats the scan
+    // actually reports to the CBO: fresh ANALYZE stats reach columnStats(), but after an INSERT
+    // bumps the manifest version the exact-version check (default allow.stale=false) rejects them,
+    // so the scan surfaces NO column stats for the column. (Asserting on row count would be
+    // vacuous — the scan's rowCount is always live from the manifest, never from the persisted
+    // payload, so it can't distinguish a working staleness guard from a broken one.)
+    String tableName = "t_runtime_stale_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    org.apache.spark.sql.connector.expressions.NamedReference idRef =
+        org.apache.spark.sql.connector.expressions.FieldReference.column("id");
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    // Fresh: the persisted stats reach the scan's columnStats().
+    assertTrue(
+        scanColumnStats(tableName).containsKey(idRef),
+        "fresh ANALYZE stats must reach Statistics.columnStats()");
+
+    // A subsequent INSERT bumps the manifest version → computedAtVersion < currentVersion → the
+    // read path rejects the now-stale stats and surfaces no column stats for id.
+    spark.sql("INSERT INTO " + fullName + " VALUES (3)");
+    assertFalse(
+        scanColumnStats(tableName).containsKey(idRef),
+        "stale ANALYZE stats must be rejected after an INSERT bumps the manifest version");
+
+    // Sanity: SELECTs still return correct (live) data.
+    assertEquals(
+        3L, spark.sql("SELECT COUNT(*) FROM " + fullName).collectAsList().get(0).getLong(0));
+  }
+
+  @Test
+  public void reAnalyzeClearsStaleKeysWhenColumnBecomesAllNull() throws Exception {
+    String tableName = "t_reanalyze_clear_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, v BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 10), (2, 20), (3, 30)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    String vMin = LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN;
+    String vMax = LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX;
+    String vNdv =
+        LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT;
+    String vNull = LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT;
+    java.util.Map<String, String> run1 = properties(tableName);
+    assertNotNull(run1.get(vMin), "run1 should persist v.min");
+    assertNotNull(run1.get(vNdv), "run1 should persist v.distinctCount");
+
+    // v becomes all-NULL; re-ANALYZE must CLEAR the now-invalid min/max keys (Spark computes no
+    // min/max for an all-null column) so the reader never surfaces a prior run's bounds tagged with
+    // the fresh manifest version. distinctCount is overwritten to "0" (Spark's computeColumnStats
+    // emits NDV=0 for all-null); the reader treats a 0 NDV as "no distinct-count info".
+    spark.sql(
+        "INSERT OVERWRITE "
+            + fullName
+            + " VALUES (1, CAST(NULL AS BIGINT)), (2, CAST(NULL AS BIGINT))");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> run2 = properties(tableName);
+    assertNull(run2.get(vMin), "stale v.min must be cleared after re-ANALYZE");
+    assertNull(run2.get(vMax), "stale v.max must be cleared after re-ANALYZE");
+    assertEquals("0", run2.get(vNdv), "v.distinctCount must be overwritten to 0 (all-null column)");
+    assertEquals("2", run2.get(vNull), "v.nullCount must reflect the 2 nulls");
+    // id is still non-null, so its stats survive the re-ANALYZE.
+    assertNotNull(
+        run2.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+  }
+
+  @Test
+  public void analyzeDecimalColumnPersistsDecStat() throws Exception {
+    String tableName = "t_decimal_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, amount DECIMAL(10,2)) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 1.50), (2, 9.99)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    // DECIMAL min/max round-trip through Spark's CatalogColumnStat external-string form (the plain
+    // decimal text, e.g. "1.50"), not a tagged codec form. Compare numerically to be robust to
+    // scale formatting.
+    java.util.Map<String, String> props = properties(tableName);
+    String amountMin =
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "amount" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN);
+    assertNotNull(amountMin, "DECIMAL min must be persisted, not dropped");
+    assertEquals(
+        0,
+        new java.math.BigDecimal(amountMin).compareTo(new java.math.BigDecimal("1.50")),
+        "expected DECIMAL min == 1.50, got: " + amountMin);
+  }
+
+  @Test
+  public void analyzePersistedStatsReachScanColumnStats() throws Exception {
+    String tableName = "t_colstats_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    // End-to-end: the persisted payload must round-trip through the scan back into Spark's
+    // DSv2 Statistics.columnStats() — proving the full write→read wiring, not just each half.
+    java.util.Map<
+            org.apache.spark.sql.connector.expressions.NamedReference,
+            org.apache.spark.sql.connector.read.colstats.ColumnStatistics>
+        cs = scanColumnStats(tableName);
+    assertNotNull(cs);
+    org.apache.spark.sql.connector.expressions.NamedReference idRef =
+        org.apache.spark.sql.connector.expressions.FieldReference.column("id");
+    assertTrue(
+        cs.containsKey(idRef), "ANALYZE-persisted stats should reach Statistics.columnStats()");
+    assertEquals(1L, cs.get(idRef).min().get());
+    assertEquals(3L, cs.get(idRef).max().get());
+  }
+
+  @Test
+  public void prunedScanDoesNotSurfaceFullTableColumnStats() throws Exception {
+    // When zonemap fragment pruning shrinks the scanned row count, the persisted FULL-table stats
+    // no longer describe the scanned subset (e.g. distinctCount could exceed the pruned numRows),
+    // so the scan must NOT surface them — otherwise the CBO gets internally-inconsistent stats.
+    String tableName = "t_prune_stats_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, region STRING) USING lance");
+    // 3 separate INSERTs → 3 fragments with disjoint id ranges, so a zonemap on id can prune.
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'a')");
+    spark.sql("INSERT INTO " + fullName + " VALUES (2, 'b')");
+    spark.sql("INSERT INTO " + fullName + " VALUES (3, 'c')");
+    spark.sql("ALTER TABLE " + fullName + " CREATE INDEX id_idx USING zonemap (id)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    org.apache.spark.sql.connector.expressions.NamedReference idRef =
+        org.apache.spark.sql.connector.expressions.FieldReference.column("id");
+    // Baseline: no predicate → no pruning → persisted stats ARE surfaced.
+    assertTrue(
+        scanColumnStats(tableName).containsKey(idRef),
+        "without pruning, persisted stats must be surfaced");
+
+    // id >= 3 prunes the first two fragments; the reported row count drops below the table total,
+    // so the full-table persisted stats must NOT be surfaced.
+    org.apache.spark.sql.connector.read.Statistics pruned = prunedScanStats(tableName, 3L);
+    assertTrue(
+        pruned.numRows().getAsLong() < 3L,
+        "precondition: id>=3 must prune fragments (numRows=" + pruned.numRows().getAsLong() + ")");
+    assertTrue(
+        pruned.columnStats().isEmpty(),
+        "fragment-pruned scan must not surface full-table column stats");
+  }
+
+  @Test
+  public void partialReAnalyzeClearsStatsForColumnsNotAnalyzed() throws Exception {
+    String tableName = "t_partial_reanalyze_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, v BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 100), (2, 200)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    String vMin = LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN;
+    String vMax = LanceStatsKeys.COLUMN_PREFIX + "v" + LanceStatsTestKeys.COLUMN_SUFFIX_MAX;
+    assertNotNull(properties(tableName).get(vMin), "FOR ALL COLUMNS run should persist v.min");
+
+    // The data changes, then ONLY `id` is re-analyzed. v's prior stats are now stale; the partial
+    // run must CLEAR them — otherwise the reader would serve them as fresh under the re-advanced
+    // table-level computedAtVersion (false-accept staleness).
+    spark.sql("INSERT INTO " + fullName + " VALUES (3, 999)");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR COLUMNS id");
+
+    java.util.Map<String, String> props = properties(tableName);
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN),
+        "re-analyzed id stats must be present");
+    assertNull(props.get(vMin), "stale v.min (not analyzed this run) must be cleared");
+    assertNull(props.get(vMax), "stale v.max (not analyzed this run) must be cleared");
+  }
+
+  @Test
+  public void analyzeNoscanFallsThroughToSpark() throws Exception {
+    String tableName = "t_noscan_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2)");
+
+    // NOSCAN parses natively as AnalyzeTable(noScan=true). LanceAnalyzeTableResolution deliberately
+    // does NOT intercept noScan (column stats require a scan), so it falls through to Spark's V2
+    // ANALYZE rejection rather than silently computing all-column stats.
+    Exception ex =
+        assertThrows(
+            Exception.class,
+            () -> spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS NOSCAN"));
+    String msg = String.valueOf(ex.getMessage()).toLowerCase(java.util.Locale.ROOT);
+    assertTrue(
+        msg.contains("v2") || msg.contains("not supported"),
+        "NOSCAN should reach Spark's V2 ANALYZE rejection, got: " + ex.getMessage());
+  }
+
+  @Test
+  public void analyzeEmptyTableSucceeds() throws Exception {
+    String tableName = "t_empty_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    // No rows inserted — ANALYZE must still complete and persist a 0-row payload, not crash.
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    assertEquals(LanceStatsKeys.SUPPORTED_VERSION, props.get(LanceStatsKeys.VERSION));
+    assertEquals("0", props.get(LanceStatsKeys.NUM_ROWS));
+    // An all-empty column has no min/max; only nullCount (= 0) is persisted.
+    assertNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    assertEquals(
+        "0",
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT));
+  }
+
+  @Test
+  public void analyzeWithoutForClauseDefaultsToAllColumns() throws Exception {
+    String tableName = "t_no_for_clause_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'a'), (2, 'b')");
+    // Bare COMPUTE STATISTICS (no FOR clause) is treated as FOR ALL COLUMNS by this connector.
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    assertEquals(LanceStatsKeys.SUPPORTED_VERSION, props.get(LanceStatsKeys.VERSION));
+    // id (BIGINT) gets min/max; name (STRING) gets no min/max but is still analyzed — assert via
+    // its distinctCount, proving the bare COMPUTE STATISTICS covered every column.
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    assertNotNull(
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX
+                + "name"
+                + LanceStatsTestKeys.COLUMN_SUFFIX_DISTINCT_COUNT));
+  }
+
+  @Test
+  public void analyzeSkipsTimestampNtzColumn() throws Exception {
+    String tableName = "t_tsntz_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, ts TIMESTAMP_NTZ) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, TIMESTAMP_NTZ '2020-01-01 00:00:00')");
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    java.util.Map<String, String> props = properties(tableName);
+    // id is analyzed; the TimestampNTZ column is skipped entirely — its persisted min/max would
+    // crash Spark's CBO FilterEstimation (no toDouble case → MatchError) on any filtered query.
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    assertNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "ts" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    assertNull(
+        props.get(
+            LanceStatsKeys.COLUMN_PREFIX + "ts" + LanceStatsTestKeys.COLUMN_SUFFIX_NULL_COUNT));
+  }
+
+  @Test
+  public void analyzeForColumnsIsCaseInsensitiveByDefault() throws Exception {
+    String tableName = "t_ci_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT, name STRING) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1, 'a'), (2, 'b')");
+    // spark.sql.caseSensitive defaults to false, so FOR COLUMNS with a different case must resolve
+    // (matching Spark's native column resolution) instead of failing with "column not found".
+    spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR COLUMNS ID");
+
+    java.util.Map<String, String> props = properties(tableName);
+    // Persisted under the table's stored column case ("id"), and present.
+    assertNotNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    // name was not requested → absent.
+    assertNull(
+        props.get(LanceStatsKeys.COLUMN_PREFIX + "name" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+  }
+
+  @Test
+  public void analyzeOnNonLanceTableIsNotHijacked() throws Exception {
+    // The headline correctness win: with the Lance extension enabled, ANALYZE on a NON-Lance
+    // (session-catalog) table must run Spark's native ANALYZE — the resolution rule keys on
+    // ResolvedTable(LanceDataset), so a non-Lance table is left untouched and NOT rewritten to
+    // LanceAnalyzeTable (which would throw "only Lance tables supported").
+    String t = "nonlance_" + System.nanoTime();
+    spark.sql("CREATE TABLE " + t + " (id INT, name STRING) USING parquet");
+    spark.sql("INSERT INTO " + t + " VALUES (1, 'a'), (2, 'b')");
+
+    // Must not throw the Lance rejection — runs natively.
+    spark.sql("ANALYZE TABLE " + t + " COMPUTE STATISTICS FOR ALL COLUMNS");
+
+    // Proof it ran natively: Spark's session catalog now holds V1 statistics for the table, which
+    // the Lance ANALYZE path never writes.
+    org.apache.spark.sql.catalyst.catalog.CatalogTable meta =
+        spark
+            .sessionState()
+            .catalog()
+            .getTableMetadata(org.apache.spark.sql.catalyst.TableIdentifier.apply(t));
+    assertTrue(meta.stats().isDefined(), "native ANALYZE must populate session-catalog statistics");
+    spark.sql("DROP TABLE " + t);
+  }
+
+  @Test
+  public void analyzeOnTempViewIsNotHijacked() {
+    // A temp view resolves to a View node, not ResolvedTable, so the Lance rule must not intercept
+    // it. Spark may accept or reject ANALYZE on a temp view, but it must never be the Lance
+    // rejection (which would mean the rule hijacked a non-table relation).
+    String view = "tmpview_" + System.nanoTime();
+    spark.range(5).createOrReplaceTempView(view);
+    try {
+      spark.sql("ANALYZE TABLE " + view + " COMPUTE STATISTICS FOR ALL COLUMNS");
+    } catch (Exception e) {
+      String msg = String.valueOf(e.getMessage());
+      assertFalse(
+          msg.contains("only Lance tables") || msg.contains("BaseLanceNamespaceSparkCatalog"),
+          "ANALYZE on a temp view must not be hijacked by the Lance rule. Got: " + msg);
+    } finally {
+      // Positive anchor (runs whether or not ANALYZE threw): the view is intact and still
+      // queryable, proving the rule neither rewrote nor broke a non-table relation.
+      assertEquals(5L, spark.table(view).count());
+      spark.catalog().dropTempView(view);
+    }
+  }
+
+  @Test
+  public void histogramEnabledDoesNotPersistHistogramButRoundTripsStats() throws Exception {
+    // Even with spark.sql.statistics.histogram.enabled=true in the session, LanceNativeColumnStats
+    // forces the flag off for the aggregation, so Spark's computeColumnStats never builds a
+    // histogram and toMap emits no `<col>.histogram[.partN]` payload. min/max/etc. still round-trip
+    // but no histogram key is persisted — avoiding the wasted percentile-sketch pass, TBLPROPERTIES
+    // bloat, and an unbounded-deserialize DoS on read.
+    String tableName = "t_hist_" + System.nanoTime();
+    String fullName = catalogName + ".default." + tableName;
+    spark.sql("CREATE TABLE " + fullName + " (id BIGINT) USING lance");
+    spark.sql("INSERT INTO " + fullName + " VALUES (1), (2), (3), (4), (5)");
+    try {
+      spark.conf().set("spark.sql.statistics.histogram.enabled", "true");
+      spark.sql("ANALYZE TABLE " + fullName + " COMPUTE STATISTICS FOR ALL COLUMNS");
+    } finally {
+      spark.conf().unset("spark.sql.statistics.histogram.enabled");
+    }
+
+    java.util.Map<String, String> props = properties(tableName);
+    assertEquals(
+        "1", props.get(LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_MIN));
+    String histogramPrefix =
+        LanceStatsKeys.COLUMN_PREFIX + "id" + LanceStatsTestKeys.COLUMN_SUFFIX_HISTOGRAM;
+    for (String k : props.keySet()) {
+      assertFalse(
+          k.startsWith(histogramPrefix), "histogram must not be persisted, found key: " + k);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `ANALYZE TABLE … COMPUTE STATISTICS [FOR ALL COLUMNS | FOR COLUMNS …]` for Lance tables, persisting per-column statistics into the Lance manifest so Spark's CBO can consume them on subsequent scans — O(1) per column, with no per-scan re-aggregation.

The implementation **reuses Spark's own statistics infrastructure** rather than hand-rolling aggregation or a serialization format, and adds **no new SQL grammar** (Spark already parses `ANALYZE`; an injected resolution rule rewrites it for Lance tables).

Full design, wire format, correctness guarantees, configuration, and known limitations are in **#629** — this PR implements that design.

Closes #629
Fixes part of the CBO roadmap (persistent column statistics).

## What's in here

- **Reuse Spark's stats engine.** `ANALYZE` delegates to `CommandUtils.computeColumnStats` (one aggregation job: min / max / nullCount / HLL-approx distinctCount / avgLen / maxLen) and persists each column with Spark's `CatalogColumnStat.toMap`. The read path decodes via `CatalogColumnStat.fromMap` / `toPlanStat` and feeds the CBO directly.
- **No new grammar.** `LanceAnalyzeTableResolution` rewrites Spark's native `AnalyzeColumn` / `AnalyzeTable` → `LanceAnalyzeTable` when the target is a Lance dataset, pre-empting the V2-table rejection thrown in `DataSourceV2Strategy`. Non-Lance `ANALYZE` is untouched.
- **Wire format** (`lance.stats.version=1`): an envelope plus `lance.stats.column.<name>.<suffix>` per-column keys in Spark's `CatalogColumnStat` map form, in manifest `TBLPROPERTIES`.
- **Correctness guarantees:** single-commit write ending in `complete=true`; SHA-256 schema-drift guard; `computedAtVersion` exact-equality invalidation; a `readVersion+1` read-side staleness guard. Fail-safe everywhere (any decode problem → live aggregation).
- **Config:** `spark.lance.cbo.column.stats.enabled` (master kill-switch, default `true`) and `spark.lance.cbo.column.stats.allow.stale` (default `false`).
- **Skipped/rejected types:** complex containers, interval types, and TimestampNTZ are skipped under `FOR ALL COLUMNS` / rejected under `FOR COLUMNS`.

## Key classes

- `read/LanceStatsKeys.java` — wire-format spec, key constants, schema hash.
- `v2/LanceNativeColumnStats.scala` — reflective bridge to `CommandUtils.computeColumnStats` (3.x/4.x split).
- `v2/LanceColumnStatCodec.scala` — read-side `CatalogColumnStat` → V2 `ColumnStatistics` bridge (fail-safe).
- `v2/LanceAnalyzeTableResolution.scala` — analyzer rule rewriting native ANALYZE for Lance tables.
- `v2/LanceAnalyzeTableExec.scala` — ANALYZE executor (writer, single-commit ordering, orphan-key GC).
- `read/LanceScanBuilder.java` — `loadPersistedColumnStats` fast path.

## Test plan

- **Unit:** `LanceStatsKeysTest`, `LanceAnalyzeTableSchemaHashTest`, `LoadPersistedColumnStatsTest`, `LanceSparkReadOptionsSerializationTest`.
- **End-to-end:** `BaseAnalyzeTableTest` (run per Spark version via `AnalyzeTableTest`) — `FOR ALL COLUMNS` / `FOR COLUMNS`, decimal / empty / all-null / re-analyze / partial, stats-reach-scan, TimestampNTZ-skip, case-insensitivity, NOSCAN-falls-through-to-Spark, and kill-switch paths.
- Verified locally: the Spark **3.5** module suite is green (base + 3.5, incl. the new `AnalyzeTableTest`). Spark **4.0 / 4.1** reuse the 3.5 test sources via `build-helper`; **3.4** compiles. The full four-version + integration matrix runs in CI.
