### PR TITLE
chore: update lance dependency to v9.1.0-beta.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>9.1.0-beta.7</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- update `lance-core` from `9.0.0-rc.1` to `9.1.0-beta.7`
- verify Docker versions remain synchronized with Maven properties (`LANCE_SPARK_VERSION=0.6.1` and `LANCE_NS_IMPL_VERSION=0.4.0`)
- verify the default Spark 3.5 / Scala 2.12 build

## Verification

- `make lint`
- `make install`

Triggered by [refs/tags/v9.1.0-beta.7](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.7).
