### PR TITLE
fix: merge write-time storage options into staged commits

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -178,6 +178,14 @@ public class LanceBatchWrite implements BatchWrite {
       if (enableStableRowIds != null) {
         stagedCommit.setEnableStableRowIds(enableStableRowIds);
       }
+      // StagedCommit.storageOptions was captured at stage-create time from the catalog's static
+      // config only; it does not include write-time options or namespace-vended credentials
+      // obtained afterward (e.g. describeTable()/declareTable() results in initialStorageOptions).
+      // Merge both in now so the manifest commit below authenticates with them instead of falling
+      // back to ambient credential discovery. Same merge semantics as the non-staged branch below.
+      stagedCommit.mergeStorageOptions(
+          LanceRuntime.mergeStorageOptions(
+              writeOptions.getStorageOptions(), initialStorageOptions));
     } else {
       // For non-staged tables, commit immediately
       long version =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -178,11 +178,9 @@ public class LanceBatchWrite implements BatchWrite {
       if (enableStableRowIds != null) {
         stagedCommit.setEnableStableRowIds(enableStableRowIds);
       }
-      // StagedCommit.storageOptions was captured at stage-create time from the catalog's static
-      // config only; it does not include write-time options or namespace-vended credentials
-      // obtained afterward (e.g. describeTable()/declareTable() results in initialStorageOptions).
-      // Merge both in now so the manifest commit below authenticates with them instead of falling
-      // back to ambient credential discovery. Same merge semantics as the non-staged branch below.
+      // For a path-based staged create, StagedCommit only has the catalog's static storage
+      // options at this point. Merge in write-time and namespace-vended options now so
+      // StagedCommit.commit() uses them. Mirrors the non-staged merge below.
       stagedCommit.mergeStorageOptions(
           LanceRuntime.mergeStorageOptions(
               writeOptions.getStorageOptions(), initialStorageOptions));

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,7 +92,7 @@ public class StagedCommit {
     this.fragments = new ArrayList<>(fragments);
     this.schema = schema;
     this.datasetUri = datasetUri;
-    this.storageOptions = options.getStorageOptions();
+    this.storageOptions = new HashMap<>(options.getStorageOptions());
     this.isNewTable = datasetUri != null;
     this.enableStableRowIds = options.isEnableStableRowIds();
     this.namespace = options.getNamespace();
@@ -113,6 +114,29 @@ public class StagedCommit {
 
   public void setShardingSpec(ShardingSpec shardingSpec) {
     this.shardingSpec = shardingSpec;
+  }
+
+  /**
+   * Merges additional storage options into this staged commit's storage options.
+   *
+   * <p>{@code storageOptions} is captured once at {@code StagedCommit} construction time (from
+   * {@link StagedCommitOptions#getStorageOptions()}), before write-time options or namespace-vended
+   * credentials (e.g. from {@code declareTable()}) are necessarily known. This allows the caller to
+   * layer those in afterward, once available, so the final {@link #commit()} call authenticates
+   * with them instead of falling back to ambient credential discovery.
+   *
+   * @param extra additional storage options to merge in; a no-op when null or empty. Keys in {@code
+   *     extra} take precedence over any existing entry with the same key.
+   */
+  public void mergeStorageOptions(Map<String, String> extra) {
+    if (extra != null && !extra.isEmpty()) {
+      this.storageOptions.putAll(extra);
+    }
+  }
+
+  /** Returns the current storage options. Visible for testing. */
+  Map<String, String> getStorageOptions() {
+    return storageOptions;
   }
 
   /** Performs the actual commit using the stored dataset and fragments. */

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
@@ -117,13 +117,8 @@ public class StagedCommit {
   }
 
   /**
-   * Merges additional storage options into this staged commit's storage options.
-   *
-   * <p>{@code storageOptions} is captured once at {@code StagedCommit} construction time (from
-   * {@link StagedCommitOptions#getStorageOptions()}), before write-time options or namespace-vended
-   * credentials (e.g. from {@code declareTable()}) are necessarily known. This allows the caller to
-   * layer those in afterward, once available, so the final {@link #commit()} call authenticates
-   * with them instead of falling back to ambient credential discovery.
+   * Merges additional storage options into this staged commit's storage options, for options that
+   * were not yet known when this {@code StagedCommit} was constructed.
    *
    * @param extra additional storage options to merge in; a no-op when null or empty. Keys in {@code
    *     extra} take precedence over any existing entry with the same key.

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -15,6 +15,7 @@ package org.lance.spark.write;
 
 import org.lance.Dataset;
 import org.lance.WriteParams;
+import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.TestUtils;
 
@@ -40,6 +41,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -132,6 +135,107 @@ public class LanceBatchWriteTest {
       writerA.commit(new WriterCommitMessage[] {messageA});
       assertThrows(Exception.class, () -> writerB.commit(new WriterCommitMessage[] {messageB}));
     }
+  }
+
+  /**
+   * Reproduces the bug fixed by {@link StagedCommit#mergeStorageOptions}: for a staged create (e.g.
+   * {@code stageCreateAtPath}), {@code StagedCommit} is constructed with only the catalog's static
+   * storage options, before {@code initialStorageOptions} (namespace-vended credentials, e.g. from
+   * {@code declareTable()}) or write-time options are known. Without the merge, {@link
+   * LanceBatchWrite#commit} would leave those credentials out of the final commit and the manifest
+   * write would authenticate with the empty/static set instead.
+   */
+  @Test
+  public void testCommitMergesInitialStorageOptionsIntoStagedCommit(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+
+    // Simulates stageCreateAtPath: StagedCommit built with empty storage options, since no
+    // namespace round trip has happened yet at stage-create time.
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+
+    // Simulates namespace-vended credentials obtained afterward (describeTable()/declareTable()),
+    // passed into LanceBatchWrite the same way BaseLanceNamespaceSparkCatalog does.
+    Map<String, String> initialStorageOptions = new HashMap<>();
+    initialStorageOptions.put("access_key_id", "AKIA-from-namespace");
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema,
+            writeOptions,
+            false,
+            initialStorageOptions,
+            null, // namespaceImpl
+            null, // namespaceProperties
+            null, // tableId
+            false, // managedVersioning
+            stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals("AKIA-from-namespace", stagedCommit.getStorageOptions().get("access_key_id"));
+
+    // The merge must also survive an actual commit, not just land in the field.
+    stagedCommit.commit();
+    try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+      assertEquals(0, dataset.countRows());
+    }
+  }
+
+  /**
+   * {@link LanceRuntime#mergeStorageOptions} is documented as: initialStorageOptions overrides
+   * write-time options on key conflict, but write-time-only options are still included. Confirms
+   * both halves: (1) the staged-commit merge preserves conflict precedence, and (2) a write-time
+   * option with no namespace-vended counterpart still survives into the final merged map. Without
+   * (2), an implementation that merged only {@code initialStorageOptions} into {@code stagedCommit}
+   * — silently dropping {@code writeOptions.getStorageOptions()} from the merge entirely — would
+   * satisfy (1) alone.
+   */
+  @Test
+  public void testCommitStagedMergePrefersInitialStorageOptionsOnConflict(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+    Map<String, String> writeTimeOptions = new HashMap<>();
+    writeTimeOptions.put("access_key_id", "stale-write-time-key");
+    writeTimeOptions.put("region", "us-west-2");
+    LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.from(datasetUri).toBuilder()
+            .storageOptions(writeTimeOptions)
+            .build();
+
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema,
+            writeOptions,
+            false,
+            Collections.singletonMap("access_key_id", "fresh-namespace-key"),
+            null,
+            null,
+            null,
+            false,
+            stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    // initialStorageOptions wins on the conflicting key...
+    assertEquals("fresh-namespace-key", stagedCommit.getStorageOptions().get("access_key_id"));
+    // ...but a write-time-only key (absent from initialStorageOptions) must still come through.
+    assertEquals("us-west-2", stagedCommit.getStorageOptions().get("region"));
   }
 
   private static WriterCommitMessage writeRows(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -138,12 +138,9 @@ public class LanceBatchWriteTest {
   }
 
   /**
-   * Reproduces the bug fixed by {@link StagedCommit#mergeStorageOptions}: for a staged create (e.g.
-   * {@code stageCreateAtPath}), {@code StagedCommit} is constructed with only the catalog's static
-   * storage options, before {@code initialStorageOptions} (namespace-vended credentials, e.g. from
-   * {@code declareTable()}) or write-time options are known. Without the merge, {@link
-   * LanceBatchWrite#commit} would leave those credentials out of the final commit and the manifest
-   * write would authenticate with the empty/static set instead.
+   * A staged create (e.g. {@code stageCreateAtPath}) builds {@code StagedCommit} with only the
+   * catalog's static storage options. Confirms {@link LanceBatchWrite#commit} merges {@code
+   * initialStorageOptions} in before the eventual {@link StagedCommit#commit()}.
    */
   @Test
   public void testCommitMergesInitialStorageOptionsIntoStagedCommit(TestInfo testInfo) {
@@ -155,14 +152,13 @@ public class LanceBatchWriteTest {
     StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
     LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
 
-    // Simulates stageCreateAtPath: StagedCommit built with empty storage options, since no
-    // namespace round trip has happened yet at stage-create time.
+    // StagedCommit starts with no storage options, as for a path-based staged create.
     StagedCommit stagedCommit =
         StagedCommit.forNewTable(
             schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
 
-    // Simulates namespace-vended credentials obtained afterward (describeTable()/declareTable()),
-    // passed into LanceBatchWrite the same way BaseLanceNamespaceSparkCatalog does.
+    // initialStorageOptions represents namespace-vended credentials, passed to LanceBatchWrite
+    // independently of how stagedCommit was constructed.
     Map<String, String> initialStorageOptions = new HashMap<>();
     initialStorageOptions.put("access_key_id", "AKIA-from-namespace");
 
@@ -182,7 +178,7 @@ public class LanceBatchWriteTest {
 
     assertEquals("AKIA-from-namespace", stagedCommit.getStorageOptions().get("access_key_id"));
 
-    // The merge must also survive an actual commit, not just land in the field.
+    // The merged options must not break the subsequent commit.
     stagedCommit.commit();
     try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
       assertEquals(0, dataset.countRows());
@@ -190,13 +186,8 @@ public class LanceBatchWriteTest {
   }
 
   /**
-   * {@link LanceRuntime#mergeStorageOptions} is documented as: initialStorageOptions overrides
-   * write-time options on key conflict, but write-time-only options are still included. Confirms
-   * both halves: (1) the staged-commit merge preserves conflict precedence, and (2) a write-time
-   * option with no namespace-vended counterpart still survives into the final merged map. Without
-   * (2), an implementation that merged only {@code initialStorageOptions} into {@code stagedCommit}
-   * — silently dropping {@code writeOptions.getStorageOptions()} from the merge entirely — would
-   * satisfy (1) alone.
+   * On key conflict, {@code initialStorageOptions} wins over write-time options; a write-time-only
+   * key (no namespace-vended counterpart) must still be included in the merge.
    */
   @Test
   public void testCommitStagedMergePrefersInitialStorageOptionsOnConflict(TestInfo testInfo) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -96,5 +98,86 @@ public class StagedCommitTest {
         StagedCommit.forExistingTable(
             dataset, ARROW_SCHEMA, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
     commit.abort();
+  }
+
+  @Test
+  public void testMergeStorageOptionsAddsNewKeys() {
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA,
+            "unused://uri",
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+
+    Map<String, String> extra = new HashMap<>();
+    extra.put("access_key_id", "AKIA...");
+    extra.put("secret_access_key", "s3cr3t");
+    commit.mergeStorageOptions(extra);
+
+    assertEquals(extra, commit.getStorageOptions());
+  }
+
+  @Test
+  public void testMergeStorageOptionsOverridesExistingKeys() {
+    Map<String, String> base = new HashMap<>();
+    base.put("access_key_id", "stale-key");
+    base.put("region", "us-west-2");
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false));
+
+    commit.mergeStorageOptions(Collections.singletonMap("access_key_id", "fresh-key"));
+
+    assertEquals("fresh-key", commit.getStorageOptions().get("access_key_id"));
+    assertEquals("us-west-2", commit.getStorageOptions().get("region"));
+  }
+
+  @Test
+  public void testMergeStorageOptionsNullAndEmptyAreNoOps() {
+    Map<String, String> base = Collections.singletonMap("access_key_id", "AKIA...");
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false));
+
+    commit.mergeStorageOptions(null);
+    commit.mergeStorageOptions(Collections.emptyMap());
+
+    assertEquals(base, commit.getStorageOptions());
+  }
+
+  @Test
+  public void testMergeStorageOptionsDoesNotMutateCallerMap() {
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA,
+            "unused://uri",
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+
+    Map<String, String> extra = new HashMap<>();
+    extra.put("access_key_id", "AKIA...");
+    commit.mergeStorageOptions(extra);
+    commit.getStorageOptions().put("access_key_id", "mutated-after-merge");
+
+    assertEquals("AKIA...", extra.get("access_key_id"));
+  }
+
+  @Test
+  public void testMergeStorageOptionsAcceptsUnmodifiableBaseMap() {
+    // BaseLanceNamespaceSparkCatalog.stageCreateAtPath/stageReplaceAtPath pass
+    // catalogConfig.getStorageOptions() directly, which LanceSparkCatalogConfig wraps in
+    // Collections.unmodifiableMap(...) and shares across every staged operation on the catalog.
+    // Without a defensive copy in the constructor, merging into that map throws
+    // UnsupportedOperationException on every real path-based staged create.
+    Map<String, String> unmodifiableCatalogOptions =
+        Collections.unmodifiableMap(Collections.singletonMap("region", "us-west-2"));
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA,
+            "unused://uri",
+            StagedCommitOptions.pathBased(unmodifiableCatalogOptions, false));
+
+    assertDoesNotThrow(
+        () -> commit.mergeStorageOptions(Collections.singletonMap("access_key_id", "AKIA...")));
+    assertEquals("AKIA...", commit.getStorageOptions().get("access_key_id"));
+    assertEquals("us-west-2", commit.getStorageOptions().get("region"));
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
@@ -162,11 +162,9 @@ public class StagedCommitTest {
 
   @Test
   public void testMergeStorageOptionsAcceptsUnmodifiableBaseMap() {
-    // BaseLanceNamespaceSparkCatalog.stageCreateAtPath/stageReplaceAtPath pass
-    // catalogConfig.getStorageOptions() directly, which LanceSparkCatalogConfig wraps in
-    // Collections.unmodifiableMap(...) and shares across every staged operation on the catalog.
-    // Without a defensive copy in the constructor, merging into that map throws
-    // UnsupportedOperationException on every real path-based staged create.
+    // Path-based staged creates pass catalogConfig.getStorageOptions() directly, which
+    // LanceSparkCatalogConfig wraps in Collections.unmodifiableMap(...). Without a defensive
+    // copy in the constructor, merging into that map throws UnsupportedOperationException.
     Map<String, String> unmodifiableCatalogOptions =
         Collections.unmodifiableMap(Collections.singletonMap("region", "us-west-2"));
     StagedCommit commit =


### PR DESCRIPTION
## What changes are included in this PR?

Fixes #712.

`StagedCommit` captures storage options once at stage-create time from the catalog's static config. For path-based staged creates/replaces (no namespace), that is the only storage-options source available at that point, so write-time `.option(...)` values and namespace-vended credentials obtained afterward were silently dropped from the final manifest commit, falling back to ambient credential discovery instead.

This PR:

- Adds `StagedCommit.mergeStorageOptions(Map<String, String>)` to layer in additional options after construction.
- Calls it from `LanceBatchWrite.commit()`'s staged branch with `LanceRuntime.mergeStorageOptions(writeOptions.getStorageOptions(), initialStorageOptions)` — the same merge and precedence the non-staged branch and `LanceSparkWriteOptions.toWriteParams()` (executor-side fragment writes) already use.
- Makes `StagedCommit`'s constructor defensively copy the incoming storage options map, since callers (e.g. `LanceSparkCatalogConfig.getStorageOptions()`) can hand it an unmodifiable map, which would otherwise make the new merge throw `UnsupportedOperationException` on every real path-based staged create.

All six staged entry points (`stageCreate[AtPath]`, `stageReplace[AtPath]`, `stageCreateOrReplace[AtPath]`) funnel through this single `LanceBatchWrite.commit()` staged branch, so the fix closes the gap uniformly without touching call sites individually. `AddColumnsBackfillBatchWrite`/`UpdateColumnsBackfillBatchWrite`/`SparkPositionDeltaWrite` are unaffected — they never use `StagedCommit` and already perform their own correct merge.

## Are these changes tested?

- New tests in `StagedCommitTest`: `mergeStorageOptions` adds new keys, overrides existing keys on conflict, is a no-op for null/empty input, does not mutate the caller's map, and accepts an unmodifiable base map (regression test for the `UnsupportedOperationException` risk above).
- New tests in `LanceBatchWriteTest`: `LanceBatchWrite.commit()` merges `initialStorageOptions` into a `StagedCommit` that started with empty options (simulating `stageCreateAtPath`), including a full round-trip through an actual dataset commit; and a separate test confirming write-time-only options survive the merge while `initialStorageOptions` still wins on key conflict, matching `LanceRuntime.mergeStorageOptions`'s documented precedence.
- `./mvnw test -pl lance-spark-3.5_2.12 -am` — 1238 tests, 0 failures, 0 errors.