### PR TITLE
chore: update lance dependency to v10.0.0-beta.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0</lance.version>
+        <lance.version>10.0.0-beta.6</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- update `lance-core` from 9.0.0 to 10.0.0-beta.6
- verify Docker versions already match the current Maven properties (`LANCE_SPARK_VERSION=0.6.1` and `LANCE_NS_IMPL_VERSION=0.4.0`), so no Dockerfile changes are required
- verify formatting and compilation with `make lint` and `make install`

Triggered by [refs/tags/v10.0.0-beta.6](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.6).
