### PR TITLE
chore: update lance dependency to v9.1.0-beta.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>9.1.0-beta.8</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- update `lance.version` from `9.0.0-rc.1` to `9.1.0-beta.8`
- verify Docker versions remain aligned with the POM: `LANCE_SPARK_VERSION=0.6.1` and `LANCE_NS_IMPL_VERSION=0.4.0`
- link the triggering tag: [`refs/tags/v9.1.0-beta.8`](https://github.com/lance-format/lance/releases/tag/v9.1.0-beta.8)

## Verification

- `make lint`
- `make install` (Spark 3.5 / Scala 2.12 default build)
