### PR TITLE
chore: upgrade to lance-namespace v0.8.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     <properties>
         <lance-spark.version>0.6.0</lance-spark.version>
         <lance.version>8.0.0</lance.version>
-        <lance-namespace.version>0.7.5</lance-namespace.version>
-        <lance-namespace-impl.version>0.3.0</lance-namespace-impl.version>
+        <lance-namespace.version>0.8.6</lance-namespace.version>
+        <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>
         <arrow15.version>15.0.2</arrow15.version>


### PR DESCRIPTION
# Changes

- Bumps lance-namespace version to 0.8.6 to match [pylance](https://github.com/lance-format/lance/blob/main/python/pyproject.toml#L4) requirements for lance core v8.0.0
- Bumps glue IT client impl version to 0.4.0