### PR TITLE
feat: add BITMAP index support to CREATE INDEX

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -24,10 +24,10 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
-| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
-| `bitmap` | Bitmap index for efficient point queries on low-cardinality columns.        |
-| `fts`   | Full-text search (inverted) index for text search on string columns.        |
 | `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
+| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
+| `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| `bitmap` | Bitmap index for efficient point queries on low-cardinality columns.        |
 
 ## Options
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -63,10 +63,7 @@ For the `btree` method, the following options are supported:
 
 ### Bitmap Options
 
-For the `bitmap` method, the following options are supported:
-
-| Option           | Type   | Description                                                                                                                                                                                                         |
-|------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+The `bitmap` method has no method-specific options; only the common `train` option applies.
 
 Bitmap indexes do not require any special configuration parameters. They create a bitmap for each distinct value, making them efficient for equality filters on columns with a limited set of distinct values (up to a few thousand unique values).
 
@@ -234,7 +231,7 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. `zonemap` publishes those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `bitmap`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. `bitmap` and `zonemap` publish those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -24,9 +24,10 @@ The following index methods are supported:
 
 | Method  | Description                                                                 |
 |---------|-----------------------------------------------------------------------------|
-| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
 | `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
+| `bitmap` | Bitmap index for efficient point queries on low-cardinality columns.        |
 | `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
 
 ## Options
 
@@ -59,6 +60,15 @@ For the `btree` method, the following options are supported:
 | `build_mode`     | String | Index building mode: 'fragment' builds indexes in parallel by fragment; 'range' sorts data by indexed columns first, then partitions and builds indexes in parallel by partition. Default is 'fragment'. |
 | `rows_per_range` | Long   | The number of rows per range when built using range mode. Default is 1000000.                                                                                                                            |
 
+
+### Bitmap Options
+
+For the `bitmap` method, the following options are supported:
+
+| Option           | Type   | Description                                                                                                                                                                                                         |
+|------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+Bitmap indexes do not require any special configuration parameters. They create a bitmap for each distinct value, making them efficient for equality filters on columns with a limited set of distinct values (up to a few thousand unique values).
 
 ### FTS Options
 
@@ -120,6 +130,15 @@ Create a zonemap index when you want lightweight min/max-based fragment pruning:
 === "SQL"
     ```sql
     ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id);
+    ```
+
+### Bitmap Index on Low-Cardinality Column
+
+Create a bitmap index on a status column for fast equality lookups:
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.users CREATE INDEX idx_status_bitmap USING bitmap (status);
     ```
 
 ### Indexing with Options
@@ -189,7 +208,7 @@ to scanning the data until it is populated. There are two ways to populate it:
     dataset.optimizeIndices(OptimizeOptions.builder().build());
     ```
 
-`train = false` is supported for all index methods (`btree`, `fts`, `zonemap`). Because a deferred
+`train = false` is supported for all index methods (`btree`, `fts`, `zonemap`, `bitmap`). Because a deferred
 index performs no segmented build at creation time, `num_segments` cannot be combined with
 `train = false` — pass it on the eager build that populates the index instead.
 
@@ -209,6 +228,7 @@ Consider creating an index when:
 - You frequently filter a large table on a specific column.
 - You want lightweight fragment pruning based on per-zone min/max statistics.
 - Your queries involve point lookups or small range scans.
+- You need fast equality lookups on low-cardinality columns (bitmap indexes).
 
 ## How It Works
 
@@ -220,7 +240,7 @@ The `CREATE INDEX` command operates as follows:
 
 ## Notes and Limitations
 
-- **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
+- **Index Methods**: The `zonemap`, `btree`, `bitmap`, and `fts` methods are supported for scalar index creation.
 - **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one.
 - **Deferred Training**: With `train = false` the index is registered empty and is populated later, either by re-running `CREATE INDEX` (a full distributed build that replaces the empty index) or, for incremental coverage of newly appended fragments, by `Dataset.optimizeIndices` in the SDK. The SQL `OPTIMIZE` command compacts fragments and does not train deferred indexes.

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -54,6 +54,8 @@ import scala.collection.JavaConverters._
  *   metadata, and commits an index-creation transaction.
  * <li><b>ZONEMAP</b>: builds uncommitted index segments in parallel across fragment batches
  *   and commits the logical index on the driver.
