### PR TITLE
fix: forward user table properties to declareTable requests

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -624,7 +624,12 @@ public abstract class BaseLanceNamespaceSparkCatalog
     String fileFormatVersion = spec.fileFormatVersion();
 
     // Create dataset using namespace - WriteDatasetBuilder handles declareTable internally
-    // and properly leverages namespace client for credential vending
+    // and properly leverages namespace client for credential vending.
+    // TODO: WriteDatasetBuilder (lance-core) builds the internal DeclareTableRequest without table
+    // properties, so user properties (e.g. governance hints like access.group) are dropped on this
+    // no-location create path. The LOCATION/register/stage paths forward them via
+    // setDeclareTableProperties(...); this path needs WriteDatasetBuilder to accept and forward
+    // table properties to its declareTable call before it can do the same.
     String location;
     WriteDatasetBuilder writeBuilder =
         Dataset.write()
@@ -711,6 +716,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     DeclareTableRequest declareRequest = new DeclareTableRequest();
     tableIdList.forEach(declareRequest::addIdItem);
     declareRequest.setLocation(userLocation);
+    setDeclareTableProperties(declareRequest, properties);
     DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
     String location = declareResponse.getLocation();
     Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
@@ -1089,6 +1095,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
     if (userLocation != null && !userLocation.trim().isEmpty()) {
       declareRequest.setLocation(userLocation);
     }
+    setDeclareTableProperties(declareRequest, properties);
     DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
     String location = declareResponse.getLocation();
     Map<String, String> initialStorageOptions = declareResponse.getStorageOptions();
@@ -1295,6 +1302,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       if (userLocation != null && !userLocation.trim().isEmpty()) {
         declareRequest.setLocation(userLocation);
       }
+      setDeclareTableProperties(declareRequest, properties);
       DeclareTableResponse declareResponse = namespace.declareTable(declareRequest);
       location = declareResponse.getLocation();
       initialStorageOptions = declareResponse.getStorageOptions();
@@ -1562,6 +1570,20 @@ public abstract class BaseLanceNamespaceSparkCatalog
       }
     }
     return userProperties.isEmpty() ? Collections.emptyMap() : userProperties;
+  }
+
+  /**
+   * Forwards the user-supplied table properties (minus Spark-reserved keys) onto a {@link
+   * DeclareTableRequest} so the namespace server sees them at declare time. Without this, table
+   * properties such as governance hints are dropped and never reach the catalog's declareTable
+   * handler.
+   */
+  private static void setDeclareTableProperties(
+      DeclareTableRequest declareRequest, Map<String, String> properties) {
+    Map<String, String> userProperties = copyUserTableProperties(properties);
+    if (!userProperties.isEmpty()) {
+      declareRequest.setProperties(userProperties);
+    }
   }
 
   private static Map<String, String> tablePropertiesToPersistOnCreate(

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -628,9 +628,10 @@ public abstract class BaseLanceNamespaceSparkCatalog
     // properties so governance hints (e.g. access.group) reach the namespace declareTable call on
     // this no-location create path, mirroring the LOCATION/register/stage paths.
     //
-    // TODO: WriteDatasetBuilder.tableProperties(...) is added by lance-core
-    //   (https://github.com/lance-format/lance/pull/7711). This call does not compile until the
-    //   lance dependency (lance.version in pom.xml) is bumped to a release that includes it.
+    // TODO: WriteDatasetBuilder.properties(...) is added by lance-core
+    //   (https://github.com/lance-format/lance/pull/7711, renamed in #7715). This call does not
+    //   compile until the lance dependency (lance.version in pom.xml) is bumped to a release that
+    //   includes it.
     String location;
     WriteDatasetBuilder writeBuilder =
         Dataset.write()
@@ -640,7 +641,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
             .mode(WriteParams.WriteMode.CREATE)
             .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
-            .tableProperties(copyUserTableProperties(properties))
+            .properties(copyUserTableProperties(properties))
             .storageOptions(catalogConfig.getStorageOptions());
     if (fileFormatVersion != null) {
       writeBuilder.dataStorageVersion(fileFormatVersion);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -624,12 +624,13 @@ public abstract class BaseLanceNamespaceSparkCatalog
     String fileFormatVersion = spec.fileFormatVersion();
 
     // Create dataset using namespace - WriteDatasetBuilder handles declareTable internally
-    // and properly leverages namespace client for credential vending.
-    // TODO: WriteDatasetBuilder (lance-core) builds the internal DeclareTableRequest without table
-    // properties, so user properties (e.g. governance hints like access.group) are dropped on this
-    // no-location create path. The LOCATION/register/stage paths forward them via
-    // setDeclareTableProperties(...); this path needs WriteDatasetBuilder to accept and forward
-    // table properties to its declareTable call before it can do the same.
+    // and properly leverages namespace client for credential vending. Forward the user table
+    // properties so governance hints (e.g. access.group) reach the namespace declareTable call on
+    // this no-location create path, mirroring the LOCATION/register/stage paths.
+    //
+    // TODO: WriteDatasetBuilder.tableProperties(...) is added by lance-core
+    //   (https://github.com/lance-format/lance/pull/7711). This call does not compile until the
+    //   lance dependency (lance.version in pom.xml) is bumped to a release that includes it.
     String location;
     WriteDatasetBuilder writeBuilder =
         Dataset.write()
@@ -639,6 +640,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
             .schema(LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true))
             .mode(WriteParams.WriteMode.CREATE)
             .enableStableRowIds(catalogConfig.isEnableStableRowIds(properties))
+            .tableProperties(copyUserTableProperties(properties))
             .storageOptions(catalogConfig.getStorageOptions());
     if (fileFormatVersion != null) {
       writeBuilder.dataStorageVersion(fileFormatVersion);


### PR DESCRIPTION
## What

The Spark namespace catalog dropped user-supplied table properties (`TBLPROPERTIES` / `CREATE TABLE ... TBLPROPERTIES (...)`) on `declareTable`: requests were built without `setProperties(...)`, so properties such as governance hints (e.g. `access.group`) never reached the namespace server (it saw `properties: {}`).

## Fix

Forward user properties (minus Spark-reserved keys, via the existing `copyUserTableProperties` filter) on **all** create paths:

- `createTableAtLocation`, `stageCreate`, `stageCreateOrReplace` — the catalog builds the `DeclareTableRequest` itself; added `setDeclareTableProperties(...)`.
- **No-location create path** — declare happens inside lance-core's `WriteDatasetBuilder`; now forwarded via `WriteDatasetBuilder.tableProperties(...)`.

## ⚠️ Draft — depends on lance-core

The no-location path uses `WriteDatasetBuilder.tableProperties(Map)`, added by **lance-format/lance#7711**. This branch **will not compile until the lance dependency (`lance.version` in `pom.xml`, currently `8.0.0`) is bumped** to a release that includes #7711. Keeping this in **draft** until then; the TODO at the call site tracks it.

Once #7711 is released and the version is bumped, this is ready to un-draft.

## Related

- lance-core: lance-format/lance#7711 (adds `WriteDatasetBuilder.tableProperties`)
- lance-spark bug: #78

## How verified

The direct-declare paths were verified against a REST namespace server behind a request-capturing proxy (before: `properties: {}`; after: the property reaches the declare handler). The no-location path is verified by the same mechanism once the lance dep bump lands.
