### PR TITLE
chore(deps): bump jupyter/pytest to close dependabot security alerts

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,7 +1,7 @@
-pytest==8.3.5
-pytest-timeout==2.3.1
-jupyterlab==3.6.7
-jupyter-server==1.24.0
+pytest==9.0.3
+pytest-timeout==2.4.0
+jupyterlab==4.5.9
+jupyter-server==2.20.0
 pandas==2.3.1
 numpy==1.26.4
 matplotlib==3.10.5


### PR DESCRIPTION
## Summary

Bumps three pinned Python packages in `docker/requirements.txt` to close all 14 open Dependabot security alerts on this file.

| Package | Current | New | Alerts closed | Severities |
|---|---|---|---|---|
| `jupyter-server` | `1.24.0` | `2.20.0` | #1, #2, #3, #9, #10, #11, #12, **#14** | 1 critical + 3 high + 4 medium |
| `jupyterlab` | `3.6.7` | `4.5.9` | #4, #6, #8, #13, #15 | 3 high + 1 medium + 1 low |
| `pytest` | `8.3.5` | `9.0.3` | #7 | 1 medium |
| `pytest-timeout` | `2.3.1` | `2.4.0` | — (compat bump) | — |

Full list: https://github.com/lance-format/lance-spark/security/dependabot

The critical one is #14 — a stored-XSS in `NbconvertFileHandler` (`jupyter-server` ≤ 2.19.0, GHSA advisory).

## Blast radius

`docker/requirements.txt` is consumed **only** by `docker/Dockerfile` — the interactive Jupyter/notebook demo image built by `make docker-build`. The CI integration-test image (`docker/Dockerfile.test-base`, exercised by the `Spark`, `Spark AWS`, and `Spark Search Docker` workflows via `.github/actions/docker-build`) installs its own pytest dependencies via `pip install pytest pytest-timeout packaging azure-storage-blob boto3` and is not affected by this file — its `pytest` will pick up the latest at build time regardless.

So this bump changes the notebook demo image only, not the CI test image and not the Maven build.

## `jupyter-server` 1.x → 2.x compatibility note

The 1.x → 2.x jump renames the primary config class from `NotebookApp` to `ServerApp`. The notebook launcher in `docker/Dockerfile` already uses the 2.x-style flags (`--ServerApp.token=''`, `--ServerApp.password=''`, `--port=8888`), so those flags become effective under 2.x rather than being silently ignored under 1.x. This is a bug fix, not a regression.

`jupyterlab` 3.x → 4.x is also a major bump, but the launcher only invokes `jupyter-lab` (no dependency on 3.x-specific extension APIs), so risk is low.

## Test plan

The `Spark Search Docker` workflow does trigger on `docker/**` changes and gets exercised on this PR (via `.github/actions/docker-build`), but its build path uses `docker/Dockerfile.test-base` → `docker/Dockerfile.test` — **neither of those Dockerfiles reads `docker/requirements.txt`**. `Dockerfile.test-base` installs its own pytest deps inline (`pip install pytest pytest-timeout packaging azure-storage-blob boto3`, no pin file), and `Dockerfile.test` only adds the lance-spark bundle on top. So a green Search Docker run confirms `docker/**` changes didn't break the CI image layout, but it does **not** exercise this bump.

The interactive notebook image (`docker/Dockerfile`, `make docker-build`) is the sole consumer of `requirements.txt`, and no CI job builds it today. So verification was done locally against a minimal image that mirrors the apt + venv layers of `docker/Dockerfile` exactly, with the new `requirements.txt` pinned in.

Smoke image (identical apt packages, `python3 -m venv /opt/venv`, `pip install -r requirements.txt`) built cleanly on Ubuntu 24.04.

Installed versions (verified via `pip show` inside the image):

```
jupyter_server = 2.20.0
jupyterlab     = 4.5.9
pytest         = 9.0.3
pytest-timeout = 2.4.0
```

Runtime checks:

```
from jupyter_server.serverapp import ServerApp     # ✓ imports (2.x config class)
which jupyter-lab                                  # ✓ /opt/venv/bin/jupyter-lab
jupyter-lab --version                              # ✓ 4.5.9
```

Simulating the `docker/Dockerfile` notebook launcher — `jupyter-lab --ServerApp.token='' --ServerApp.password='' --port=8888 --no-browser --allow-root`:

```
[I ServerApp] jupyter_lsp             | extension was successfully loaded.
[I ServerApp] jupyter_server_terminals | extension was successfully loaded.
[I ServerApp] jupyterlab              | extension was successfully loaded.
[I ServerApp] Jupyter Server 2.20.0 is running at:
[I ServerApp] http://127.0.0.1:8888/lab
port 8888 LISTENING                                # ✓ TCP connect succeeds
```

One expected `WARN`: `ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.` — the flags still work; migrating to `IdentityProvider.token` is a separate concern and not in scope for this security-bump PR.

### Follow-up (not part of this PR)

The CI gap that let all 14 alerts accumulate — `docker/Dockerfile` never being built by CI, even though `docker/**` changes trigger the Search Docker workflow — is worth closing with its own PR (`chore(ci): build docker/Dockerfile on changes to docker/Dockerfile or docker/requirements.txt` — build-only, no publish). Not bundled here per "one PR, one concern."

