### PR TITLE
feat: add use_scalar_index in storage options

### DIFF
--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -237,7 +237,7 @@ These options control how data is read from Lance datasets. They can be set usin
 | Option                | Type    | Default | Description                                                                                                       |
 |-----------------------|---------|---------|-------------------------------------------------------------------------------------------------------------------|
 | `batch_size`          | Integer | `8192`  | Number of rows to read per batch during scanning. Larger values may improve throughput but increase memory usage. |
-| `use_scalar_index`    | Boolean | `true`  | Whether to use scalar indices (e.g. zonemap) for filter acceleration during scanning.                             |
+| `use_scalar_index`    | Boolean | `false` | Whether to use scalar indices (e.g. btree) for filter acceleration during scanning.                               |
 | `version`             | Integer | Latest  | Specific dataset version to read. If not specified, reads the latest version.                                     |
 | `block_size`          | Integer | -       | Block size in bytes for reading data.                                                                             |
 | `index_cache_size`    | Integer | -       | Size of the index cache in number of entries.                                                                     |

--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -236,7 +236,8 @@ These options control how data is read from Lance datasets. They can be set usin
 
 | Option                | Type    | Default | Description                                                                                                       |
 |-----------------------|---------|---------|-------------------------------------------------------------------------------------------------------------------|
-| `batch_size`          | Integer | `512`   | Number of rows to read per batch during scanning. Larger values may improve throughput but increase memory usage. |
+| `batch_size`          | Integer | `8192`  | Number of rows to read per batch during scanning. Larger values may improve throughput but increase memory usage. |
+| `use_scalar_index`    | Boolean | `true`  | Whether to use scalar indices (e.g. zonemap) for filter acceleration during scanning.                             |
 | `version`             | Integer | Latest  | Specific dataset version to read. If not specified, reads the latest version.                                     |
 | `block_size`          | Integer | -       | Block size in bytes for reading data.                                                                             |
 | `index_cache_size`    | Integer | -       | Size of the index cache in number of entries.                                                                     |

--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -237,7 +237,7 @@ These options control how data is read from Lance datasets. They can be set usin
 | Option                | Type    | Default | Description                                                                                                       |
 |-----------------------|---------|---------|-------------------------------------------------------------------------------------------------------------------|
 | `batch_size`          | Integer | `8192`  | Number of rows to read per batch during scanning. Larger values may improve throughput but increase memory usage. |
