### PR TITLE
fix: null LanceColumnarPartitionReader.fragmentReader before releasing

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceColumnarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceColumnarPartitionReader.java
@@ -41,8 +41,13 @@ public class LanceColumnarPartitionReader implements PartitionReader<ColumnarBat
       return true;
     }
     while (fragmentIndex < inputPartition.getLanceSplit().getFragments().size()) {
+      // Null-first so if create(...) below throws, the subsequent close() sees fragmentReader ==
+      // null and short-circuits, rather than re-closing the already-closed previous scanner and
+      // raising `ArrowArrayStream is already closed`.
       if (fragmentReader != null) {
-        fragmentReader.close();
+        LanceFragmentColumnarBatchScanner toClose = fragmentReader;
+        fragmentReader = null;
+        toClose.close();
       }
       fragmentReader =
           LanceFragmentColumnarBatchScanner.create(
@@ -93,17 +98,22 @@ public class LanceColumnarPartitionReader implements PartitionReader<ColumnarBat
 
   @Override
   public void close() throws IOException {
-    if (fragmentReader != null) {
-      if (!currentScanStatsAdded) {
-        metricsTracker.addScanStats(fragmentReader.getScanStats());
-        currentScanStatsAdded = true;
-      }
-
-      try {
-        fragmentReader.close();
-      } catch (Exception e) {
-        throw new IOException(e);
-      }
+    if (fragmentReader == null) {
+      return;
+    }
+    if (!currentScanStatsAdded) {
+      metricsTracker.addScanStats(fragmentReader.getScanStats());
+      currentScanStatsAdded = true;
+    }
+    // Null-first so close() is idempotent (PartitionReader extends Closeable, whose contract
+    // requires it): a repeat call short-circuits rather than raising
+    // `ArrowArrayStream is already closed` from a second ArrowArrayStream.release().
+    LanceFragmentColumnarBatchScanner toClose = fragmentReader;
+    fragmentReader = null;
+    try {
+      toClose.close();
+    } catch (Exception e) {
+      throw new IOException(e);
     }
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceColumnarPartitionReaderTest.java
@@ -24,8 +24,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LanceColumnarPartitionReaderTest {
   @Test
@@ -154,6 +156,81 @@ public class LanceColumnarPartitionReaderTest {
         }
         batch.close();
       }
+    }
+  }
+
+  @Test
+  public void testCloseAfterMidIterationCreateFailure() throws Exception {
+    // Fragment 0 exists; fragment 999999 does not. Iterating 0 → 999999 must fail on the second
+    // fragment; close() must then be idempotent — not re-close the already-closed fragment 0
+    // scanner and raise `ArrowArrayStream is already closed`.
+    LanceSplit split = new LanceSplit(Arrays.asList(0, 999999));
+    LanceInputPartition partition =
+        new LanceInputPartition(
+            TestUtils.TestTable1Config.schema,
+            0 /* partitionId */,
+            split,
+            TestUtils.TestTable1Config.readOptions,
+            Optional.empty() /* whereCondition */,
+            Optional.empty() /* limit */,
+            Optional.empty() /* offset */,
+            Optional.empty() /* topNSortOrders */,
+            Optional.empty() /* pushedAggregation */,
+            "testCloseAfterMidIterationCreateFailure" /* scanId */,
+            null /* initialStorageOptions */,
+            null /* namespaceImpl */,
+            null /* namespaceProperties */,
+            null /* partitionKeyRow */);
+    LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition);
+    try {
+      // Drain fragment 0 first so next() advances into the create(fragment=999999) branch, which
+      // must throw.
+      assertThrows(
+          RuntimeException.class,
+          () -> {
+            while (reader.next()) {
+              ColumnarBatch batch = reader.get();
+              assertNotNull(batch);
+              batch.close();
+            }
+          });
+      assertDoesNotThrow(reader::close, "close() must be idempotent after mid-iteration failure");
+    } finally {
+      // Defensive close in case an AssertionError above (from assertNotNull / assertDoesNotThrow)
+      // bypassed the inline close() call — AssertionError is not caught by assertThrows.
+      reader.close();
+    }
+  }
+
+  @Test
+  public void testCloseIsIdempotent() throws Exception {
+    // Second close() must be a no-op — verifies the null-first idempotence guard.
+    LanceSplit split = new LanceSplit(Collections.singletonList(0));
+    LanceInputPartition partition =
+        new LanceInputPartition(
+            TestUtils.TestTable1Config.schema,
+            0 /* partitionId */,
+            split,
+            TestUtils.TestTable1Config.readOptions,
+            Optional.empty() /* whereCondition */,
+            Optional.empty() /* limit */,
+            Optional.empty() /* offset */,
+            Optional.empty() /* topNSortOrders */,
+            Optional.empty() /* pushedAggregation */,
+            "testCloseIsIdempotent" /* scanId */,
+            null /* initialStorageOptions */,
+            null /* namespaceImpl */,
+            null /* namespaceProperties */,
+            null /* partitionKeyRow */);
+    LanceColumnarPartitionReader reader = new LanceColumnarPartitionReader(partition);
+    try {
+      while (reader.next()) {
+        reader.get().close();
+      }
+      assertDoesNotThrow(reader::close, "first close() after full iteration must succeed");
+      assertDoesNotThrow(reader::close, "second close() must be a no-op");
+    } finally {
+      reader.close();
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix M3 from an internal audit: `LanceColumnarPartitionReader.next()` releases the previous fragment's scanner before opening the next one, but leaves the `fragmentReader` field pointing to the just-closed scanner. If `LanceFragmentColumnarBatchScanner.create(...)` then throws, Spark's task-completion listener calls `close()` on this reader, which re-closes the already-closed scanner and raises `ArrowArrayStream is already closed` (NPE from `ArrowArrayStream.memoryAddress()` on a second `release()` inside `ArrowArrayStreamReader.closeReadSource`, wrapped as IOException).

## Root cause

`lance-spark-base_2.12/.../read/LanceColumnarPartitionReader.java` **Before**:

```java
while (fragmentIndex < inputPartition.getLanceSplit().getFragments().size()) {
  if (fragmentReader != null) {
    fragmentReader.close();          // fragment 0 released
  }
  fragmentReader =                   // if this throws, field still points at
      LanceFragmentColumnarBatchScanner.create(...);   // the released scanner
  fragmentIndex++;
  ...
}
```

The `LanceFragmentScanner.create()` path can throw for a missing fragment (`getFragment == null` → `IllegalStateException`, wrapped in `RuntimeException`), a storage/IO error during dataset open, or any scan-option builder failure. Any of these leaves the field dangling.

The Lance JNI handles themselves are guarded and idempotent, but the enclosing `arrow-java` `ArrowArrayStream.release()` is not — its second call hits `checkNotNull(data, "ArrowArrayStream is already closed")` in `ArrowArrayStream.memoryAddress()`.

## Fix

Null-first in `next()` — release the field's reference before invoking `close()`, so the follow-up `close()` short-circuits:

```java
while (fragmentIndex < inputPartition.getLanceSplit().getFragments().size()) {
  // Null-first so if create(...) below throws, the subsequent close() sees fragmentReader ==
  // null and short-circuits, rather than re-closing the already-closed previous scanner and
  // raising `ArrowArrayStream is already closed`.
  if (fragmentReader != null) {
    LanceFragmentColumnarBatchScanner toClose = fragmentReader;
    fragmentReader = null;
    toClose.close();
  }
  fragmentReader = LanceFragmentColumnarBatchScanner.create(...);
  ...
}
```

Apply the same shape to `close()` so the reader is idempotent — `PartitionReader` extends `Closeable`, whose contract requires `close()` to have no effect on repeat calls (JDK `Closeable.close` Javadoc; `AutoCloseable.close` calls out this distinction explicitly).

## Tests

Two regression tests (`LanceColumnarPartitionReaderTest`):

- **`testCloseAfterMidIterationCreateFailure`** — split `[0, 999999]`. Drains fragment 0, then `next()` attempts to open fragment 999999 which throws. `close()` must be a no-op. Uses `assertThrows(RuntimeException.class, drain)` + `assertDoesNotThrow(close)`, with a `finally reader.close()` guard so an `AssertionError` mid-lambda still releases the Arrow allocator.

- **`testCloseIsIdempotent`** — single fragment, full drain, then two consecutive `close()` calls. Both must succeed.

Both fail on `origin/main` (`ArrowArrayStream is already closed` NPE) and pass with the fix.

## Verification

| Command | Result |
|---|---|
| `mvn -pl lance-spark-base_2.12 test -Dtest=LanceColumnarPartitionReaderTest` | ✅ 5/5 |
| `mvn -pl lance-spark-base_2.12 test` (base module) | ✅ 460, 0 fail |
| `make test` (default 3.5 / 2.12) | ✅ 988, 0 fail, 48 skipped |
| `make lint` (Checkstyle + Spotless, full matrix) | ✅ 15 modules SUCCESS |

Full Spark × Scala matrix (3.4/3.5 × 2.12/2.13, 4.0/4.1 × 2.13) delegated to CI.