+ * <li><b>BITMAP</b>: processes each fragment independently in parallel, merges index
+ *   metadata, and commits an index-creation transaction. Suitable for low-cardinality columns.
  * </ul>
  *
  * <p><b>Deferred training ({@code WITH (train=false)})</b>: commits an empty index on the driver
@@ -190,7 +192,7 @@ case class AddIndexExec(
     // Both fragment mode (Lance sorts each fragment) and range mode (Spark
     // pre-sorts each fragment's data) produce segments with disjoint fragment
     // coverage, so they can be committed as a single logical index directly.
-    if (indexType == IndexType.BTREE) {
+    if (indexType == IndexType.BTREE || indexType == IndexType.BITMAP) {
       val segments: Seq[Index] =
         if (btreeBuildMode.contains("range")) {
           new RangeBasedBTreeIndexJob(
@@ -209,7 +211,8 @@ case class AddIndexExec(
             nsImpl,
             nsProps,
             tableId,
-            initialStorageOpts).run()
+            initialStorageOpts,
+            indexType = indexType).run()
         }
       commitIndexSegments(readOptions, canonicalColumns.head, segments)
       return Seq(new GenericInternalRow(Array[Any](
@@ -552,7 +555,8 @@ class BTreeFragmentIndexJob(
     nsImpl: Option[String],
     nsProps: Option[Map[String, String]],
     tableId: Option[List[String]],
-    initialStorageOpts: Option[Map[String, String]]) extends Serializable {
+    initialStorageOpts: Option[Map[String, String]],
+    indexType: IndexType = IndexType.BTREE) extends Serializable {
 
   def run(): Seq[Index] = {
     val encodedReadOptions = encode(readOptions)
@@ -569,7 +573,8 @@ class BTreeFragmentIndexJob(
         nsImpl,
         nsProps,
         tableId,
-        initialStorageOpts)
+        initialStorageOpts,
+        indexType = indexType)
     }
 
     addIndexExec.session.sparkContext
@@ -603,7 +608,8 @@ case class BTreeFragmentSegmentTask(
     namespaceImpl: Option[String],
     namespaceProperties: Option[Map[String, String]],
     tableId: Option[List[String]],
-    initialStorageOptions: Option[Map[String, String]]) extends Serializable {
+    initialStorageOptions: Option[Map[String, String]],
+    indexType: IndexType = IndexType.BTREE) extends Serializable {
 
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
@@ -616,7 +622,7 @@ case class BTreeFragmentSegmentTask(
     // No index name or UUID: Lance generates the segment UUID, and the logical
     // index name is assigned when the segments are committed on the driver.
     val indexOptions = IndexOptions
-      .builder(java.util.Arrays.asList(columns: _*), IndexType.BTREE, params)
+      .builder(java.util.Arrays.asList(columns: _*), indexType, params)
       .replace(false)
       .withFragmentIds(Collections.singletonList(fragmentId))
       .build()
@@ -993,6 +999,7 @@ object IndexUtils {
       case "btree" => IndexType.BTREE
       case "zonemap" => IndexType.ZONEMAP
       case "fts" => IndexType.INVERTED
+      case "bitmap" => IndexType.BITMAP
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }
@@ -1002,6 +1009,7 @@ object IndexUtils {
       case "btree" => "btree"
       case "zonemap" => "zonemap"
       case "fts" => "inverted"
+      case "bitmap" => "bitmap"
       case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
     }
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -54,8 +54,8 @@ import scala.collection.JavaConverters._
  *   metadata, and commits an index-creation transaction.
  * <li><b>ZONEMAP</b>: builds uncommitted index segments in parallel across fragment batches
  *   and commits the logical index on the driver.
- * <li><b>BITMAP</b>: processes each fragment independently in parallel, merges index
- *   metadata, and commits an index-creation transaction. Suitable for low-cardinality columns.
+ * <li><b>BITMAP</b>: builds uncommitted per-fragment index segments in parallel and
+ *   commits them as a single logical index on the driver. Suitable for low-cardinality columns.
  * </ul>
  *
  * <p><b>Deferred training ({@code WITH (train=false)})</b>: commits an empty index on the driver

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -1138,6 +1138,46 @@ public abstract class BaseAddIndexTest {
     }
   }
 
+  @Test
+  public void testCreateBitmapIndex() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index test_bitmap_idx using bitmap (id)", fullTable));
+
+    Assertions.assertEquals(
+        "StructType(StructField(fragments_indexed,LongType,true),StructField(index_name,StringType,true))",
+        result.schema().toString());
+
+    Row row = result.collectAsList().get(0);
+    long fragmentsIndexed = row.getLong(0);
+    String indexName = row.getString(1);
+
+    Assertions.assertTrue(fragmentsIndexed >= 2, "Expected at least 2 fragments to be indexed");
+    Assertions.assertEquals("test_bitmap_idx", indexName);
+
+    // Check index is created successfully
+    checkIndex("test_bitmap_idx");
+
+    // Verify query using the indexed field
+    Dataset<Row> query = spark.sql(String.format("select * from %s where id=5", fullTable));
+    Assertions.assertEquals(1L, query.count());
+    Row r = query.collectAsList().get(0);
+    Assertions.assertEquals(5, r.getInt(0));
+    Assertions.assertEquals("text_5", r.getString(1));
+  }
+
+  @Test
+  public void testBitmapIndexHasIndexDetails() {
+    prepareDataset();
+    spark.sql(
+        String.format(
+            "alter table %s create index idx_details_bitmap using bitmap (id)", fullTable));
+    verifyIndexDetails("idx_details_bitmap", "BITMAP");
+  }
+
   private Index checkIndex(String indexName) {
     // Check index is created successfully
     org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
@@ -179,4 +179,16 @@ class IndexUtilsTest {
       classOf[UnsupportedOperationException],
       () => IndexUtils.buildIndexType("ivf_pq"))
   }
+
+  @Test
+  def buildIndexType_bitmapCaseInsensitive(): Unit = {
+    import org.lance.index.IndexType
+    assertEquals(IndexType.BITMAP, IndexUtils.buildIndexType("bitmap"))
+    assertEquals(IndexType.BITMAP, IndexUtils.buildIndexType("BITMAP"))
+  }
+
+  @Test
+  def buildScalarIndexParamType_bitmapReturnsBitmap(): Unit = {
+    assertEquals("bitmap", IndexUtils.buildScalarIndexParamType("bitmap"))
+  }
 }


### PR DESCRIPTION
## Summary

Add `bitmap` index method to `CREATE INDEX` (`ALTER TABLE ... CREATE INDEX USING bitmap`). The BITMAP index type already exists in lance-core (`IndexType.BITMAP`, `BitmapIndexParams`) and is suitable for low-cardinality columns (e.g. status codes, categories).

## Changes

| File | Change |
|------|--------|
| AddIndexExec.scala | Add `bitmap` case to `buildIndexType` and `buildScalarIndexParamType`. Add BITMAP to the segment-commit code path (alongside BTree) instead of the `mergeIndexMetadata` path. Generalize `BTreeFragmentSegmentTask` and `BTreeFragmentIndexJob` to accept a dynamic `IndexType` parameter (defaults to `IndexType.BTREE` for backward compatibility). Update Javadoc. |
| create-index.md | Document bitmap method, add options section, usage examples |
| IndexUtilsTest.scala | Unit tests for `buildIndexType("bitmap")` and `buildScalarIndexParamType("bitmap")` |
| BaseAddIndexTest.java | Integration tests for bitmap index creation and index-details verification |

## Why segment-commit for BITMAP

lance-core 9.0.0 requires BITMAP indexes to use the segment-based commit API (`create_index_uncommitted` / `commit_existing_index_segments`) rather than the older `merge_index_metadata` approach. BITMAP now shares the same code path as BTree: per-fragment segments are built by `BTreeFragmentIndexJob` (which is index-type-agnostic after this change), then committed atomically via `commitIndexSegments` on the driver.

## Test results

**Unit tests** (pure JVM, no native deps):
- `./mvnw clean test -pl lance-spark-base_2.12 -Dtest=IndexUtilsTest`
- New: `buildIndexType_bitmapCaseInsensitive`, `buildScalarIndexParamType_bitmapReturnsBitmap`

**Integration tests** (added to `BaseAddIndexTest`, shared across all Spark/Scala version modules):
- `testCreateBitmapIndex` — creates bitmap index on 2-fragment table, verifies point query
- `testBitmapIndexHasIndexDetails` — verifies index_details and `describeIndices` return BITMAP

Full build compiles clean for `lance-spark-base_2.12` and `lance-spark-3.5_2.13`.