### PR TITLE
fix: create index succeeds without creating an index on empty tables

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -193,6 +193,10 @@ to scanning the data until it is populated. There are two ways to populate it:
 index performs no segmented build at creation time, `num_segments` cannot be combined with
 `train = false` — pass it on the eager build that populates the index instead.
 
+Creating a scalar index on an empty table also registers an empty index with zero fragment
+coverage. The index is immediately visible through `SHOW INDEXES`. After data is appended, populate
+it by re-running `CREATE INDEX` or calling `Dataset.optimizeIndices`.
+
 ## Output
 
 The `CREATE INDEX` command returns the following information about the operation:

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -1000,7 +1000,7 @@ class TestDDLIndex:
         assert metadata["index_version"] == 2
 
     def test_create_index_empty_table(self, spark):
-        """Test CREATE INDEX on empty table."""
+        """Test creating scalar indexes on an empty table."""
         spark.sql("""
             CREATE TABLE default.test_table (
                 id INT,
@@ -1008,14 +1008,26 @@ class TestDDLIndex:
             )
         """)
 
-        # Creating index on empty table should return 0 fragments indexed
-        result = spark.sql("""
-            ALTER TABLE default.test_table
-            CREATE INDEX idx_id USING btree (id)
-        """).collect()
+        statements = [
+            "CREATE INDEX idx_id USING btree (id)",
+            "CREATE INDEX idx_name_zonemap USING zonemap (name)",
+            """CREATE INDEX idx_name_fts USING fts (name) WITH (
+                base_tokenizer = 'simple', language = 'English',
+                max_token_length = 40, lower_case = true, stem = false,
+                remove_stop_words = false, ascii_folding = false,
+                with_position = true
+            )""",
+        ]
 
-        # Should return with 0 fragments indexed
-        assert result[0][0] == 0
+        for statement in statements:
+            result = spark.sql(
+                f"ALTER TABLE default.test_table {statement}"
+            ).collect()
+            assert result[0]["fragments_indexed"] == 0
+
+        indexes = spark.sql("SHOW INDEXES IN default.test_table").collect()
+        index_names = {row["name"] for row in indexes}
+        assert index_names == {"idx_id", "idx_name_zonemap", "idx_name_fts"}
 
     def test_drop_index(self, spark):
         """Test DROP INDEX removes an existing index."""

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -58,11 +58,12 @@ import scala.collection.JavaConverters._
  *
  * <p><b>Deferred training ({@code WITH (train=false)})</b>: commits an empty index on the driver
  * with an empty fragment bitmap (all rows appear unindexed), skipping data processing. Supported
- * for all index types; ignored for empty tables. Populate it later by re-running {@code CREATE
- * INDEX} with the same name (a full distributed build that replaces the empty index) or, for
- * incremental coverage of appended fragments, by {@code Dataset.optimizeIndices} (the SQL
- * {@code OPTIMIZE} only compacts fragments). {@code num_segments} is rejected with this option,
- * since no segmented build occurs.
+ * for all supported scalar index methods. Empty tables use the same path even when
+ * {@code train=true}, since there are no fragments to train. Populate the index later by re-running
+ * {@code CREATE INDEX} with the same name (a full distributed build that replaces the empty index)
+ * or, for incremental coverage of appended fragments, by {@code Dataset.optimizeIndices} (the SQL
+ * {@code OPTIMIZE} only compacts fragments). {@code num_segments} is rejected with
+ * {@code train=false}, since no segmented build occurs.
  *
  * <p>The following options are consumed at the Spark execution layer and are never forwarded
  * to the Lance index backend: {@code train}, {@code build_mode}, {@code rows_per_range},
@@ -99,11 +100,6 @@ case class AddIndexExec(
       } finally {
         ds.close()
       }
-    }
-
-    if (fragmentIds.isEmpty) {
-      // No fragments to index
-      return Seq(new GenericInternalRow(Array[Any](0L, UTF8String.fromString(indexName))))
     }
 
     val train = IndexUtils.extractTrain(args)
@@ -143,15 +139,14 @@ case class AddIndexExec(
       }
     }
 
