### PR TITLE
feat: propagate file_format_version to CommitBuilder.storageFormat()

### DIFF
--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -207,6 +207,10 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
                 .writeParams(
                     LanceRuntime.mergeStorageOptions(
                         writeOptions.getStorageOptions(), initialStorageOptions));
+        String fileFormatVersion = writeOptions.getFileFormatVersion();
+        if (fileFormatVersion != null) {
+          commitBuilder.storageFormat(fileFormatVersion);
+        }
         if (dataset.hasStableRowIds()
             || Boolean.TRUE.equals(writeOptions.getEnableStableRowIds())) {
           commitBuilder.useStableRowIds(true);

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/write/SparkPositionDeltaWrite.java
@@ -228,6 +228,10 @@ public class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistribution
                 .writeParams(
                     LanceRuntime.mergeStorageOptions(
                         writeOptions.getStorageOptions(), initialStorageOptions));
+        String fileFormatVersion = writeOptions.getFileFormatVersion();
+        if (fileFormatVersion != null) {
+          commitBuilder.storageFormat(fileFormatVersion);
+        }
         if (useStableRowIds) {
           commitBuilder.useStableRowIds(true);
         }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -1125,6 +1125,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
         StagedCommitOptions.of(
             merged,
             catalogConfig.isEnableStableRowIds(properties),
+            fileFormatVersion,
             namespace,
             tableIdList,
             managedVersioning);
@@ -1161,7 +1162,9 @@ public abstract class BaseLanceNamespaceSparkCatalog
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
     final StagedCommitOptions commitOptions =
         StagedCommitOptions.pathBased(
-            catalogConfig.getStorageOptions(), catalogConfig.isEnableStableRowIds(properties));
+            catalogConfig.getStorageOptions(),
+            catalogConfig.isEnableStableRowIds(properties),
+            fileFormatVersion);
     StagedCommit stagedCommit = StagedCommit.forNewTable(arrowSchema, datasetUri, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
     return createStagedDataset(
@@ -1201,19 +1204,20 @@ public abstract class BaseLanceNamespaceSparkCatalog
     Dataset ds = Utils.openDatasetBuilder(resolved.readOptions).build();
     Map<String, String> merged =
         LanceRuntime.mergeStorageOptions(catalogConfig.getStorageOptions(), initialStorageOptions);
+    // Use specified file format version, or fall back to existing table's version
+    if (fileFormatVersion == null) {
+      fileFormatVersion = ds.getLanceFileFormatVersion();
+    }
     final StagedCommitOptions commitOptions =
         StagedCommitOptions.of(
             merged,
             catalogConfig.isEnableStableRowIds(properties),
+            fileFormatVersion,
             namespace,
             resolved.tableIdList,
             managedVersioning);
     StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
     stagedCommit.setShardingSpec(shardingSpec);
-    // Use specified file format version, or fall back to existing table's version
-    if (fileFormatVersion == null) {
-      fileFormatVersion = ds.getLanceFileFormatVersion();
-    }
     return createStagedDataset(
         resolved.readOptions,
         processedSchema,
@@ -1250,16 +1254,18 @@ public abstract class BaseLanceNamespaceSparkCatalog
       throw new NoSuchTableException(ident);
     }
 
-    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
-    final StagedCommitOptions commitOptions =
-        StagedCommitOptions.pathBased(
-            catalogConfig.getStorageOptions(), catalogConfig.isEnableStableRowIds(properties));
-    StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
-    stagedCommit.setShardingSpec(shardingSpec);
     // Use specified file format version, or fall back to existing table's version
     if (fileFormatVersion == null) {
       fileFormatVersion = ds.getLanceFileFormatVersion();
     }
+    Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
+    final StagedCommitOptions commitOptions =
+        StagedCommitOptions.pathBased(
+            catalogConfig.getStorageOptions(),
+            catalogConfig.isEnableStableRowIds(properties),
+            fileFormatVersion);
+    StagedCommit stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
+    stagedCommit.setShardingSpec(shardingSpec);
     return createStagedDataset(
         readOptions,
         processedSchema,
@@ -1333,24 +1339,32 @@ public abstract class BaseLanceNamespaceSparkCatalog
             name);
 
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
-    // Use specified file format version, or fall back to existing table's version
     Map<String, String> merged =
         LanceRuntime.mergeStorageOptions(catalogConfig.getStorageOptions(), initialStorageOptions);
-    final StagedCommitOptions commitOptions =
-        StagedCommitOptions.of(
-            merged,
-            catalogConfig.isEnableStableRowIds(properties),
-            namespace,
-            tableIdList,
-            managedVersioning);
     StagedCommit stagedCommit;
     if (exists) {
       Dataset ds = Utils.openDatasetBuilder(readOptions).build();
-      stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
       if (fileFormatVersion == null) {
         fileFormatVersion = ds.getLanceFileFormatVersion();
       }
+      final StagedCommitOptions commitOptions =
+          StagedCommitOptions.of(
+              merged,
+              catalogConfig.isEnableStableRowIds(properties),
+              fileFormatVersion,
+              namespace,
+              tableIdList,
+              managedVersioning);
+      stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
     } else {
+      final StagedCommitOptions commitOptions =
+          StagedCommitOptions.of(
+              merged,
+              catalogConfig.isEnableStableRowIds(properties),
+              fileFormatVersion,
+              namespace,
+              tableIdList,
+              managedVersioning);
       stagedCommit = StagedCommit.forNewTable(arrowSchema, location, commitOptions);
     }
     stagedCommit.setShardingSpec(shardingSpec);
@@ -1384,18 +1398,24 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     boolean exists = tableExistsAtPath(ident);
     Schema arrowSchema = LanceArrowUtils.toArrowSchema(processedSchema, "UTC", true);
-    final StagedCommitOptions commitOptions =
-        StagedCommitOptions.pathBased(
-            catalogConfig.getStorageOptions(), catalogConfig.isEnableStableRowIds(properties));
     StagedCommit stagedCommit;
-    // Use specified file format version, or fall back to existing table's version
     if (exists) {
       Dataset ds = Utils.openDatasetBuilder(readOptions).build();
-      stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
       if (fileFormatVersion == null) {
         fileFormatVersion = ds.getLanceFileFormatVersion();
       }
+      final StagedCommitOptions commitOptions =
+          StagedCommitOptions.pathBased(
+              catalogConfig.getStorageOptions(),
+              catalogConfig.isEnableStableRowIds(properties),
+              fileFormatVersion);
+      stagedCommit = StagedCommit.forExistingTable(ds, arrowSchema, commitOptions);
     } else {
+      final StagedCommitOptions commitOptions =
+          StagedCommitOptions.pathBased(
+              catalogConfig.getStorageOptions(),
+              catalogConfig.isEnableStableRowIds(properties),
+              fileFormatVersion);
       stagedCommit = StagedCommit.forNewTable(arrowSchema, datasetUri, commitOptions);
     }
     stagedCommit.setShardingSpec(shardingSpec);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
@@ -149,14 +149,18 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
 
       // Commit merge operation using CommitBuilder
       Merge merge = Merge.builder().fragments(fragments).schema(arrowSchema).build();
+      CommitBuilder commitBuilder =
+          new CommitBuilder(dataset)
+              .writeParams(
+                  LanceRuntime.mergeStorageOptions(
+                      writeOptions.getStorageOptions(), initialStorageOptions));
+      String fileFormatVersion = writeOptions.getFileFormatVersion();
+      if (fileFormatVersion != null) {
+        commitBuilder.storageFormat(fileFormatVersion);
+      }
       try (Transaction txn =
               new Transaction.Builder().readVersion(version).operation(merge).build();
-          Dataset committed =
-              new CommitBuilder(dataset)
-                  .writeParams(
-                      LanceRuntime.mergeStorageOptions(
-                          writeOptions.getStorageOptions(), initialStorageOptions))
-                  .execute(txn)) {
+          Dataset committed = commitBuilder.execute(txn)) {
         // auto-close txn and committed dataset
       }
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -202,6 +202,10 @@ public class LanceBatchWrite implements BatchWrite {
                 .writeParams(
                     LanceRuntime.mergeStorageOptions(
                         writeOptions.getStorageOptions(), initialStorageOptions));
+        String fileFormatVersion = writeOptions.getFileFormatVersion();
+        if (fileFormatVersion != null) {
+          commitBuilder.storageFormat(fileFormatVersion);
+        }
         // When enableStableRowIds is null (user didn't pass the option),
         // lance-core auto-inherits the flag from the existing manifest.
         // Appending to a table with stable row IDs works without

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -178,6 +178,10 @@ public class LanceBatchWrite implements BatchWrite {
       if (enableStableRowIds != null) {
         stagedCommit.setEnableStableRowIds(enableStableRowIds);
       }
+      String fileFormatVersion = writeOptions.getFileFormatVersion();
+      if (fileFormatVersion != null) {
+        stagedCommit.setFileFormatVersion(fileFormatVersion);
+      }
       // For a path-based staged create, StagedCommit only has the catalog's static storage
       // options at this point. Merge in write-time and namespace-vended options now so
       // StagedCommit.commit() uses them. Mirrors the non-staged merge below.

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
@@ -53,6 +53,7 @@ public class StagedCommit {
   // The non-staged path (LanceBatchWrite) uses boxed Boolean because null means
   // "user didn't specify" and lets lance-core inherit the flag from the manifest.
   private boolean enableStableRowIds;
+  private final String fileFormatVersion;
   private List<FragmentMetadata> fragments;
   private Schema schema;
   private ShardingSpec shardingSpec;
@@ -95,6 +96,7 @@ public class StagedCommit {
     this.storageOptions = new HashMap<>(options.getStorageOptions());
     this.isNewTable = datasetUri != null;
     this.enableStableRowIds = options.isEnableStableRowIds();
+    this.fileFormatVersion = options.getFileFormatVersion();
     this.namespace = options.getNamespace();
     this.tableId = options.getTableId();
     this.managedVersioning = options.isManagedVersioning();
@@ -150,6 +152,9 @@ public class StagedCommit {
     if (enableStableRowIds) {
       builder.useStableRowIds(true);
     }
+    if (fileFormatVersion != null) {
+      builder.storageFormat(fileFormatVersion);
+    }
     applyManagedVersioning(builder);
     try (Transaction txn = new Transaction.Builder().operation(operation).build();
         Dataset committed = builder.execute(txn)) {
@@ -167,6 +172,9 @@ public class StagedCommit {
     final CommitBuilder builder =
         new CommitBuilder(uri, LanceRuntime.allocator()).writeParams(storageOptions);
     builder.useStableRowIds(enableStableRowIds);
+    if (fileFormatVersion != null) {
+      builder.storageFormat(fileFormatVersion);
+    }
     applyManagedVersioning(builder);
     try (Dataset committed = commitOperation(builder, version, operation)) {
       SparkLanceShardingUtils.initializeMemWal(committed, shardingSpec);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommit.java
@@ -53,7 +53,7 @@ public class StagedCommit {
   // The non-staged path (LanceBatchWrite) uses boxed Boolean because null means
   // "user didn't specify" and lets lance-core inherit the flag from the manifest.
   private boolean enableStableRowIds;
-  private final String fileFormatVersion;
+  private String fileFormatVersion;
   private List<FragmentMetadata> fragments;
   private Schema schema;
   private ShardingSpec shardingSpec;
@@ -114,6 +114,10 @@ public class StagedCommit {
     this.enableStableRowIds = enableStableRowIds;
   }
 
+  public void setFileFormatVersion(String fileFormatVersion) {
+    this.fileFormatVersion = fileFormatVersion;
+  }
+
   public void setShardingSpec(ShardingSpec shardingSpec) {
     this.shardingSpec = shardingSpec;
   }
@@ -134,6 +138,11 @@ public class StagedCommit {
   /** Returns the current storage options. Visible for testing. */
   Map<String, String> getStorageOptions() {
     return storageOptions;
+  }
+
+  /** Returns the current file format version. Visible for testing. */
+  String getFileFormatVersion() {
+    return fileFormatVersion;
   }
 
   /** Performs the actual commit using the stored dataset and fragments. */

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommitOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/StagedCommitOptions.java
@@ -27,6 +27,7 @@ public class StagedCommitOptions {
 
   private final Map<String, String> storageOptions;
   private final boolean enableStableRowIds;
+  private final String fileFormatVersion;
   private final LanceNamespace namespace;
   private final List<String> tableId;
   private final boolean managedVersioning;
@@ -34,11 +35,13 @@ public class StagedCommitOptions {
   private StagedCommitOptions(
       final Map<String, String> storageOptions,
       final boolean enableStableRowIds,
+      final String fileFormatVersion,
       final LanceNamespace namespace,
       final List<String> tableId,
       final boolean managedVersioning) {
     this.storageOptions = storageOptions;
     this.enableStableRowIds = enableStableRowIds;
+    this.fileFormatVersion = fileFormatVersion;
     this.namespace = namespace;
     this.tableId = tableId;
     this.managedVersioning = managedVersioning;
@@ -47,17 +50,30 @@ public class StagedCommitOptions {
   public static StagedCommitOptions of(
       final Map<String, String> storageOptions,
       final boolean enableStableRowIds,
+      final String fileFormatVersion,
       final LanceNamespace namespace,
       final List<String> tableId,
       final boolean managedVersioning) {
     return new StagedCommitOptions(
-        storageOptions, enableStableRowIds, namespace, tableId, managedVersioning);
+        storageOptions,
+        enableStableRowIds,
+        fileFormatVersion,
+        namespace,
+        tableId,
+        managedVersioning);
   }
 
   public static StagedCommitOptions pathBased(
-      final Map<String, String> storageOptions, final boolean enableStableRowIds) {
+      final Map<String, String> storageOptions,
+      final boolean enableStableRowIds,
+      final String fileFormatVersion) {
     return new StagedCommitOptions(
-        storageOptions, enableStableRowIds, NO_NAMESPACE, NO_TABLE_ID, NO_MANAGED_VERSIONING);
+        storageOptions,
+        enableStableRowIds,
+        fileFormatVersion,
+        NO_NAMESPACE,
+        NO_TABLE_ID,
+        NO_MANAGED_VERSIONING);
   }
 
   public Map<String, String> getStorageOptions() {
@@ -66,6 +82,10 @@ public class StagedCommitOptions {
 
   public boolean isEnableStableRowIds() {
     return enableStableRowIds;
+  }
+
+  public String getFileFormatVersion() {
+    return fileFormatVersion;
   }
 
   public LanceNamespace getNamespace() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
@@ -156,14 +156,18 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
           Objects.requireNonNull(
               writeOptions.getVersion(),
               "version must be set (resolved in UpdateColumnsBackfillBatchWrite constructor)");
+      CommitBuilder commitBuilder =
+          new CommitBuilder(dataset)
+              .writeParams(
+                  LanceRuntime.mergeStorageOptions(
+                      writeOptions.getStorageOptions(), initialStorageOptions));
+      String fileFormatVersion = writeOptions.getFileFormatVersion();
+      if (fileFormatVersion != null) {
+        commitBuilder.storageFormat(fileFormatVersion);
+      }
       try (Transaction txn =
               new Transaction.Builder().readVersion(version).operation(update).build();
-          Dataset committed =
-              new CommitBuilder(dataset)
-                  .writeParams(
-                      LanceRuntime.mergeStorageOptions(
-                          writeOptions.getStorageOptions(), initialStorageOptions))
-                  .execute(txn)) {
+          Dataset committed = commitBuilder.execute(txn)) {
         // auto-close txn and committed dataset
       }
     }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -155,7 +155,7 @@ public class LanceBatchWriteTest {
     // StagedCommit starts with no storage options, as for a path-based staged create.
     StagedCommit stagedCommit =
         StagedCommit.forNewTable(
-            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
 
     // initialStorageOptions represents namespace-vended credentials, passed to LanceBatchWrite
     // independently of how stagedCommit was constructed.
@@ -207,7 +207,7 @@ public class LanceBatchWriteTest {
 
     StagedCommit stagedCommit =
         StagedCommit.forNewTable(
-            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
 
     LanceBatchWrite batchWrite =
         new LanceBatchWrite(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LanceBatchWriteTest {
@@ -227,6 +228,106 @@ public class LanceBatchWriteTest {
     assertEquals("fresh-namespace-key", stagedCommit.getStorageOptions().get("access_key_id"));
     // ...but a write-time-only key (absent from initialStorageOptions) must still come through.
     assertEquals("us-west-2", stagedCommit.getStorageOptions().get("region"));
+  }
+
+  /**
+   * When a write-time option sets {@code file_format_version} (e.g. via {@code
+   * DataFrameWriterV2.option("file_format_version", "2.2")}), the staged commit must use that
+   * version even if none was set at stage time.
+   */
+  @Test
+  public void testCommitStagedPropagatesWriteTimeFileFormatVersion(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+
+    // Stage-time: no file format version set (simulates stageCreate without table property)
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
+    assertNull(stagedCommit.getFileFormatVersion());
+
+    // Write-time: user set file_format_version via DataFrameWriterV2.option(...)
+    LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.from(datasetUri).toBuilder().fileFormatVersion("2.1").build();
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema, writeOptions, false, null, null, null, null, false, stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals("2.1", stagedCommit.getFileFormatVersion());
+  }
+
+  /**
+   * Write-time {@code file_format_version} takes precedence over the stage-time value. This covers
+   * the case where the catalog resolved a default at stage time but the user explicitly overrides
+   * it at write time.
+   */
+  @Test
+  public void testCommitStagedWriteTimeFileFormatVersionTakesPrecedence(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+
+    // Stage-time: catalog resolved file format version "2.0"
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, "2.0"));
+    assertEquals("2.0", stagedCommit.getFileFormatVersion());
+
+    // Write-time: user explicitly overrides to "2.2"
+    LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.from(datasetUri).toBuilder().fileFormatVersion("2.2").build();
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema, writeOptions, false, null, null, null, null, false, stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals("2.2", stagedCommit.getFileFormatVersion());
+  }
+
+  /**
+   * When write options have no {@code file_format_version}, the stage-time value must be preserved.
+   * Null write-time must not overwrite a stage-time resolution.
+   */
+  @Test
+  public void testCommitStagedPreservesStageTimeVersionWhenWriteTimeIsNull(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+
+    // Stage-time: version set from table properties
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, "2.1"));
+
+    // Write-time: no file_format_version option
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema, writeOptions, false, null, null, null, null, false, stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+
+    assertEquals("2.1", stagedCommit.getFileFormatVersion());
   }
 
   private static WriterCommitMessage writeRows(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitOptionsTest.java
@@ -49,12 +49,14 @@ public class StagedCommitOptionsTest {
         StagedCommitOptions.of(
             storageOptions,
             STABLE_ROW_IDS_ENABLED,
+            "2.2",
             NO_NAMESPACE,
             tableId,
             MANAGED_VERSIONING_ENABLED);
 
     assertEquals(storageOptions, options.getStorageOptions());
     assertTrue(options.isEnableStableRowIds());
+    assertEquals("2.2", options.getFileFormatVersion());
     assertNull(options.getNamespace());
     assertEquals(tableId, options.getTableId());
     assertTrue(options.isManagedVersioning());
@@ -69,6 +71,7 @@ public class StagedCommitOptionsTest {
         StagedCommitOptions.of(
             storageOptions,
             STABLE_ROW_IDS_DISABLED,
+            null,
             NO_NAMESPACE,
             tableId,
             MANAGED_VERSIONING_DISABLED);
@@ -82,10 +85,11 @@ public class StagedCommitOptionsTest {
     final Map<String, String> storageOptions = Collections.singletonMap("path", "/tmp/lance");
 
     final StagedCommitOptions options =
-        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_ENABLED);
+        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_ENABLED, "2.1");
 
     assertEquals(storageOptions, options.getStorageOptions());
     assertTrue(options.isEnableStableRowIds());
+    assertEquals("2.1", options.getFileFormatVersion());
     assertNull(options.getNamespace());
     assertNull(options.getTableId());
     assertFalse(options.isManagedVersioning());
@@ -96,7 +100,7 @@ public class StagedCommitOptionsTest {
     final Map<String, String> storageOptions = Collections.emptyMap();
 
     final StagedCommitOptions options =
-        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_DISABLED);
+        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_DISABLED, null);
 
     assertFalse(options.isEnableStableRowIds());
     assertNull(options.getNamespace());
@@ -110,6 +114,7 @@ public class StagedCommitOptionsTest {
         StagedCommitOptions.of(
             Collections.emptyMap(),
             STABLE_ROW_IDS_DISABLED,
+            null,
             NO_NAMESPACE,
             NO_TABLE_ID,
             MANAGED_VERSIONING_DISABLED);
@@ -124,7 +129,7 @@ public class StagedCommitOptionsTest {
     storageOptions.put("key", "original");
 
     final StagedCommitOptions options =
-        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_DISABLED);
+        StagedCommitOptions.pathBased(storageOptions, STABLE_ROW_IDS_DISABLED, null);
     storageOptions.put("key", "modified");
 
     assertEquals("modified", options.getStorageOptions().get("key"));

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
@@ -169,6 +169,37 @@ public class StagedCommitTest {
   }
 
   @Test
+  public void testCommitNewTableWithFileFormatVersion(TestInfo testInfo) {
+    String datasetUri =
+        TestUtils.getDatasetUri(tempDir.toString(), testInfo.getTestMethod().get().getName());
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, "2.1"));
+    commit.commit();
+    try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+      assertEquals("2.1", dataset.getLanceFileFormatVersion());
+    }
+  }
+
+  @Test
+  public void testSetFileFormatVersionOverridesStageTime(TestInfo testInfo) {
+    String datasetUri =
+        TestUtils.getDatasetUri(tempDir.toString(), testInfo.getTestMethod().get().getName());
+    StagedCommit commit =
+        StagedCommit.forNewTable(
+            ARROW_SCHEMA,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, "2.0"));
+    commit.setFileFormatVersion("2.1");
+    commit.commit();
+    try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+      assertEquals("2.1", dataset.getLanceFileFormatVersion());
+    }
+  }
+
+  @Test
   public void testMergeStorageOptionsAcceptsUnmodifiableBaseMap() {
     // Path-based staged creates pass catalogConfig.getStorageOptions() directly, which
     // LanceSparkCatalogConfig wraps in Collections.unmodifiableMap(...). Without a defensive

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/StagedCommitTest.java
@@ -60,7 +60,9 @@ public class StagedCommitTest {
         TestUtils.getDatasetUri(tempDir.toString(), testInfo.getTestMethod().get().getName());
     StagedCommit commit =
         StagedCommit.forNewTable(
-            ARROW_SCHEMA, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            ARROW_SCHEMA,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
     commit.commit();
     try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
       assertEquals(0, dataset.countRows());
@@ -73,7 +75,9 @@ public class StagedCommitTest {
     Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator());
     StagedCommit commit =
         StagedCommit.forExistingTable(
-            dataset, ARROW_SCHEMA, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            dataset,
+            ARROW_SCHEMA,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
     commit.commit();
     try (Dataset reopened = Dataset.open(datasetUri, LanceRuntime.allocator())) {
       assertEquals(0, reopened.countRows());
@@ -86,7 +90,9 @@ public class StagedCommitTest {
         TestUtils.getDatasetUri(tempDir.toString(), testInfo.getTestMethod().get().getName());
     StagedCommit commit =
         StagedCommit.forNewTable(
-            ARROW_SCHEMA, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            ARROW_SCHEMA,
+            datasetUri,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
     commit.abort();
   }
 
@@ -96,7 +102,9 @@ public class StagedCommitTest {
     Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator());
     StagedCommit commit =
         StagedCommit.forExistingTable(
-            dataset, ARROW_SCHEMA, StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            dataset,
+            ARROW_SCHEMA,
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
     commit.abort();
   }
 
@@ -106,7 +114,7 @@ public class StagedCommitTest {
         StagedCommit.forNewTable(
             ARROW_SCHEMA,
             "unused://uri",
-            StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
 
     Map<String, String> extra = new HashMap<>();
     extra.put("access_key_id", "AKIA...");
@@ -123,7 +131,7 @@ public class StagedCommitTest {
     base.put("region", "us-west-2");
     StagedCommit commit =
         StagedCommit.forNewTable(
-            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false));
+            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false, null));
 
     commit.mergeStorageOptions(Collections.singletonMap("access_key_id", "fresh-key"));
 
@@ -136,7 +144,7 @@ public class StagedCommitTest {
     Map<String, String> base = Collections.singletonMap("access_key_id", "AKIA...");
     StagedCommit commit =
         StagedCommit.forNewTable(
-            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false));
+            ARROW_SCHEMA, "unused://uri", StagedCommitOptions.pathBased(base, false, null));
 
     commit.mergeStorageOptions(null);
     commit.mergeStorageOptions(Collections.emptyMap());
@@ -150,7 +158,7 @@ public class StagedCommitTest {
         StagedCommit.forNewTable(
             ARROW_SCHEMA,
             "unused://uri",
-            StagedCommitOptions.pathBased(Collections.emptyMap(), false));
+            StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
 
     Map<String, String> extra = new HashMap<>();
     extra.put("access_key_id", "AKIA...");
@@ -171,7 +179,7 @@ public class StagedCommitTest {
         StagedCommit.forNewTable(
             ARROW_SCHEMA,
             "unused://uri",
-            StagedCommitOptions.pathBased(unmodifiableCatalogOptions, false));
+            StagedCommitOptions.pathBased(unmodifiableCatalogOptions, false, null));
 
     assertDoesNotThrow(
         () -> commit.mergeStorageOptions(Collections.singletonMap("access_key_id", "AKIA...")));

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0</lance.version>
+        <lance.version>11.0.0-beta.1</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

When `file_format_version` is set in Spark write options, lance-spark correctly encodes fragment data files in the requested format. However, at commit time `CommitBuilder.storageFormat()` was never called, so the manifest's `data_storage_format` was never updated. This causes lance-core's `check_storage_version` to reject the commit.

Closes #729

**Depends on:** [lance-format/lance#8063](https://github.com/lance-format/lance/pull/8063) (lance-core must accept numeric format strings like "2.1", "2.2" in `CommitBuilder.storageFormat()`)

## Changes

Forward `writeOptions.getFileFormatVersion()` to `commitBuilder.storageFormat()` in all code paths that construct a `CommitBuilder`:

- `LanceBatchWrite.commit()` — batch write (Append/Overwrite)
- `StagedCommit.commitNewTable()` and `commitExistingTable()` — staged catalog operations
- `SparkPositionDeltaWrite` (Spark 3.4 + 3.5) — row-level UPDATE/DELETE/MERGE
- `AddColumnsBackfillBatchWrite` — add-columns backfill
- `UpdateColumnsBackfillBatchWrite` — column rewrite backfill

Add `fileFormatVersion` field to `StagedCommitOptions` so staged commit paths receive the value from the catalog's `CreateTableSpec` resolution.

## Backward Compatibility

When `fileFormatVersion` is null (user didn't set the option), `storageFormat` is not called on `CommitBuilder`. Behavior is identical to before.

## Test Plan

All 19 existing unit tests pass. `StagedCommitOptionsTest` updated to verify `getFileFormatVersion()` accessor.

## CI Note

The full test suite requires lance-core with the `parse_storage_format` fix from [lance#8063](https://github.com/lance-format/lance/pull/8063), which extends the JNI format string parser to accept numeric strings ("2.1", "2.2") in addition to the existing prefixed variants ("v2.1", "v2_1"). Without that change, any test path that exercises `CommitBuilder.storageFormat()` with a numeric string will fail with "Unknown storage format".