### PR TITLE
fix: preserve timestamp timezones across schema roundtrips

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -50,6 +50,7 @@ object LanceArrowUtils {
   val ARROW_DATE_MILLISECOND_KEY = DateMilliUtils.ARROW_DATE_MILLISECOND_KEY
   val ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY =
     FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY
+  val ARROW_TIMESTAMP_TIMEZONE_KEY = "lance.arrow.timestamp.timezone"
 
   // Namespaced keys used to embed child Spark Metadata on a parent StructField when the
   // child sits inside an ArrayType/MapType — Spark has no per-element metadata slot of its
@@ -249,6 +250,8 @@ object LanceArrowUtils {
         // Preserve FixedSizeBinary byte width so a subsequent write reproduces
         // FixedSizeBinary(n) instead of falling back to variable-length Binary.
         builder.putLong(ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY, fsb.getByteWidth.toLong)
+      case timestamp: ArrowType.Timestamp if timestamp.getTimezone != null =>
+        builder.putString(ARROW_TIMESTAMP_TIMEZONE_KEY, timestamp.getTimezone)
       case _ =>
     }
   }
@@ -342,7 +345,9 @@ object LanceArrowUtils {
         .readValue(metadata.json, classOf[java.util.LinkedHashMap[_, _]])
         .asScala
         .collect {
-          case (k, v) if !LANCE_INTERNAL_METADATA_KEYS.contains(k.toString) =>
+          case (k, v)
+              if !LANCE_INTERNAL_METADATA_KEYS.contains(k.toString) &&
+                k.toString != ARROW_TIMESTAMP_TIMEZONE_KEY =>
             (k.toString, String.valueOf(v))
         }
         .toMap
@@ -481,8 +486,19 @@ object LanceArrowUtils {
             arrowUInt64Field("position"),
             arrowUInt64Field("size")).asJava)
       case dataType =>
+        val effectiveTimeZoneId =
+          if (dataType == TimestampType && metadata != null
+            && metadata.contains(ARROW_TIMESTAMP_TIMEZONE_KEY)) {
+            metadata.getString(ARROW_TIMESTAMP_TIMEZONE_KEY)
+          } else {
+            timeZoneId
+          }
         val fieldType =
-          new FieldType(nullable, toArrowType(dataType, timeZoneId, large, name), null, meta.asJava)
+          new FieldType(
+            nullable,
+            toArrowType(dataType, effectiveTimeZoneId, large, name),
+            null,
+            meta.asJava)
         new Field(name, fieldType, Seq.empty[Field].asJava)
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceArrowUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceArrowUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.util;
+
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LanceArrowUtilsTest {
+  @Test
+  public void testTimestampTimezoneSurvivesSchemaRoundtripThroughSparkMetadata() {
+    Schema arrowSchema =
+        new Schema(
+            List.of(
+                new Field(
+                    "value",
+                    FieldType.nullable(
+                        new ArrowType.Timestamp(TimeUnit.MICROSECOND, "Asia/Shanghai")),
+                    Collections.emptyList())));
+
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(arrowSchema);
+    Schema converted = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false);
+    ArrowType.Timestamp timestampType =
+        (ArrowType.Timestamp) converted.findField("value").getType();
+
+    assertEquals("Asia/Shanghai", timestampType.getTimezone());
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
@@ -18,11 +18,25 @@ import org.lance.spark.read.LanceInputPartition;
 import org.lance.spark.read.LanceSplit;
 import org.lance.spark.utils.Optional;
 
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
@@ -107,6 +121,46 @@ public class TestUtils {
       return sb.append(datasetUri).append(".lance").toString();
     }
     return sb.append(datasetUri).toString();
+  }
+
+  public static Schema nonUtcTimestampSchema(String timezone) {
+    return new Schema(
+        Arrays.asList(
+            new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null),
+            new Field(
+                "created_time",
+                FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MICROSECOND, timezone)),
+                null)));
+  }
+
+  public static void writeNonUtcTimestampDataset(String datasetUri, String timezone)
+      throws Exception {
+    Schema arrowSchema = nonUtcTimestampSchema(timezone);
+    BufferAllocator allocator = LanceRuntime.allocator();
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      root.allocateNew();
+      IntVector idVec = (IntVector) root.getVector("id");
+      TimeStampMicroTZVector timestampVec = (TimeStampMicroTZVector) root.getVector("created_time");
+      for (int i = 0; i < 5; i++) {
+        idVec.setSafe(i, i);
+        timestampVec.setSafe(i, 1_700_000_000_000_000L + i);
+      }
+      root.setRowCount(5);
+
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try (ArrowStreamWriter writer = new ArrowStreamWriter(root, null, baos)) {
+        writer.start();
+        writer.writeBatch();
+        writer.end();
+      }
+
+      try (ArrowStreamReader reader =
+              new ArrowStreamReader(new ByteArrayInputStream(baos.toByteArray()), allocator);
+          ArrowArrayStream arrowStream = ArrowArrayStream.allocateNew(allocator)) {
+        Data.exportArrayStream(allocator, reader, arrowStream);
+        org.lance.Dataset.write().stream(arrowStream).uri(datasetUri).execute().close();
+      }
+    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddColumnsBackfillTest.java
@@ -266,6 +266,50 @@ public abstract class BaseAddColumnsBackfillTest {
     }
   }
 
