### PR TITLE
chore: update lance dependency to v10.0.0-beta.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>10.0.0-beta.3</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- update the Lance dependency from `9.0.0-rc.1` to `10.0.0-beta.3`
- verify Docker versions remain aligned with `lance-spark.version` (`0.6.1`) and `lance-namespace-impl.version` (`0.4.0`)
- verify the update with `make lint` and `make install`

Triggered by [refs/tags/v10.0.0-beta.3](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.3).
