### PR TITLE
feat: support otel for spark connector

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -72,6 +72,23 @@ and namespace-specific options:
 | `spark.sql.catalog.{name}.parent`           | String | ✗        | Parent prefix for multi-level namespaces. See [Note on Namespace Levels](#note-on-namespace-levels).                             |
 | `spark.sql.catalog.{name}.parent_delimiter` | String | ✗        | Delimiter for parent prefix (default: `.`). See [Note on Namespace Levels](#note-on-namespace-levels).                           |
 
+## OpenTelemetry Metrics
+
+Lance Spark can bridge Lance's native Java metrics into the JVM OpenTelemetry
+pipeline. Enable it with:
+
+```shell
+--conf spark.lance.otel.enabled=true
+```
+
+or set `LANCE_SPARK_OTEL_ENABLED=true` in each JVM environment.
+
+The bridge uses the OpenTelemetry `GlobalOpenTelemetry` meter provider, so
+configure your exporter, resource, and reader with the standard OpenTelemetry
+Java SDK settings. Spark driver and executor JVMs are independent processes;
+set the Spark conf or environment variable for every process that should emit
+Lance metrics.
+
 ## Example Namespace Implementations
 
 ### Directory Namespace

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -81,7 +81,13 @@ pipeline. Enable it with:
 --conf spark.lance.otel.enabled=true
 ```
 
-or set `LANCE_SPARK_OTEL_ENABLED=true` in each JVM environment.
+You can also set the JVM system property
+`-Dspark.lance.otel.enabled=true`, or set
+`LANCE_SPARK_OTEL_ENABLED=true` in each JVM environment. When multiple sources
+are set, Spark configuration takes precedence over the JVM system property,
+which takes precedence over the environment variable. Values must be `true` or
+`false` (case-insensitive); invalid values disable the bridge and produce a
+warning.
 
 The bridge uses the OpenTelemetry `GlobalOpenTelemetry` meter provider, so
 configure your exporter, resource, and reader with the standard OpenTelemetry

--- a/lance-spark-3.4_2.12/pom.xml
+++ b/lance-spark-3.4_2.12/pom.xml
@@ -160,7 +160,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-3.4_2.13/pom.xml
+++ b/lance-spark-3.4_2.13/pom.xml
@@ -167,7 +167,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-3.5_2.12/pom.xml
+++ b/lance-spark-3.5_2.12/pom.xml
@@ -159,7 +159,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-3.5_2.13/pom.xml
+++ b/lance-spark-3.5_2.13/pom.xml
@@ -167,7 +167,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-4.0_2.13/pom.xml
+++ b/lance-spark-4.0_2.13/pom.xml
@@ -182,7 +182,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-4.1_2.13/pom.xml
+++ b/lance-spark-4.1_2.13/pom.xml
@@ -182,7 +182,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-4.2_2.13/pom.xml
+++ b/lance-spark-4.2_2.13/pom.xml
@@ -182,7 +182,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-spark-base,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-base_2.12/pom.xml
+++ b/lance-spark-base_2.12/pom.xml
@@ -72,7 +72,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
@@ -16,9 +16,13 @@ package org.lance.spark;
 import org.lance.Session;
 import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.otel.LanceMetrics;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.spark.SparkEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -48,6 +52,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * }</pre>
  */
 public final class LanceRuntime {
+  private static final Logger LOG = LoggerFactory.getLogger(LanceRuntime.class);
 
   /** Environment variable for allocator size. */
   public static final String ENV_ALLOCATOR_SIZE = "LANCE_ALLOCATOR_SIZE";
@@ -57,6 +62,12 @@ public final class LanceRuntime {
 
   /** Environment variable for metadata cache size in bytes. */
   public static final String ENV_METADATA_CACHE_SIZE = "LANCE_METADATA_CACHE_SIZE";
+
+  /** Spark configuration key that enables Lance OpenTelemetry metrics in each JVM. */
+  public static final String SPARK_CONF_OPEN_TELEMETRY_ENABLED = "spark.lance.otel.enabled";
+
+  /** Environment variable fallback for enabling Lance OpenTelemetry metrics in each JVM. */
+  public static final String ENV_OPEN_TELEMETRY_ENABLED = "LANCE_SPARK_OTEL_ENABLED";
 
   /** Default allocator size (unlimited). */
   public static final long DEFAULT_ALLOCATOR_SIZE = Long.MAX_VALUE;
@@ -198,6 +209,42 @@ public final class LanceRuntime {
   public static Session session(String catalogName) {
     String key = catalogName != null ? catalogName : DEFAULT_CATALOG;
     return CATALOG_SESSIONS.computeIfAbsent(key, k -> createSession());
+  }
+
+  /**
+   * Installs Lance's JNI-backed OpenTelemetry metrics bridge when enabled.
+   *
+   * <p>The bridge is process-global and {@link LanceMetrics#instrument()} is idempotent, so Spark
+   * driver and executor code paths can call this before Lance work starts in each JVM.
+   *
+   * @return true if OpenTelemetry was enabled and the bridge was installed, false otherwise
+   */
+  public static boolean enableOpenTelemetry() {
+    if (!isOpenTelemetryEnabled()) {
+      return false;
+    }
+
+    boolean instrumented = LanceMetrics.instrument();
+    if (!instrumented) {
+      LOG.warn(
+          "Lance OpenTelemetry metrics were enabled, but the native metrics recorder could not be"
+              + " installed. Another Rust metrics recorder may already be installed in this JVM.");
+    }
+    return instrumented;
+  }
+
+  static boolean isOpenTelemetryEnabled() {
+    String configured = System.getProperty(SPARK_CONF_OPEN_TELEMETRY_ENABLED);
+    if (configured == null || configured.isEmpty()) {
+      SparkEnv sparkEnv = SparkEnv.get();
+      if (sparkEnv != null) {
+        configured = sparkEnv.conf().get(SPARK_CONF_OPEN_TELEMETRY_ENABLED, null);
+      }
+    }
+    if (configured == null || configured.isEmpty()) {
+      configured = System.getenv(ENV_OPEN_TELEMETRY_ENABLED);
+    }
+    return Boolean.parseBoolean(configured);
   }
 
   private static Session createSession() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
@@ -18,6 +18,8 @@ import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.model.QueryTableRequest;
 import org.lance.otel.LanceMetrics;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.spark.SparkEnv;
@@ -28,6 +30,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -91,6 +94,17 @@ public final class LanceRuntime {
 
   /** Cached {@code queryTable} support per namespace impl alias or class name. */
   private static final Map<String, Boolean> QUERY_TABLE_SUPPORT = new ConcurrentHashMap<>();
+
+  /** Invalid OpenTelemetry values already reported in this JVM. */
+  private static final Set<String> REPORTED_INVALID_OPEN_TELEMETRY_VALUES =
+      ConcurrentHashMap.newKeySet();
+
+  /** Process-local OpenTelemetry bridge initialization state. */
+  private static volatile OpenTelemetryInitialization OPEN_TELEMETRY_INITIALIZATION =
+      OpenTelemetryInitialization.NOT_ATTEMPTED;
+
+  /** OpenTelemetry provider used by the current bridge instruments. */
+  private static volatile MeterProvider OPEN_TELEMETRY_PROVIDER;
 
   private LanceRuntime() {}
 
@@ -224,27 +238,88 @@ public final class LanceRuntime {
       return false;
     }
 
-    boolean instrumented = LanceMetrics.instrument();
-    if (!instrumented) {
-      LOG.warn(
-          "Lance OpenTelemetry metrics were enabled, but the native metrics recorder could not be"
-              + " installed. Another Rust metrics recorder may already be installed in this JVM.");
+    MeterProvider meterProvider = GlobalOpenTelemetry.get().getMeterProvider();
+    OpenTelemetryInitialization initialization = OPEN_TELEMETRY_INITIALIZATION;
+    if (initialization == OpenTelemetryInitialization.FAILED) {
+      return false;
     }
-    return instrumented;
+    if (initialization == OpenTelemetryInitialization.INSTALLED
+        && OPEN_TELEMETRY_PROVIDER == meterProvider) {
+      return true;
+    }
+
+    synchronized (LanceRuntime.class) {
+      initialization = OPEN_TELEMETRY_INITIALIZATION;
+      if (initialization == OpenTelemetryInitialization.FAILED) {
+        return false;
+      }
+      if (initialization == OpenTelemetryInitialization.INSTALLED
+          && OPEN_TELEMETRY_PROVIDER == meterProvider) {
+        return true;
+      }
+
+      boolean instrumented = LanceMetrics.instrument(meterProvider);
+      if (instrumented) {
+        OPEN_TELEMETRY_PROVIDER = meterProvider;
+        OPEN_TELEMETRY_INITIALIZATION = OpenTelemetryInitialization.INSTALLED;
+      } else {
+        OPEN_TELEMETRY_INITIALIZATION = OpenTelemetryInitialization.FAILED;
+        LOG.warn(
+            "Lance OpenTelemetry metrics were enabled, but the native metrics recorder could not"
+                + " be installed. Another Rust metrics recorder may already be installed in this"
+                + " JVM.");
+      }
+      return instrumented;
+    }
   }
 
   static boolean isOpenTelemetryEnabled() {
-    String configured = System.getProperty(SPARK_CONF_OPEN_TELEMETRY_ENABLED);
-    if (configured == null || configured.isEmpty()) {
-      SparkEnv sparkEnv = SparkEnv.get();
-      if (sparkEnv != null) {
-        configured = sparkEnv.conf().get(SPARK_CONF_OPEN_TELEMETRY_ENABLED, null);
-      }
+    SparkEnv sparkEnv = SparkEnv.get();
+    String sparkConfigured =
+        sparkEnv == null ? null : sparkEnv.conf().get(SPARK_CONF_OPEN_TELEMETRY_ENABLED, null);
+    return resolveOpenTelemetryEnabled(
+        sparkConfigured,
+        System.getProperty(SPARK_CONF_OPEN_TELEMETRY_ENABLED),
+        System.getenv(ENV_OPEN_TELEMETRY_ENABLED));
+  }
+
+  static boolean resolveOpenTelemetryEnabled(
+      String sparkConfigured, String systemConfigured, String environmentConfigured) {
+    if (hasText(sparkConfigured)) {
+      return parseOpenTelemetryEnabled(sparkConfigured, "Spark configuration");
     }
-    if (configured == null || configured.isEmpty()) {
-      configured = System.getenv(ENV_OPEN_TELEMETRY_ENABLED);
+    if (hasText(systemConfigured)) {
+      return parseOpenTelemetryEnabled(systemConfigured, "JVM system property");
     }
-    return Boolean.parseBoolean(configured);
+    if (hasText(environmentConfigured)) {
+      return parseOpenTelemetryEnabled(environmentConfigured, "environment variable");
+    }
+    return false;
+  }
+
+  private static boolean parseOpenTelemetryEnabled(String configured, String source) {
+    String normalized = configured.trim();
+    if ("true".equalsIgnoreCase(normalized)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(normalized)) {
+      return false;
+    }
+
+    String reportedValue = source + '\0' + configured;
+    if (REPORTED_INVALID_OPEN_TELEMETRY_VALUES.add(reportedValue)) {
+      LOG.warn(
+          "Invalid boolean value '{}' for {} from {}; expected 'true' or 'false'. OpenTelemetry"
+              + " metrics will remain disabled.",
+          configured,
+          SPARK_CONF_OPEN_TELEMETRY_ENABLED,
+          source);
+    }
+    return false;
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.trim().isEmpty();
   }
 
   private static Session createSession() {
@@ -324,6 +399,21 @@ public final class LanceRuntime {
       }
       CATALOG_SESSIONS.clear();
     }
+  }
+
+  static void clearOpenTelemetry() {
+    synchronized (LanceRuntime.class) {
+      LanceMetrics.close();
+      OPEN_TELEMETRY_PROVIDER = null;
+      OPEN_TELEMETRY_INITIALIZATION = OpenTelemetryInitialization.NOT_ATTEMPTED;
+      REPORTED_INVALID_OPEN_TELEMETRY_VALUES.clear();
+    }
+  }
+
+  private enum OpenTelemetryInitialization {
+    NOT_ATTEMPTED,
+    INSTALLED,
+    FAILED
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -15,6 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.ColumnOrdering;
+import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.read.metric.LanceCustomMetrics;
 import org.lance.spark.sharding.SparkLanceShardingUtils;
@@ -538,6 +539,7 @@ public class LanceScan
   private static class LanceReaderFactory implements PartitionReaderFactory {
     @Override
     public PartitionReader<InternalRow> createReader(InputPartition partition) {
+      LanceRuntime.enableOpenTelemetry();
       Preconditions.checkArgument(
           partition instanceof LanceInputPartition,
           "Unknown InputPartition type. Expecting LanceInputPartition");
@@ -546,6 +548,7 @@ public class LanceScan
 
     @Override
     public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
+      LanceRuntime.enableOpenTelemetry();
       Preconditions.checkArgument(
           partition instanceof LanceInputPartition,
           "Unknown InputPartition type. Expecting LanceInputPartition");

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceHybridSearchPartitionReaderFactory.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceHybridSearchPartitionReaderFactory.java
@@ -13,6 +13,8 @@
  */
 package org.lance.spark.search;
 
+import org.lance.spark.LanceRuntime;
+
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
@@ -23,6 +25,7 @@ public class LanceHybridSearchPartitionReaderFactory implements PartitionReaderF
 
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
+    LanceRuntime.enableOpenTelemetry();
     return new LanceHybridSearchRowPartitionReader(asHybridPartition(partition));
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceSearchPartitionReaderFactory.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceSearchPartitionReaderFactory.java
@@ -13,6 +13,8 @@
  */
 package org.lance.spark.search;
 
+import org.lance.spark.LanceRuntime;
+
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
@@ -24,12 +26,14 @@ public class LanceSearchPartitionReaderFactory implements PartitionReaderFactory
 
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
+    LanceRuntime.enableOpenTelemetry();
     return new LanceSearchRowPartitionReader(
         new LanceSearchColumnarPartitionReader(asSearchPartition(partition)));
   }
 
   @Override
   public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
+    LanceRuntime.enableOpenTelemetry();
     return new LanceSearchColumnarPartitionReader(asSearchPartition(partition));
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -122,6 +122,8 @@ public class Utils {
     }
 
     public Dataset build() {
+      LanceRuntime.enableOpenTelemetry();
+
       Map<String, String> base = storageOptions != null ? storageOptions : Collections.emptyMap();
       Map<String, String> merged = LanceRuntime.mergeStorageOptions(base, initialStorageOptions);
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
@@ -239,6 +239,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      LanceRuntime.enableOpenTelemetry();
+
       return new AddColumnsWriter(
           writeOptions,
           schema,

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceDataWriter.java
@@ -315,6 +315,8 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      LanceRuntime.enableOpenTelemetry();
+
       ShardingBatchKeyEvaluator shardingKeyEvaluator =
           shardingSpec == null
               ? null

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
@@ -245,6 +245,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
 
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
+      LanceRuntime.enableOpenTelemetry();
+
       return new UpdateColumnsWriter(
           writeOptions,
           schema,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
@@ -65,6 +65,21 @@ class LanceRuntimeQueryTableSupportTest {
     }
   }
 
+  @Test
+  void openTelemetryConfigurationUsesDocumentedPrecedence() {
+    assertTrue(LanceRuntime.resolveOpenTelemetryEnabled("true", "false", "false"));
+    assertFalse(LanceRuntime.resolveOpenTelemetryEnabled("false", "true", "true"));
+    assertTrue(LanceRuntime.resolveOpenTelemetryEnabled(null, "true", "false"));
+    assertTrue(LanceRuntime.resolveOpenTelemetryEnabled(null, null, "true"));
+    assertFalse(LanceRuntime.resolveOpenTelemetryEnabled(null, null, null));
+  }
+
+  @Test
+  void openTelemetryConfigurationRejectsInvalidValues() {
+    assertTrue(LanceRuntime.resolveOpenTelemetryEnabled(" TRUE ", null, null));
+    assertFalse(LanceRuntime.resolveOpenTelemetryEnabled("yes", "true", "true"));
+  }
+
   /** Stands in for catalog-only namespaces such as Glue, which never implement queryTable. */
   public static class CatalogOnlyNamespace implements LanceNamespace {
     public CatalogOnlyNamespace() {}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
@@ -47,6 +47,24 @@ class LanceRuntimeQueryTableSupportTest {
     assertFalse(LanceRuntime.supportsQueryTable("org.lance.namespace.DoesNotExist"));
   }
 
+  @Test
+  void openTelemetryCanBeEnabledBySystemProperty() {
+    String previous = System.getProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED);
+    try {
+      System.setProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED, "false");
+      assertFalse(LanceRuntime.isOpenTelemetryEnabled());
+
+      System.setProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED, "true");
+      assertTrue(LanceRuntime.isOpenTelemetryEnabled());
+    } finally {
+      if (previous == null) {
+        System.clearProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED);
+      } else {
+        System.setProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED, previous);
+      }
+    }
+  }
+
   /** Stands in for catalog-only namespaces such as Glue, which never implement queryTable. */
   public static class CatalogOnlyNamespace implements LanceNamespace {
     public CatalogOnlyNamespace() {}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/TestUtils.java
@@ -109,6 +109,10 @@ public class TestUtils {
     return sb.append(datasetUri).toString();
   }
 
+  public static void clearOpenTelemetry() {
+    LanceRuntime.clearOpenTelemetry();
+  }
+
   /**
    * A non-functional {@link LanceNamespace} stub for toBuilder identity and serialization tests:
    * assigned to the transient {@code LanceSparkWriteOptions#namespace} field before serialization,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
@@ -117,8 +117,9 @@ public abstract class BaseSparkConnectorReadTest {
           LanceMetrics.catalog().stream()
               .anyMatch(desc -> OBJECT_STORE_REQUEST_DURATION.equals(desc.getName())),
           "expected Spark read path to register Lance OpenTelemetry metrics");
+      assertTrue(LanceRuntime.enableOpenTelemetry());
     } finally {
-      LanceMetrics.close();
+      TestUtils.clearOpenTelemetry();
       if (previous == null) {
         System.clearProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED);
       } else {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseSparkConnectorReadTest.java
@@ -13,7 +13,9 @@
  */
 package org.lance.spark.read;
 
+import org.lance.otel.LanceMetrics;
 import org.lance.spark.LanceDataSource;
+import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
 
@@ -40,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public abstract class BaseSparkConnectorReadTest {
+  private static final String OBJECT_STORE_REQUEST_DURATION =
+      "lance_object_store_request_duration_seconds";
   private static SparkSession spark;
   private static String dbPath;
   private static Dataset<Row> data;
@@ -92,6 +96,35 @@ public abstract class BaseSparkConnectorReadTest {
   @Test
   public void readAll() {
     validateData(data, TestUtils.TestTable1Config.expectedValues);
+  }
+
+  @Test
+  public void readWithOpenTelemetryEnabledRegistersLanceMetrics() {
+    String previous = System.getProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED);
+    try {
+      System.setProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED, "true");
+      Dataset<Row> df =
+          spark
+              .read()
+              .format(LanceDataSource.name)
+              .option(
+                  LanceSparkReadOptions.CONFIG_DATASET_URI,
+                  TestUtils.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName))
+              .load();
+
+      assertEquals(TestUtils.TestTable1Config.expectedValues.size(), df.count());
+      assertTrue(
+          LanceMetrics.catalog().stream()
+              .anyMatch(desc -> OBJECT_STORE_REQUEST_DURATION.equals(desc.getName())),
+          "expected Spark read path to register Lance OpenTelemetry metrics");
+    } finally {
+      LanceMetrics.close();
+      if (previous == null) {
+        System.clearProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED);
+      } else {
+        System.setProperty(LanceRuntime.SPARK_CONF_OPEN_TELEMETRY_ENABLED, previous);
+      }
+    }
   }
 
   @Test

--- a/lance-spark-base_2.13/pom.xml
+++ b/lance-spark-base_2.13/pom.xml
@@ -116,7 +116,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-3.4_2.12/pom.xml
+++ b/lance-spark-bundle-3.4_2.12/pom.xml
@@ -50,7 +50,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark34.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark34.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-3.4_2.13/pom.xml
+++ b/lance-spark-bundle-3.4_2.13/pom.xml
@@ -52,7 +52,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark34.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark34.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-3.5_2.12/pom.xml
+++ b/lance-spark-bundle-3.5_2.12/pom.xml
@@ -47,7 +47,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark35.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark35.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-3.5_2.13/pom.xml
+++ b/lance-spark-bundle-3.5_2.13/pom.xml
@@ -51,7 +51,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark35.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark35.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-4.0_2.13/pom.xml
+++ b/lance-spark-bundle-4.0_2.13/pom.xml
@@ -53,7 +53,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark40.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark40.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-4.1_2.13/pom.xml
+++ b/lance-spark-bundle-4.1_2.13/pom.xml
@@ -53,7 +53,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark41.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark41.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/lance-spark-bundle-4.2_2.13/pom.xml
+++ b/lance-spark-bundle-4.2_2.13/pom.xml
@@ -53,7 +53,7 @@
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>false</overWriteSnapshots>
                             <overWriteIfNewer>true</overWriteIfNewer>
-                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark42.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,arrow-dataset</includeArtifactIds>
+                            <includeArtifactIds>lance-core,lance-namespace-core,lance-namespace-apache-client,lance-spark-base_${scala.compat.version},lance-spark-${spark42.compat.version}_${scala.compat.version},arrow-c-data,jar-jni,opentelemetry-api,opentelemetry-context,arrow-dataset</includeArtifactIds>
                         </configuration>
                     </execution>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
             */
         </spotless.license.header>
 
+        <opentelemetry.version>1.64.0</opentelemetry.version>
         <junit.version>5.10.1</junit.version>
         <scalatest.version>3.2.10</scalatest.version>
 
@@ -218,6 +219,11 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>${opentelemetry.version}</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>


### PR DESCRIPTION
## Summary

  Add opt-in OpenTelemetry metrics integration for Lance Spark using the Java `LanceMetrics` bridge provided by `lance-core`.

  This updates Lance Spark to `lance-core` `10.1.0-beta.2`, wires OTel initialization into driver and executor read/write/search paths, and exposes
  configuration through `spark.lance.otel.enabled` or `LANCE_SPARK_OTEL_ENABLED`. It also includes the required OpenTelemetry dependencies in shaded bundle
  whitelists and documents the new configuration.

  ## Testing

  - `./mvnw spotless:apply`
  - `./mvnw compile -pl lance-spark-3.5_2.13 -am`
  - `./mvnw test -pl lance-spark-3.5_2.13 -Dtest=org.lance.spark.LanceRuntimeQueryTableSupportTest,org.lance.spark.read.SparkConnectorReadTest`