-    // train=false: commit an empty index on the driver for any index type,
-    // skipping all data processing. See the class doc for how it is populated.
-    if (!train) {
+    // train=false, or an empty table: commit an empty index on the driver and skip data
+    // processing. Index and option validation above still applies to empty tables.
+    if (!train || fragmentIds.isEmpty) {
       val uuid = UUID.randomUUID()
       val dataset = Utils.openDatasetBuilder(readOptions).build()
       try {
         return commitEmptyIndex(
           dataset,
-          readOptions,
           indexName,
           indexType,
           canonicalColumns,
@@ -294,7 +289,6 @@ case class AddIndexExec(
   /** Commits an empty (untrained) index on the driver, with an empty fragment bitmap. */
   private def commitEmptyIndex(
       dataset: Dataset,
-      readOptions: LanceSparkReadOptions,
       indexName: String,
       indexType: IndexType,
       canonicalColumns: Seq[String],
@@ -312,45 +306,9 @@ case class AddIndexExec(
       .train(false)
       .build()
 
-    val emptyIndex = dataset.createIndex(opts)
-
-    val fieldIds = canonicalColumns.map { column =>
-      FieldPathUtils.resolveLeafField(dataset.getLanceSchema, column).getId
-    }.toList
-
-    val indexBuilder = Index
-      .builder()
-      .uuid(uuid)
-      .name(indexName)
-      .fields(fieldIds.map(java.lang.Integer.valueOf).asJava)
-      .datasetVersion(dataset.version())
-      .indexDetails(emptyIndex.indexDetails().orElse(Array.empty[Byte]))
-      .indexVersion(emptyIndex.indexVersion())
-      .indexType(indexType)
-      .fragments(java.util.Collections.emptyList())
-    emptyIndex.createdAt().ifPresent(indexBuilder.createdAt)
-    val index = indexBuilder.build()
-
-    val removedIndices = dataset.getIndexes.asScala
-      .filter(_.name() == indexName)
-      .toList.asJava
-
-    val op = AddIndexOperation.builder()
-      .withNewIndices(Collections.singletonList(index))
-      .withRemovedIndices(removedIndices)
-      .build()
-    val txn = new Transaction.Builder()
-      .readVersion(dataset.version())
-      .operation(op)
-      .build()
-    try {
-      val newDataset = new CommitBuilder(dataset)
-        .writeParams(readOptions.getStorageOptions)
-        .execute(txn)
-      newDataset.close()
-    } finally {
-      txn.close()
-    }
+    // Without fragmentIds, Lance commits createIndex atomically. Do not manually commit the
+    // returned metadata a second time.
+    dataset.createIndex(opts)
 
     Seq(new GenericInternalRow(Array[Any](0L, UTF8String.fromString(indexName))))
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -128,6 +128,35 @@ public abstract class BaseAddIndexTest {
   }
 
   @Test
+  public void testCreateIndexOnEmptyTable() {
+    spark.sql(String.format("create table %s (id int) using lance", fullTable));
+
+    long initialVersion;
+    try (org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      initialVersion = lanceDataset.version();
+    }
+
+    Row result =
+        spark
+            .sql(String.format("alter table %s create index idx_empty using btree (id)", fullTable))
+            .collectAsList()
+            .get(0);
+    Assertions.assertEquals(0L, result.getLong(0));
+
+    try (org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      Assertions.assertEquals(
+          initialVersion + 1,
+          lanceDataset.version(),
+          "Empty index creation should commit exactly one dataset version");
+
+      List<Index> indexes = lanceDataset.getIndexes();
+      Assertions.assertEquals(1, indexes.size());
+      Assertions.assertEquals("idx_empty", indexes.get(0).name());
+      Assertions.assertTrue(indexes.get(0).fragments().orElse(Collections.emptyList()).isEmpty());
+    }
+  }
+
+  @Test
   public void testCreateIndexDistributed() {
     prepareDataset();
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -18,7 +18,9 @@ import org.lance.index.IndexCriteria;
 import org.lance.index.IndexDescription;
 import org.lance.index.IndexType;
 import org.lance.index.OptimizeOptions;
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.FieldPathUtils;
+import org.lance.spark.utils.Utils;
 
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
@@ -130,9 +132,10 @@ public abstract class BaseAddIndexTest {
   @Test
   public void testCreateIndexOnEmptyTable() {
     spark.sql(String.format("create table %s (id int) using lance", fullTable));
+    LanceSparkReadOptions readOptions = LanceSparkReadOptions.from(tableDir);
 
     long initialVersion;
-    try (org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build()) {
+    try (var lanceDataset = Utils.openDatasetBuilder(readOptions).build()) {
       initialVersion = lanceDataset.version();
     }
 
@@ -143,7 +146,7 @@ public abstract class BaseAddIndexTest {
             .get(0);
     Assertions.assertEquals(0L, result.getLong(0));
 
-    try (org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build()) {
+    try (var lanceDataset = Utils.openDatasetBuilder(readOptions).build()) {
       Assertions.assertEquals(
           initialVersion + 1,
           lanceDataset.version(),


### PR DESCRIPTION
## Summary

- register empty scalar index metadata when `CREATE INDEX` runs on an empty table
- validate index options before taking the empty-table path
- rely on Lance's atomic `createIndex` commit and avoid the previous duplicate metadata commit
- document the behavior and add unit/integration coverage for empty scalar indexes

## Root cause

`AddIndexExec` returned early when a table had no fragments, so the command reported success without registering index metadata. The deferred-index helper also manually committed metadata after `Dataset.createIndex`, even though the SDK call without fragment IDs already commits atomically.

## Validation

- `AddIndexTest`: 30 tests passed on Spark 3.5 / Scala 2.12
- `spotless:check` passed for `lance-spark-base_2.12`
- `git diff --check` passed
- Python integration test file parsed successfully

Closes #738