### PR TITLE
feat: support distributed scalar index builds

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -22,11 +22,16 @@ The command uses the `ALTER TABLE` syntax to add an index.
 
 The following index methods are supported:
 
-| Method  | Description                                                                 |
-|---------|-----------------------------------------------------------------------------|
-| `zonemap` | Lightweight min/max index for fragment pruning on a scalar column. |
-| `btree` | B-tree index for efficient range queries and point lookups on scalar columns. |
-| `fts`   | Full-text search (inverted) index for text search on string columns.        |
+| Method        | Description                                                                   |
+|---------------|-------------------------------------------------------------------------------|
+| `zonemap`     | Lightweight min/max index for fragment pruning on a scalar column.            |
+| `btree`       | B-tree index for efficient range queries and point lookups on ordered values. |
+| `bitmap`      | Bitmap index for low-cardinality values.                                      |
+| `label_list`  | Label membership index for array/list columns.                                |
+| `ngram`       | N-gram index for string values.                                               |
+| `bloomfilter` | Bloom filter index for approximate membership pruning.                        |
+| `rtree`       | R-tree index for GeoArrow geometry columns.                                   |
+| `fts`         | Full-text search (inverted) index for text search on string columns.          |
 
 ## Options
 
@@ -40,14 +45,22 @@ These options apply to all index methods:
 |---------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `train` | Boolean | When `false`, defer index training: register an empty index covering no rows without scanning any data, to be populated later. Default `true`. See [Deferred Index Creation](#deferred-index-creation). |
 
+### Distributed Index Options
+
+The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and
+`rtree` supports:
+
+| Option         | Type    | Description                                                                                                                                                                                                 |
+|----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Each task covers a contiguous batch of fragments. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+
 ### ZoneMap Options
 
 For the `zonemap` method, the following options are supported:
 
-| Option          | Type | Description                                  |
-|-----------------|------|----------------------------------------------|
-| `rows_per_zone` | Long    | The approximate number of rows per zonemap zone. |
-| `num_segments`  | Integer | Target number of index segments (upper bound; clamped to fragment count when larger). Each segment covers a batch of fragments. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+| Option          | Type | Description                                      |
+|-----------------|------|--------------------------------------------------|
+| `rows_per_zone` | Long | The approximate number of rows per zonemap zone. |
 
 ### BTree Options
 
@@ -140,6 +153,73 @@ Create a zonemap index and specify the approximate number of rows per zone:
     ALTER TABLE lance.db.users CREATE INDEX idx_id_zonemap USING zonemap (id) WITH (rows_per_zone = 2048);
     ```
 
+### Bitmap
+
+Use `bitmap` for columns with a relatively small number of distinct values.
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.events CREATE INDEX idx_status_bitmap
+        USING bitmap (status) WITH (num_segments = 8);
+    ```
+
+### Label List
+
+Use `label_list` for membership filtering on an array/list column. The list item type must be
+non-nested.
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.events CREATE INDEX idx_labels
+        USING label_list (labels) WITH (num_segments = 8);
+    ```
+
+### NGram
+
+Use `ngram` to build a fixed trigram index on a string column.
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.documents CREATE INDEX idx_content_ngram
+        USING ngram (content) WITH (num_segments = 8);
+    ```
+
+### Bloom Filter
+
+Use `bloomfilter` for membership pruning when a compact probabilistic index is appropriate.
+
+| Option            | Type   | Description                                                                                              |
+|-------------------|--------|----------------------------------------------------------------------------------------------------------|
+| `number_of_items` | Long   | Expected number of values per Bloom filter block. Default `8192`.                                        |
+| `probability`     | Double | Target false-positive probability. Default `0.00057` (approximately one false positive in 1,754 probes). |
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.events CREATE INDEX idx_id_bloom
+        USING bloomfilter (id) WITH (
+            number_of_items = 16384,
+            probability = 0.001,
+            num_segments = 8
+        );
+    ```
+
+### RTree
+
+Use `rtree` for spatial filtering on a supported GeoArrow geometry column. For example, a point
+can be represented by a struct carrying `ARROW:extension:name=geoarrow.point` metadata.
+
+| Option      | Type    | Description                                            |
+|-------------|---------|--------------------------------------------------------|
+| `page_size` | Integer | Maximum number of entries per R-tree page. Minimum `2`; default `4096`. |
+
+=== "SQL"
+    ```sql
+    ALTER TABLE lance.db.places CREATE INDEX idx_geometry
+        USING rtree (geometry) WITH (page_size = 2048, num_segments = 8);
+    ```
+
+Lance validates each method's column type and parameters during index creation.
+
 ### Full-Text Search Index
 
 Create an FTS index on a text column:
@@ -189,9 +269,9 @@ to scanning the data until it is populated. There are two ways to populate it:
     dataset.optimizeIndices(OptimizeOptions.builder().build());
     ```
 
-`train = false` is supported for all index methods (`btree`, `fts`, `zonemap`). Because a deferred
-index performs no segmented build at creation time, `num_segments` cannot be combined with
-`train = false` — pass it on the eager build that populates the index instead.
+`train = false` is supported for all index methods. Because deferred index creation does not build
+index data, `num_segments` cannot be combined with `train = false` — pass it on the eager build
+that populates the index instead.
 
 ## Output
 
@@ -214,13 +294,13 @@ Consider creating an index when:
 
 The `CREATE INDEX` command operates as follows:
 
-1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. Methods such as `btree`, `fts`, and `zonemap` can build physical index segments in parallel across fragments. `zonemap` publishes those segments directly as one logical index. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data.
+1.  **Index Build Execution**: Lance Spark chooses an execution path based on the index method. `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and `rtree` split source fragments into batches and build them in parallel. Range-mode `btree` uses Spark repartitioning and sorted preprocessed data. FTS uses its existing fragment-parallel metadata flow.
 2.  **Metadata Finalization**: Lance Spark merges or commits the resulting index metadata on the driver so the new logical index becomes visible atomically.
 3.  **Transactional Commit**: A new table version is committed with the new index information. The operation is atomic and ensures that concurrent reads are not affected.
 
 ## Notes and Limitations
 
-- **Index Methods**: The `zonemap`, `btree`, and `fts` methods are supported for scalar index creation.
-- **Zonemap Column Count**: Zonemap indexes currently support a single column only. The generic `CREATE INDEX` grammar accepts a column list, but Lance rejects multi-column zonemap creation.
+- **Index Methods**: The `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, `rtree`, `btree`, and `fts` methods are supported for index creation.
+- **Indexed Column Count**: `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`, and `rtree` currently support exactly one indexed column.
 - **Index Replacement**: If you create an index with the same name as an existing one, the old index will be replaced by the new one.
 - **Deferred Training**: With `train = false` the index is registered empty and is populated later, either by re-running `CREATE INDEX` (a full distributed build that replaces the empty index) or, for incremental coverage of newly appended fragments, by `Dataset.optimizeIndices` in the SDK. The SQL `OPTIMIZE` command compacts fragments and does not train deferred indexes.

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -782,7 +782,7 @@ class TestDDLBlobV2:
 
 
 class TestDDLIndex:
-    """Test DDL index operations: CREATE INDEX (BTree, FTS)."""
+    """Test DDL index operations."""
 
     def test_create_btree_index_on_int(self, spark):
         """Test CREATE INDEX with BTree on integer column."""
@@ -889,6 +889,31 @@ class TestDDLIndex:
         """).collect()
         assert len(query_result) == 1
         assert query_result[0].id == 50
+
+    def test_create_distributed_bitmap_index(self, spark):
+        """Test distributed Bitmap creation with multiple fragments in one segment."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                status INT
+            )
+        """)
+        spark.sql("INSERT INTO default.test_table VALUES (1, 10), (2, 20)")
+        spark.sql("INSERT INTO default.test_table VALUES (3, 10), (4, 20)")
+
+        result = spark.sql("""
+            ALTER TABLE default.test_table
+            CREATE INDEX idx_status_bitmap USING bitmap (status)
+            WITH (num_segments = 1)
+        """).collect()
+
+        assert len(result) == 1
+        assert result[0][0] >= 2
+        assert result[0][1] == "idx_status_bitmap"
+        _assert_lance_index_metadata(
+            spark, "default.test_table", "idx_status_bitmap", "BITMAP"
+        )
+        assert spark.sql("SELECT * FROM default.test_table").count() == 4
 
     def test_create_btree_index_on_nested_literal_dot_field(self, spark):
         """Test CREATE INDEX on nested struct fields, including literal dots."""

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FieldPathUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/FieldPathUtils.java
@@ -44,13 +44,16 @@ public final class FieldPathUtils {
   }
 
   public static LanceField resolveLeafField(LanceSchema schema, String canonicalPath) {
-    List<String> parts = parseCanonicalPath(canonicalPath);
-    LanceField field = resolveField(schema, parts);
+    LanceField field = resolveField(schema, canonicalPath);
     if (!field.getChildren().isEmpty()) {
       throw new IllegalArgumentException(
           "Index column must be a leaf field, got: " + canonicalPath);
     }
     return field;
+  }
+
+  public static LanceField resolveField(LanceSchema schema, String canonicalPath) {
+    return resolveField(schema, parseCanonicalPath(canonicalPath));
   }
 
   public static String pathByFieldId(LanceSchema schema, int fieldId) {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -968,6 +968,19 @@ object IndexUtils extends Logging {
     IndexType.BLOOM_FILTER,
     IndexType.RTREE)
 
+  // ScalarIndexParams uses Lance Core's scalar plugin names, which are a separate contract from
+  // both Spark SQL method names and the Java IndexType enum names. Keep the mapping explicit instead
+  // of deriving it from either naming convention.
+  private val scalarParamTypesByIndexType: Map[IndexType, String] = Map(
+    IndexType.BTREE -> "btree",
+    IndexType.ZONEMAP -> "zonemap",
+    IndexType.BITMAP -> "bitmap",
+    IndexType.LABEL_LIST -> "labellist",
+    IndexType.NGRAM -> "ngram",
+    IndexType.BLOOM_FILTER -> "bloomfilter",
+    IndexType.RTREE -> "rtree",
+    IndexType.INVERTED -> "inverted")
+
   def scalarSegmentIndexType(method: String): Option[IndexType] =
     methodToIndexTypes
       .get(method.toLowerCase(Locale.ROOT))
@@ -1003,15 +1016,11 @@ object IndexUtils extends Logging {
   }
 
   def buildScalarIndexParamType(method: String): String = {
-    scalarSegmentIndexType(method)
-      .map(_.name().toLowerCase(Locale.ROOT).replace("_", ""))
-      .getOrElse {
-        method.toLowerCase(Locale.ROOT) match {
-          case "btree" => "btree"
-          case "fts" => "inverted"
-          case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
-        }
-      }
+    val normalized = method.toLowerCase(Locale.ROOT)
+    val indexType = buildIndexType(normalized)
+    scalarParamTypesByIndexType.getOrElse(
+      indexType,
+      throw new UnsupportedOperationException(s"Unsupported scalar index method: $normalized"))
   }
 
   def btreeBuildMode(indexType: IndexType, args: Seq[LanceNamedArgument]): Option[String] = {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -37,9 +37,10 @@ import org.lance.spark.utils.{CloseableUtil, FieldPathUtils, Utils}
 import org.lance.spark.write.SingleBatchArrowReader
 
 import java.time.Instant
-import java.util.{Collections, Optional, UUID}
+import java.util.{Collections, Locale, Optional, UUID}
 
 import scala.collection.JavaConverters._
+import scala.reflect.ClassTag
 
 /**
  * Physical execution of distributed CREATE INDEX (ALTER TABLE ... CREATE INDEX ...) for Lance datasets.
@@ -52,8 +53,8 @@ import scala.collection.JavaConverters._
  *   {@code build_mode='fragment'}.
  * <li><b>FTS / INVERTED</b>: processes each fragment independently in parallel, merges index
  *   metadata, and commits an index-creation transaction.
- * <li><b>ZONEMAP</b>: builds uncommitted index segments in parallel across fragment batches
- *   and commits the logical index on the driver.
+ * <li><b>ZONEMAP / BITMAP / LABEL_LIST / NGRAM / BLOOMFILTER / RTREE</b>: build uncommitted
+ *   index segments in parallel across fragment batches and commit the logical index on the driver.
  * </ul>
  *
  * <p><b>Deferred training ({@code WITH (train=false)})</b>: commits an empty index on the driver
@@ -85,12 +86,16 @@ case class AddIndexExec(
     }
 
     val readOptions = lanceDataset.readOptions()
+    val scalarSegmentIndexType = IndexUtils.scalarSegmentIndexType(method)
 
     val (fragmentIds, canonicalColumns) = {
       val ds = Utils.openDatasetBuilder(readOptions).build()
       try {
         val canonical = columns.map { column =>
-          val field = FieldPathUtils.resolveLeafField(ds.getLanceSchema, column)
+          val field = scalarSegmentIndexType match {
+            case Some(_) => FieldPathUtils.resolveField(ds.getLanceSchema, column)
+            case None => FieldPathUtils.resolveLeafField(ds.getLanceSchema, column)
+          }
           FieldPathUtils.pathByFieldId(ds.getLanceSchema, field.getId)
         }
         (
@@ -109,18 +114,17 @@ case class AddIndexExec(
     val train = IndexUtils.extractTrain(args)
     val indexType = IndexUtils.buildIndexType(method)
 
-    if (indexType == IndexType.ZONEMAP && canonicalColumns.size != 1) {
+    if (scalarSegmentIndexType.isDefined && canonicalColumns.size != 1) {
       throw new UnsupportedOperationException(
-        "Zonemap index currently supports a single column only")
+        s"${indexType.name()} indexes currently support a single column only")
     }
 
     val btreeBuildMode = IndexUtils.btreeBuildMode(indexType, args)
-    val useLogicalSegmentCommit = IndexUtils.useLogicalSegmentCommit(indexType)
 
     val numSegmentsOpt = args.find(_.name == "num_segments")
-    if (numSegmentsOpt.isDefined && !useLogicalSegmentCommit) {
+    if (numSegmentsOpt.isDefined && scalarSegmentIndexType.isEmpty) {
       throw new IllegalArgumentException(
-        "num_segments option is only supported for index types that use segmented builds (e.g., zonemap)")
+        s"num_segments is not supported for ${indexType.name()} indexes")
     }
     if (numSegmentsOpt.isDefined && !train) {
       throw new IllegalArgumentException(
@@ -164,9 +168,9 @@ case class AddIndexExec(
     val (nsImpl, nsProps, tableId, initialStorageOpts) =
       extractNamespaceInfo(lanceDataset, readOptions)
 
-    // Zonemap uses logical segment commit path
-    if (useLogicalSegmentCommit) {
-      val zonemapJob = new ZonemapIndexJob(
+    // Scalar segment indexes use the logical segment commit path.
+    if (scalarSegmentIndexType.isDefined) {
+      val scalarSegmentJob = new ScalarSegmentIndexJob(
         this.copy(columns = canonicalColumns),
         readOptions,
         fragmentIds,
@@ -175,7 +179,7 @@ case class AddIndexExec(
         nsProps,
         tableId,
         initialStorageOpts)
-      val segments = zonemapJob.run()
+      val segments = scalarSegmentJob.run()
       // Atomic add+remove via Lance core; see commitIndexSegments
       commitIndexSegments(readOptions, canonicalColumns.head, segments)
       return Seq(new GenericInternalRow(Array[Any](
@@ -315,7 +319,12 @@ case class AddIndexExec(
     val emptyIndex = dataset.createIndex(opts)
 
     val fieldIds = canonicalColumns.map { column =>
-      FieldPathUtils.resolveLeafField(dataset.getLanceSchema, column).getId
+      val field = if (IndexUtils.scalarSegmentIndexType(method).isDefined) {
+        FieldPathUtils.resolveField(dataset.getLanceSchema, column)
+      } else {
+        FieldPathUtils.resolveLeafField(dataset.getLanceSchema, column)
+      }
+      field.getId
     }.toList
 
     val indexBuilder = Index
@@ -839,11 +848,11 @@ case class RangeBTreeIndexBuilder(
 }
 
 /**
- * A job implementation for creating zonemap indexes using logical segment commit.
+ * A job implementation for creating scalar segment indexes using logical segment commit.
  * Fragments are batched into segments, each built in parallel, and committed
  * as a logical index on the driver.
  */
-class ZonemapIndexJob(
+class ScalarSegmentIndexJob(
     addIndexExec: AddIndexExec,
     readOptions: LanceSparkReadOptions,
     fragmentIds: List[Integer],
@@ -851,22 +860,27 @@ class ZonemapIndexJob(
     nsImpl: Option[String],
     nsProps: Option[Map[String, String]],
     tableId: Option[List[String]],
-    initialStorageOpts: Option[Map[String, String]])
-  extends Logging {
+    initialStorageOpts: Option[Map[String, String]]) {
 
   def run(): Seq[Index] = {
+    val indexType = IndexUtils.scalarSegmentIndexType(addIndexExec.method).getOrElse {
+      throw new UnsupportedOperationException(
+        s"Unsupported Lance index method: ${addIndexExec.method}")
+    }
     val encodedReadOptions = encode(readOptions)
     val columns = addIndexExec.columns.toList
     val argsJson = IndexUtils.toJson(addIndexExec.args)
-    val fragmentBatches = batchFragments(fragmentIds, numSegments)
+    val fragmentBatches = IndexUtils.batchFragments(
+      fragmentIds,
+      numSegments,
+      addIndexExec.session.sparkContext.defaultParallelism)
 
     val tasks = fragmentBatches.map { batch =>
-      ZonemapIndexTask(
+      ScalarSegmentIndexTask(
         encodedReadOptions,
         columns,
         addIndexExec.method,
         argsJson,
-        addIndexExec.indexName,
         batch,
         nsImpl,
         nsProps,
@@ -874,56 +888,22 @@ class ZonemapIndexJob(
         initialStorageOpts)
     }.toSeq
 
-    try {
-      addIndexExec.session.sparkContext
-        .parallelize(tasks, tasks.size)
-        .map(t => t.execute())
-        .collect()
-        .map(decode[Index])
-        .toSeq
-    } catch {
-      case e: Exception =>
-        throw new RuntimeException(
-          "Zonemap segment build failed. Uncommitted segments are not " +
-            "visible to readers and will not affect query correctness.",
-          e)
-    }
-  }
-
-  private def batchFragments(
-      fragmentIds: List[Integer],
-      numSegments: Option[Int]): Seq[List[Integer]] = {
-    val n = fragmentIds.size
-    val k = numSegments match {
-      case Some(requested) =>
-        val clamped = math.max(1, math.min(n, requested))
-        if (clamped != requested) {
-          logInfo(
-            s"num_segments=$requested clamped to $clamped " +
-              s"(fragment count=$n)")
-        }
-        clamped
-      case None => math.max(
-          1,
-          math.min(n, addIndexExec.session.sparkContext.defaultParallelism))
-    }
-    (0 until k).map { i =>
-      fragmentIds.slice(
-        (i.toLong * n / k).toInt,
-        ((i.toLong + 1) * n / k).toInt)
-    }.filter(_.nonEmpty)
+    IndexUtils.runSegmentTasks(
+      addIndexExec.session.sparkContext,
+      tasks,
+      s"${indexType.name()} index build failed. Uncommitted segments are not " +
+        "visible to readers and will not affect query correctness.")(_.execute())
   }
 }
 
 /**
- * A task to create a zonemap index segment on a batch of fragments.
+ * A task to create a scalar index segment on a batch of fragments.
  */
-case class ZonemapIndexTask(
+case class ScalarSegmentIndexTask(
     encodedReadOptions: String,
     columns: List[String],
     method: String,
     argsJson: String,
-    indexName: String,
     fragmentIds: List[Integer],
     namespaceImpl: Option[String],
     namespaceProperties: Option[Map[String, String]],
@@ -932,9 +912,13 @@ case class ZonemapIndexTask(
 
   def execute(): String = {
     val readOptions = decode[LanceSparkReadOptions](encodedReadOptions)
-    val indexType = IndexUtils.buildIndexType(method)
+    val indexType = IndexUtils.scalarSegmentIndexType(method).getOrElse {
+      throw new UnsupportedOperationException(
+        s"Unsupported Lance index method: $method")
+    }
     val params = IndexParams.builder()
-      .setScalarIndexParams(ScalarIndexParams.create(method, argsJson))
+      .setScalarIndexParams(
+        ScalarIndexParams.create(IndexUtils.buildScalarIndexParamType(method), argsJson))
       .build()
 
     val indexOptions = IndexOptions
@@ -962,9 +946,32 @@ case class ZonemapIndexTask(
 /**
  * Utility methods for working with index types.
  */
-object IndexUtils {
+object IndexUtils extends Logging {
 
   private val jsonMapper = new ObjectMapper()
+
+  private val MethodToIndexType: Map[String, IndexType] = Map(
+    "btree" -> IndexType.BTREE,
+    "zonemap" -> IndexType.ZONEMAP,
+    "bitmap" -> IndexType.BITMAP,
+    "label_list" -> IndexType.LABEL_LIST,
+    "ngram" -> IndexType.NGRAM,
+    "bloomfilter" -> IndexType.BLOOM_FILTER,
+    "rtree" -> IndexType.RTREE,
+    "fts" -> IndexType.INVERTED)
+
+  private val ScalarSegmentIndexTypes: Set[IndexType] = Set(
+    IndexType.ZONEMAP,
+    IndexType.BITMAP,
+    IndexType.LABEL_LIST,
+    IndexType.NGRAM,
+    IndexType.BLOOM_FILTER,
+    IndexType.RTREE)
+
+  def scalarSegmentIndexType(method: String): Option[IndexType] =
+    MethodToIndexType
+      .get(method.toLowerCase(Locale.ROOT))
+      .filter(ScalarSegmentIndexTypes.contains)
 
   /**
    * Extracts the `train` option from named arguments, defaulting to `true`.
@@ -989,21 +996,22 @@ object IndexUtils {
    * @throws UnsupportedOperationException if the method is not supported
    */
   def buildIndexType(method: String): IndexType = {
-    method.toLowerCase match {
-      case "btree" => IndexType.BTREE
-      case "zonemap" => IndexType.ZONEMAP
-      case "fts" => IndexType.INVERTED
-      case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
-    }
+    val normalized = method.toLowerCase(Locale.ROOT)
+    MethodToIndexType.getOrElse(
+      normalized,
+      throw new UnsupportedOperationException(s"Unsupported index method: $normalized"))
   }
 
   def buildScalarIndexParamType(method: String): String = {
-    method.toLowerCase match {
-      case "btree" => "btree"
-      case "zonemap" => "zonemap"
-      case "fts" => "inverted"
-      case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
-    }
+    scalarSegmentIndexType(method)
+      .map(_.name().toLowerCase(Locale.ROOT).replace("_", ""))
+      .getOrElse {
+        method.toLowerCase(Locale.ROOT) match {
+          case "btree" => "btree"
+          case "fts" => "inverted"
+          case other => throw new UnsupportedOperationException(s"Unsupported index method: $other")
+        }
+      }
   }
 
   def btreeBuildMode(indexType: IndexType, args: Seq[LanceNamedArgument]): Option[String] = {
@@ -1019,10 +1027,6 @@ object IndexUtils {
             s"Unrecognized build_mode: '$unknown'. Supported values are 'fragment' and 'range'.")
       }
     }
-  }
-
-  def useLogicalSegmentCommit(indexType: IndexType): Boolean = {
-    indexType == IndexType.ZONEMAP
   }
 
   /** Extracts the commit metadata from a newly created Index. */
@@ -1091,6 +1095,53 @@ object IndexUtils {
         }
       }
       jsonMapper.writeValueAsString(node)
+    }
+  }
+
+  def runSegmentTasks[T <: Serializable: ClassTag](
+      sc: org.apache.spark.SparkContext,
+      tasks: Seq[T],
+      failureMessage: String)(execute: T => String): Seq[Index] = {
+    if (tasks.isEmpty) {
+      Seq.empty
+    } else {
+      try {
+        sc.parallelize(tasks, tasks.size)
+          .map(execute)
+          .collect()
+          .map(encoded => decode[Index](encoded))
+          .toSeq
+      } catch {
+        case e: Exception => throw new RuntimeException(failureMessage, e)
+      }
+    }
+  }
+
+  def batchFragments(
+      fragmentIds: List[Integer],
+      numSegments: Option[Int],
+      defaultParallelism: Int): Seq[List[Integer]] = {
+    val fragmentCount = fragmentIds.size
+    if (fragmentCount == 0) {
+      return Seq.empty
+    }
+
+    val segmentCount = numSegments match {
+      case Some(requested) =>
+        val clamped = math.max(1, math.min(fragmentCount, requested))
+        if (clamped != requested) {
+          logWarning(
+            s"num_segments=$requested clamped to $clamped " +
+              s"(fragment count=$fragmentCount)")
+        }
+        clamped
+      case None => math.max(1, math.min(fragmentCount, defaultParallelism))
+    }
+
+    (0 until segmentCount).map { index =>
+      fragmentIds.slice(
+        (index.toLong * fragmentCount / segmentCount).toInt,
+        ((index.toLong + 1) * fragmentCount / segmentCount).toInt)
     }
   }
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -950,7 +950,7 @@ object IndexUtils extends Logging {
 
   private val jsonMapper = new ObjectMapper()
 
-  private val MethodToIndexType: Map[String, IndexType] = Map(
+  private val methodToIndexTypes: Map[String, IndexType] = Map(
     "btree" -> IndexType.BTREE,
     "zonemap" -> IndexType.ZONEMAP,
     "bitmap" -> IndexType.BITMAP,
@@ -960,7 +960,7 @@ object IndexUtils extends Logging {
     "rtree" -> IndexType.RTREE,
     "fts" -> IndexType.INVERTED)
 
-  private val ScalarSegmentIndexTypes: Set[IndexType] = Set(
+  private val scalarSegmentIndexTypes: Set[IndexType] = Set(
     IndexType.ZONEMAP,
     IndexType.BITMAP,
     IndexType.LABEL_LIST,
@@ -969,9 +969,9 @@ object IndexUtils extends Logging {
     IndexType.RTREE)
 
   def scalarSegmentIndexType(method: String): Option[IndexType] =
-    MethodToIndexType
+    methodToIndexTypes
       .get(method.toLowerCase(Locale.ROOT))
-      .filter(ScalarSegmentIndexTypes.contains)
+      .filter(scalarSegmentIndexTypes.contains)
 
   /**
    * Extracts the `train` option from named arguments, defaulting to `true`.
@@ -997,7 +997,7 @@ object IndexUtils extends Logging {
    */
   def buildIndexType(method: String): IndexType = {
     val normalized = method.toLowerCase(Locale.ROOT)
-    MethodToIndexType.getOrElse(
+    methodToIndexTypes.getOrElse(
       normalized,
       throw new UnsupportedOperationException(s"Unsupported index method: $normalized"))
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -88,7 +90,12 @@ public abstract class BaseBlobV2CopyTest extends AbstractBlobV2CopyTest {
               .allocator(LanceRuntime.allocator())
               .uri(datasetUriOf(tgt))
               .build()) {
-        assertEquals(1, ds.takeBlobs(tgtAddrs, "data").size(), "v2 takeBlobs skips null rows");
+        List<org.lance.BlobFile> blobs = ds.takeBlobs(tgtAddrs, "data");
+        assertEquals(2, blobs.size(), "v2 takeBlobs preserves null rows");
+        try (org.lance.BlobFile nonNullBlob = blobs.get(0)) {
+          assertNotNull(nonNullBlob, "non-null blob should return a BlobFile");
+          assertNull(blobs.get(1), "null blob should return a null element");
+        }
       }
 
       assertTargetBlobBytes(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -23,23 +23,36 @@ import org.lance.spark.utils.FieldPathUtils;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /** Base test for distributed CREATE INDEX. */
 public abstract class BaseAddIndexTest {
@@ -331,6 +344,166 @@ public abstract class BaseAddIndexTest {
     }
   }
 
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("scalarSegmentIndexMethods")
+  public void testCreateScalarSegmentIndex(
+      String method,
+      String column,
+      IndexType expectedIndexType,
+      int numSegments,
+      String methodOptions)
+      throws Exception {
+    prepareScalarSegmentDataset(method);
+    List<String> rowsBeforeIndex = tableRowsAsJson();
+    String indexName = "test_segment_" + method;
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index %s using %s (%s) " + "with (num_segments = %d%s)",
+                fullTable, indexName, method, column, numSegments, methodOptions));
+
+    Row resultRow = result.collectAsList().get(0);
+    Assertions.assertEquals(indexName, resultRow.getString(1));
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      Set<Integer> expectedFragments =
+          lanceDataset.getFragments().stream()
+              .map(fragment -> Integer.valueOf(fragment.getId()))
+              .collect(Collectors.toSet());
+      Assertions.assertTrue(expectedFragments.size() >= 2, "Expected multiple fragments");
+      Assertions.assertEquals(
+          expectedFragments.size(),
+          resultRow.getLong(0),
+          "fragments_indexed should report every source fragment");
+
+      List<Index> segments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> indexName.equals(index.name()))
+              .collect(Collectors.toList());
+      Assertions.assertEquals(
+          Math.min(numSegments, expectedFragments.size()),
+          segments.size(),
+          "The number of physical segments should match num_segments up to the fragment count");
+
+      Set<Integer> coveredFragments = new HashSet<>();
+      for (Index segment : segments) {
+        Assertions.assertEquals(expectedIndexType, segment.indexType());
+        List<Integer> segmentFragments = segment.fragments().orElse(Collections.emptyList());
+        Assertions.assertFalse(
+            segmentFragments.isEmpty(), "Each physical segment must cover at least one fragment");
+        for (Integer fragmentId : segmentFragments) {
+          Assertions.assertTrue(
+              coveredFragments.add(fragmentId),
+              "Physical segment fragment coverage must be disjoint: " + fragmentId);
+        }
+      }
+      Assertions.assertEquals(
+          expectedFragments,
+          coveredFragments,
+          "Physical segments must cover all source fragments exactly once");
+    } finally {
+      lanceDataset.close();
+    }
+
+    Assertions.assertEquals(
+        rowsBeforeIndex,
+        tableRowsAsJson(),
+        "Creating an index must not change the table's readable rows");
+  }
+
+  private static Stream<Arguments> scalarSegmentIndexMethods() {
+    return Stream.of(
+        Arguments.of("zonemap", "value", IndexType.ZONEMAP, 2, ""),
+        Arguments.of("bitmap", "value", IndexType.BITMAP, 1, ""),
+        Arguments.of("label_list", "labels", IndexType.LABEL_LIST, 2, ""),
+        Arguments.of("ngram", "text", IndexType.NGRAM, 2, ""),
+        Arguments.of(
+            "bloomfilter",
+            "value",
+            IndexType.BLOOM_FILTER,
+            2,
+            ", number_of_items = 16, probability = 0.01"),
+        Arguments.of("rtree", "geometry", IndexType.RTREE, 2, ", page_size = 16"));
+  }
+
+  private void prepareScalarSegmentDataset(String method) throws Exception {
+    StructType schema = scalarSegmentSchema(method);
+    spark
+        .createDataFrame(scalarSegmentRows(method, 0, 4), schema)
+        .coalesce(1)
+        .writeTo(fullTable)
+        .using("lance")
+        .create();
+    spark
+        .createDataFrame(scalarSegmentRows(method, 4, 8), schema)
+        .coalesce(1)
+        .writeTo(fullTable)
+        .append();
+  }
+
+  private StructType scalarSegmentSchema(String method) {
+    switch (method) {
+      case "label_list":
+        return new StructType(
+            new StructField[] {
+              new StructField(
+                  "labels",
+                  DataTypes.createArrayType(DataTypes.IntegerType, false),
+                  false,
+                  Metadata.empty())
+            });
+      case "ngram":
+        return new StructType(
+            new StructField[] {
+              new StructField("text", DataTypes.StringType, false, Metadata.empty())
+            });
+      case "rtree":
+        StructType pointType =
+            new StructType(
+                new StructField[] {
+                  new StructField("x", DataTypes.DoubleType, false, Metadata.empty()),
+                  new StructField("y", DataTypes.DoubleType, false, Metadata.empty())
+                });
+        Metadata geoArrowPoint =
+            new MetadataBuilder().putString("ARROW:extension:name", "geoarrow.point").build();
+        return new StructType(
+            new StructField[] {new StructField("geometry", pointType, false, geoArrowPoint)});
+      default:
+        return new StructType(
+            new StructField[] {
+              new StructField("value", DataTypes.IntegerType, false, Metadata.empty())
+            });
+    }
+  }
+
+  private List<Row> scalarSegmentRows(String method, int startInclusive, int endExclusive) {
+    List<Row> rows = new ArrayList<>();
+    for (int i = startInclusive; i < endExclusive; i++) {
+      switch (method) {
+        case "label_list":
+          rows.add(RowFactory.create(Arrays.asList(i % 3, (i + 1) % 3)));
+          break;
+        case "ngram":
+          rows.add(RowFactory.create("document_" + i));
+          break;
+        case "rtree":
+          rows.add(RowFactory.create(RowFactory.create((double) i, i * 2.0)));
+          break;
+        default:
+          rows.add(RowFactory.create(i % 4));
+      }
+    }
+    return rows;
+  }
+
+  private List<String> tableRowsAsJson() {
+    List<String> rows = spark.table(fullTable).toJSON().collectAsList();
+    Collections.sort(rows);
+    return rows;
+  }
+
   @Test
   public void testRepeatedCreateZonemapIndexReplacesExistingSegments() {
     prepareDataset();
@@ -400,6 +573,32 @@ public abstract class BaseAddIndexTest {
             spark.sql(
                 String.format(
                     "alter table %s create index idx_multi using zonemap (id, text)", fullTable)));
+  }
+
+  @Test
+  public void testIndexBuildFailureUsesIndexTypeName() {
+    prepareDataset();
+
+    Exception failure =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark.sql(
+                    String.format(
+                        "alter table %s create index idx_bad_rtree using rtree (id)", fullTable)));
+
+    Assertions.assertTrue(
+        hasMessageInCauseChain(failure, "RTREE index build failed"),
+        "Expected a type-specific RTree build error, got: " + failure);
+  }
+
+  private boolean hasMessageInCauseChain(Throwable failure, String expectedText) {
+    for (Throwable current = failure; current != null; current = current.getCause()) {
+      if (current.getMessage() != null && current.getMessage().contains(expectedText)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
@@ -16,6 +16,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.catalyst.plans.logical.LanceNamedArgument
 import org.junit.jupiter.api.Assertions._
 import org.junit.jupiter.api.Test
+import org.lance.index.IndexType
 
 /**
  * Unit tests for [[IndexUtils]] helper methods.
@@ -153,7 +154,6 @@ class IndexUtilsTest {
 
   @Test
   def buildIndexType_btreeCaseInsensitive(): Unit = {
-    import org.lance.index.IndexType
     assertEquals(IndexType.BTREE, IndexUtils.buildIndexType("btree"))
     assertEquals(IndexType.BTREE, IndexUtils.buildIndexType("BTREE"))
     assertEquals(IndexType.BTREE, IndexUtils.buildIndexType("BTree"))
@@ -161,16 +161,37 @@ class IndexUtilsTest {
 
   @Test
   def buildIndexType_ftsReturnsInverted(): Unit = {
-    import org.lance.index.IndexType
     assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("fts"))
     assertEquals(IndexType.INVERTED, IndexUtils.buildIndexType("FTS"))
   }
 
   @Test
-  def buildIndexType_zonemapCaseInsensitive(): Unit = {
-    import org.lance.index.IndexType
-    assertEquals(IndexType.ZONEMAP, IndexUtils.buildIndexType("zonemap"))
-    assertEquals(IndexType.ZONEMAP, IndexUtils.buildIndexType("ZONEMAP"))
+  def scalarSegmentIndexType_mapsAllSupportedMethods(): Unit = {
+    val expected = Seq(
+      ("zonemap", IndexType.ZONEMAP, "zonemap"),
+      ("bitmap", IndexType.BITMAP, "bitmap"),
+      ("label_list", IndexType.LABEL_LIST, "labellist"),
+      ("ngram", IndexType.NGRAM, "ngram"),
+      ("bloomfilter", IndexType.BLOOM_FILTER, "bloomfilter"),
+      ("rtree", IndexType.RTREE, "rtree"))
+
+    expected.foreach { case (method, indexType, coreParamType) =>
+      Seq(method, method.toUpperCase).foreach { spelling =>
+        assertEquals(indexType, IndexUtils.scalarSegmentIndexType(spelling).get)
+        assertEquals(indexType, IndexUtils.buildIndexType(spelling))
+        assertEquals(coreParamType, IndexUtils.buildScalarIndexParamType(spelling))
+      }
+    }
+  }
+
+  @Test
+  def scalarSegmentIndexType_rejectsAliases(): Unit = {
+    Seq("labellist", "bloom_filter", "r_tree").foreach { alias =>
+      assertTrue(IndexUtils.scalarSegmentIndexType(alias).isEmpty)
+      assertThrows(
+        classOf[UnsupportedOperationException],
+        () => IndexUtils.buildIndexType(alias))
+    }
   }
 
   @Test
@@ -178,5 +199,27 @@ class IndexUtilsTest {
     assertThrows(
       classOf[UnsupportedOperationException],
       () => IndexUtils.buildIndexType("ivf_pq"))
+  }
+
+  @Test
+  def batchFragments_respectsNumSegmentsAndDefaults(): Unit = {
+    val ids = (0 until 4).map(java.lang.Integer.valueOf).toList
+
+    assertEquals(Seq(2, 2), IndexUtils.batchFragments(ids, Some(2), 4).map(_.size))
+    assertEquals(4, IndexUtils.batchFragments(ids, Some(10), 4).size)
+    assertEquals(4, IndexUtils.batchFragments(ids, None, 8).size)
+    assertEquals(2, IndexUtils.batchFragments(ids, None, 2).size)
+    assertEquals(Seq.empty, IndexUtils.batchFragments(Nil, None, 4))
+  }
+
+  @Test
+  def batchFragments_coversAllFragmentsExactlyOnce(): Unit = {
+    val ids = (0 until 7).map(java.lang.Integer.valueOf).toList
+    val batches = IndexUtils.batchFragments(ids, Some(3), 4)
+
+    assertEquals(Seq(2, 2, 3), batches.map(_.size))
+    assertEquals(ids, batches.flatten)
+    assertEquals(ids.size, batches.flatten.distinct.size)
+    assertTrue(batches.forall(_.nonEmpty))
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.7.1</lance-spark.version>
-        <lance.version>9.0.0</lance.version>
+        <lance.version>10.0.0-rc.3</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

Lance Core now supports independently built segments for its scalar index families. This PR adds a shared distributed segment-build path in Lance Spark instead of implementing nearly identical fragment batching, executor tasks, and driver commits for each index type.

The shared path supports:

- ZoneMap
- Bitmap
- Label List
- NGram
- Bloom Filter
- RTree

This PR covers index construction only. BTree keeps its existing fragment/range build paths, FTS/Inverted segment construction is handled separately in #701, and FMIndex remains outside this change.

## Changes

- centralize SQL method, `IndexType`, and Lance scalar parameter mappings
- batch source fragments into balanced segments with the common `num_segments` option
- build uncommitted index segments on Spark executors and commit them atomically on the driver
- support container fields required by Label List and RTree indexes
- upgrade `lance-core` to `10.0.0-rc.3`
- document the new index methods and method-specific options
- add parameterized coverage for index type, physical segment count, and disjoint fragment coverage
- add a PySpark/Docker integration smoke test for the Bitmap segment path

## Related work

Closes #236.
Closes #237.

Related to #605, which establishes a similar distributed segment-build structure for vector indexes.

FTS/Inverted is being migrated to independent segment builds separately in #701.

This overlaps with #736 for Bitmap support. The difference is that this PR introduces one shared scalar segment workflow and includes the other Lance Core segment-capable scalar indexes instead of routing Bitmap through another index-specific job.

## Testing

- `./mvnw -q -pl lance-spark-3.5_2.12 -Dtest=IndexUtilsTest,AddIndexTest test`
- `./mvnw -q spotless:check`
- `./mvnw -q -pl lance-spark-3.5_2.12 -am -DskipTests compile`
- Spark 4.2 / Scala 2.13 compile
- Python integration-test syntax check

The Docker integration test was not run locally because the Docker daemon was unavailable.
