### PR TITLE
fix: render pushed-down timestamp literals in UTC

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/FilterPushDown.java
@@ -27,12 +27,30 @@ import org.apache.spark.sql.types.DataTypes;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class FilterPushDown {
+  /**
+   * Renders a Spark {@code TimestampType} (micros-since-epoch UTC) as a {@code uuuu-MM-dd HH:mm:ss}
+   * literal in UTC. Fractional seconds are emitted only when non-zero. Pinned to {@link
+   * ZoneOffset#UTC} and {@link Locale#ROOT} so the pushed literal is independent of the driver
+   * JVM's default time zone and locale.
+   */
+  private static final DateTimeFormatter UTC_TIMESTAMP_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .appendPattern("uuuu-MM-dd HH:mm:ss")
+          .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+          .toFormatter(Locale.ROOT);
+
   /**
    * Create SQL 'where clause' from Spark V2 predicates.
    *
@@ -203,9 +221,13 @@ public class FilterPushDown {
     }
     if (literal.dataType() == DataTypes.TimestampType && value instanceof Long) {
       long micros = (Long) value;
-      java.time.Instant instant =
-          java.time.Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1_000);
-      return "timestamp '" + Timestamp.from(instant) + "'";
+      Instant instant =
+          Instant.ofEpochSecond(
+              Math.floorDiv(micros, 1_000_000L), Math.floorMod(micros, 1_000_000L) * 1_000L);
+      // Spark TimestampType is micros-since-epoch UTC. Render the UTC wall clock explicitly:
+      // java.sql.Timestamp.toString() renders in the JVM default zone, which would shift the
+      // pushed literal on non-UTC drivers and silently drop or include the wrong rows.
+      return "timestamp '" + UTC_TIMESTAMP_FORMATTER.format(instant.atOffset(ZoneOffset.UTC)) + "'";
     }
     if (value instanceof Date) {
       return "date '" + value.toString().replace("'", "''") + "'";

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/FilterPushDownTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.sql.Date;
-import java.sql.Timestamp;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -209,14 +208,80 @@ public class FilterPushDownTest {
   @Test
   public void testTimestampFilterPushDown() {
     // Timestamp literals must use the 'timestamp' keyword so Lance's DataFusion parser produces
-    // Timestamp, not Utf8.
+    // Timestamp, not Utf8. Spark hands timestamps to pushdown as micros-since-epoch UTC, so the
+    // literal is built from a UTC instant (not Timestamp.valueOf, which would parse in the JVM
+    // default zone) and rendered as the UTC wall clock with no trailing fractional zeros.
+    long micros = epochMicros("2024-01-15T10:30:00Z");
+    Predicate[] filters = new Predicate[] {TestPredicates.eqTimestampMicros("created_at", micros)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(created_at == timestamp '2024-01-15 10:30:00')", whereClause.get());
+  }
+
+  @Test
+  public void testTimestampFilterPushDownIsTimeZoneIndependent() {
+    // Regression: Spark TimestampType is micros-since-epoch UTC. The pushed literal must be the
+    // UTC wall clock regardless of the driver JVM's default time zone. Before the fix,
+    // java.sql.Timestamp.toString() rendered in the default zone, shifting the literal (here it
+    // would become 02:30 under America/Los_Angeles) and silently matching the wrong rows.
+    long micros = epochMicros("2024-01-15T10:30:00.123456Z");
+    java.util.TimeZone original = java.util.TimeZone.getDefault();
+    try {
+      java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("America/Los_Angeles"));
+      Predicate[] filters =
+          new Predicate[] {TestPredicates.eqTimestampMicros("created_at", micros)};
+      Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+      assertTrue(whereClause.isPresent());
+      assertEquals("(created_at == timestamp '2024-01-15 10:30:00.123456')", whereClause.get());
+    } finally {
+      java.util.TimeZone.setDefault(original);
+    }
+  }
+
+  @Test
+  public void testTimestampFilterPushDownTrimsTrailingFractionalZeros() {
+    // appendFraction(..., true) trims trailing zeros: .120000 micros must render as .12, not
+    // .120000 -- a property a naive zero-padded reimplementation would get wrong.
+    long micros = epochMicros("2024-01-15T10:30:00.120000Z");
+    Predicate[] filters = new Predicate[] {TestPredicates.eqTimestampMicros("created_at", micros)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(created_at == timestamp '2024-01-15 10:30:00.12')", whereClause.get());
+  }
+
+  @Test
+  public void testTimestampFilterPushDownHandlesPreEpochMicros() {
+    // Math.floorDiv/floorMod render pre-1970 (negative) micros as the correct UTC wall clock;
+    // plain / and % would produce a wrong nano-of-second for negative values.
+    long micros = epochMicros("1969-12-31T23:59:59.750000Z");
+    Predicate[] filters = new Predicate[] {TestPredicates.eqTimestampMicros("created_at", micros)};
+    Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
+    assertTrue(whereClause.isPresent());
+    assertEquals("(created_at == timestamp '1969-12-31 23:59:59.75')", whereClause.get());
+  }
+
+  @Test
+  public void testTimestampRangePushDownUsesUtcForAllOperators() {
+    // The canonical timestamp use case is a half-open range, not equality. Both bounds and the AND
+    // composition route through the same compileLiteral chokepoint, so non-= operators must render
+    // the UTC wall clock too -- this guards the binaryOp path, not just `=`.
+    long lo = epochMicros("2024-01-15T00:00:00Z");
+    long hi = epochMicros("2024-01-16T00:00:00Z");
     Predicate[] filters =
         new Predicate[] {
-          TestPredicates.eq("created_at", Timestamp.valueOf("2024-01-15 10:30:00.0"))
+          TestPredicates.cmpTimestampMicros(">=", "created_at", lo),
+          TestPredicates.cmpTimestampMicros("<", "created_at", hi)
         };
     Optional<String> whereClause = FilterPushDown.compileFiltersToSqlWhereClause(filters);
     assertTrue(whereClause.isPresent());
-    assertEquals("(created_at == timestamp '2024-01-15 10:30:00.0')", whereClause.get());
+    assertEquals(
+        "(created_at >= timestamp '2024-01-15 00:00:00') AND (created_at < timestamp '2024-01-16 00:00:00')",
+        whereClause.get());
+  }
+
+  private static long epochMicros(String isoInstant) {
+    java.time.Instant instant = java.time.Instant.parse(isoInstant);
+    return instant.getEpochSecond() * 1_000_000L + instant.getNano() / 1_000L;
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/TestPredicates.java
@@ -40,6 +40,26 @@ final class TestPredicates {
     return new Predicate("=", new Expression[] {FieldReference.apply(column), literalOf(value)});
   }
 
+  /**
+   * Builds an equality predicate whose literal is a raw {@code TimestampType} value carrying {@code
+   * micros}-since-epoch UTC, exactly as Spark hands timestamps to V2 pushdown. Unlike {@link
+   * #eq(String, Object)} with a {@link Timestamp}, the value is not derived from the JVM default
+   * time zone, so it pins time-zone-independent rendering.
+   */
+  static Predicate eqTimestampMicros(String column, long micros) {
+    return cmpTimestampMicros("=", column, micros);
+  }
+
+  /**
+   * Like {@link #eqTimestampMicros(String, long)} but for any comparison operator ({@code "<"},
+   * {@code ">="}, ...), so range/non-equality pushdown of {@code TimestampType} literals can be
+   * exercised through the same raw {@code Long}-micros shape Spark produces.
+   */
+  static Predicate cmpTimestampMicros(String op, String column, long micros) {
+    LiteralValue<Long> lit = new LiteralValue<>(micros, DataTypes.TimestampType);
+    return new Predicate(op, new Expression[] {FieldReference.apply(column), lit});
+  }
+
   static Predicate lt(String column, Object value) {
     return new Predicate("<", new Expression[] {FieldReference.apply(column), literalOf(value)});
   }


### PR DESCRIPTION
Closes #662

## Summary

Fix wrong-row drift in pushed-down `TimestampType` predicates on non-UTC drivers.

## Root cause

> `FilterPushDown.compileLiteral` rendered the literal via `java.sql.Timestamp.toString()`, which formats in the JVM default time zone — but Spark stores `TimestampType` as micros-since-epoch **UTC**.

**Before** — `lance-spark-base_2.12/.../read/FilterPushDown.java`:

```java
java.time.Instant instant =
    java.time.Instant.ofEpochSecond(micros / 1_000_000, (micros % 1_000_000) * 1_000);
return "timestamp '" + Timestamp.from(instant) + "'";
```

Problems:

- `Timestamp.toString()` uses the JVM default time zone → literal shifted by the driver's UTC offset on non-UTC JVMs, silently dropping or including the wrong rows.
- `/` and `%` round toward zero → wrong wall-clock components for pre-1970 micros.
- `Timestamp.toString()` carries the default `Locale`, which is inappropriate for an SQL literal.

The sibling `Date` branch (`LocalDate.ofEpochDay`) was already TZ-independent, so the bug was timestamp-specific.

## Fix

**After**:

```java
private static final DateTimeFormatter UTC_TIMESTAMP_FORMATTER =
    new DateTimeFormatterBuilder()
        .appendPattern("uuuu-MM-dd HH:mm:ss")
        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
        .toFormatter(Locale.ROOT);

// ...

Instant instant =
    Instant.ofEpochSecond(
        Math.floorDiv(micros, 1_000_000L),
        Math.floorMod(micros, 1_000_000L) * 1_000L);
return "timestamp '"
    + UTC_TIMESTAMP_FORMATTER.format(instant.atOffset(ZoneOffset.UTC))
    + "'";
```

- Pin a `DateTimeFormatter` to `ZoneOffset.UTC` + `Locale.ROOT` so the literal is independent of the driver's JVM time zone and locale.
- Switch the micros split to `Math.floorDiv` / `Math.floorMod` for pre-epoch correctness.
- Emit fractional seconds only when non-zero (`appendFraction(..., 0, 9, true)`).
- `Date` branch unchanged.

## Tests

In `FilterPushDownTest`, using raw `Long`-micros helpers added to `TestPredicates` so the literal isn't pre-shifted by `Timestamp.valueOf` before reaching the converter:

- [x] TZ-independence under `user.timezone=America/Los_Angeles`
- [x] Trailing fractional-zero trimming
- [x] Pre-epoch negative micros via `floorDiv` / `floorMod`
- [x] Range predicates (`>=`, `<`) routed through the same `compileLiteral` chokepoint
