### PR TITLE
fix: hide system indexes from SHOW INDEXES

### DIFF
--- a/docs/src/operations/ddl/show-indexes.md
+++ b/docs/src/operations/ddl/show-indexes.md
@@ -58,6 +58,7 @@ The `SHOW INDEXES` command returns the following columns:
 ## Notes
 
 - The `fields` column returns the logical column names from the Lance schema, ordered according to the index definition.
+- Lance-maintained system indexes, including fragment-reuse and MemWAL indexes, are excluded from the output.
 
 ## See Also
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
@@ -24,6 +24,13 @@ import org.lance.spark.utils.{FieldPathUtils, Utils}
 
 import scala.collection.JavaConverters._
 
+object ShowIndexesExec {
+  private val SystemIndexTypes = Set("FragmentReuse", "MemWal")
+
+  private def isSystemIndex(indexType: String): Boolean =
+    indexType != null && SystemIndexTypes.exists(_.equalsIgnoreCase(indexType))
+}
+
 /**
  * Physical execution of SHOW INDEXES for Lance datasets.
  *
@@ -46,7 +53,9 @@ case class ShowIndexesExec(
 
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
-      val indexes = dataset.describeIndices().asScala.toSeq
+      val indexes = dataset.describeIndices().asScala.toSeq.filterNot { idx =>
+        ShowIndexesExec.isSystemIndex(idx.getIndexType)
+      }
       val lanceSchema = dataset.getLanceSchema()
 
       indexes.map { idx =>

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
@@ -25,10 +25,10 @@ import org.lance.spark.utils.{FieldPathUtils, Utils}
 import scala.collection.JavaConverters._
 
 object ShowIndexesExec {
-  private val SystemIndexTypes = Set("FragmentReuse", "MemWal")
+  private val SystemIndexNames = Set("__lance_frag_reuse", "__lance_mem_wal")
 
-  private def isSystemIndex(indexType: String): Boolean =
-    indexType != null && SystemIndexTypes.exists(_.equalsIgnoreCase(indexType))
+  private def isSystemIndex(indexName: String): Boolean =
+    indexName != null && SystemIndexNames.exists(_.equalsIgnoreCase(indexName))
 }
 
 /**
@@ -53,13 +53,16 @@ case class ShowIndexesExec(
 
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
-      val indexes = dataset.describeIndices().asScala.toSeq.filterNot { idx =>
-        ShowIndexesExec.isSystemIndex(idx.getIndexType)
-      }
+      val indexes = dataset.getIndexes.asScala.toSeq
+        .filterNot(idx => ShowIndexesExec.isSystemIndex(idx.name()))
+        .groupBy(_.name())
+        .toSeq
+        .sortBy(_._1)
+        .map(_._2.head)
       val lanceSchema = dataset.getLanceSchema()
 
       indexes.map { idx =>
-        val fieldIds = idx.getFieldIds
+        val fieldIds = idx.fields()
         val fieldNamesArray =
           if (fieldIds == null) {
             null
@@ -72,7 +75,7 @@ case class ShowIndexesExec(
             new GenericArrayData(names.toArray[AnyRef])
           }
 
-        val name = idx.getName
+        val name = idx.name()
         val stats = dataset.getIndexStatistics(name)
         val indexTypeValue = stats.get("index_type")
         val indexTypeUtf8 =

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -13,6 +13,10 @@
  */
 package org.lance.spark.update;
 
+import org.lance.index.IndexOptions;
+import org.lance.index.IndexParams;
+import org.lance.index.IndexType;
+import org.lance.index.scalar.ScalarIndexParams;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Utils;
 