+  /** Verifies add-columns backfill preserves existing Arrow timestamp timezones. */
+  @Test
+  public void testAddColumnsBackfillPreservesExistingTimestampTimezone(TestInfo testInfo)
+      throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+    TestUtils.writeNonUtcTimestampDataset(datasetUri, "Asia/Shanghai");
+
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+    StructType backfillSchema =
+        new StructType()
+            .add(LanceConstant.ROW_ADDRESS, DataTypes.LongType, false)
+            .add(LanceConstant.FRAGMENT_ID, DataTypes.IntegerType, false)
+            .add("new_col", DataTypes.IntegerType, true);
+
+    AddColumnsBackfillBatchWrite backfillWrite =
+        new AddColumnsBackfillBatchWrite(
+            backfillSchema,
+            writeOptions,
+            Collections.singletonList("new_col"),
+            null,
+            null,
+            null,
+            null);
+
+    DataWriterFactory factory = backfillWrite.createBatchWriterFactory(() -> 1);
+    WriterCommitMessage backfillMsg;
+    try (DataWriter<InternalRow> writer = factory.createWriter(0, 0)) {
+      for (int i = 0; i < 5; i++) {
+        writer.write(new GenericInternalRow(new Object[] {(long) i, 0, i * 10}));
+      }
+      backfillMsg = writer.commit();
+    }
+    backfillWrite.commit(new WriterCommitMessage[] {backfillMsg});
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        org.lance.Dataset dataset = org.lance.Dataset.open(datasetUri, allocator)) {
+      ArrowType.Timestamp timestampType =
+          (ArrowType.Timestamp) dataset.getSchema().findField("created_time").getType();
+      Assertions.assertEquals("Asia/Shanghai", timestampType.getTimezone());
+      Assertions.assertNotNull(dataset.getSchema().findField("new_col"));
+    }
+  }
+
   /**
    * Pins a read version in AddColumnsBackfillBatchWrite's constructor, then advances the table with
    * an overwrite before the backfill driver commit. The stale commit must fail (OCC).

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
@@ -388,6 +388,52 @@ public abstract class BaseUpdateColumnsBackfillTest {
     }
   }
 
+  /** Verifies update-columns backfill preserves existing Arrow timestamp timezones. */
+  @Test
+  public void testUpdateTimestampColumnPreservesExistingTimezone(TestInfo testInfo)
+      throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+    TestUtils.writeNonUtcTimestampDataset(datasetUri, "Asia/Shanghai");
+
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+    StructType existingSchema =
+        LanceArrowUtils.fromArrowSchema(TestUtils.nonUtcTimestampSchema("Asia/Shanghai"));
+    StructType updateSchema =
+        new StructType()
+            .add(LanceConstant.ROW_ADDRESS, DataTypes.LongType, false)
+            .add(LanceConstant.FRAGMENT_ID, DataTypes.IntegerType, false)
+            .add(existingSchema.apply("created_time"));
+
+    UpdateColumnsBackfillBatchWrite updateWrite =
+        new UpdateColumnsBackfillBatchWrite(
+            updateSchema,
+            writeOptions,
+            Collections.singletonList("created_time"),
+            null,
+            null,
+            null,
+            null);
+
+    DataWriterFactory factory = updateWrite.createBatchWriterFactory(() -> 1);
+    WriterCommitMessage updateMsg;
+    try (DataWriter<InternalRow> writer = factory.createWriter(0, 0)) {
+      for (int i = 0; i < 5; i++) {
+        writer.write(
+            new GenericInternalRow(new Object[] {(long) i, 0, 1_800_000_000_000_000L + i}));
+      }
+      updateMsg = writer.commit();
+    }
+    updateWrite.commit(new WriterCommitMessage[] {updateMsg});
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        org.lance.Dataset dataset = org.lance.Dataset.open(datasetUri, allocator)) {
+      ArrowType.Timestamp timestampType =
+          (ArrowType.Timestamp) dataset.getSchema().findField("created_time").getType();
+      Assertions.assertEquals("Asia/Shanghai", timestampType.getTimezone());
+    }
+  }
+
   /**
    * Pins a read version in UpdateColumnsBackfillBatchWrite's constructor, then advances the table
    * with an overwrite before the update driver commit. The stale commit must fail (OCC).

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -134,6 +134,36 @@ public class LanceBatchWriteTest {
     }
   }
 
+  @Test
+  public void testOverwritePreservesExistingTimestampTimezone(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+    TestUtils.writeNonUtcTimestampDataset(datasetUri, "Asia/Shanghai");
+
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+    Schema schema = TestUtils.nonUtcTimestampSchema("Asia/Shanghai");
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+    LanceBatchWrite overwriteWrite =
+        new LanceBatchWrite(sparkSchema, writeOptions, true, null, null, null, null, false, null);
+
+    DataWriterFactory factory = overwriteWrite.createBatchWriterFactory(() -> 1);
+    WriterCommitMessage message;
+    try (DataWriter<InternalRow> writer = factory.createWriter(0, 0)) {
+      for (int i = 0; i < 5; i++) {
+        writer.write(new GenericInternalRow(new Object[] {i, 1_900_000_000_000_000L + i}));
+      }
+      message = writer.commit();
+    }
+    overwriteWrite.commit(new WriterCommitMessage[] {message});
+
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        Dataset dataset = Dataset.open(datasetUri, allocator)) {
+      ArrowType.Timestamp timestampType =
+          (ArrowType.Timestamp) dataset.getSchema().findField("created_time").getType();
+      assertEquals("Asia/Shanghai", timestampType.getTimezone());
+    }
+  }
+
   private static WriterCommitMessage writeRows(
       LanceBatchWrite batchWrite, StructType sparkSchema, int numRows, int startValue)
       throws Exception {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
@@ -24,6 +24,8 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
@@ -75,6 +77,29 @@ public class StagedCommitTest {
     commit.commit();
     try (Dataset reopened = Dataset.open(datasetUri, LanceRuntime.allocator())) {
       assertEquals(0, reopened.countRows());
+    }
+  }
+
+  @Test
+  public void testCommitExistingTablePreservesTimestampTimezone(TestInfo testInfo)
+      throws Exception {
+    String datasetUri =
+        TestUtils.getDatasetUri(tempDir.toString(), testInfo.getTestMethod().get().getName());
+    TestUtils.writeNonUtcTimestampDataset(datasetUri, "Asia/Shanghai");
+    StructType sparkSchema =
+        LanceArrowUtils.fromArrowSchema(TestUtils.nonUtcTimestampSchema("Asia/Shanghai"));
+    Schema stagedSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", true);
+
+    Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator());
+    StagedCommit commit =
+        StagedCommit.forExistingTable(
+            dataset, stagedSchema, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+    commit.commit();
+
+    try (Dataset reopened = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+      ArrowType.Timestamp timestampType =
+          (ArrowType.Timestamp) reopened.getSchema().findField("created_time").getType();
+      assertEquals("Asia/Shanghai", timestampType.getTimezone());
     }
   }
 


### PR DESCRIPTION
## Summary

This PR preserves Arrow timestamp timezones when schemas roundtrip through Spark metadata.

Before this change, an Arrow schema like `timestamp[us, Asia/Shanghai]` could lose its original timezone after:

- Arrow schema -> Spark `StructType`
- Spark `StructType` -> Arrow schema

In write paths that rebuild Arrow schema with a caller-provided timezone (for example `"UTC"`), this could change an existing field from `timestamp:us:Asia/Shanghai` to `timestamp:us:UTC` and fail schema validation during commit.

## Root cause

`LanceArrowUtils.fromArrowSchema` converted timezone-aware Arrow timestamps into Spark `TimestampType`, but did not preserve the original Arrow timezone anywhere.

Later, `LanceArrowUtils.toArrowSchema` rebuilt Arrow timestamps from Spark types using the provided `timeZoneId`, which could overwrite the original logical type.

## What this PR changes

- store the original Arrow timestamp timezone in Spark field metadata during `fromArrowSchema`
- restore that timezone during `toArrowSchema` when the metadata is present
- avoid writing this internal metadata key back into Arrow field metadata

## Regression coverage

This PR adds regression coverage for:

- Arrow schema roundtrip through Spark metadata
- `ADD COLUMNS` backfill
- `UPDATE COLUMNS` backfill
- overwrite write path
- staged commit for an existing table

## Compatibility

This change is backward compatible:

- it only affects Arrow timestamps that already carry a timezone
- existing Spark-originated schemas without this metadata keep their previous behavior
- timestamp types without a timezone are unchanged

## Testing

Verified locally:

- `./mvnw -pl lance-spark-base_2.12 -Dtest=LanceArrowUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`

Added native-backed regression tests for add/update backfill, overwrite, and staged commit flows as part of this PR.

Note: I could not fully execute the native-backed write-path tests on my local machine because the available local JNI/JDK setup was architecture-mismatched (`darwin-aarch64` native library vs `x86_64` JDK). The tests are included so they can run in CI / a matching environment.