### PR TITLE
chore: update lance dependency to v10.0.0-beta.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>10.0.0-beta.2</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Update the Lance dependency from `9.0.0-rc.1` to `10.0.0-beta.2`.
- Verify Docker's `LANCE_SPARK_VERSION` and `LANCE_NS_IMPL_VERSION` already match the Maven properties (`0.6.1` and `0.4.0`), so no Dockerfile changes were required.
- Triggered by [`refs/tags/v10.0.0-beta.2`](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.2).

## Verification

- `make lint`
- `make install` (Spark 3.5 / Scala 2.12 default build)
