### PR TITLE
chore: update lance dependency to v9.0.0-beta.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.5.1</lance-spark.version>
-        <lance.version>8.0.0-beta.9</lance.version>
+        <lance.version>9.0.0-beta.6</lance.version>
         <lance-namespace.version>0.7.5</lance-namespace.version>
         <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary
- Update the Lance dependency from `8.0.0-beta.9` to `9.0.0-beta.6`.
- Confirm `docker/Dockerfile` hardcoded versions already match the evaluated Maven properties: `LANCE_SPARK_VERSION=0.5.1` and `LANCE_NS_IMPL_VERSION=0.3.0`.
- Triggering tag: `refs/tags/v9.0.0-beta.6`

## Verification
- `make lint`
- `make install`
