### PR TITLE
fix: disable commit coordinator for position delta write

### DIFF
--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -143,6 +143,11 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public void commit(WriterCommitMessage[] messages) {
       List<FragmentMetadata> newFragments = new ArrayList<>();
       Map<Integer, RoaringBitmap> aggregatedDeletions = new HashMap<>();

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -144,6 +144,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     @Override
     public boolean useCommitCoordinator() {
+      // Lance commits are atomic at the dataset level via CommitBuilder/Transaction on the
+      // driver; Spark's OutputCommitCoordinator is unnecessary and can break under speculation or
+      // retries.
       return false;
     }
 

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.Dataset;
+import org.lance.WriteParams;
+import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.TestUtils;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.connector.write.DeltaBatchWrite;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SparkPositionDeltaWriteTest {
+  @TempDir static Path tempDir;
+
+  private static final Schema ARROW_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+              new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+
+  @Test
+  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Dataset.create(allocator, datasetUri, ARROW_SCHEMA, new WriteParams.Builder().build())
+          .close();
+
+      StructType sparkSchema = LanceArrowUtils.fromArrowSchema(ARROW_SCHEMA);
+      SparkPositionDeltaWrite write =
+          new SparkPositionDeltaWrite(
+              sparkSchema, LanceSparkWriteOptions.from(datasetUri), null, null, null, false, null);
+
+      DeltaBatchWrite batchWrite = write.toBatch();
+      assertFalse(batchWrite.useCommitCoordinator());
+    }
+  }
+}

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -31,9 +31,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class SparkPositionDeltaWriteTest {
@@ -46,7 +48,7 @@ public class SparkPositionDeltaWriteTest {
               new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
 
   @Test
-  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) {
+  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) throws Exception {
     String datasetName = testInfo.getTestMethod().get().getName();
     String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
 
@@ -60,6 +62,11 @@ public class SparkPositionDeltaWriteTest {
               sparkSchema, LanceSparkWriteOptions.from(datasetUri), null, null, null, false, null);
 
       DeltaBatchWrite batchWrite = write.toBatch();
+      Method useCommitCoordinator = batchWrite.getClass().getMethod("useCommitCoordinator");
+      assertEquals(
+          batchWrite.getClass(),
+          useCommitCoordinator.getDeclaringClass(),
+          "Position delta writes must explicitly override Spark's commit coordinator default");
       assertFalse(batchWrite.useCommitCoordinator());
     }
   }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -164,6 +164,9 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
 
     @Override
     public boolean useCommitCoordinator() {
+      // Lance commits are atomic at the dataset level via CommitBuilder/Transaction on the
+      // driver; Spark's OutputCommitCoordinator is unnecessary and can break under speculation or
+      // retries.
       return false;
     }
 

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -163,6 +163,11 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
     }
 
     @Override
+    public boolean useCommitCoordinator() {
+      return false;
+    }
+
+    @Override
     public void commit(WriterCommitMessage[] messages) {
       List<FragmentMetadata> newFragments = new ArrayList<>();
       Map<Integer, RoaringBitmap> aggregatedDeletions = new HashMap<>();

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -31,10 +31,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class SparkPositionDeltaWriteTest {
@@ -47,7 +49,7 @@ public class SparkPositionDeltaWriteTest {
               new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
 
   @Test
-  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) {
+  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) throws Exception {
     String datasetName = testInfo.getTestMethod().get().getName();
     String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
 
@@ -68,6 +70,11 @@ public class SparkPositionDeltaWriteTest {
               Collections.emptyMap());
 
       DeltaBatchWrite batchWrite = write.toBatch();
+      Method useCommitCoordinator = batchWrite.getClass().getMethod("useCommitCoordinator");
+      assertEquals(
+          batchWrite.getClass(),
+          useCommitCoordinator.getDeclaringClass(),
+          "Position delta writes must explicitly override Spark's commit coordinator default");
       assertFalse(batchWrite.useCommitCoordinator());
     }
   }

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.Dataset;
+import org.lance.WriteParams;
+import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.TestUtils;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.connector.write.DeltaBatchWrite;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SparkPositionDeltaWriteTest {
+  @TempDir static Path tempDir;
+
+  private static final Schema ARROW_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+              new Field("value", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+
+  @Test
+  public void positionDeltaWriteDoesNotUseCommitCoordinator(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Dataset.create(allocator, datasetUri, ARROW_SCHEMA, new WriteParams.Builder().build())
+          .close();
+
+      StructType sparkSchema = LanceArrowUtils.fromArrowSchema(ARROW_SCHEMA);
+      SparkPositionDeltaWrite write =
+          new SparkPositionDeltaWrite(
+              sparkSchema,
+              LanceSparkWriteOptions.from(datasetUri),
+              null,
+              null,
+              null,
+              false,
+              null,
+              Collections.emptyMap());
+
+      DeltaBatchWrite batchWrite = write.toBatch();
+      assertFalse(batchWrite.useCommitCoordinator());
+    }
+  }
+}


### PR DESCRIPTION
Spark Delete or merge into may throw followed exception when speculative execution is enabled

Spark's OutputCommitCoordinator can reject retried/speculative position-delta task commits even though Lance commits are already atomic at the dataset level through CommitBuilder/Transaction on the driver. Disable Spark commit coordination for position-delta writes so retries rely on Lance's transaction/version conflict handling instead.


```
Job aborted due to stage failure: Task 1635 in stage 57.0 failed 4 times, most recent failure: Lost task 1635.4 in stage 57.0 (TID 2661) (9.143.166.140 executor 38): org.apache.spark.SparkException: Commit denied for partition 1635 (task 2661, attempt 4, stage 57.0).
	at org.apache.spark.sql.errors.QueryExecutionErrors$.commitDeniedError(QueryExecutionErrors.scala:915)
	at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.$anonfun$run$1(WriteToDataSourceV2Exec.scala:462)
	at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1435)
	at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run(WriteToDataSourceV2Exec.scala:486)
	at org.apache.spark.sql.execution.datasources.v2.WritingSparkTask.run$(WriteToDataSourceV2Exec.scala:425)
	at org.apache.spark.sql.execution.datasources.v2.DeltaWithMetadataWritingSparkTask.run(WriteToDataSourceV2Exec.scala:526)
	at org.apache.spark.sql.execution.datasources.v2.V2TableWriteExec.$anonfun$writeWithV2$2(WriteToDataSourceV2Exec.scala:388)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:93)
	at org.apache.spark.TaskContext.runTaskWithListeners(TaskContext.scala:166)
	at org.apache.spark.scheduler.Task.run(Task.scala:141)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$4(Executor.scala:645)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally(SparkErrorUtils.scala:64)
	at org.apache.spark.util.SparkErrorUtils.tryWithSafeFinally$(SparkErrorUtils.scala:61)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:93)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:648)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)

Driver stacktrace:
```