### PR TITLE
chore: update lance dependency to v9.1.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>9.1.0-beta.3</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- bump `lance-core` from `9.0.0-rc.1` to `9.1.0-beta.3`
- verify Docker pins already match the current Lance Spark (`0.6.1`) and Lance namespace implementation (`0.4.0`) versions
- triggered by [refs/tags/v9.1.0-beta.3](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.3)

## Verification

- `make lint`
- `make install` (Spark 3.5 / Scala 2.12 default)
