### PR TITLE
chore: update lance dependency to v9.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0-rc.1</lance.version>
+        <lance.version>9.0.0</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- update the Lance dependency from `9.0.0-rc.1` to `9.0.0`
- verify Docker's `LANCE_SPARK_VERSION` and `LANCE_NS_IMPL_VERSION` already match the current Maven properties (`0.6.1` and `0.4.0`)
- verify linting and the default Spark 3.5 / Scala 2.12 install build

Triggered by [Lance v9.0.0](https://github.com/lance-format/lance/releases/tag/v9.0.0).

## Verification

- `make lint`
- `make install`
