### PR TITLE
feat: build FTS indexes as independent segments

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -32,6 +32,7 @@ The following index methods are supported:
 | `bloomfilter` | Bloom filter index for approximate membership pruning.                        |
 | `rtree`       | R-tree index for GeoArrow geometry columns.                                   |
 | `fts`         | Full-text search (inverted) index for text search on string columns.          |
+| `inverted`    | Alias for `fts`; creates the same full-text inverted index.                   |
 
 ## Options
 
@@ -47,8 +48,8 @@ These options apply to all index methods:
 
 ### Distributed Index Options
 
-The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and
-`rtree` supports:
+The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`,
+and `fts` (or `inverted`) supports:
 
 | Option         | Type    | Description                                                                                                                                                                                                 |
 |----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -73,9 +74,9 @@ For the `btree` method, the following options are supported:
 | `rows_per_range` | Long   | The number of rows per range when built using range mode. Default is 1000000.                                                                                                                            |
 
 
-### FTS Options
+### FTS / Inverted Options
 
-For the `fts` method, the following options are required:
+For the `fts` method (or its `inverted` alias), the following options are required:
 
 | Option             | Type    | Description                                                    |
 |--------------------|---------|----------------------------------------------------------------|
@@ -104,7 +105,7 @@ Lance FTS index format v2 is selected by the Lance runtime environment variable 
         ...
     ```
 
-Spark SQL currently does not expose a per-index `fts_version` option. Use `USING fts` with the normal FTS options shown above; Spark records the index details and version returned by Lance.
+Spark SQL currently does not expose a per-index `fts_version` option. Use `USING fts` (or `USING inverted`) with the normal FTS options shown above; Spark records the index details and version returned by Lance.
 
 ## Examples
 
@@ -234,7 +235,8 @@ Create an FTS index on a text column:
         stem = false,
         remove_stop_words = false,
         ascii_folding = false,
-        with_position = true
+        with_position = true,
+        num_segments = 8
     );
     ```
 
@@ -298,13 +300,13 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and `rtree` split source fragments into batches and build them in parallel. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data. FTS uses its existing fragment-parallel metadata flow.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`, and `fts` split source fragments into batches and build them in parallel. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
 ## Notes and Limitations
 
