### PR TITLE
fix: make catalog namespace and function contracts self-consistent

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -302,13 +302,15 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
   @Override
   public Identifier[] listFunctions(String[] namespace) throws NoSuchNamespaceException {
-    if (namespace != null && namespace.length > 0 && !namespaceExists(namespace)) {
-      throw new NoSuchNamespaceException(namespace);
+    if (namespace != null && namespace.length > 0) {
+      if (!namespaceExists(namespace)) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+      return new Identifier[0];
     }
-    String[] targetNamespace = namespace == null ? new String[0] : namespace;
     return new Identifier[] {
-      Identifier.of(targetNamespace, LanceFragmentIdWithDefaultFunction.NAME),
-      Identifier.of(targetNamespace, LanceBucketFunction.NAME)
+      Identifier.of(new String[0], LanceFragmentIdWithDefaultFunction.NAME),
+      Identifier.of(new String[0], LanceBucketFunction.NAME)
     };
   }
 
@@ -367,8 +369,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
       }
 
       return result.toArray(new String[0][]);
-    } catch (Exception e) {
-      throw new NoSuchNamespaceException(new String[0]);
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        throw new NoSuchNamespaceException(new String[0]);
+      }
+      throw e;
     }
   }
 
@@ -396,8 +401,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
       }
 
       return result.toArray(new String[0][]);
-    } catch (Exception e) {
-      throw new NoSuchNamespaceException(parent);
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        throw new NoSuchNamespaceException(parent);
+      }
+      throw e;
     }
   }
 
@@ -419,8 +427,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
     try {
       this.namespace.namespaceExists(request);
       return true;
-    } catch (Exception e) {
-      return false;
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        return false;
+      }
+      throw e;
     }
   }
 
@@ -441,8 +452,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
       Map<String, String> properties = response.getProperties();
       return properties != null ? properties : Collections.emptyMap();
-    } catch (Exception e) {
-      throw new NoSuchNamespaceException(namespace);
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+      throw e;
     }
   }
 
@@ -463,11 +477,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     try {
       this.namespace.createNamespace(request);
-    } catch (Exception e) {
-      if (e.getMessage() != null && e.getMessage().contains("already exists")) {
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_ALREADY_EXISTS) {
         throw new NamespaceAlreadyExistsException(namespace);
       }
-      throw new RuntimeException("Failed to create namespace", e);
+      throw e;
     }
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/SparkLanceNamespaceTestBase.java
@@ -19,8 +19,12 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1097,6 +1102,49 @@ public abstract class SparkLanceNamespaceTestBase {
             AnalysisException.class,
             () -> spark.sql("CREATE TABLE " + fullName + " (id BIGINT NOT NULL)"));
     assertEquals("TABLE_OR_VIEW_ALREADY_EXISTS", ex.getErrorClass());
+  }
+
+  @Test
+  public void testListFunctionsAtRootAreLoadable() throws Exception {
+    FunctionCatalog functions = (FunctionCatalog) catalog;
+    Identifier[] rootFunctions = functions.listFunctions(new String[0]);
+    assertEquals(2, rootFunctions.length);
+    for (Identifier function : rootFunctions) {
+      assertNotNull(functions.loadFunction(function));
+    }
+  }
+
+  @Test
+  public void testListFunctionsForNonRootNamespaceIsEmpty() throws Exception {
+    FunctionCatalog functions = (FunctionCatalog) catalog;
+    assertEquals(0, functions.listFunctions(new String[] {"default"}).length);
+  }
+
+  @Test
+  public void testCreateExistingNamespaceThrows() throws Exception {
+    SupportsNamespaces namespaces = (SupportsNamespaces) catalog;
+    String[] namespace = {"dup_ns_" + UUID.randomUUID().toString().replace("-", "")};
+    namespaces.createNamespace(namespace, Collections.emptyMap());
+
+    assertThrows(
+        NamespaceAlreadyExistsException.class,
+        () -> namespaces.createNamespace(namespace, Collections.emptyMap()));
+  }
+
+  @Test
+  public void testLoadMissingNamespaceMetadataThrows() {
+    SupportsNamespaces namespaces = (SupportsNamespaces) catalog;
+    String[] namespace = {"missing_" + UUID.randomUUID().toString().replace("-", "")};
+
+    assertThrows(NoSuchNamespaceException.class, () -> namespaces.loadNamespaceMetadata(namespace));
+  }
+
+  @Test
+  public void testMissingNamespaceDoesNotExist() {
+    SupportsNamespaces namespaces = (SupportsNamespaces) catalog;
+    String[] namespace = {"missing_" + UUID.randomUUID().toString().replace("-", "")};
+
+    assertFalse(namespaces.namespaceExists(namespace));
   }
 
   private boolean checkDataset(int expectedSize, String tableName) {


### PR DESCRIPTION
This PR fixes two catalog contract bugs.

`listFunctions` was returning Lance functions under default, but `loadFunction` only works at root. You could list functions you couldn't load. Functions now list at root only, and non-root namespaces return `[]`.

Also, namespace ops were swallowing every error as `not found`, or detecting create conflicts with contains("already exists"). Real failures (permissions, backend down, bad input) got hidden. We now map only `NAMESPACE_NOT_FOUND` and `NAMESPACE_ALREADY_EXISTS` and rethrow everything else.

No API or config changes.