-| `use_scalar_index`    | Boolean | `false` | Whether to use scalar indices (e.g. btree) for filter acceleration during scanning.                               |
+| `use_scalar_index`    | Boolean | `true`  | Whether to use scalar indices (e.g. btree) for filter acceleration during scanning.                               |
 | `version`             | Integer | Latest  | Specific dataset version to read. If not specified, reads the latest version.                                     |
 | `block_size`          | Integer | -       | Block size in bytes for reading data.                                                                             |
 | `index_cache_size`    | Integer | -       | Size of the index cache in number of entries.                                                                     |

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -51,6 +51,7 @@ public class LanceSparkReadOptions implements Serializable {
   public static final String CONFIG_INDEX_CACHE_SIZE = "index_cache_size";
   public static final String CONFIG_METADATA_CACHE_SIZE = "metadata_cache_size";
   public static final String CONFIG_BATCH_SIZE = "batch_size";
+  public static final String CONFIG_USE_SCALAR_INDEX = "use_scalar_index";
   public static final String CONFIG_TOP_N_PUSH_DOWN = "topN_push_down";
   private static final String DEPRECATED_CONFIG_NEAREST = "nearest";
 
@@ -93,6 +94,7 @@ public class LanceSparkReadOptions implements Serializable {
   private static final boolean DEFAULT_PUSH_DOWN_FILTERS = true;
   // Changed from 512 to 8192 for better OLAP scan performance (33x improvement)
   private static final int DEFAULT_BATCH_SIZE = 8192;
+  private static final boolean DEFAULT_USE_SCALAR_INDEX = false;
   private static final boolean DEFAULT_TOP_N_PUSH_DOWN = true;
   private static final boolean DEFAULT_EXECUTOR_CREDENTIAL_REFRESH = true;
 
@@ -105,6 +107,7 @@ public class LanceSparkReadOptions implements Serializable {
   private final Integer indexCacheSize;
   private final Integer metadataCacheSize;
   private final int batchSize;
+  private final boolean useScalarIndex;
   private final boolean topNPushDown;
   private final Map<String, String> storageOptions;
 
@@ -134,6 +137,7 @@ public class LanceSparkReadOptions implements Serializable {
     this.indexCacheSize = builder.indexCacheSize;
     this.metadataCacheSize = builder.metadataCacheSize;
     this.batchSize = builder.batchSize;
+    this.useScalarIndex = builder.useScalarIndex;
     this.topNPushDown = builder.topNPushDown;
     this.storageOptions = new HashMap<>(builder.storageOptions);
     this.namespace = builder.namespace;
@@ -246,6 +250,10 @@ public class LanceSparkReadOptions implements Serializable {
     return batchSize;
   }
 
+  public boolean isUseScalarIndex() {
+    return useScalarIndex;
+  }
+
   public boolean isTopNPushDown() {
     return topNPushDown;
   }
@@ -305,6 +313,7 @@ public class LanceSparkReadOptions implements Serializable {
         .indexCacheSize(this.indexCacheSize)
         .metadataCacheSize(this.metadataCacheSize)
         .batchSize(this.batchSize)
+        .useScalarIndex(this.useScalarIndex)
         .topNPushDown(this.topNPushDown)
         .storageOptions(this.storageOptions)
         .namespace(this.namespace)
@@ -348,6 +357,7 @@ public class LanceSparkReadOptions implements Serializable {
     LanceSparkReadOptions that = (LanceSparkReadOptions) o;
     return pushDownFilters == that.pushDownFilters
         && batchSize == that.batchSize
+        && useScalarIndex == that.useScalarIndex
         && topNPushDown == that.topNPushDown
         && executorCredentialRefresh == that.executorCredentialRefresh
         && Objects.equals(datasetUri, that.datasetUri)
@@ -369,6 +379,7 @@ public class LanceSparkReadOptions implements Serializable {
         indexCacheSize,
         metadataCacheSize,
         batchSize,
+        useScalarIndex,
         topNPushDown,
         storageOptions,
         tableId,
@@ -384,6 +395,7 @@ public class LanceSparkReadOptions implements Serializable {
     private Integer indexCacheSize;
     private Integer metadataCacheSize;
     private int batchSize = DEFAULT_BATCH_SIZE;
+    private boolean useScalarIndex = DEFAULT_USE_SCALAR_INDEX;
     private boolean topNPushDown = DEFAULT_TOP_N_PUSH_DOWN;
     private Map<String, String> storageOptions = new HashMap<>();
     private LanceNamespace namespace;
@@ -425,6 +437,11 @@ public class LanceSparkReadOptions implements Serializable {
 
     public Builder batchSize(int batchSize) {
       this.batchSize = batchSize;
+      return this;
+    }
+
+    public Builder useScalarIndex(boolean useScalarIndex) {
+      this.useScalarIndex = useScalarIndex;
       return this;
     }
 
@@ -519,6 +536,9 @@ public class LanceSparkReadOptions implements Serializable {
       }
       if (opts.containsKey(CONFIG_TOP_N_PUSH_DOWN)) {
         this.topNPushDown = Boolean.parseBoolean(opts.get(CONFIG_TOP_N_PUSH_DOWN));
+      }
+      if (opts.containsKey(CONFIG_USE_SCALAR_INDEX)) {
+        this.useScalarIndex = Boolean.parseBoolean(opts.get(CONFIG_USE_SCALAR_INDEX));
       }
       if (opts.containsKey(CONFIG_EXECUTOR_CREDENTIAL_REFRESH)) {
         this.executorCredentialRefresh =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -94,7 +94,7 @@ public class LanceSparkReadOptions implements Serializable {
   private static final boolean DEFAULT_PUSH_DOWN_FILTERS = true;
   // Changed from 512 to 8192 for better OLAP scan performance (33x improvement)
   private static final int DEFAULT_BATCH_SIZE = 8192;
-  private static final boolean DEFAULT_USE_SCALAR_INDEX = false;
+  private static final boolean DEFAULT_USE_SCALAR_INDEX = true;
   private static final boolean DEFAULT_TOP_N_PUSH_DOWN = true;
   private static final boolean DEFAULT_EXECUTOR_CREDENTIAL_REFRESH = true;
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -129,6 +129,7 @@ public class LanceFragmentScanner implements AutoCloseable {
         scanOptions.filter(inputPartition.getWhereCondition().get());
       }
       scanOptions.batchSize(readOptions.getBatchSize());
+      scanOptions.useScalarIndex(readOptions.isUseScalarIndex());
       if (inputPartition.getLimit().isPresent()) {
         scanOptions.limit(inputPartition.getLimit().get());
       }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -81,6 +81,7 @@ public class LanceCountStarPartitionReader implements PartitionReader<ColumnarBa
       metricsTracker.addNumFragmentsScanned(fragmentIds.size());
 
       ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+      scanOptionsBuilder.useScalarIndex(readOptions.isUseScalarIndex());
       if (inputPartition.getWhereCondition().isPresent()) {
         scanOptionsBuilder.filter(inputPartition.getWhereCondition().get());
       }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
@@ -144,4 +144,34 @@ public class LanceSparkReadOptionsSerializationTest {
         options.isExecutorCredentialRefresh(),
         "per-read .option(...) must override the catalog-level default");
   }
+
+  @Test
+  public void testUseScalarIndexFromOptions() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(LanceSparkReadOptions.CONFIG_DATASET_URI, "s3://bucket/path");
+    properties.put(LanceSparkReadOptions.CONFIG_USE_SCALAR_INDEX, "false");
+
+    LanceSparkReadOptions options = LanceSparkReadOptions.from(properties);
+    Assertions.assertFalse(options.isUseScalarIndex());
+  }
+
+  @Test
+  public void testUseScalarIndexSerialization() throws IOException, ClassNotFoundException {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .useScalarIndex(false)
+            .build();
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(baos);
+    oos.writeObject(options);
+    oos.close();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    ObjectInputStream ois = new ObjectInputStream(bais);
+    LanceSparkReadOptions deserializedOptions = (LanceSparkReadOptions) ois.readObject();
+
+    Assertions.assertFalse(deserializedOptions.isUseScalarIndex());
+  }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
@@ -132,6 +132,7 @@ public class LanceSparkReadOptionsSerializationTest {
 
     Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
     merged.put(LanceSparkReadOptions.CONFIG_EXECUTOR_CREDENTIAL_REFRESH, "true");
+    merged.put(LanceSparkReadOptions.CONFIG_USE_SCALAR_INDEX, "false");
 
     LanceSparkReadOptions options =
         LanceSparkReadOptions.builder()
@@ -143,6 +144,25 @@ public class LanceSparkReadOptionsSerializationTest {
     Assertions.assertTrue(
         options.isExecutorCredentialRefresh(),
         "per-read .option(...) must override the catalog-level default");
+
+    Assertions.assertFalse(
+        options.isUseScalarIndex(),
+        "per-read .option(...) must override the catalog-level default");
+  }
+
+  @Test
+  public void testUseScalarIndexFromCatalogDefaults() {
+    Map<String, String> catalogOpts = new HashMap<>();
+    LanceSparkCatalogConfig catalogConfig = LanceSparkCatalogConfig.from(catalogOpts);
+
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .withCatalogDefaults(catalogConfig)
+            .build();
+
+    Assertions.assertTrue(
+        options.isUseScalarIndex(), "use_scalar_index default value must be true");
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/metric/BaseLanceReadMetricsIntegrationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/metric/BaseLanceReadMetricsIntegrationTest.java
@@ -100,7 +100,6 @@ public abstract class BaseLanceReadMetricsIntegrationTest {
                 "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
             .config("spark.sql.catalog.lance.impl", "dir")
             .config("spark.sql.catalog.lance.root", tempDir.toString())
-            .config("spark.sql.catalog.lance.storage.use_scalar_index", "true")
             .getOrCreate();
     metricsListener = new MetricsCapturingListener();
     spark.sparkContext().addSparkListener(metricsListener);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/metric/BaseLanceReadMetricsIntegrationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/metric/BaseLanceReadMetricsIntegrationTest.java
@@ -100,6 +100,7 @@ public abstract class BaseLanceReadMetricsIntegrationTest {
                 "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
             .config("spark.sql.catalog.lance.impl", "dir")
             .config("spark.sql.catalog.lance.root", tempDir.toString())
+            .config("spark.sql.catalog.lance.storage.use_scalar_index", "true")
             .getOrCreate();
     metricsListener = new MetricsCapturingListener();
     spark.sparkContext().addSparkListener(metricsListener);


### PR DESCRIPTION
Close https://github.com/lance-format/lance-spark/issues/659


# Description
This PR adds support for the use_scalar_index read option in LanceSparkReadOptions and wires it through to scan execution.

# What changed

- Added use_scalar_index as a supported read option in LanceSparkReadOptions
- Parsed the option from storage/read properties and exposed it through the builder/getter
- Propagated the option to ScanOptions in both fragment scanning and count(*) execution paths
- Added serialization and option parsing tests for use_scalar_index
- Updated the documentation for read options in select.md
- Fixed an integration test by explicitly enabling spark.sql.catalog.lance.storage.use_scalar_index

# Why
This change allows users to control whether scalar indices are used during scan-time filtering, making the read behavior configurable through Spark read/storage options.