### PR TITLE
fix: fix List child field name inconsistent between pylance and lance-spark

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/ListChildUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/ListChildUtils.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.spark.sql.types.Metadata;
+
+/** Utility methods for preserving Arrow List child field names via Spark metadata. */
+public class ListChildUtils {
+
+  public static final String LANCE_LIST_CHILD_NAME_METADATA_KEY = "_lance.list.child.name";
+  public static final String LIST_CHILD_NAME_DEFAULT = "item";
+
+  /** Returns the persisted Arrow List child name, or the default if metadata is absent. */
+  public static String listChildName(Metadata metadata) {
+    if (metadata == null || !metadata.contains(LANCE_LIST_CHILD_NAME_METADATA_KEY)) {
+      return LIST_CHILD_NAME_DEFAULT;
+    }
+    return metadata.getString(LANCE_LIST_CHILD_NAME_METADATA_KEY);
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -260,7 +260,16 @@ object LanceArrowUtils {
         val children = field.getChildren
         if (!children.isEmpty) {
           val childField = children.get(0)
-          builder.putString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY, childField.getName)
+          // Arrow permits unnamed List children; a null here would survive into the Metadata map
+          // and only blow up later when it is serialized to JSON.
+          val childName =
+            Option(childField.getName).getOrElse(ListChildUtils.LIST_CHILD_NAME_DEFAULT)
+          // Only record a non-default name. Writeback resolves an absent key to the same default,
+          // so stamping it would add nothing while putting an internal key on the Spark schema of
+          // every array column, breaking equality against an equivalent plain Spark schema.
+          if (childName != ListChildUtils.LIST_CHILD_NAME_DEFAULT) {
+            builder.putString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY, childName)
+          }
           if (!Float16Utils.isFloat16ArrowField(field)) {
             // For Float16 vectors, the child's HALF type is encoded in `arrow.float16` on the
             // parent, so there is no extra child-side metadata worth embedding.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
-import org.lance.spark.utils.{BlobUtils, DateMilliUtils, FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, VectorUtils}
+import org.lance.spark.utils.{BlobUtils, DateMilliUtils, FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, ListChildUtils, VectorUtils}
 
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
@@ -70,7 +70,8 @@ object LanceArrowUtils {
   private val LANCE_INTERNAL_METADATA_KEYS = Set(
     LANCE_ELEMENT_METADATA_KEY,
     LANCE_MAP_KEY_METADATA_KEY,
-    LANCE_MAP_VALUE_METADATA_KEY)
+    LANCE_MAP_VALUE_METADATA_KEY,
+    ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY)
 
   def fromArrowField(field: Field): DataType = {
     val baseType = convertArrowFieldType(field)
@@ -257,12 +258,16 @@ object LanceArrowUtils {
     field.getType match {
       case _: ArrowType.FixedSizeList | _: ArrowType.List =>
         val children = field.getChildren
-        if (!children.isEmpty && !Float16Utils.isFloat16ArrowField(field)) {
-          // For Float16 vectors, the child's HALF type is encoded in `arrow.float16` on the
-          // parent, so there is no extra child-side metadata worth embedding.
-          val childMeta = buildFieldMetadata(children.get(0))
-          if (hasContent(childMeta)) {
-            builder.putString(LANCE_ELEMENT_METADATA_KEY, childMeta.json)
+        if (!children.isEmpty) {
+          val childField = children.get(0)
+          builder.putString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY, childField.getName)
+          if (!Float16Utils.isFloat16ArrowField(field)) {
+            // For Float16 vectors, the child's HALF type is encoded in `arrow.float16` on the
+            // parent, so there is no extra child-side metadata worth embedding.
+            val childMeta = buildFieldMetadata(childField)
+            if (hasContent(childMeta)) {
+              builder.putString(LANCE_ELEMENT_METADATA_KEY, childMeta.json)
+            }
           }
         }
       case _: ArrowType.Map =>
@@ -351,6 +356,7 @@ object LanceArrowUtils {
     dt match {
       case ArrayType(elementType, containsNull) =>
         val elementMetadata = parseEmbeddedMetadata(metadata, LANCE_ELEMENT_METADATA_KEY)
+        val elementName = ListChildUtils.listChildName(metadata)
         if (shouldBeFixedSizeList(metadata, elementType)) {
           val listSize = metadata.getLong(ARROW_FIXED_SIZE_LIST_SIZE_KEY).toInt
           val fieldType =
@@ -364,7 +370,7 @@ object LanceArrowUtils {
                   "Current Arrow version does not support Float2Vector.")
             }
             new Field(
-              "element",
+              elementName,
               new FieldType(
                 containsNull,
                 new ArrowType.FloatingPoint(FloatingPointPrecision.HALF),
@@ -372,7 +378,7 @@ object LanceArrowUtils {
               Seq.empty[Field].asJava)
           } else {
             toArrowField(
-              "element",
+              elementName,
               elementType,
               containsNull,
               timeZoneId,
@@ -390,7 +396,7 @@ object LanceArrowUtils {
             fieldType,
             Seq(
               toArrowField(
-                "element",
+                elementName,
                 elementType,
                 containsNull,
                 timeZoneId,

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -526,6 +526,55 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     assert(arrowSchema.findField("tags").getChildren.get(0).getName === "legacy_element")
   }
 
+  test("nested Array<Array<String>> preserves inner list child name from metadata") {
+    val innerMetadata = new MetadataBuilder()
+      .putString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY, "legacy_inner")
+      .build()
+    val outerMetadata = new MetadataBuilder()
+      .putString(
+        LanceArrowUtils.LANCE_ELEMENT_METADATA_KEY,
+        innerMetadata.json)
+      .build()
+    val sparkSchema = new StructType()
+      .add(
+        "nested_tags",
+        ArrayType(ArrayType(StringType, containsNull = true), containsNull = true),
+        nullable = true,
+        outerMetadata)
+
+    val arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val outerChild = arrowSchema.findField("nested_tags").getChildren.get(0)
+    val innerChild = outerChild.getChildren.get(0)
+
+    assert(outerChild.getName === ListChildUtils.LIST_CHILD_NAME_DEFAULT)
+    assert(innerChild.getName === "legacy_inner")
+    assert(innerChild.getType === ArrowType.Utf8.INSTANCE)
+  }
+
+  test("nested Array<Array<String>> roundtrips from Arrow schema preserving child names") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "nested_tags",
+      listField("legacy_inner_list", primitiveField("legacy_inner_element", ArrowType.Utf8.INSTANCE)))))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val outerMetadata = sparkSchema("nested_tags").metadata
+    val innerMetadata = org.apache.spark.sql.types.Metadata.fromJson(
+      outerMetadata.getString(LanceArrowUtils.LANCE_ELEMENT_METADATA_KEY))
+    assert(
+      outerMetadata.getString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY) ===
+        "legacy_inner_list")
+    assert(
+      innerMetadata.getString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY) ===
+        "legacy_inner_element")
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val outerChild = arrowBack.findField("nested_tags").getChildren.get(0)
+    val innerChild = outerChild.getChildren.get(0)
+    assert(outerChild.getName === "legacy_inner_list")
+    assert(innerChild.getName === "legacy_inner_element")
+    assert(innerChild.getType === ArrowType.Utf8.INSTANCE)
+  }
+
   test("FixedSizeList(Float16) nested inside an Array preserves size + float16 markers") {
     val float16Element = primitiveField(
       "element",

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -508,6 +508,53 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
         "legacy_element")
   }
 
+  test("default list child name is not recorded in Spark metadata") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "tags",
+      primitiveField(ListChildUtils.LIST_CHILD_NAME_DEFAULT, ArrowType.Utf8.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    // A default-named child must leave no internal key behind, so the result stays equal to the
+    // equivalent plain Spark schema rather than only equal in dataType.
+    assert(sparkSchema("tags").metadata.json === "{}")
+    assert(sparkSchema === new StructType().add("tags", ArrayType(StringType, containsNull = true)))
+  }
+
+  test("unnamed Arrow list child falls back to the default name") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "tags",
+      primitiveField(null, ArrowType.Utf8.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    // Reading `json` is what would surface a null smuggled into the Metadata map.
+    assert(sparkSchema("tags").metadata.json === "{}")
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    assert(
+      arrowBack.findField("tags").getChildren.get(0).getName ===
+        ListChildUtils.LIST_CHILD_NAME_DEFAULT)
+  }
+
+  test("unnamed Arrow list child inside a nested list falls back to the default name") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "nested_tags",
+      listField("legacy_inner_list", primitiveField(null, ArrowType.Utf8.INSTANCE)))))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    val outerMetadata = sparkSchema("nested_tags").metadata
+    // The outer list keeps its non-default child name. The unnamed innermost child defaults to
+    // `item`, so the inner list contributes nothing and `_lance.element` is omitted entirely.
+    assert(
+      outerMetadata.getString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY) ===
+        "legacy_inner_list")
+    assert(!outerMetadata.contains(LanceArrowUtils.LANCE_ELEMENT_METADATA_KEY))
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val outerChild = arrowBack.findField("nested_tags").getChildren.get(0)
+    val innerChild = outerChild.getChildren.get(0)
+    assert(outerChild.getName === "legacy_inner_list")
+    assert(innerChild.getName === ListChildUtils.LIST_CHILD_NAME_DEFAULT)
+    assert(innerChild.getType === ArrowType.Utf8.INSTANCE)
+  }
+
   test("Spark ArrayType writes list child name as item by default") {
     val sparkSchema = new StructType().add("tags", ArrayType(StringType, containsNull = true))
     val arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -554,7 +554,9 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
   test("nested Array<Array<String>> roundtrips from Arrow schema preserving child names") {
     val arrow = new Schema(java.util.Arrays.asList(listField(
       "nested_tags",
-      listField("legacy_inner_list", primitiveField("legacy_inner_element", ArrowType.Utf8.INSTANCE)))))
+      listField(
+        "legacy_inner_list",
+        primitiveField("legacy_inner_element", ArrowType.Utf8.INSTANCE)))))
 
     val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
     val outerMetadata = sparkSchema("nested_tags").metadata

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -29,7 +29,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.SparkUnsupportedOperationException
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
-import org.lance.spark.utils.{FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, VectorUtils}
+import org.lance.spark.utils.{FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, ListChildUtils, VectorUtils}
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.ZoneId
@@ -495,6 +495,35 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     assert(
       innermost.getType === new ArrowType.Date(DateUnit.MILLISECOND),
       s"Innermost element should remain Date(MILLISECOND), got ${innermost.getType}")
+  }
+
+  test("list child name is preserved in Spark metadata on read") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "tags",
+      primitiveField("legacy_element", ArrowType.Utf8.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    assert(sparkSchema("tags").metadata.contains(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY))
+    assert(
+      sparkSchema("tags").metadata.getString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY) ===
+        "legacy_element")
+  }
+
+  test("Spark ArrayType writes list child name as item by default") {
+    val sparkSchema = new StructType().add("tags", ArrayType(StringType, containsNull = true))
+    val arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    assert(
+      arrowSchema.findField("tags").getChildren.get(0).getName ===
+        ListChildUtils.LIST_CHILD_NAME_DEFAULT)
+  }
+
+  test("list child name stored in metadata is used on writeback") {
+    val metadata = new MetadataBuilder()
+      .putString(ListChildUtils.LANCE_LIST_CHILD_NAME_METADATA_KEY, "legacy_element")
+      .build()
+    val sparkSchema = new StructType()
+      .add("tags", ArrayType(StringType, containsNull = true), nullable = true, metadata)
+    val arrowSchema = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    assert(arrowSchema.findField("tags").getChildren.get(0).getName === "legacy_element")
   }
 
   test("FixedSizeList(Float16) nested inside an Array preserves size + float16 markers") {


### PR DESCRIPTION
Close https://github.com/lance-format/lance-spark/issues/687

## Why

This PR fixes schema drift caused by inconsistent `List` child field names between PyLance and lance-spark. In the reported case, PyLance used `item` while lance-spark rewrote the same list field with `element`, which could change the schema after an Arrow ↔ Spark roundtrip and break compatibility for existing datasets<cite-inline data-index="1" data-url="https://github.com/lance-format/lance-spark/pull/697" data-title="fix: fix List child field name inconsistent between pylance and lance-spark by fangbo · Pull Request #697 · lance-format/lance-spark · GitHub"></cite-inline>.

## How

This change preserves the original Arrow list child field name in Spark metadata and restores it when converting back to Arrow. It introduces `ListChildUtils`, stores the list child name under `_lance.list.child.name`, uses that metadata during writeback, and falls back to `item` when no metadata is present<cite-inline data-index="1" data-url="https://github.com/lance-format/lance-spark/pull/697" data-title="fix: fix List child field name inconsistent between pylance and lance-spark by fangbo · Pull Request #697 · lance-format/lance-spark · GitHub"></cite-inline>.

## Tests

The test coverage includes:
- preserving list child names when reading Arrow schema into Spark
- defaulting Spark `ArrayType` writes to `item` when no metadata exists
- writing back the stored child field name from metadata
- preserving nested `Array<Array<String>>` child names
- roundtripping nested list schemas without losing inner child field names