### PR TITLE
fix: remove unreachable scala.math.BigDecimal case in toNumber

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/search/LanceSearchTableFunctions.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/search/LanceSearchTableFunctions.scala
@@ -338,7 +338,6 @@ object LanceSearchTableFunctions {
   private def toNumber(value: Any): Number = value match {
     case number: Number => number
     case decimal: org.apache.spark.sql.types.Decimal => decimal.toJavaBigDecimal
-    case decimal: scala.math.BigDecimal => decimal.bigDecimal
     case other => throw new IllegalArgumentException(s"Expected numeric literal, got $other")
   }
 


### PR DESCRIPTION
## Summary

Removes the dead `case decimal: scala.math.BigDecimal` branch in `LanceSearchTableFunctions.toNumber`. The Scala compiler emits

```
lance-spark-base_2.12/src/main/scala/org/lance/spark/search/LanceSearchTableFunctions.scala:341: unreachable code
```

for every 2.12 and 2.13 module build, and the warning is real.

## Why the case is unreachable

`toNumber` is only ever fed `Literal.value` (via `literalValue(expr)` upstream). Spark's `Literal` never holds a `scala.math.BigDecimal`:

- Numeric literals with `DecimalType` are stored as `org.apache.spark.sql.types.Decimal` — caught by the previous case, `case decimal: org.apache.spark.sql.types.Decimal`.
- Any `java.math.BigDecimal` yielded by foldable-expression evaluation is a `java.lang.Number` — caught by the first case, `case number: Number`.

So a `scala.math.BigDecimal` can never match, and the pattern is dead code. Removing it doesn't change runtime behavior on any code path that has ever executed.

## Verification

- `./mvnw -pl lance-spark-base_2.12,lance-spark-3.4_2.12,lance-spark-3.5_2.12 -am -DskipTests -Dspotless.skip -Dcheckstyle.skip clean compile` → 0 scala warnings (was 3).
- `./mvnw -pl lance-spark-base_2.13,lance-spark-3.4_2.13,lance-spark-3.5_2.13,lance-spark-4.0_2.13,lance-spark-4.1_2.13 -am -DskipTests -Dspotless.skip -Dcheckstyle.skip clean compile` → 0 `unreachable code` warnings (was 5). The remaining aggregated `deprecations (since 2.13.0)` line is unrelated (JavaConverters / IndexedSeq); left for a separate PR per "one PR, one concern."
- `./mvnw -pl lance-spark-3.5_2.12 -am -Dtest="*Search*Test,*SearchTableFunction*" test` → `Tests run: 8, Failures: 0, Errors: 0, Skipped: 1`.
- `make lint` → BUILD SUCCESS.