### PR TITLE
chore: update lance dependency to v10.0.0-beta.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.6.1</lance-spark.version>
-        <lance.version>9.0.0</lance.version>
+        <lance.version>10.0.0-beta.7</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Update the Lance dependency from 9.0.0 to 10.0.0-beta.7.
- Confirm Docker versions remain aligned with lance-spark 0.6.1 and lance-namespace implementation 0.4.0.

## Verification

- `make lint`
- `make install` (Spark 3.5 / Scala 2.12 default)

Triggered by tag [`refs/tags/v10.0.0-beta.7`](https://github.com/lance-format/lance/releases/tag/v10.0.0-beta.7).