-- **Index Methods**: The `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`, `btree`, and `fts` methods are supported for index creation.
-- **Indexed Column Count**: `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and `rtree` currently support exactly one indexed column.
+- **Index Methods**: The `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`, `btree`, and `fts` (or `inverted`) methods are supported for index creation.
+- **Indexed Column Count**: `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`, and `fts` (or `inverted`) currently support exactly one indexed column.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one.
 - **Deferred Training**: With `train = false` the index is registered empty and is populated later, either by re-running `CREATE INDEX` (a full distributed build that replaces the empty index) or, for incremental coverage of newly appended fragments, by `Dataset.optimizeIndices` in the SDK. The SQL `OPTIMIZE` command compacts fragments and does not train deferred indexes.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -36,8 +36,7 @@ import org.lance.spark.arrow.LanceArrowWriter
 import org.lance.spark.utils.{CloseableUtil, FieldPathUtils, Utils}
 import org.lance.spark.write.SingleBatchArrowReader
 
-import java.time.Instant
-import java.util.{Collections, Locale, Optional, UUID}
+import java.util.{Collections, Locale, UUID}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -51,10 +50,9 @@ import scala.reflect.ClassTag
  *   partitions, creates indexes for each range in parallel, and merges them into a global
  *   index structure. Supports {@code build_mode='range'} (default) and
  *   {@code build_mode='fragment'}.
- * <li><b>FTS / INVERTED</b>: processes each fragment independently in parallel, merges index
- *   metadata, and commits an index-creation transaction.
- * <li><b>ZONEMAP / BITMAP / LABEL_LIST / NGRAM / BLOOMFILTER / RTREE</b>: build uncommitted
- *   index segments in parallel across fragment batches and commit the logical index on the driver.
+ * <li><b>ZONEMAP / BITMAP / LABEL_LIST / NGRAM / BLOOMFILTER / RTREE / FTS / INVERTED</b>:
+ *   build uncommitted index segments in parallel across fragment batches and commit the logical
+ *   index on the driver.
  * </ul>
  *
  * <p><b>Deferred training ({@code WITH (train=false)})</b>: commits an empty index on the driver
@@ -216,78 +214,7 @@ case class AddIndexExec(
         UTF8String.fromString(indexName))))
     }
 
-    // FTS/INVERTED still uses a caller-assigned UUID: each fragment writes
-    // partial metadata under that UUID and the driver merges them into a single
-    // index root before committing the resulting index transaction.
-    val uuid = UUID.randomUUID()
-    val dataset = Utils.openDatasetBuilder(readOptions).build()
-
-    // The finally closes the dataset on every exit path. If the index-build job or the commit
-    // below fails, partial index files written under this uuid (per-fragment partials and any
-    // merged root) stay uncommitted: unreferenced by the manifest, so invisible to readers, and
-    // eventually reclaimable by VACUUM with delete_unverified = true.
-    try {
-      val indexBuildResult =
-        new FragmentBasedIndexJob(
-          this.copy(columns = canonicalColumns),
-          readOptions,
-          uuid.toString,
-          fragmentIds,
-          nsImpl,
-          nsProps,
-          tableId,
-          initialStorageOpts).run()
-
-      // Merge index metadata after all fragments are indexed
-      dataset.mergeIndexMetadata(uuid.toString, indexType, Optional.empty())
-
-      val fieldIds = canonicalColumns.map { column =>
-        FieldPathUtils.resolveLeafField(dataset.getLanceSchema, column).getId
-      }.toList
-
-      val datasetVersion = dataset.version()
-
-      val indexBuilder = Index
-        .builder()
-        .uuid(uuid)
-        .name(indexName)
-        .fields(fieldIds.map(java.lang.Integer.valueOf).asJava)
-        .datasetVersion(datasetVersion)
-        .indexDetails(indexBuildResult.indexDetails)
-        .indexVersion(indexBuildResult.indexVersion)
-        .indexType(indexBuildResult.indexType)
-        .fragments(fragmentIds.asJava)
-      indexBuildResult.createdAt.foreach(indexBuilder.createdAt)
-      val index = indexBuilder.build()
-
-      // Find existing indices with the same name to mark as removed (for replace)
-      val removedIndices = dataset.getIndexes.asScala
-        .filter(_.name() == indexName)
-        .toList.asJava
-
-      val op = AddIndexOperation.builder()
-        .withNewIndices(Collections.singletonList(index))
-        .withRemovedIndices(removedIndices)
-        .build()
-      val txn = new Transaction.Builder()
-        .readVersion(dataset.version())
-        .operation(op)
-        .build()
-      try {
-        val newDataset = new CommitBuilder(dataset)
-          .writeParams(readOptions.getStorageOptions)
-          .execute(txn)
-        newDataset.close()
-      } finally {
-        txn.close()
-      }
-    } finally {
-      dataset.close()
-    }
-
-    Seq(new GenericInternalRow(Array[Any](
-      fragmentIds.size.toLong,
-      UTF8String.fromString(indexName))))
+    throw new UnsupportedOperationException(s"Unsupported index type: $indexType")
   }
 
   /** Commits an empty (untrained) index on the driver, with an empty fragment bitmap. */
@@ -353,145 +280,6 @@ case class AddIndexExec(
     }
   }
 
-}
-
-/**
- * Interface for index job to implement different indexing strategies.
- */
-trait IndexJob extends Serializable {
-
-  /** @return index metadata returned by workers. */
-  def run(): IndexBuildResult
-}
-
-case class IndexBuildResult(
-    indexDetails: Array[Byte],
-    indexVersion: Int,
-    createdAt: Option[Instant],
-    indexType: IndexType) extends Serializable
-
-/**
- * A job implementation for creating indexes on fragments of a dataset in parallel.
- * Each fragment is processed independently to build its local index, which will later be
- * merged into a global index structure.
- *
- * @param addIndexExec         The AddIndexExec instance that initiated this job
- * @param readOptions          Configuration options for reading the Lance dataset
- * @param uuid                 Unique identifier for this index operation
- * @param fragmentIds          List of fragment IDs to process
- * @param nsImpl               Optional namespace implementation class for credential vending
- * @param nsProps              Optional namespace properties for credential vending
- * @param tableId              Optional table identifier for credential vending
- * @param initialStorageOpts   Optional initial storage options for the dataset
- */
-class FragmentBasedIndexJob(
-    addIndexExec: AddIndexExec,
-    readOptions: LanceSparkReadOptions,
-    uuid: String,
-    fragmentIds: List[Integer],
-    nsImpl: Option[String],
-    nsProps: Option[Map[String, String]],
-    tableId: Option[List[String]],
-    initialStorageOpts: Option[Map[String, String]]) extends IndexJob {
-
-  override def run(): IndexBuildResult = {
-    val encodedReadOptions = encode(readOptions)
-    val columns = addIndexExec.columns.toList
-    val argsJson = IndexUtils.toJson(addIndexExec.args)
-
-    // Build per-fragment tasks
-    val tasks = fragmentIds.zipWithIndex.map { case (fid, pos) =>
-      FragmentIndexTask(
-        encodedReadOptions,
-        columns,
-        addIndexExec.method,
-        argsJson,
-        addIndexExec.indexName,
-        uuid,
-        fid,
-        nsImpl,
-        nsProps,
-        tableId,
-        initialStorageOpts,
-        returnBuildResult = pos == 0)
-    }.toSeq
-
-    val results = addIndexExec.session.sparkContext
-      .parallelize(tasks, tasks.size)
-      .map(t => t.execute())
-      .collect()
-
-    IndexUtils.collectIndexBuildResult(results, IndexUtils.buildIndexType(addIndexExec.method))
-  }
-}
-
-/**
- * A task to create index on a single fragment of the dataset.
- * This is used in distributed index creation where each fragment is processed independently.
- *
- * @param encodedReadOptions    Configuration for Lance dataset access, serialized
- * @param columns               column names to index
- * @param method                Indexing method to use (e.g., "fts")
- * @param argsJson              JSON string containing index parameters
- * @param indexName             Name of the index being created
- * @param uuid                  Unique identifier for this index operation
- * @param fragmentId            ID of the fragment to create index on
- * @param namespaceImpl         Implementation class for namespace operations
- * @param namespaceProperties   Properties of the namespace
- * @param tableId               Identifier for the table within the namespace
- * @param initialStorageOptions Initial storage configuration options
- * @param returnBuildResult     Whether this task should return commit metadata to the driver
- */
-case class FragmentIndexTask(
-    encodedReadOptions: String,
-    columns: List[String],
-    method: String,
-    argsJson: String,
-    indexName: String,
-    uuid: String,
-    fragmentId: Int,
-    namespaceImpl: Option[String],
-    namespaceProperties: Option[Map[String, String]],
-    tableId: Option[List[String]],
-    initialStorageOptions: Option[Map[String, String]],
-    returnBuildResult: Boolean) extends Serializable {
-
-  def execute(): String = {
-    val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
-    val indexType = IndexUtils.buildIndexType(method)
-    val params = IndexParams.builder()
-      .setScalarIndexParams(ScalarIndexParams.create(
-        IndexUtils.buildScalarIndexParamType(method),
-        argsJson))
-      .build()
-
-    val indexOptions = IndexOptions
-      .builder(java.util.Arrays.asList(columns: _*), indexType, params)
-      .replace(true)
-      .withIndexName(indexName)
-      .withIndexUUID(uuid)
-      .withFragmentIds(Collections.singletonList(fragmentId))
-      .build()
-
-    val dataset = Utils.openDatasetBuilder(readOptions)
-      .initialStorageOptions(initialStorageOptions.map(_.asJava).orNull)
-      .runtimeNamespace(
-        namespaceImpl.orNull,
-        namespaceProperties.map(_.asJava).orNull,
-        tableId.map(_.asJava).orNull)
-      .build()
-
-    try {
-      val createdIndex = dataset.createIndex(indexOptions)
-      if (returnBuildResult) {
-        encode(Some(IndexUtils.extractIndexBuildResult(createdIndex)))
-      } else {
-        encode(None: Option[IndexBuildResult])
-      }
-    } finally {
-      dataset.close()
-    }
-  }
 }
 
 /**
@@ -911,7 +699,8 @@ object IndexUtils extends Logging {
     "ngram" -> IndexType.NGRAM,
     "bloomfilter" -> IndexType.BLOOM_FILTER,
     "rtree" -> IndexType.RTREE,
-    "fts" -> IndexType.INVERTED)
+    "fts" -> IndexType.INVERTED,
+    "inverted" -> IndexType.INVERTED)
 
   private val scalarSegmentIndexTypes: Set[IndexType] = Set(
     IndexType.ZONEMAP,
@@ -919,7 +708,8 @@ object IndexUtils extends Logging {
     IndexType.LABEL_LIST,
     IndexType.NGRAM,
     IndexType.BLOOM_FILTER,
-    IndexType.RTREE)
+    IndexType.RTREE,
+    IndexType.INVERTED)
 
   // ScalarIndexParams uses Lance Core's scalar plugin names, which are a separate contract from
   // both Spark SQL method names and the Java IndexType enum names. Keep the mapping explicit instead
@@ -989,43 +779,6 @@ object IndexUtils extends Logging {
             s"Unrecognized build_mode: '$unknown'. Supported values are 'fragment' and 'range'.")
       }
     }
-  }
-
-  /** Extracts the commit metadata from a newly created Index. */
-  def extractIndexBuildResult(index: Index): IndexBuildResult = {
-    val details = index.indexDetails()
-    if (!details.isPresent || details.get().isEmpty) {
-      throw new IllegalStateException(
-        s"Index ${index.name()} was created without index details")
-    }
-    val indexType = Option(index.indexType()).getOrElse {
-      throw new IllegalStateException(s"Index ${index.name()} was created without index type")
-    }
-    IndexBuildResult(
-      details.get().clone(),
-      index.indexVersion(),
-      Option(index.createdAt().orElse(null)),
-      indexType)
-  }
-
-  /** Returns the first index metadata from serialized worker results. */
-  def collectIndexBuildResult(
-      encodedResults: Array[String],
-      expectedType: IndexType): IndexBuildResult = {
-    val first = encodedResults.iterator
-      .map(encoded => decode[Option[IndexBuildResult]](encoded))
-      .collectFirst { case Some(result) => result }
-      .getOrElse(throw new IllegalStateException("No per-task index metadata was returned"))
-
-    if (first.indexType != expectedType) {
-      throw new IllegalStateException(
-        s"Expected index type $expectedType but worker returned ${first.indexType}")
-    }
-    if (first.indexDetails.isEmpty) {
-      throw new IllegalStateException("Per-task index metadata is missing index details")
-    }
-
-    first
   }
 
   // Options consumed at the Spark execution layer that must not be forwarded to the Lance

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -18,10 +18,10 @@ import org.lance.index.IndexCriteria;
 import org.lance.index.IndexDescription;
 import org.lance.index.IndexType;
 import org.lance.index.OptimizeOptions;
-import org.lance.spark.LanceSparkReadOptions;
 import org.lance.ipc.FullTextQuery;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.FieldPathUtils;
 import org.lance.spark.utils.Utils;
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -19,9 +19,13 @@ import org.lance.index.IndexDescription;
 import org.lance.index.IndexType;
 import org.lance.index.OptimizeOptions;
 import org.lance.spark.LanceSparkReadOptions;
+import org.lance.ipc.FullTextQuery;
+import org.lance.ipc.LanceScanner;
+import org.lance.ipc.ScanOptions;
 import org.lance.spark.utils.FieldPathUtils;
 import org.lance.spark.utils.Utils;
 
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -1139,6 +1143,88 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateFtsSegmentIndexSupportsTermAndPhraseQueries() throws Exception {
+    spark.sql(String.format("create table %s (id int, body string) using lance", fullTable));
+    spark.sql(
+        String.format(
+            "insert into %s values " + "(1, 'hello world'), " + "(2, 'hello lance')", fullTable));
+    spark.sql(
+        String.format(
+            "insert into %s values " + "(3, 'world hello'), " + "(4, 'other text')", fullTable));
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index body_fts_segments using fts (body) with ("
+                    + "base_tokenizer='simple', "
+                    + "language='English', "
+                    + "max_token_length=40, "
+                    + "lower_case=true, "
+                    + "stem=false, "
+                    + "remove_stop_words=false, "
+                    + "ascii_folding=false, "
+                    + "with_position=true, "
+                    + "num_segments=2"
+                    + ")",
+                fullTable));
+
+    Row output = result.collectAsList().get(0);
+    Assertions.assertEquals("body_fts_segments", output.getString(1));
+
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      int fragmentCount = dataset.getFragments().size();
+      List<Index> segments =
+          dataset.getIndexes().stream()
+              .filter(index -> "body_fts_segments".equals(index.name()))
+              .collect(Collectors.toList());
+
+      Assertions.assertEquals(
+          Math.min(2, fragmentCount),
+          segments.size(),
+          "num_segments=2 should produce two physical FTS segments when two fragments exist");
+      Assertions.assertEquals(
+          segments.size(),
+          segments.stream().map(Index::uuid).collect(Collectors.toSet()).size(),
+          "Every committed FTS segment must have a distinct UUID");
+      Assertions.assertTrue(
+          segments.stream().allMatch(index -> index.indexType() == IndexType.INVERTED),
+          "Every physical segment must be an INVERTED index");
+
+      List<Integer> coveredFragments =
+          segments.stream()
+              .flatMap(index -> index.fragments().orElse(Collections.emptyList()).stream())
+              .collect(Collectors.toList());
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments.size(),
+          "FTS segment coverage must include every fragment exactly once");
+      Assertions.assertEquals(
+          coveredFragments.size(),
+          coveredFragments.stream().collect(Collectors.toSet()).size(),
+          "FTS segment coverage must not overlap");
+
+      byte[] expectedDetails = segments.get(0).indexDetails().orElseThrow(AssertionError::new);
+      Assertions.assertTrue(
+          segments.stream()
+              .allMatch(
+                  segment ->
+                      segment.indexDetails().isPresent()
+                          && java.util.Arrays.equals(
+                              expectedDetails, segment.indexDetails().get())),
+          "All FTS segments must preserve identical tokenizer parameters");
+
+      Assertions.assertEquals(
+          3L,
+          countFtsMatches(dataset, FullTextQuery.match("hello", "body")),
+          "Term query should search across all physical segments");
+      Assertions.assertEquals(
+          1L,
+          countFtsMatches(dataset, FullTextQuery.phrase("hello world", "body")),
+          "Phrase query should use positions across the logical FTS index");
+    }
+  }
+
+  @Test
   public void testCreateFtsIndexWithStemming() {
     prepareDataset();
 
@@ -1397,6 +1483,18 @@ public abstract class BaseAddIndexTest {
     Assertions.assertTrue(index.indexVersion() > 0, "FTS index version should be positive");
     if ("2".equals(System.getenv("LANCE_FTS_FORMAT_VERSION"))) {
       Assertions.assertEquals(2, index.indexVersion());
+    }
+  }
+
+  private long countFtsMatches(org.lance.Dataset dataset, FullTextQuery query) throws Exception {
+    ScanOptions scanOptions = new ScanOptions.Builder().fullTextQuery(query).build();
+    try (LanceScanner scanner = dataset.newScan(scanOptions);
+        ArrowReader reader = scanner.scanBatches()) {
+      long count = 0L;
+      while (reader.loadNextBatch()) {
+        count += reader.getVectorSchemaRoot().getRowCount();
+      }
+      return count;
     }
   }
 

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
@@ -160,9 +160,17 @@ class IndexUtilsTest {
   }
 
   @Test
-  def buildIndexType_ftsReturnsInverted(): Unit = {
+  def buildIndexType_ftsAndInvertedReturnInverted(): Unit = {
     assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("fts"))
     assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("FTS"))
+    assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("inverted"))
+    assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("INVERTED"))
+  }
+
+  @Test
+  def buildScalarIndexParamType_ftsAndInvertedReturnInverted(): Unit = {
+    assertEquals("inverted", IndexUtils.buildScalarIndexParamType("fts"))
+    assertEquals("inverted", IndexUtils.buildScalarIndexParamType("inverted"))
   }
 
   @Test
@@ -173,7 +181,9 @@ class IndexUtilsTest {
       ("label_list", IndexType.LABEL_LIST, "labellist"),
       ("ngram", IndexType.NGRAM, "ngram"),
       ("bloomfilter", IndexType.BLOOM_FILTER, "bloomfilter"),
-      ("rtree", IndexType.RTREE, "rtree"))
+      ("rtree", IndexType.RTREE, "rtree"),
+      ("fts", IndexType.INVERTED, "inverted"),
+      ("inverted", IndexType.INVERTED, "inverted"))
 
     expected.foreach { case (method, indexType, coreParamType) =>
       Seq(method, method.toUpperCase).foreach { spelling =>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.7.1</lance-spark.version>
-        <lance.version>10.0.0</lance.version>
+        <lance.version>11.0.0-beta.3</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Background

Distributed FTS builds currently give every fragment task the same caller-provided UUID. Executors write partial indexes into that shared physical index, and the driver calls `mergeIndexMetadata` before committing it. This differs from the independent segment workflow in Lance and allows retries or speculative attempts to target the same physical index directory.

## Implementation

- Batch fragments according to `num_segments` and let each Spark task build one uncommitted FTS segment with its own Lance-generated UUID.
- Publish the task-produced segments in one driver-side `commitExistingIndexSegments` transaction, removing the FTS dependency on a shared UUID and `mergeIndexMetadata`.
- Add integration coverage for distinct segment UUIDs, complete non-overlapping fragment coverage, consistent index details, and term and phrase queries across segments.
- Document the `num_segments` option and the FTS physical segment build workflow.

## Validation

- `./mvnw test -pl lance-spark-3.5_2.13 -Dtest=AddIndexTest#testCreateIndexFailureLeavesTableUsable+testCreateFtsSegmentIndexSupportsTermAndPhraseQueries`
- `./mvnw spotless:check -pl lance-spark-3.5_2.13 -am`
