### PR TITLE
fix: fall back to local scan for FTS on catalog-only namespaces

### DIFF
--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/FtsCatalogOnlyNamespaceTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/FtsCatalogOnlyNamespaceTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class FtsCatalogOnlyNamespaceTest extends BaseFtsCatalogOnlyNamespaceTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/FtsCatalogOnlyNamespaceTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/FtsCatalogOnlyNamespaceTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class FtsCatalogOnlyNamespaceTest extends BaseFtsCatalogOnlyNamespaceTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
@@ -15,10 +15,12 @@ package org.lance.spark;
 
 import org.lance.Session;
 import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.QueryTableRequest;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -76,6 +78,9 @@ public final class LanceRuntime {
   private static final Map<String, Boolean> USE_NAMESPACE_ON_WORKERS =
       createUseNamespaceOnWorkers();
 
+  /** Cached {@code queryTable} support per namespace impl alias or class name. */
+  private static final Map<String, Boolean> QUERY_TABLE_SUPPORT = new ConcurrentHashMap<>();
+
   private LanceRuntime() {}
 
   private static Map<String, String> createExternalNamespaceImpls() {
@@ -104,6 +109,43 @@ public final class LanceRuntime {
 
   public static boolean useNamespaceOnWorkers(String namespaceImpl) {
     return USE_NAMESPACE_ON_WORKERS.getOrDefault(namespaceImpl, true);
+  }
+
+  /**
+   * Returns whether the namespace implementation executes queries server-side through {@code
+   * queryTable}.
+   *
+   * <p>{@link LanceNamespace#queryTable} is a default interface method that throws {@link
+   * org.lance.namespace.errors.UnsupportedOperationException}, and catalog-only implementations
+   * such as Glue, Hive, and Iceberg never override it. Callers use this to decide whether a query
+   * can be pushed to the namespace or has to be executed against the dataset directly.
+   *
+   * @param namespaceImpl the namespace implementation alias or class name
+   * @return true if the implementation overrides {@code queryTable}
+   */
+  public static boolean supportsQueryTable(String namespaceImpl) {
+    if (namespaceImpl == null) {
+      return false;
+    }
+    return QUERY_TABLE_SUPPORT.computeIfAbsent(namespaceImpl, LanceRuntime::probeQueryTable);
+  }
+
+  private static boolean probeQueryTable(String namespaceImpl) {
+    registerKnownNamespaceImpl(namespaceImpl);
+    String className = LanceNamespace.NATIVE_IMPLS.get(namespaceImpl);
+    if (className == null) {
+      className = LanceNamespace.REGISTERED_IMPLS.get(namespaceImpl);
+    }
+    if (className == null) {
+      className = namespaceImpl;
+    }
+    try {
+      Method queryTable = Class.forName(className).getMethod("queryTable", QueryTableRequest.class);
+      return !queryTable.isDefault();
+    } catch (ClassNotFoundException | NoSuchMethodException | LinkageError e) {
+      // Treat an unresolvable implementation as unsupported; connect() reports the real error.
+      return false;
+    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -25,6 +25,7 @@ import org.lance.memwal.ShardingSpec;
 import org.lance.schema.LanceField;
 import org.lance.schema.LanceSchema;
 import org.lance.spark.LanceConstant;
+import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.search.LanceSearchQuery;
 import org.lance.spark.search.LanceSearchScan;
@@ -171,10 +172,11 @@ public class LanceScanBuilder
       }
 
       // Namespace-configured full-text search executes server-side via queryTable (single
-      // partition). A full-text query without a namespace falls through to the local per-fragment
-      // scan below. COUNT(*) is excluded because countTableRows has no full-text field.
+      // partition). A full-text query without a namespace, or against a catalog-only namespace such
+      // as Glue that does not implement queryTable, falls through to the local per-fragment scan
+      // below. COUNT(*) is excluded because countTableRows has no full-text field.
       if (readOptions.getFullTextQuery() != null
-          && namespaceImpl != null
+          && LanceRuntime.supportsQueryTable(namespaceImpl)
           && !pushedAggregation.isPresent()) {
         return buildNamespaceFtsScan();
       }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.QueryTableRequest;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LanceRuntimeQueryTableSupportTest {
+
+  @Test
+  void catalogOnlyNamespaceDoesNotSupportQueryTable() {
+    assertFalse(LanceRuntime.supportsQueryTable(CatalogOnlyNamespace.class.getName()));
+  }
+
+  @Test
+  void queryingNamespaceSupportsQueryTable() {
+    assertTrue(LanceRuntime.supportsQueryTable(QueryingNamespace.class.getName()));
+  }
+
+  @Test
+  void directoryNamespaceSupportsQueryTable() {
+    assertTrue(LanceRuntime.supportsQueryTable("dir"));
+  }
+
+  @Test
+  void nullAndUnknownImplsAreUnsupported() {
+    assertFalse(LanceRuntime.supportsQueryTable(null));
+    assertFalse(LanceRuntime.supportsQueryTable("org.lance.namespace.DoesNotExist"));
+  }
+
+  /** Stands in for catalog-only namespaces such as Glue, which never implement queryTable. */
+  public static class CatalogOnlyNamespace implements LanceNamespace {
+    public CatalogOnlyNamespace() {}
+
+    @Override
+    public void initialize(Map<String, String> properties, BufferAllocator allocator) {}
+
+    @Override
+    public String namespaceId() {
+      return "catalog-only";
+    }
+  }
+
+  public static class QueryingNamespace extends CatalogOnlyNamespace {
+    public QueryingNamespace() {}
+
+    @Override
+    public byte[] queryTable(QueryTableRequest request) {
+      return new byte[0];
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.namespace.DirectoryNamespace;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.DropTableResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.RegisterTableRequest;
+import org.lance.namespace.model.RegisterTableResponse;
+import org.lance.namespace.model.RenameTableRequest;
+import org.lance.namespace.model.RenameTableResponse;
+import org.lance.namespace.model.TableExistsRequest;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that FTS predicates work against a catalog-only namespace — one that manages table
+ * metadata but does not implement {@code queryTable}, as AWS Glue, Hive, and Iceberg namespaces do.
+ * Such a namespace cannot run the query server-side, so the scan must fall back to the local
+ * per-fragment path instead of failing with {@code Not supported: queryTable}.
+ */
+public abstract class BaseFtsCatalogOnlyNamespaceTest {
+
+  protected SparkSession spark;
+  protected String catalogName = "lance_catalog_only_fts";
+  protected String fullTable;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+
+    spark =
+        SparkSession.builder()
+            .appName("lance-fts-catalog-only-namespace-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config(
+                "spark.sql.catalog." + catalogName + ".impl", CatalogOnlyNamespace.class.getName())
+            .config("spark.sql.catalog." + catalogName + ".root", rootPath.toString())
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .config("spark.sql.defaultCatalog", catalogName)
+            .config("spark.sql.adaptive.enabled", "false")
+            .getOrCreate();
+
+    fullTable = catalogName + ".default.fts_" + UUID.randomUUID().toString().replace("-", "");
+    createAndIndexTable();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  /**
+   * Two fragments: ids 0-9 with body "hello world doc_N", then ids 10-14 with "foo bar doc_N" and
+   * ids 15-19 with "hello spark doc_N".
+   */
+  private void createAndIndexTable() {
+    spark.sql(String.format("CREATE TABLE %s (id INT, body STRING) USING lance", fullTable));
+    String frag1 =
+        IntStream.range(0, 10)
+            .mapToObj(i -> String.format("(%d, 'hello world doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    spark.sql(String.format("INSERT INTO %s VALUES %s", fullTable, frag1));
+    String frag2a =
+        IntStream.range(10, 15)
+            .mapToObj(i -> String.format("(%d, 'foo bar doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    String frag2b =
+        IntStream.range(15, 20)
+            .mapToObj(i -> String.format("(%d, 'hello spark doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    spark.sql(String.format("INSERT INTO %s VALUES %s, %s", fullTable, frag2a, frag2b));
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX fts_body USING fts (body) WITH ("
+                + "base_tokenizer='simple', language='English', max_token_length=40, "
+                + "lower_case=true, stem=false, remove_stop_words=false, "
+                + "ascii_folding=false, with_position=true)",
+            fullTable));
+  }
+
+  @Test
+  public void lanceMatchFallsBackToLocalScan() {
+    List<Row> rows =
+        spark
+            .sql(String.format("SELECT id FROM %s WHERE lance_match(body, 'hello')", fullTable))
+            .collectAsList();
+    assertEquals(15, rows.size(), "Expected the 15 rows whose body contains 'hello'");
+  }
+
+  @Test
+  public void lanceMatchPhraseFallsBackToLocalScan() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id FROM %s WHERE lance_match_phrase(body, 'hello world')", fullTable))
+            .collectAsList();
+    assertEquals(10, rows.size(), "Expected the 10 rows whose body contains 'hello world'");
+  }
+
+  /**
+   * Delegates every operation the connector uses to a {@link DirectoryNamespace}, but deliberately
+   * leaves {@code queryTable} unimplemented so it keeps the interface default that throws.
+   */
+  public static class CatalogOnlyNamespace implements LanceNamespace {
+    private final DirectoryNamespace delegate = new DirectoryNamespace();
+
+    public CatalogOnlyNamespace() {}
+
+    @Override
+    public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
+      delegate.initialize(configProperties, allocator);
+    }
+
+    @Override
+    public String namespaceId() {
+      return delegate.namespaceId();
+    }
+
+    @Override
+    public ListNamespacesResponse listNamespaces(ListNamespacesRequest request) {
+      return delegate.listNamespaces(request);
+    }
+
+    @Override
+    public DescribeNamespaceResponse describeNamespace(DescribeNamespaceRequest request) {
+      return delegate.describeNamespace(request);
+    }
+
+    @Override
+    public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
+      return delegate.createNamespace(request);
+    }
+
+    @Override
+    public DropNamespaceResponse dropNamespace(DropNamespaceRequest request) {
+      return delegate.dropNamespace(request);
+    }
+
+    @Override
+    public void namespaceExists(NamespaceExistsRequest request) {
+      delegate.namespaceExists(request);
+    }
+
+    @Override
+    public ListTablesResponse listTables(ListTablesRequest request) {
+      return delegate.listTables(request);
+    }
+
+    @Override
+    public DescribeTableResponse describeTable(DescribeTableRequest request) {
+      return delegate.describeTable(request);
+    }
+
+    @Override
+    public DeclareTableResponse declareTable(DeclareTableRequest request) {
+      return delegate.declareTable(request);
+    }
+
+    @Override
+    public RegisterTableResponse registerTable(RegisterTableRequest request) {
+      return delegate.registerTable(request);
+    }
+
+    @Override
+    public DeregisterTableResponse deregisterTable(DeregisterTableRequest request) {
+      return delegate.deregisterTable(request);
+    }
+
+    @Override
+    public void tableExists(TableExistsRequest request) {
+      delegate.tableExists(request);
+    }
+
+    @Override
+    public DropTableResponse dropTable(DropTableRequest request) {
+      return delegate.dropTable(request);
+    }
+
+    @Override
+    public RenameTableResponse renameTable(RenameTableRequest request) {
+      return delegate.renameTable(request);
+    }
+  }
+}


### PR DESCRIPTION
Previously, a full-text query was routed to the namespace `queryTable` endpoint whenever a namespace was configured (`LanceScanBuilder.build()` gated only on `namespaceImpl != null`). `LanceNamespace.queryTable` is a default interface method that throws, and catalog-only implementations such as Glue, Hive, and Iceberg never override it, so `lance_match`, `lance_match_phrase`, and `lance_multi_match` failed with `Not supported: queryTable`. `DirectoryNamespace` implements it natively, which is why only the Glue job failed:

https://github.com/lance-format/lance-spark/actions/runs/29837726315/job/88658279987

```
UnsupportedOperationException{code=0, message='Not supported: queryTable'}
	at org.lance.namespace.LanceNamespace.queryTable(LanceNamespace.java:391)
	at org.lance.spark.search.LanceSearchColumnarPartitionReader.openArrowReader(LanceSearchColumnarPartitionReader.java:87)
```

The routing is now gated on whether the namespace implementation actually overrides `queryTable` (`LanceRuntime.supportsQueryTable`, cached per impl); otherwise the query falls through to the local per-fragment scan, which pushes the `FullTextQuery` into `ScanOptions`.

## Tests

- `FtsCatalogOnlyNamespaceTest` — a namespace that delegates every operation the connector uses to `DirectoryNamespace` but leaves `queryTable` unimplemented, i.e. the Glue shape. Without the fix it reproduces the CI failure exactly; with it, `lance_match(body, 'hello')` returns 15 rows and `lance_match_phrase(body, 'hello world')` returns 10 — the local path applies structured queries correctly.
- `LanceRuntimeQueryTableSupportTest` — catalog-only, query-capable, `dir`, and null/unknown impls.

## Not addressed here

On `dir`-backed catalogs FTS still routes through `queryTable`, which ignores `structured_query` and returns all rows — hence the `Assumptions.assumeTrue(false)` in `BaseFtsMatchPushdownTest`, `BaseFtsPhraseMatchPushdownTest`, `BaseFtsAdvancedOptionsTest`, and the `xfail` on the SEARCH TVF test. The local scan path already handles phrase and slop correctly today, so preferring it whenever the dataset is directly reachable would let those tests be re-enabled without waiting on the lance-core `dir.rs` bump. That is a larger behavioral change and left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)