### PR TITLE
fix: preserve target column metadata on update columns from command

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
@@ -17,6 +17,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, Project}
 import org.apache.spark.sql.connector.catalog._
+import org.apache.spark.sql.types.{MetadataBuilder, StructType}
 import org.lance.spark.{LanceConstant, LanceDataset}
 
 /**
@@ -63,10 +64,15 @@ case class UpdateColumnsBackfillExec(
       query
     }
 
+    val writeSchema = UpdateColumnsBackfillExec.withTargetMetadataForUpdateColumns(
+      actualQuery.schema,
+      originalTable.schema(),
+      columnNames)
+
     val relation = DataSourceV2Relation.create(
       new LanceDataset(
         originalTable.readOptions(),
-        actualQuery.schema,
+        writeSchema,
         originalTable.getInitialStorageOptions,
         originalTable.getNamespaceImpl,
         originalTable.getNamespaceProperties,
@@ -84,5 +90,28 @@ case class UpdateColumnsBackfillExec(
     qe.assertCommandExecuted()
 
     Nil
+  }
+}
+
+object UpdateColumnsBackfillExec {
+  private[sql] def withTargetMetadataForUpdateColumns(
+      sourceSchema: StructType,
+      targetSchema: StructType,
+      columnNames: Seq[String]): StructType = {
+    val updateColumnSet = columnNames.toSet
+    val targetFieldsByName = targetSchema.fields.map(field => field.name -> field).toMap
+
+    StructType(sourceSchema.fields.map { sourceField =>
+      targetFieldsByName.get(sourceField.name) match {
+        case Some(targetField) if updateColumnSet.contains(sourceField.name) =>
+          val metadata = new MetadataBuilder()
+            .withMetadata(sourceField.metadata)
+            .withMetadata(targetField.metadata)
+            .build()
+          sourceField.copy(metadata = metadata)
+        case _ =>
+          sourceField
+      }
+    })
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
@@ -181,6 +181,64 @@ public abstract class BaseUpdateColumnsBackfillTest {
   }
 
   @Test
+  public void testUpdateLargeVarCharColumnFromSqlTempView() {
+    spark.sql(
+        String.format(
+            "create table %s (id int, score int, payload string, note string) using lance "
+                + "tblproperties ('payload.arrow.large_var_char' = 'true')",
+            fullTable));
+    spark.sql(
+        String.format(
+            "insert into %s values "
+                + "(1, 10, 'one', 'note_one'), "
+                + "(2, 20, 'two', 'note_two')",
+            fullTable));
+
+    spark.sql(
+        String.format(
+            "create temporary view update_source as "
+                + "select concat(payload, '_updated') as payload, "
+                + "_fragid, "
+                + "score + 100 as score, "
+                + "_rowaddr "
+                + "from %s where id = 2",
+            fullTable));
+
+    spark.sql(
+        String.format(
+            "alter table %s update columns score, payload from update_source", fullTable));
+
+    List<Row> results =
+        spark
+            .sql(String.format("select id, score, payload, note from %s order by id", fullTable))
+            .collectAsList();
+    assertEquals(1, results.get(0).getInt(0));
+    assertEquals(10, results.get(0).getInt(1));
+    assertEquals("one", results.get(0).getString(2));
+    assertEquals("note_one", results.get(0).getString(3));
+    assertEquals(2, results.get(1).getInt(0));
+    assertEquals(120, results.get(1).getInt(1));
+    assertEquals("two_updated", results.get(1).getString(2));
+    assertEquals("note_two", results.get(1).getString(3));
+    Assertions.assertTrue(
+        spark
+            .table(fullTable)
+            .schema()
+            .apply("payload")
+            .metadata()
+            .contains("arrow:large-var-char"),
+        "updated large varchar column should keep LargeUtf8 metadata");
+    assertEquals(
+        "true",
+        spark
+            .table(fullTable)
+            .schema()
+            .apply("payload")
+            .metadata()
+            .getString("arrow:large-var-char"));
+  }
+
+  @Test
   public void testUpdateNonExistentColumn() {
     prepareDataset();
 


### PR DESCRIPTION
Closes: https://github.com/lance-format/lance-spark/issues/641