### PR TITLE
feat(sql): blob v2 copy-through for MERGE/UPDATE row-level commands

### DIFF
--- a/docs/src/operations/dml/insert-into.md
+++ b/docs/src/operations/dml/insert-into.md
@@ -209,12 +209,23 @@ Blob v2 columns [read as descriptor structs](../../config.md#blob-v2-reads). Cop
 INSERT INTO documents_copy SELECT id, content FROM documents;
 ```
 
-`writeTo().append()` and `.overwrite()` work the same way. Joins and filters are fine if the blob column stays a direct select or alias.
+Only direct column references (or simple aliases) from a single Lance source table are
+copied this way; `ORDER BY` and `LIMIT` on the SELECT are supported. `writeTo().append()`
+and `.overwrite()` work the same way. Transformed values (e.g. `content.size`),
+`DISTINCT`, `GROUP BY`, `UNION`, ordering by the blob column itself, and joins of multiple
+blob sources keep their descriptor semantics and cannot be inserted into a blob column. See
+[CREATE TABLE](../ddl/create-table.md#copying-blob-v2-columns-with-ctas) for creating a new
+table from a blob v2 query.
 
-**Limitations**
+On Spark 3.5+, `MERGE INTO` and `UPDATE` deep-copy blob v2 columns the same way: a blob
+assigned from a source column (`SET t.content = s.content`) is copied from the source table,
+and blobs the command does not touch are carried forward from the target. Additional
+limitations apply:
 
-- Do not transform the blob column (`CASE`, `content.size`, `GROUP BY`, `UNION`, `DISTINCT` fail the write).
-- `MERGE`, `UPDATE`, and dynamic partition overwrite are not supported.
+- Assigning a binary literal to a blob v2 column through `UPDATE` or `MERGE` is rejected at
+  analysis; use `INSERT` for direct binary writes.
+- Dynamic partition overwrite is not supported.
+- On Spark 3.4, `MERGE` and `UPDATE` are not supported for blob v2 tables.
 
 ## Writing Large String Data
 

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2RowLevelUnsupportedTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/BlobV2RowLevelUnsupportedTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BlobV2RowLevelUnsupportedTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void testMergeIntoBlobV2TableFailsLoudly() throws Exception {
+    String src = "v2_rl34_merge_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl34_merge_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(141, 16)));
+    createV2BlobSource(fqTgt, row(1, deterministicBlob(142, 16)));
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () ->
+                  spark.sql(
+                      "MERGE INTO "
+                          + fqTgt
+                          + " t USING "
+                          + fqSrc
+                          + " s ON t.id = s.id"
+                          + " WHEN MATCHED THEN UPDATE SET t.data = s.data"));
+      assertTrue(
+          ex.getMessage() != null && !ex.getMessage().isEmpty(),
+          "MERGE must fail with a message, got: " + ex);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testUpdateBlobV2TableFailsLoudly() throws Exception {
+    String tgt = "v2_rl34_update_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqTgt, row(1, deterministicBlob(143, 16)));
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () -> spark.sql("UPDATE " + fqTgt + " SET data = X'00' WHERE id = 1"));
+      assertTrue(
+          ex.getMessage() != null && !ex.getMessage().isEmpty(),
+          "UPDATE must fail with a message, got: " + ex);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+}

--- a/lance-spark-3.5_2.12/pom.xml
+++ b/lance-spark-3.5_2.12/pom.xml
@@ -97,6 +97,7 @@
                                 <source>src/main/java</source>
                                 <source>src/main/java11</source>
                                 <source>src/main/scala</source>
+                                <source>src/main/scala-rowlevel</source>
                                 <source>${project.build.directory}/generated-sources/antlr4</source>
                             </sources>
                         </configuration>

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -14,6 +14,8 @@
 package org.lance.spark;
 
 import org.lance.spark.read.LanceScanBuilder;
+import org.lance.spark.utils.BlobSourceContext;
+import org.lance.spark.utils.BlobUtils;
 import org.lance.spark.write.SparkPositionDeltaWriteBuilder;
 
 import org.apache.spark.sql.connector.expressions.Expressions;
@@ -23,9 +25,11 @@ import org.apache.spark.sql.connector.write.DeltaWriteBuilder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.RowLevelOperation;
 import org.apache.spark.sql.connector.write.SupportsDelta;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
+import java.util.Collections;
 import java.util.Map;
 
 public class LancePositionDeltaOperation implements RowLevelOperation, SupportsDelta {
@@ -50,6 +54,8 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
 
   private final Map<String, String> tableProperties;
 
+  private final Map<String, BlobSourceContext> blobSourceContexts;
+
   public LancePositionDeltaOperation(
       Command command,
       StructType sparkSchema,
@@ -60,6 +66,30 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
       boolean managedVersioning,
       String fileFormatVersion,
       Map<String, String> tableProperties) {
+    this(
+        command,
+        sparkSchema,
+        readOptions,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        managedVersioning,
+        fileFormatVersion,
+        tableProperties,
+        Collections.emptyMap());
+  }
+
+  private LancePositionDeltaOperation(
+      Command command,
+      StructType sparkSchema,
+      LanceSparkReadOptions readOptions,
+      Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      Map<String, String> namespaceProperties,
+      boolean managedVersioning,
+      String fileFormatVersion,
+      Map<String, String> tableProperties,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.command = command;
     this.sparkSchema = sparkSchema;
     this.readOptions = readOptions;
@@ -69,6 +99,22 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
     this.managedVersioning = managedVersioning;
     this.fileFormatVersion = fileFormatVersion;
     this.tableProperties = tableProperties;
+    this.blobSourceContexts = blobSourceContexts;
+  }
+
+  public LancePositionDeltaOperation withBlobSourceContexts(
+      Map<String, BlobSourceContext> contexts) {
+    return new LancePositionDeltaOperation(
+        command,
+        sparkSchema,
+        readOptions,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        managedVersioning,
+        fileFormatVersion,
+        tableProperties,
+        contexts);
   }
 
   @Override
@@ -84,7 +130,7 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
 
   @Override
   public DeltaWriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
-    // Create write options from read options for delta operations
+    rejectBlobV2Descriptors(logicalWriteInfo.schema());
     LanceSparkWriteOptions.Builder writeOptionsBuilder =
         LanceSparkWriteOptions.builder()
             .datasetUri(readOptions.getDatasetUri())
@@ -102,6 +148,10 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
       }
     }
     LanceSparkWriteOptions writeOptions = writeOptionsBuilder.build();
+    Map<String, BlobSourceContext> contexts =
+        blobSourceContexts.isEmpty()
+            ? BlobSourceContext.decodeFromWriteOptions(logicalWriteInfo.options())
+            : blobSourceContexts;
     return new SparkPositionDeltaWriteBuilder(
         sparkSchema,
         writeOptions,
@@ -109,7 +159,33 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
         namespaceImpl,
         namespaceProperties,
         managedVersioning,
-        readOptions.getTableId());
+        readOptions.getTableId(),
+        contexts);
+  }
+
+  /**
+   * A blob v2 column accepts only BINARY on write. If a descriptor struct reaches the delta writer
+   * it would serialize as opaque bytes and silently corrupt the column, so any row-level plan the
+   * copy-through rewrite could not convert to copy tokens must fail here.
+   */
+  private void rejectBlobV2Descriptors(StructType writeSchema) {
+    for (StructField tableField : sparkSchema.fields()) {
+      if (!BlobUtils.isBlobV2SparkField(tableField)) {
+        continue;
+      }
+      for (StructField writeField : writeSchema.fields()) {
+        if (writeField.name().equals(tableField.name())
+            && writeField.dataType() instanceof StructType) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot run this MERGE/UPDATE on Lance table %s: blob v2 column '%s' would "
+                      + "receive descriptor structs instead of binary data. Assign the column "
+                      + "directly from a blob v2 source column (deep copy) or omit it from the "
+                      + "command",
+                  readOptions.getDatasetUri(), tableField.name()));
+        }
+      }
+    }
   }
 
   @Override
@@ -128,5 +204,9 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
   @Override
   public boolean representUpdateAsDeleteAndInsert() {
     return command != Command.UPDATE;
+  }
+
+  Map<String, BlobSourceContext> blobSourceContexts() {
+    return blobSourceContexts;
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -27,6 +27,8 @@ import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkCatalogConfig;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.function.LanceFragmentIdWithDefaultFunction;
+import org.lance.spark.utils.BlobReferenceResolver;
+import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.Utils;
 
 import com.google.common.collect.ImmutableList;
@@ -94,6 +96,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
   private final boolean managedVersioning;
   private final boolean hasStableRowIds;
 
+  /** Blob source contexts for resolving copy tokens, keyed by source dataset URI. */
+  private final Map<String, BlobSourceContext> blobSourceContexts;
+
   public SparkPositionDeltaWrite(
       StructType sparkSchema,
       LanceSparkWriteOptions writeOptions,
@@ -101,7 +106,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       String namespaceImpl,
       Map<String, String> namespaceProperties,
       boolean managedVersioning,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.sparkSchema = sparkSchema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
       this.writeOptions = writeOptions.withVersion(ds.version());
@@ -116,6 +122,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
     this.managedVersioning = managedVersioning;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   @Override
@@ -151,7 +158,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
           namespaceImpl,
           namespaceProperties,
           tableId,
-          hasStableRowIds);
+          hasStableRowIds,
+          blobSourceContexts);
     }
 
     @Override
@@ -251,6 +259,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
     private final boolean hasStableRowIds;
+    private final Map<String, BlobSourceContext> blobSourceContexts;
 
     PositionDeltaWriteFactory(
         StructType sparkSchema,
@@ -259,7 +268,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
         String namespaceImpl,
         Map<String, String> namespaceProperties,
         List<String> tableId,
-        boolean hasStableRowIds) {
+        boolean hasStableRowIds,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       this.sparkSchema = sparkSchema;
       this.writeOptions = writeOptions;
       this.initialStorageOptions = initialStorageOptions;
@@ -267,6 +277,7 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
       this.hasStableRowIds = hasStableRowIds;
+      this.blobSourceContexts = blobSourceContexts;
     }
 
     @Override
@@ -274,19 +285,27 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
       int batchSize = writeOptions.getBatchSize();
       boolean useQueuedBuffer = writeOptions.isUseQueuedWriteBuffer();
       boolean useLargeVarTypes = writeOptions.isUseLargeVarTypes();
+      long maxBatchBytes = writeOptions.getMaxBatchBytes();
 
       LanceSparkWriteOptions fragmentWriteOptions =
           writeOptions.toBuilder().enableStableRowIds(false).build();
       WriteParams params = fragmentWriteOptions.toWriteParams(initialStorageOptions);
+
+      // One resolver per write task, closed via LanceDataWriter when the task finishes. Always
+      // created so copy tokens resolve even without captured contexts (falls back to open-by-URI).
+      BlobReferenceResolver blobResolver = new BlobReferenceResolver(blobSourceContexts);
 
       // Select buffer type based on configuration
       ArrowBatchWriteBuffer writeBuffer;
       if (useQueuedBuffer) {
         int queueDepth = writeOptions.getQueueDepth();
         writeBuffer =
-            new QueuedArrowBatchWriteBuffer(sparkSchema, batchSize, queueDepth, useLargeVarTypes);
+            new QueuedArrowBatchWriteBuffer(
+                sparkSchema, batchSize, queueDepth, useLargeVarTypes, maxBatchBytes, blobResolver);
       } else {
-        writeBuffer = new SemaphoreArrowBatchWriteBuffer(sparkSchema, batchSize, useLargeVarTypes);
+        writeBuffer =
+            new SemaphoreArrowBatchWriteBuffer(
+                sparkSchema, batchSize, useLargeVarTypes, maxBatchBytes, blobResolver);
       }
 
       // Create fragment in background thread
@@ -305,7 +324,8 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
       return new LanceDeltaWriter(
           writeOptions,
-          new LanceDataWriter(writeBuffer, fragmentCreationTask, fragmentCreationThread),
+          new LanceDataWriter(
+              writeBuffer, fragmentCreationTask, fragmentCreationThread, null, null, blobResolver),
           initialStorageOptions,
           hasStableRowIds);
     }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWriteBuilder.java
@@ -14,6 +14,7 @@
 package org.lance.spark.write;
 
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobSourceContext;
 
 import org.apache.spark.sql.connector.write.DeltaWrite;
 import org.apache.spark.sql.connector.write.DeltaWriteBuilder;
@@ -39,6 +40,9 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
   private final List<String> tableId;
   private final boolean managedVersioning;
 
+  /** Blob source contexts for resolving copy tokens, keyed by source dataset URI. */
+  private final Map<String, BlobSourceContext> blobSourceContexts;
+
   public SparkPositionDeltaWriteBuilder(
       StructType sparkSchema,
       LanceSparkWriteOptions writeOptions,
@@ -46,7 +50,8 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
       String namespaceImpl,
       Map<String, String> namespaceProperties,
       boolean managedVersioning,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.sparkSchema = sparkSchema;
     this.writeOptions = writeOptions;
     this.initialStorageOptions = initialStorageOptions;
@@ -54,6 +59,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
     this.namespaceProperties = namespaceProperties;
     this.managedVersioning = managedVersioning;
     this.tableId = tableId;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   public DeltaWrite build() {
@@ -64,6 +70,7 @@ public class SparkPositionDeltaWriteBuilder implements DeltaWriteBuilder {
         namespaceImpl,
         namespaceProperties,
         managedVersioning,
-        tableId);
+        tableId,
+        blobSourceContexts);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/scala-rowlevel/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2RowLevelCopyRule.scala
+++ b/lance-spark-3.5_2.12/src/main/scala-rowlevel/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2RowLevelCopyRule.scala
@@ -1,0 +1,344 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.ProjectingInternalRow
+import org.apache.spark.sql.catalyst.analysis.NamedRelation
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeReference, Expression, ExprId, LanceBlobV2CopyRef, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, MergeRows, Project, WriteDelta}
+import org.apache.spark.sql.catalyst.plans.logical.MergeRows.{Instruction, Keep, Split}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.connector.write.RowLevelOperationTable
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.{BinaryType, StructType}
+import org.lance.spark.{LanceConstant, LanceDataset, LancePositionDeltaOperation}
+import org.lance.spark.utils.BlobUtils
+
+/**
+ * Copy-through for blob v2 columns in lowered MERGE/UPDATE plans.
+ *
+ * Runs in the optimizer after the analyzer's DML rewrite. Descriptors become [[LanceBlobV2CopyRef]]
+ * tokens; instruction conditions are left untouched (SQL null is a non-null sentinel descriptor).
+ */
+case class LanceBlobV2RowLevelCopyRule() extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
+    case w: WriteDelta if maskedTarget(w.table).isDefined => rewriteWriteDelta(w)
+    case a: AppendData if maskedTarget(a.table).isDefined => rewriteLoweredAppend(a)
+  }
+
+  private def maskedTarget(table: org.apache.spark.sql.catalyst.analysis.NamedRelation)
+      : Option[LanceDataset] = table match {
+    case r: DataSourceV2Relation =>
+      r.table match {
+        case op: RowLevelOperationTable =>
+          op.table match {
+            case masked: RowLevelMaskedLanceTable => Some(masked.delegate)
+            case _ => None
+          }
+        case masked: RowLevelMaskedLanceTable => Some(masked.delegate)
+        case _ => None
+      }
+    case _ => None
+  }
+
+  // Restore ACCEPT_ANY_SCHEMA before write (Spark 4.x re-validates after each optimizer rule).
+  private def unmaskTarget(
+      table: org.apache.spark.sql.catalyst.analysis.NamedRelation)
+      : org.apache.spark.sql.catalyst.analysis.NamedRelation = table match {
+    case r: DataSourceV2Relation =>
+      r.table match {
+        case op: RowLevelOperationTable =>
+          op.table match {
+            case masked: RowLevelMaskedLanceTable =>
+              r.copy(table = op.copy(table = masked.delegate))
+            case _ => r
+          }
+        case masked: RowLevelMaskedLanceTable => r.copy(table = masked.delegate)
+        case _ => r
+      }
+    case other => other
+  }
+
+  private def lanceRelations(query: LogicalPlan): Seq[(DataSourceV2Relation, LanceDataset)] =
+    query.collectWithSubqueries {
+      case r: DataSourceV2Relation if relationDataset(r).isDefined => (r, relationDataset(r).get)
+    }
+
+  private def relationDataset(r: DataSourceV2Relation): Option[LanceDataset] = r.table match {
+    case ds: LanceDataset => Some(ds)
+    case op: RowLevelOperationTable =>
+      op.table match {
+        case masked: RowLevelMaskedLanceTable => Some(masked.delegate)
+        case ds: LanceDataset => Some(ds)
+        case _ => None
+      }
+    case masked: RowLevelMaskedLanceTable => Some(masked.delegate)
+    case _ => None
+  }
+
+  private case class SourceBinding(
+      rowAddress: Attribute,
+      datasetUri: String,
+      relation: DataSourceV2Relation,
+      addressAlreadyProjected: Boolean)
+
+  private def bindBlobSources(
+      query: LogicalPlan,
+      target: LanceDataset): Option[Map[ExprId, SourceBinding]] = {
+    val relations = lanceRelations(query)
+    val blobAttrs: Seq[(AttributeReference, DataSourceV2Relation, LanceDataset)] =
+      relations.flatMap { case (relation, ds) =>
+        relation.output.collect {
+          case a: AttributeReference if BlobUtils.isBlobV2SparkMetadata(a.metadata) =>
+            (a, relation, ds)
+        }
+      }
+    if (blobAttrs.isEmpty) {
+      return Some(Map.empty)
+    }
+
+    // Same URI under different read identities is ambiguous for copy tokens.
+    val tokenUris = blobAttrs.map { case (_, _, ds) => ds.readOptions().getDatasetUri }.toSet
+    val ambiguous = relations
+      .filter { case (_, ds) => tokenUris.contains(ds.readOptions().getDatasetUri) }
+      .groupBy { case (_, ds) => ds.readOptions().getDatasetUri }
+      .exists { case (_, sameUri) =>
+        sameUri.map { case (relation, ds) =>
+          (ds.readOptions(), relation.options.asCaseSensitiveMap)
+        }.distinct.size > 1
+      }
+    if (ambiguous) {
+      return None
+    }
+
+    Some(blobAttrs.flatMap { case (a, relation, ds) =>
+      val uri = ds.readOptions().getDatasetUri
+      val fromOutput = relation.output.find(_.name == LanceConstant.ROW_ADDRESS)
+      val fromMetadata = relation.metadataOutput
+        .find(_.name == LanceConstant.ROW_ADDRESS)
+        .map(_.markAsAllowAnyAccess())
+      (fromOutput orElse fromMetadata).map { addr =>
+        a.exprId -> SourceBinding(addr, uri, relation, fromOutput.isDefined)
+      }
+    }.toMap)
+  }
+
+  private def rewriteWriteDelta(w: WriteDelta): LogicalPlan = {
+    val target = maskedTarget(w.table).get
+    val unmasked = w.copy(table = unmaskTarget(w.table))
+    val targetBlobColumns =
+      target.schema().fields.collect { case f if BlobUtils.isBlobV2SparkField(f) => f.name }.toSet
+    if (targetBlobColumns.isEmpty || alreadyRewritten(w.query)) {
+      return unmasked
+    }
+    val bindings = bindBlobSources(w.query, target) match {
+      case Some(b) if b.nonEmpty => b
+      case _ => return unmasked
+    }
+
+    var rewrittenColumns = Set.empty[String]
+
+    // Rewrite only the writer-facing project; join-side descriptors stay struct until consumed.
+    val newQuery = w.query match {
+      case p: Project =>
+        val (rewritten, names) = rewriteProjectList(p.projectList, targetBlobColumns, bindings)
+        rewrittenColumns ++= names
+        if (names.isEmpty) p else p.copy(projectList = rewritten)
+      case m: MergeRows =>
+        val blobOrdinals = m.output.zipWithIndex.collect {
+          case (attr, i) if targetBlobColumns.contains(attr.name) => i
+        }.toSet
+        if (blobOrdinals.isEmpty) {
+          m
+        } else {
+          // Retype to BINARY only when every instruction row has a token or null (NOT MATCHED BY
+          // SOURCE DELETE carries null literals for deleted rows).
+          val rows = (m.matchedInstructions ++ m.notMatchedInstructions ++
+            m.notMatchedBySourceInstructions).flatMap {
+            case k: Keep => Seq(k.output)
+            case s: Split => Seq(s.output, s.otherOutput)
+            case _ => Seq.empty
+          }
+          def ordinalSafe(i: Int): Boolean = rows.forall { row =>
+            row.lift(i).exists {
+              case a: AttributeReference => bindings.contains(a.exprId)
+              case lit: Literal => lit.value == null
+              case _ => false
+            }
+          }
+          val safeOrdinals = blobOrdinals.filter(ordinalSafe)
+          if (safeOrdinals.isEmpty) {
+            m
+          } else {
+            def rewriteRow(row: Seq[Expression]): Seq[Expression] = row.zipWithIndex.map {
+              case (a: AttributeReference, i)
+                  if safeOrdinals.contains(i) && bindings.contains(a.exprId) =>
+                val b = bindings(a.exprId)
+                LanceBlobV2CopyRef(a, b.rowAddress, b.datasetUri, a.name)
+              case (lit: Literal, i) if safeOrdinals.contains(i) && lit.value == null =>
+                Literal(null, BinaryType)
+              case (e, _) => e
+            }
+            def rewriteOutputs(instruction: Instruction): Instruction = instruction match {
+              case k: Keep => k.copy(output = rewriteRow(k.output))
+              case s: Split =>
+                s.copy(output = rewriteRow(s.output), otherOutput = rewriteRow(s.otherOutput))
+              case other => other
+            }
+            safeOrdinals.foreach(i => rewrittenColumns += m.output(i).name)
+            val updated = m.copy(
+              matchedInstructions = m.matchedInstructions.map(rewriteOutputs),
+              notMatchedInstructions = m.notMatchedInstructions.map(rewriteOutputs),
+              notMatchedBySourceInstructions =
+                m.notMatchedBySourceInstructions.map(rewriteOutputs))
+            updated.copy(output = updated.output.zipWithIndex.map {
+              case (a: AttributeReference, i) if safeOrdinals.contains(i) =>
+                a.copy(dataType = BinaryType)(a.exprId, a.qualifier)
+              case (attr, _) => attr
+            })
+          }
+        }
+      case other => other
+    }
+
+    if (rewrittenColumns.isEmpty) {
+      return unmasked
+    }
+    unmasked.copy(
+      table = attachBlobSourceContexts(unmasked.table, bindings),
+      query = injectRowAddresses(newQuery, bindings),
+      projections = retypeRowProjection(w.projections, rewrittenColumns))
+  }
+
+  // WriteDelta write options are empty; attach pinned source contexts on the operation instead.
+  private def attachBlobSourceContexts(
+      table: NamedRelation,
+      bindings: Map[ExprId, SourceBinding]): NamedRelation = {
+    val sourceDatasets = bindings.values.map(_.relation).toSeq.distinct.flatMap(relationDataset)
+    val contexts = LanceBlobSourceContextRule.contextsForDatasets(sourceDatasets)
+    if (contexts.isEmpty) {
+      return table
+    }
+    table match {
+      case r: DataSourceV2Relation =>
+        r.table match {
+          case op: RowLevelOperationTable =>
+            op.operation match {
+              case delta: LancePositionDeltaOperation =>
+                r.copy(table = op.copy(operation = delta.withBlobSourceContexts(contexts)))
+              case _ => table
+            }
+          case _ => table
+        }
+      case _ => table
+    }
+  }
+
+  private def rewriteLoweredAppend(a: AppendData): LogicalPlan = {
+    val target = maskedTarget(a.table).get
+    val unmasked = a.copy(table = unmaskTarget(a.table))
+    val targetBlobColumns =
+      target.schema().fields.collect { case f if BlobUtils.isBlobV2SparkField(f) => f.name }.toSet
+    if (targetBlobColumns.isEmpty || alreadyRewritten(a.query)) {
+      return unmasked
+    }
+    val bindings = bindBlobSources(a.query, target) match {
+      case Some(b) if b.nonEmpty => b
+      case _ => return unmasked
+    }
+
+    a.query match {
+      case p: Project =>
+        val (rewritten, names) = rewriteProjectList(p.projectList, targetBlobColumns, bindings)
+        if (names.isEmpty) {
+          unmasked
+        } else {
+          val newChild = injectRowAddresses(p.child, bindings)
+          unmasked.copy(query = p.copy(projectList = rewritten, child = newChild))
+        }
+      case q =>
+        // Optimizer may drop a no-op project; rewrap outputs as copy tokens.
+        val (rewritten, names) = rewriteProjectList(q.output, targetBlobColumns, bindings)
+        if (names.isEmpty) {
+          unmasked
+        } else {
+          unmasked.copy(query = Project(rewritten, injectRowAddresses(q, bindings)))
+        }
+    }
+  }
+
+  private def rewriteProjectList(
+      projectList: Seq[NamedExpression],
+      targetBlobColumns: Set[String],
+      bindings: Map[ExprId, SourceBinding]): (Seq[NamedExpression], Set[String]) = {
+    var names = Set.empty[String]
+    val rewritten = projectList.map {
+      case al @ Alias(a: AttributeReference, name)
+          if targetBlobColumns.contains(name) && bindings.contains(a.exprId) =>
+        val b = bindings(a.exprId)
+        names += name
+        Alias(LanceBlobV2CopyRef(a, b.rowAddress, b.datasetUri, a.name), name)(
+          al.exprId,
+          al.qualifier)
+      case a: AttributeReference
+          if targetBlobColumns.contains(a.name) && bindings.contains(a.exprId) =>
+        val b = bindings(a.exprId)
+        names += a.name
+        Alias(LanceBlobV2CopyRef(a, b.rowAddress, b.datasetUri, a.name), a.name)(
+          a.exprId,
+          a.qualifier)
+      case al @ Alias(lit: Literal, name)
+          if targetBlobColumns.contains(name) && lit.value == null =>
+        names += name
+        Alias(Literal(null, BinaryType), name)(al.exprId, al.qualifier)
+      case other => other
+    }
+    (rewritten, names)
+  }
+
+  private def alreadyRewritten(query: LogicalPlan): Boolean =
+    query.exists(_.expressions.exists(_.exists(_.isInstanceOf[LanceBlobV2CopyRef])))
+
+  private def injectRowAddresses(
+      query: LogicalPlan,
+      bindings: Map[ExprId, SourceBinding]): LogicalPlan = {
+    val missing = bindings.values.filterNot(_.addressAlreadyProjected).toSeq
+    if (missing.isEmpty) {
+      return query
+    }
+    val neededAddresses = missing.map(_.rowAddress.exprId).toSet
+    val relationsToRepair = missing.map(_.relation).toSet
+    query.transformUp {
+      case r: DataSourceV2Relation if relationsToRepair.contains(r) => r.withMetadataColumns()
+      case p: Project =>
+        val reachable = p.child.output.filter(out =>
+          neededAddresses.contains(out.exprId) && !p.projectList.exists(_.exprId == out.exprId))
+        if (reachable.isEmpty) p else p.copy(projectList = p.projectList ++ reachable)
+    }
+  }
+
+  private def retypeRowProjection(
+      projections: WriteDeltaProjections,
+      rewrittenColumns: Set[String]): WriteDeltaProjections = {
+    def retype(p: ProjectingInternalRow): ProjectingInternalRow = {
+      val newSchema = StructType(p.schema.fields.map { f =>
+        if (rewrittenColumns.contains(f.name)) f.copy(dataType = BinaryType) else f
+      })
+      ProjectingInternalRow(newSchema, p.colOrdinals)
+    }
+    projections.copy(rowProjection = projections.rowProjection.map(retype))
+  }
+}

--- a/lance-spark-3.5_2.12/src/main/scala-rowlevel/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2RowLevelResolutionRule.scala
+++ b/lance-spark-3.5_2.12/src/main/scala-rowlevel/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2RowLevelResolutionRule.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, LogicalPlan, MergeIntoTable, UpdateTable}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{MetadataColumn, SupportsMetadataColumns, SupportsRead, SupportsRowLevelOperations, SupportsWrite, Table, TableCapability}
+import org.apache.spark.sql.connector.read.ScanBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, RowLevelOperationBuilder, RowLevelOperationInfo, WriteBuilder}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.lance.spark.LanceDataset
+import org.lance.spark.utils.BlobUtils
+
+import java.util
+
+/**
+ * Masks ACCEPT_ANY_SCHEMA on MERGE/UPDATE/DELETE targets so row-level resolution runs on blob v2
+ * tables. Lowered plans are rewritten by [[LanceBlobV2RowLevelCopyRule]].
+ */
+case class LanceBlobV2RowLevelResolutionRule() extends Rule[LogicalPlan] {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan.resolveOperatorsDown {
+    case m: MergeIntoTable => m.copy(targetTable = mask(m.targetTable))
+    case u: UpdateTable => u.copy(table = mask(u.table))
+    case d: DeleteFromTable => d.copy(table = mask(d.table))
+  }
+
+  private def mask(target: LogicalPlan): LogicalPlan = target.resolveOperators {
+    case r: DataSourceV2Relation =>
+      r.table match {
+        case _: RowLevelMaskedLanceTable => r
+        case ds: LanceDataset with SupportsRowLevelOperations
+            if BlobUtils.hasBlobV2Fields(ds.schema()) =>
+          r.copy(table = new RowLevelMaskedLanceTable(ds))
+        case _ => r
+      }
+  }
+}
+
+/** Delegates everything to the wrapped Lance dataset, minus ACCEPT_ANY_SCHEMA. */
+class RowLevelMaskedLanceTable(val delegate: LanceDataset with SupportsRowLevelOperations)
+  extends Table
+  with SupportsRead
+  with SupportsWrite
+  with SupportsMetadataColumns
+  with SupportsRowLevelOperations {
+
+  override def name(): String = delegate.name()
+
+  override def schema(): StructType = delegate.schema()
+
+  override def capabilities(): util.Set[TableCapability] = {
+    val filtered = new util.HashSet[TableCapability](delegate.capabilities())
+    filtered.remove(TableCapability.ACCEPT_ANY_SCHEMA)
+    filtered
+  }
+
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
+    delegate.newScanBuilder(options)
+
+  override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder =
+    delegate.newWriteBuilder(info)
+
+  override def metadataColumns(): Array[MetadataColumn] = delegate.metadataColumns()
+
+  override def newRowLevelOperationBuilder(
+      info: RowLevelOperationInfo): RowLevelOperationBuilder =
+    delegate.newRowLevelOperationBuilder(info)
+}

--- a/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -29,6 +29,10 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // blob v2 copy-through for CTAS/INSERT (resolution rule)
     extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
+
+    extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
+
+    extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV1RowLevelCopyTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV1RowLevelCopyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV1RowLevelCopyTest extends BaseBlobV1RowLevelCopyTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2RowLevelContextTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2RowLevelContextTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.spark.utils.BlobSourceContext;
+
+import org.apache.spark.sql.catalyst.analysis.NamedRelation;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
+import org.apache.spark.sql.connector.write.RowLevelOperationTable;
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
+import org.junit.jupiter.api.Test;
+import scala.collection.Seq;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class BlobV2RowLevelContextTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void testMergeCopyingSourceBlobAttachesPinnedSourceContexts() throws Exception {
+    String src = "v2_ctx_src_" + System.currentTimeMillis();
+    String tgt = "v2_ctx_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(10, 16)));
+    createV2BlobTagTarget(fqTgt);
+    spark.sql("INSERT INTO " + fqTgt + " VALUES (1, X'00', 'a')");
+    try {
+      LancePositionDeltaOperation operation =
+          deltaOperation(
+              "MERGE INTO "
+                  + fqTgt
+                  + " t USING "
+                  + fqSrc
+                  + " s ON t.id = s.id"
+                  + " WHEN MATCHED THEN UPDATE SET t.data = s.data");
+      assertNotNull(operation);
+
+      Map<String, BlobSourceContext> contexts = operation.blobSourceContexts();
+      assertFalse(contexts.isEmpty());
+      contexts.values().forEach(context -> assertNotNull(context.getReadOptions().getVersion()));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  private LancePositionDeltaOperation deltaOperation(String sql) throws ParseException {
+    LogicalPlan parsed = spark.sessionState().sqlParser().parsePlan(sql);
+    LogicalPlan analyzed = spark.sessionState().analyzer().execute(parsed);
+    LogicalPlan optimized = spark.sessionState().optimizer().execute(analyzed);
+    return findDeltaOperation(optimized);
+  }
+
+  private static LancePositionDeltaOperation findDeltaOperation(LogicalPlan plan) {
+    if (plan instanceof WriteDelta) {
+      NamedRelation target = ((WriteDelta) plan).table();
+      if (target instanceof DataSourceV2Relation) {
+        Table table = ((DataSourceV2Relation) target).table();
+        if (table instanceof RowLevelOperationTable) {
+          RowLevelOperation operation = ((RowLevelOperationTable) table).operation();
+          if (operation instanceof LancePositionDeltaOperation) {
+            return (LancePositionDeltaOperation) operation;
+          }
+        }
+      }
+    }
+    Seq<LogicalPlan> children = plan.children();
+    for (int i = 0; i < children.length(); i++) {
+      LancePositionDeltaOperation found = findDeltaOperation(children.apply(i));
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2RowLevelCopyTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/BlobV2RowLevelCopyTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+public class BlobV2RowLevelCopyTest extends BaseBlobV2RowLevelCopyTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaConflictTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaConflictTest.java
@@ -119,9 +119,11 @@ public class SparkPositionDeltaConflictTest {
       // Both writers pin at V2
       LanceSparkWriteOptions opts = LanceSparkWriteOptions.from(datasetUri);
       SparkPositionDeltaWrite writerA =
-          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, false, null);
+          new SparkPositionDeltaWrite(
+              sparkSchema, opts, null, null, null, false, null, java.util.Collections.emptyMap());
       SparkPositionDeltaWrite writerB =
-          new SparkPositionDeltaWrite(sparkSchema, opts, null, null, null, false, null);
+          new SparkPositionDeltaWrite(
+              sparkSchema, opts, null, null, null, false, null, java.util.Collections.emptyMap());
 
       // Build deletion bitmap targeting all rows in the original fragment
       Map<Integer, RoaringBitmap> deletionMapA = new HashMap<>();

--- a/lance-spark-3.5_2.13/pom.xml
+++ b/lance-spark-3.5_2.13/pom.xml
@@ -105,6 +105,7 @@
                                 <source>../lance-spark-base_2.12/src/main/java</source>
                                 <source>../lance-spark-3.5_2.12/src/main/java</source>
                                 <source>../lance-spark-3.5_2.12/src/main/scala</source>
+                                <source>../lance-spark-3.5_2.12/src/main/scala-rowlevel</source>
                                 <source>${project.build.directory}/generated-sources/antlr4</source>
                             </sources>
                         </configuration>

--- a/lance-spark-4.0_2.13/pom.xml
+++ b/lance-spark-4.0_2.13/pom.xml
@@ -109,6 +109,7 @@
                                 <source>../lance-spark-3.5_2.12/src/main/java</source>
                                 <source>src/main/java</source>
                                 <source>src/main/scala</source>
+                                <source>../lance-spark-3.5_2.12/src/main/scala-rowlevel</source>
                                 <source>${project.build.directory}/generated-sources/antlr4</source>
                             </sources>
                         </configuration>

--- a/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -29,6 +29,10 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // blob v2 copy-through for CTAS/INSERT (resolution rule)
     extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
+
+    extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
+
+    extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-4.1_2.13/pom.xml
+++ b/lance-spark-4.1_2.13/pom.xml
@@ -109,6 +109,7 @@
                                 <source>../lance-spark-3.5_2.12/src/main/java</source>
                                 <source>src/main/java</source>
                                 <source>src/main/scala</source>
+                                <source>../lance-spark-3.5_2.12/src/main/scala-rowlevel</source>
                                 <source>${project.build.directory}/generated-sources/antlr4</source>
                             </sources>
                         </configuration>

--- a/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/lance/spark/extensions/LanceSparkSessionExtensions.scala
@@ -16,7 +16,7 @@ package org.lance.spark.extensions
 import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
-import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceFragmentAwareJoinRule}
+import org.apache.spark.sql.catalyst.optimizer.{LanceBlobSourceContextRule, LanceBlobV2CopyThroughRule, LanceBlobV2RowLevelCopyRule, LanceBlobV2RowLevelResolutionRule, LanceFragmentAwareJoinRule}
 import org.apache.spark.sql.catalyst.parser.extensions.LanceSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.LanceDataSourceV2Strategy
 import org.lance.spark.search.LanceSearchTableFunctions
@@ -29,6 +29,10 @@ class LanceSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
     // blob v2 copy-through for CTAS/INSERT (resolution rule)
     extensions.injectResolutionRule(_ => LanceBlobV2CopyThroughRule())
+
+    extensions.injectResolutionRule(_ => LanceBlobV2RowLevelResolutionRule())
+
+    extensions.injectOptimizerRule(_ => LanceBlobV2RowLevelCopyRule())
 
     // optimizer rules for fragment-aware joins
     extensions.injectOptimizerRule(_ => LanceFragmentAwareJoinRule())

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -38,7 +38,6 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
-import org.apache.spark.sql.util.LanceSerializeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -337,7 +336,8 @@ public class LanceDataset
     }
     // Merge write-time options with the base options from read options
     CaseInsensitiveStringMap sparkWriteOptions = logicalWriteInfo.options();
-    Map<String, BlobSourceContext> blobSourceContexts = decodeBlobSourceContexts(sparkWriteOptions);
+    Map<String, BlobSourceContext> blobSourceContexts =
+        BlobSourceContext.decodeFromWriteOptions(sparkWriteOptions);
     Map<String, String> mergedOptions = new HashMap<>(readOptions.getStorageOptions());
     mergedOptions.putAll(sparkWriteOptions.asCaseSensitiveMap());
     // Internal-only option (see LanceBlobSourceContextRule); never forward it as a storage option.
@@ -416,21 +416,6 @@ public class LanceDataset
       builder.truncate();
     }
     return builder;
-  }
-
-  /**
-   * Decodes the blob source contexts that {@code LanceBlobSourceContextRule} injected into the
-   * write options for an INSERT whose query reads blob columns. Returns an empty map when absent
-   * (e.g. no blob sources, or the SQL extension is not enabled).
-   */
-  @SuppressWarnings("unchecked")
-  private static Map<String, BlobSourceContext> decodeBlobSourceContexts(
-      CaseInsensitiveStringMap writeOptions) {
-    String encoded = writeOptions.get(LanceConstant.BLOB_SOURCE_CONTEXTS_KEY);
-    if (encoded == null || encoded.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    return (Map<String, BlobSourceContext>) LanceSerializeUtil.decode(encoded);
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobSourceContext.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobSourceContext.java
@@ -13,9 +13,14 @@
  */
 package org.lance.spark.utils;
 
+import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkReadOptions;
 
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.apache.spark.sql.util.LanceSerializeUtil;
+
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -69,5 +74,20 @@ public class BlobSourceContext implements Serializable {
 
   public List<String> getTableId() {
     return readOptions.getTableId();
+  }
+
+  /**
+   * Decodes the contexts that {@code LanceBlobSourceContextRule} injected into the write options,
+   * keyed by source dataset URI. Returns an empty map when absent (e.g. no blob sources, or the SQL
+   * extension is not enabled); {@link BlobReferenceResolver} then falls back to opening sources by
+   * URI alone.
+   */
+  public static Map<String, BlobSourceContext> decodeFromWriteOptions(
+      CaseInsensitiveStringMap writeOptions) {
+    String encoded = writeOptions.get(LanceConstant.BLOB_SOURCE_CONTEXTS_KEY);
+    if (encoded == null || encoded.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    return LanceSerializeUtil.decode(encoded);
   }
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobSourceContextRule.scala
@@ -34,13 +34,14 @@ case class LanceBlobSourceContextRule() extends Rule[LogicalPlan] {
 
   import LanceBlobSourceContextRule._
 
+  // Context key lives on command writeOptions only. V2Writes.mergeOptions requires matching options
+  // or one side empty; INSERT/OVERWRITE targets resolve with empty relation options.
   override def apply(plan: LogicalPlan): LogicalPlan = plan.transformDown {
     case V2BlobWrite(write) if shouldAnnotate(write.table, write.writeOptions) =>
       val (table, writeOptions) = annotate(write.query, write.table, write.writeOptions)
       write.withTableAndOptions(table, writeOptions)
   }
 
-  // Spark 4.x V2Writes.mergeOptions requires command and relation options to match or one side empty.
   private def annotate(
       query: LogicalPlan,
       table: NamedRelation,
@@ -103,21 +104,15 @@ object LanceBlobSourceContextRule extends Logging {
         }
       }
     }
-    if (sources.isEmpty) {
-      return None
-    }
-    val contexts = new java.util.HashMap[String, BlobSourceContext]()
-    sources.forEach { (uri, source) =>
-      val (ds, scanPinned) = source
-      contexts.put(
-        uri,
-        new BlobSourceContext(
-          scanPinned.getOrElse(pinToCurrentVersion(ds)),
-          ds.getInitialStorageOptions(),
-          ds.getNamespaceImpl(),
-          ds.getNamespaceProperties()))
-    }
-    Some(LanceSerializeUtil.encode(contexts))
+    encodeContexts(sources)
+  }
+
+  /** Pinned source contexts for row-level copy (WriteDelta cannot carry write options). */
+  def contextsForDatasets(datasets: Seq[LanceDataset]): java.util.Map[String, BlobSourceContext] = {
+    val sources =
+      new java.util.LinkedHashMap[String, (LanceDataset, Option[LanceSparkReadOptions])]()
+    datasets.foreach(ds => sources.put(ds.readOptions().getDatasetUri, (ds, None)))
+    buildContexts(sources)
   }
 
   private def blobSource(
@@ -156,4 +151,28 @@ object LanceBlobSourceContextRule extends Logging {
 
   private def hasBlobColumns(ds: LanceDataset): Boolean =
     ds.schema().fields.exists(f => BlobUtils.isBlobReadColumn(f))
+
+  private def encodeContexts(
+      sources: java.util.LinkedHashMap[String, (LanceDataset, Option[LanceSparkReadOptions])])
+      : Option[String] = {
+    val contexts = buildContexts(sources)
+    if (contexts.isEmpty) None else Some(LanceSerializeUtil.encode(contexts))
+  }
+
+  private def buildContexts(
+      sources: java.util.LinkedHashMap[String, (LanceDataset, Option[LanceSparkReadOptions])])
+      : java.util.Map[String, BlobSourceContext] = {
+    val contexts = new java.util.HashMap[String, BlobSourceContext]()
+    sources.forEach { (uri, source) =>
+      val (ds, scanPinned) = source
+      contexts.put(
+        uri,
+        new BlobSourceContext(
+          scanPinned.getOrElse(pinToCurrentVersion(ds)),
+          ds.getInitialStorageOptions(),
+          ds.getNamespaceImpl(),
+          ds.getNamespaceProperties()))
+    }
+    contexts
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV1RowLevelCopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV1RowLevelCopyTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public abstract class BaseBlobV1RowLevelCopyTest extends AbstractBlobV2CopyTest {
+
+  private static final StructType ID_DATA_TAG =
+      new StructType(
+          new StructField[] {
+            DataTypes.createStructField("id", DataTypes.IntegerType, false),
+            DataTypes.createStructField("data", DataTypes.BinaryType, true),
+            DataTypes.createStructField("tag", DataTypes.StringType, true)
+          });
+
+  @Test
+  public void testV1MergeMatchedUpdateCopiesSourceAndCarriesForward() throws Exception {
+    String src = "v1_rl_merge_src_" + System.currentTimeMillis();
+    String tgt = "v1_rl_merge_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] sourceBlob = deterministicBlob(310, 48);
+    byte[] keptBlob = deterministicBlob(311, 48);
+    createV1BlobSource(fqSrc, row(0, sourceBlob));
+    createV1BlobSource(fqTgt, row(0, deterministicBlob(312, 48)), row(1, keptBlob));
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN MATCHED THEN UPDATE SET t.data = s.data");
+
+      assertTargetBlobBytes(
+          datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {sourceBlob, keptBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testV1UpdateScalarCarriesForwardBlob() throws Exception {
+    String tgt = "v1_rl_upd_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    byte[] blob0 = deterministicBlob(320, 48);
+    byte[] blob1 = deterministicBlob(321, 48);
+    createV1TagTable(fqTgt);
+    List<Row> rows = new ArrayList<>();
+    rows.add(RowFactory.create(0, blob0, "a"));
+    rows.add(RowFactory.create(1, blob1, "b"));
+    spark.createDataFrame(rows, ID_DATA_TAG).coalesce(1).writeTo(fqTgt).append();
+    try {
+      spark.sql("UPDATE " + fqTgt + " SET tag = 'z' WHERE id = 0");
+
+      assertEquals(
+          "z", spark.sql("SELECT tag FROM " + fqTgt + " WHERE id = 0").first().getString(0));
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blob0, blob1});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  private void createV1TagTable(String fqTable) {
+    spark.sql(
+        "CREATE TABLE "
+            + fqTable
+            + " (id INT NOT NULL, data BINARY, tag STRING) USING lance TBLPROPERTIES ("
+            + "'data.lance.encoding' = 'blob', 'file_format_version' = '2.0')");
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyFailureTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyFailureTest.java
@@ -43,36 +43,7 @@ public abstract class BaseBlobV2CopyFailureTest extends AbstractBlobV2CopyTest {
   }
 
   @Test
-  public void mergeIntoBlobV2Table_failsLoudly() throws Exception {
-    String src = "v2_fail_merge_src_" + System.currentTimeMillis();
-    String tgt = "v2_fail_merge_tgt_" + System.currentTimeMillis();
-    String fqSrc = fq(src);
-    String fqTgt = fq(tgt);
-    createV2BlobSource(fqSrc, row(1, deterministicBlob(141, 16)));
-    createV2BlobSource(fqTgt, row(1, deterministicBlob(142, 16)));
-    try {
-      Exception ex =
-          assertThrows(
-              Exception.class,
-              () ->
-                  spark.sql(
-                      "MERGE INTO "
-                          + fqTgt
-                          + " t USING "
-                          + fqSrc
-                          + " s ON t.id = s.id"
-                          + " WHEN MATCHED THEN UPDATE SET t.data = s.data"));
-      assertTrue(
-          ex.getMessage() != null && !ex.getMessage().isEmpty(),
-          "MERGE must fail with a message, got: " + ex);
-    } finally {
-      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
-      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
-    }
-  }
-
-  @Test
-  public void updateBlobV2Table_failsLoudly() throws Exception {
+  public void testUpdateBlobWithBinaryLiteralFailsAtAnalysis() throws Exception {
     String tgt = "v2_fail_update_tgt_" + System.currentTimeMillis();
     String fqTgt = fq(tgt);
     createV2BlobSource(fqTgt, row(1, deterministicBlob(143, 16)));

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2RowLevelCopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2RowLevelCopyTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.apache.spark.sql.Row;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public abstract class BaseBlobV2RowLevelCopyTest extends AbstractBlobV2CopyTest {
+
+  @Test
+  public void testUpdateScalarColumnPreservesCarriedForwardBlobs() throws Exception {
+    String tgt = "v2_rl_upd_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    byte[] blobA = deterministicBlob(150, 16);
+    byte[] blobB = deterministicBlob(151, 16);
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, blobA, "a");
+    insertTagRow(fqTgt, 2, blobB, "b");
+    try {
+      spark.sql("UPDATE " + fqTgt + " SET tag = 'z' WHERE id = 1");
+
+      List<Row> rows = spark.sql("SELECT id, tag FROM " + fqTgt + " ORDER BY id").collectAsList();
+      assertEquals(2, rows.size());
+      assertEquals("z", rows.get(0).getString(1));
+      assertEquals("b", rows.get(1).getString(1));
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blobA, blobB});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testMergeMatchedUpdateCopiesSourceBlob() throws Exception {
+    String src = "v2_rl_merge_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl_merge_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] sourceBlob = deterministicBlob(152, 16);
+    byte[] targetBlob = deterministicBlob(153, 16);
+    createV2BlobSource(fqSrc, row(1, sourceBlob));
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, targetBlob, "a");
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN MATCHED THEN UPDATE SET t.data = s.data");
+
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {sourceBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testMergeNotMatchedInsertCopiesSourceBlob() throws Exception {
+    String src = "v2_rl_ins_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl_ins_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] existingBlob = deterministicBlob(154, 16);
+    byte[] insertedBlob = deterministicBlob(155, 16);
+    createV2BlobSource(fqSrc, row(1, existingBlob), row(2, insertedBlob));
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, existingBlob, "a");
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN NOT MATCHED THEN INSERT (id, data, tag) VALUES (s.id, s.data, 'n')");
+
+      assertEquals(2, spark.sql("SELECT * FROM " + fqTgt).count());
+      assertTargetBlobBytes(
+          datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {existingBlob, insertedBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testMergeMatchedAndNotMatchedCopiesBothBranches() throws Exception {
+    String src = "v2_rl_both_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl_both_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] updatedBlob = deterministicBlob(156, 16);
+    byte[] insertedBlob = deterministicBlob(157, 16);
+    byte[] originalBlob = deterministicBlob(158, 16);
+    createV2BlobSource(fqSrc, row(1, updatedBlob), row(2, insertedBlob));
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, originalBlob, "a");
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN MATCHED THEN UPDATE SET t.data = s.data"
+              + " WHEN NOT MATCHED THEN INSERT (id, data, tag) VALUES (s.id, s.data, 'n')");
+
+      assertTargetBlobBytes(
+          datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {updatedBlob, insertedBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testMergeScalarOnlyUpdatePreservesTargetBlob() throws Exception {
+    String src = "v2_rl_scalar_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl_scalar_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] sourceBlob = deterministicBlob(159, 16);
+    byte[] targetBlob = deterministicBlob(160, 16);
+    createV2BlobSource(fqSrc, row(1, sourceBlob));
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, targetBlob, "a");
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN MATCHED THEN UPDATE SET t.tag = 'm'");
+
+      assertEquals("m", spark.sql("SELECT tag FROM " + fqTgt).first().getString(0));
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {targetBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testMergeMatchedUpdateCopiesNullBlobAsNull() throws Exception {
+    String src = "v2_rl_null_src_" + System.currentTimeMillis();
+    String tgt = "v2_rl_null_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[] targetBlob = deterministicBlob(161, 16);
+    createV2BlobSource(fqSrc, row(1, null));
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, targetBlob, "a");
+    try {
+      spark.sql(
+          "MERGE INTO "
+              + fqTgt
+              + " t USING "
+              + fqSrc
+              + " s ON t.id = s.id"
+              + " WHEN MATCHED THEN UPDATE SET t.data = s.data");
+      Row desc =
+          spark
+              .sql(
+                  "SELECT data.kind, data.position, data.size, data.blob_id, data.blob_uri FROM "
+                      + fqTgt
+                      + " WHERE id = 1")
+              .first();
+      assertEquals((short) 0, desc.getShort(0));
+      assertEquals(0L, desc.getLong(1));
+      assertEquals(0L, desc.getLong(2));
+      assertEquals(0L, desc.getLong(3));
+      assertEquals("", desc.getString(4));
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testDeleteFromBlobV2TablePreservesRemainingBlobs() throws Exception {
+    String tgt = "v2_rl_del_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    byte[] blobA = deterministicBlob(162, 16);
+    byte[] blobB = deterministicBlob(163, 16);
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, blobA, "a");
+    insertTagRow(fqTgt, 2, blobB, "b");
+    try {
+      spark.sql("DELETE FROM " + fqTgt + " WHERE id = 1");
+
+      assertEquals(1, spark.sql("SELECT * FROM " + fqTgt).count());
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {blobB});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void testUpdateBlobWithBinaryLiteralFailsAtAnalysis() throws Exception {
+    String tgt = "v2_rl_lit_tgt_" + System.currentTimeMillis();
+    String fqTgt = fq(tgt);
+    byte[] targetBlob = deterministicBlob(164, 16);
+    createV2BlobTagTarget(fqTgt);
+    insertTagRow(fqTgt, 1, targetBlob, "a");
+    try {
+      Exception ex =
+          assertThrows(
+              Exception.class,
+              () -> spark.sql("UPDATE " + fqTgt + " SET data = X'00' WHERE id = 1"));
+      assertTrue(
+          ex.getMessage() != null && ex.getMessage().contains("Cannot safely cast"),
+          "expected Spark's cast rejection, got: " + ex.getMessage());
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), new byte[][] {targetBlob});
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  private static String hex(byte[] bytes) {
+    StringBuilder sb = new StringBuilder("X'");
+    for (byte b : bytes) {
+      sb.append(String.format("%02X", b));
+    }
+    return sb.append("'").toString();
+  }
+
+  private void insertTagRow(String fqTable, int id, byte[] blob, String tag) {
+    String blobLiteral = blob == null ? "CAST(NULL AS BINARY)" : hex(blob);
+    spark.sql(
+        "INSERT INTO " + fqTable + " VALUES (" + id + ", " + blobLiteral + ", '" + tag + "')");
+  }
+}


### PR DESCRIPTION
#626 wired blob v2 copy-through for `INSERT/CTAS`. This PR does the same for Spark row-level `MERGE INTO` and `UPDATE` on Lance tables.

On Spark 3.5+, a blob assigned from a source column becomes a LanceBlobV2CopyRef deep copy. Columns you leave alone carry forward from the target row. Same model as INSERT, but the planner path is different: Spark lowers MERGE/UPDATE to `WriteDelta` + `MergeRows`, not a plain `AppendData`.

Two Catalyst rules in scala-rowlevel (compiled for 3.5 / 4.0 / 4.1):

- `LanceBlobV2RowLevelResolutionRule` which masks `ACCEPT_ANY_SCHEMA` on the target so row-level resolution runs on blob v2 tables.
- `LanceBlobV2RowLevelCopyRule` which rewrites descriptors to copy tokens in the lowered plan; attaches pinned source contexts on `LancePositionDeltaOperation` (because `WriteDelta` write options are empty).

`LancePositionDeltaOperation` also rejects plans where a blob v2 column would still receive descriptor structs at write time.