### PR TITLE
fix(spark): clarify auth errors when storage .option()s are dropped on path-based access

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -74,6 +74,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -1742,10 +1743,79 @@ public abstract class BaseLanceNamespaceSparkCatalog
       tableProperties = dataset.getConfig();
     } catch (IllegalArgumentException e) {
       throw new NoSuchTableException(ident);
+    } catch (RuntimeException e) {
+      throw describePathAccessError(datasetUri, e);
     }
 
     return createDataset(
         readOptions, schema, null, null, null, false, fileFormatVersion, tableProperties, null);
+  }
+
+  // Substrings (matched case-insensitively) that indicate a native open failed on storage
+  // authentication/authorization rather than on a missing or corrupt dataset. Best-effort: a miss
+  // simply yields the raw native error, i.e. today's behavior.
+  private static final String[] STORAGE_AUTH_ERROR_MARKERS = {
+    "identity/oauth2/token",
+    "token request",
+    "managed identity",
+    "credential",
+    "authenticat",
+    "authoriz",
+    "forbidden",
+    "access denied",
+    "signaturedoesnotmatch",
+    "invalidaccesskeyid",
+    "403",
+  };
+
+  /**
+   * Returns {@code true} if {@code error} or any of its causes carries a message that looks like a
+   * storage authentication/authorization failure (e.g. a dropped SAS token falling back to the
+   * Azure MSI/IMDS credential chain). Best-effort and message-based, since the native object-store
+   * error is surfaced only as text.
+   */
+  static boolean looksLikeStorageAuthFailure(Throwable error) {
+    for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+      String message = cause.getMessage();
+      if (message == null) {
+        continue;
+      }
+      String lower = message.toLowerCase(Locale.ROOT);
+      for (String marker : STORAGE_AUTH_ERROR_MARKERS) {
+        if (lower.contains(marker)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Enriches a native open failure on path-based access with actionable guidance when it looks like
+   * a storage authentication error, and returns it unchanged otherwise.
+   *
+   * <p>Path-based access ({@code spark.read.format("lance").load(uri)}) routes through {@code
+   * SupportsCatalogOptions}, which forwards only the table identifier to the catalog — never the
+   * per-read {@code .option(...)} map. Storage credentials passed that way (e.g. an Azure SAS
+   * token) are therefore dropped before reaching the object store, and the open falls back to the
+   * default credential chain, surfacing a confusing error far from the real cause (e.g. an Azure
+   * MSI/IMDS token request failure). This points the user at the supported alternatives.
+   */
+  static RuntimeException describePathAccessError(String datasetUri, RuntimeException error) {
+    if (!looksLikeStorageAuthFailure(error)) {
+      return error;
+    }
+    return new IllegalStateException(
+        "Failed to open Lance dataset at "
+            + datasetUri
+            + " and the underlying error looks like a storage authentication failure. Note that "
+            + "storage credentials passed via .option(...) are not applied to path-based access: "
+            + "only the table identifier is forwarded to the catalog, so a SAS token or account "
+            + "key set that way is dropped before reaching the object store. Configure storage "
+            + "credentials on the catalog instead — e.g. spark.sql.catalog.<name>.storage.<key> — "
+            + "or supply them via environment variables or a managed identity. Underlying error: "
+            + error.getMessage(),
+        error);
   }
 
   public abstract LanceDataset createDataset(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/PathAccessErrorTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/PathAccessErrorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for the path-based-access error enrichment in {@link BaseLanceNamespaceSparkCatalog}.
+ *
+ * <p>Storage credentials passed via {@code .option(...)} are dropped on path-based access (only the
+ * table identifier is forwarded to the catalog), so the native open falls back to the default
+ * credential chain and surfaces a confusing auth error far from the real cause. These tests cover
+ * the message-based detection and enrichment; no cloud account is required.
+ */
+public class PathAccessErrorTest {
+
+  private static final String URI = "abfss://fs@acct.dfs.core.windows.net/t.lance";
+
+  /** The Azure MSI/IMDS failure users actually hit when a SAS token is dropped. */
+  private static final String AZURE_MSI_ERROR =
+      "LanceError(IO): Generic MicrosoftAzure error: Error performing token request: "
+          + "Error performing GET http://169.254.169.254/metadata/identity/oauth2/token "
+          + "after 3 retries";
+
+  @Test
+  public void detectsAzureMsiTokenFailure() {
+    assertTrue(
+        BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(
+            new RuntimeException(AZURE_MSI_ERROR)));
+  }
+
+  @Test
+  public void detectsCommonAuthMarkers() {
+    assertTrue(
+        BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(
+            new RuntimeException("403 Forbidden")));
+    assertTrue(
+        BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(
+            new RuntimeException("<Code>SignatureDoesNotMatch</Code>")));
+    assertTrue(
+        BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(
+            new RuntimeException("The request is not authorized to perform this operation.")));
+  }
+
+  @Test
+  public void detectsAuthMarkerInNestedCause() {
+    RuntimeException wrapped =
+        new RuntimeException("failed to open dataset", new RuntimeException(AZURE_MSI_ERROR));
+    assertTrue(BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(wrapped));
+  }
+
+  @Test
+  public void ignoresNonAuthErrors() {
+    assertFalse(
+        BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(
+            new RuntimeException("Not a Lance dataset: missing _versions directory")));
+    assertFalse(BaseLanceNamespaceSparkCatalog.looksLikeStorageAuthFailure(new RuntimeException()));
+  }
+
+  @Test
+  public void enrichesAuthErrorWithActionableGuidance() {
+    RuntimeException cause = new RuntimeException(AZURE_MSI_ERROR);
+    RuntimeException enriched = BaseLanceNamespaceSparkCatalog.describePathAccessError(URI, cause);
+
+    String message = enriched.getMessage();
+    assertTrue(message.contains(URI), "message should name the dataset uri: " + message);
+    assertTrue(message.contains(".option("), "message should call out .option(): " + message);
+    assertTrue(
+        message.contains("spark.sql.catalog"),
+        "message should point at catalog config: " + message);
+    // The original native error is preserved as the cause for debugging.
+    assertSame(cause, enriched.getCause());
+    assertTrue(
+        message.contains(AZURE_MSI_ERROR),
+        "message should include the underlying error: " + message);
+  }
+
+  @Test
+  public void passesThroughNonAuthErrorUnchanged() {
+    RuntimeException cause = new RuntimeException("Not a Lance dataset");
+    RuntimeException result = BaseLanceNamespaceSparkCatalog.describePathAccessError(URI, cause);
+    assertSame(cause, result, "non-auth failures must be returned unchanged");
+  }
+}


### PR DESCRIPTION
## What

Give a clear, actionable error when a **path-based** Lance read fails on storage authentication because credentials were supplied via `.option()` — instead of surfacing a misleading downstream auth error (e.g. an Azure MSI/IMDS token failure) far from the real cause.

## Why

Path-based access (`spark.read.format("lance").load("abfss://…")`) routes through `SupportsCatalogOptions`, which forwards only the table `Identifier` to the catalog's `loadTable` — never the per-read `.option()` map. Any storage credentials passed that way (e.g. an Azure SAS token) are therefore dropped before reaching the native object store, and the open falls back to the default credential chain. On clusters with no managed identity that surfaces as a confusing Azure MSI/IMDS token error:

```
LanceError(IO): Generic MicrosoftAzure error: Error performing token request:
Error performing GET http://169.254.../metadata/identity/oauth2/token ... after 3 retries
  at org.lance.Dataset.openNative(Native Method)
  at org.lance.spark.BaseLanceNamespaceSparkCatalog.loadTableFromPath(...)
```

Per the discussion here, per-read `.option()` credentials are **not** something we want to plumb through the `SupportsCatalogOptions` path — catalog-managed credentials are the supported way, consistent with other Spark connectors. Thanks @hamersaw for the direction. This PR drops the earlier credential-propagation approach and instead makes the failure self-explanatory.

## What changed

- `BaseLanceNamespaceSparkCatalog.loadTableFromPath`: when the native open fails with what looks like a storage authentication/authorization error, it's wrapped with a message that explains `.option()` credentials aren't applied to path-based access and points at the supported alternatives (catalog `storage.*` config, environment variables, or a managed identity). The original native error is preserved as the cause.
- Detection is best-effort and message-based (`looksLikeStorageAuthFailure`); a miss just yields today's raw error. Non-auth failures — including genuine not-found (`IllegalArgumentException` → `NoSuchTableException`) — are rethrown unchanged, so there is no behavior change for valid reads.

## Testing

- `PathAccessErrorTest` (base module, no cloud account required): the Azure MSI/IMDS message and common auth markers (`403`, `SignatureDoesNotMatch`, "not authorized") are detected, including nested causes; non-auth errors pass through unchanged; the enriched message names the URI, `.option(...)`, and the catalog `storage.*` alternative and preserves the cause.
- Existing `read` (16) and `write` (25) connector suites pass; `./mvnw` spotless + checkstyle clean on the touched modules.