@@ -165,7 +169,22 @@ public abstract class BaseShowIndexesTest {
   @Test
   public void testShowIndexesFiltersFragmentReuseIndex() {
     prepareDataset();
-    spark.sql(String.format("alter table %s create index test_index using btree (id)", fullTable));
+
+    // Use one index segment over all fragments so compaction rewrites indexed data. Distributed
+    // CREATE INDEX produces per-task segments that the compaction planner keeps in separate bins.
+    IndexParams indexParams =
+        IndexParams.builder().setScalarIndexParams(ScalarIndexParams.create("BTREE")).build();
+    try (var dataset =
+        Utils.openDatasetBuilder(LanceSparkReadOptions.builder().datasetUri(tableDir).build())
+            .build()) {
+      dataset.createIndex(
+          IndexOptions.builder(List.of("id"), IndexType.BTREE, indexParams)
+              .replace(true)
+              .train(true)
+              .withIndexName("test_index")
+              .build());
+    }
+
     spark.sql(
         String.format(
             "optimize %s with (target_rows_per_fragment=20000, defer_index_remap=true)",

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -13,6 +13,9 @@
  */
 package org.lance.spark.update;
 
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.utils.Utils;
+
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -133,7 +136,7 @@ public abstract class BaseShowIndexesTest {
   }
 
   @Test
-  public void testShowIndexesFiltersSystemIndexes() {
+  public void testShowIndexesFiltersMemWalIndex() {
     spark.sql(
         String.format(
             "create table %s (id int, region string) using lance "
@@ -157,5 +160,30 @@ public abstract class BaseShowIndexesTest {
     Assertions.assertEquals("btree", row.getString(2));
     Assertions.assertTrue(row.getLong(3) >= 1L);
     Assertions.assertTrue(row.getLong(4) >= 1L);
+  }
+
+  @Test
+  public void testShowIndexesFiltersFragmentReuseIndex() {
+    prepareDataset();
+    spark.sql(String.format("alter table %s create index test_index using btree (id)", fullTable));
+    spark.sql(
+        String.format(
+            "optimize %s with (target_rows_per_fragment=20000, defer_index_remap=true)",
+            fullTable));
+
+    try (var dataset =
+        Utils.openDatasetBuilder(LanceSparkReadOptions.builder().datasetUri(tableDir).build())
+            .build()) {
+      Assertions.assertTrue(
+          dataset.getIndexes().stream()
+              .anyMatch(index -> "__lance_frag_reuse".equalsIgnoreCase(index.name())),
+          "OPTIMIZE with deferred index remapping must create a fragment-reuse system index");
+    }
+
+    List<Row> rows = spark.sql(String.format("show indexes from %s", fullTable)).collectAsList();
+
+    Assertions.assertEquals(1, rows.size());
+    Assertions.assertEquals("test_index", rows.get(0).getString(0));
+    Assertions.assertEquals("btree", rows.get(0).getString(2));
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -149,8 +149,7 @@ public abstract class BaseShowIndexesTest {
     Assertions.assertTrue(systemOnly.isEmpty(), "MemWAL must not appear in SHOW INDEXES");
 
     spark.sql(String.format("alter table %s create index test_index using btree (id)", fullTable));
-    List<Row> rows =
-        spark.sql(String.format("show indexes from %s", fullTable)).collectAsList();
+    List<Row> rows = spark.sql(String.format("show indexes from %s", fullTable)).collectAsList();
 
     Assertions.assertEquals(1, rows.size());
     Row row = rows.get(0);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -131,4 +131,32 @@ public abstract class BaseShowIndexesTest {
     long numIndexedRows = row.getLong(4);
     Assertions.assertTrue(numIndexedRows >= 1L, "num_indexed_rows should be at least 1");
   }
+
+  @Test
+  public void testShowIndexesFiltersSystemIndexes() {
+    spark.sql(
+        String.format(
+            "create table %s (id int, region string) using lance "
+                + "partitioned by (bucket(4, region))",
+            fullTable));
+    spark.sql(
+        String.format(
+            "insert into %s values (1, 'east'), (2, 'west'), (3, 'north'), (4, 'south')",
+            fullTable));
+
+    List<Row> systemOnly =
+        spark.sql(String.format("show indexes from %s", fullTable)).collectAsList();
+    Assertions.assertTrue(systemOnly.isEmpty(), "MemWAL must not appear in SHOW INDEXES");
+
+    spark.sql(String.format("alter table %s create index test_index using btree (id)", fullTable));
+    List<Row> rows =
+        spark.sql(String.format("show indexes from %s", fullTable)).collectAsList();
+
+    Assertions.assertEquals(1, rows.size());
+    Row row = rows.get(0);
+    Assertions.assertEquals("test_index", row.getString(0));
+    Assertions.assertEquals("btree", row.getString(2));
+    Assertions.assertTrue(row.getLong(3) >= 1L);
+    Assertions.assertTrue(row.getLong(4) >= 1L);
+  }
 }


### PR DESCRIPTION
## Summary

- Read raw Lance index metadata with `Dataset#getIndexes` so system indexes can be identified before any plugin-backed description or statistics call.
- Filter the reserved `__lance_frag_reuse` and `__lance_mem_wal` indexes from `SHOW INDEXES`.
- Keep `getIndexStatistics` for user-created indexes so indexed fragment and row counts remain available.
- Add a regression test backed by a real bucket-partitioned Lance table, which creates the MemWAL system index.
- Document that internal fragment-reuse and MemWAL indexes are excluded from command output.

## Problem

Lance datasets can contain internal indexes such as `__lance_frag_reuse` and `__lance_mem_wal`. These are implementation details and must not appear in Spark's `SHOW INDEXES` output.

`ShowIndexesExec` previously called `Dataset#describeIndices` for the complete index list and then called `Dataset#getIndexStatistics` for every returned entry. With Lance Core 9.0.0, describing a dataset containing MemWAL can fail before any `IndexDescription` is returned:

```text
No scalar index plugin found for name 'memwal'
  at org.lance.Dataset.nativeDescribeIndices
  at org.lance.Dataset.describeIndices
  at ShowIndexesExec.run
```

This means filtering by `IndexDescription#indexType` after `describeIndices()` is too late. The command fails before Spark can inspect or filter the descriptions.

## Solution

`ShowIndexesExec` now uses `Dataset#getIndexes` to read raw manifest metadata. That API does not open or resolve the index plugin, so Spark can safely:

1. Remove entries named `__lance_frag_reuse` or `__lance_mem_wal`.
2. Group raw segments by logical index name and preserve deterministic name ordering.
3. Resolve field names from the remaining user-index metadata.
4. Call `getIndexStatistics` only for those user-created indexes.

This keeps the existing user-facing statistics behavior instead of dropping all statistics calls, while ensuring system indexes never reach `getIndexStatistics`.

## Tests
Have tested in my production envirnment.

The regression test:

1. Creates a bucket-partitioned Lance table and inserts data, producing the MemWAL system index.
2. Verifies `SHOW INDEXES` succeeds and does not expose the system index.
3. Creates a user B-tree index on the same table.
4. Verifies the B-tree index remains visible with its type and indexed fragment/row statistics.

The first CI revision demonstrated the regression consistently across the Spark 3.4, 3.5, 4.0, 4.1, and 4.2 unit-test matrix, all failing at `Dataset#describeIndices` with the same MemWAL plugin error. The updated implementation avoids that failing API path for index enumeration.
