### PR TITLE
fix: fall back to describeNamespace when glue lacks namespaceExists

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -26,6 +26,7 @@ import org.lance.namespace.errors.TableNotFoundException;
 import org.lance.namespace.model.DeclareTableRequest;
 import org.lance.namespace.model.DeclareTableResponse;
 import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DescribeNamespaceRequest;
 import org.lance.namespace.model.DescribeTableRequest;
 import org.lance.namespace.model.DescribeTableResponse;
 import org.lance.namespace.model.DropNamespaceRequest;
@@ -429,6 +430,26 @@ public abstract class BaseLanceNamespaceSparkCatalog
       return true;
     } catch (LanceNamespaceException e) {
       if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        return false;
+      }
+      if (e.getErrorCode() == ErrorCode.UNSUPPORTED) {
+        return namespaceExistsViaDescribe(request.getId());
+      }
+      throw e;
+    }
+  }
+
+  private boolean namespaceExistsViaDescribe(List<String> namespaceId) {
+    DescribeNamespaceRequest request = new DescribeNamespaceRequest();
+    request.setId(namespaceId);
+    try {
+      namespace.describeNamespace(request);
+      return true;
+    } catch (LanceNamespaceException e) {
+      if (e.getErrorCode() == ErrorCode.NAMESPACE_NOT_FOUND) {
+        return false;
+      }
+      if (e.getErrorCode() == ErrorCode.TABLE_NOT_FOUND) {
         return false;
       }
       throw e;


### PR DESCRIPTION
#638 exposed a bug that was previously being hidden because `namespaceExists` was swallowing backend errors. Now that `UNSUPPORTED` propagates correctly, integration setup fails against Glue 0.3.0 since it never implemented `namespaceExists`.

Until https://github.com/lance-format/lance-namespace-impls/pull/127 lands in a release and is in the class path we fallback to `describeNamespace` and when `namespaceExists` returns unsupported. Missing namespaces map to false via `NAMESPACE_NOT_FOUND`. Glue 0.3.0 also returns `TABLE_NOT_FOUND` when describing a missing database, so handle that the same way.

This is temporary, and will be removed once fixed upstream