### PR TITLE
fix: preserve LargeBinary across a Spark schema round trip

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LargeVarBinaryUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/LargeVarBinaryUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.utils;
+
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.StructField;
+
+import java.util.Map;
+
+/**
+ * Utility class for LargeBinary Arrow type metadata handling.
+ *
+ * <p>Spark has a single {@code BinaryType} that covers both Arrow {@code Binary} (32-bit offsets)
+ * and Arrow {@code LargeBinary} (64-bit offsets). When reading a Lance table containing a
+ * LargeBinary column, the distinction is preserved in Spark field metadata so a subsequent write
+ * reproduces LargeBinary instead of silently narrowing the column to Binary.
+ *
+ * <p>This mirrors {@link LargeVarCharUtils}, which does the same for LargeUtf8.
+ */
+public class LargeVarBinaryUtils {
+
+  public static final String ARROW_LARGE_VAR_BINARY_KEY = "arrow:large-var-binary";
+  public static final String ARROW_LARGE_VAR_BINARY_VALUE = "true";
+
+  /**
+   * Check if a Spark field is a large binary field based on its metadata.
+   *
+   * @param field the Spark struct field to check
+   * @return true if the field is a large binary field, false otherwise
+   */
+  public static boolean isLargeVarBinarySparkField(StructField field) {
+    if (field == null || field.metadata() == null) {
+      return false;
+    }
+
+    if (!(field.dataType() instanceof BinaryType)) {
+      return false;
+    }
+
+    if (!field.metadata().contains(ARROW_LARGE_VAR_BINARY_KEY)) {
+      return false;
+    }
+
+    return ARROW_LARGE_VAR_BINARY_VALUE.equalsIgnoreCase(
+        field.metadata().getString(ARROW_LARGE_VAR_BINARY_KEY));
+  }
+
+  /**
+   * Check if an Arrow field is a large binary field based on its metadata.
+   *
+   * @param field the Arrow field to check
+   * @return true if the field is a large binary field, false otherwise
+   */
+  public static boolean isLargeVarBinaryArrowField(Field field) {
+    if (field == null) {
+      return false;
+    }
+
+    Map<String, String> metadata = field.getMetadata();
+    if (metadata == null || !metadata.containsKey(ARROW_LARGE_VAR_BINARY_KEY)) {
+      return false;
+    }
+
+    return ARROW_LARGE_VAR_BINARY_VALUE.equalsIgnoreCase(metadata.get(ARROW_LARGE_VAR_BINARY_KEY));
+  }
+
+  /**
+   * Create the property key for configuring large binary on a column.
+   *
+   * @param fieldName the name of the field
+   * @return the property key (e.g., "my_column.arrow.large_var_binary")
+   */
+  public static String createPropertyKey(String fieldName) {
+    return fieldName + ".arrow.large_var_binary";
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LanceArrowColumnVector.java
@@ -19,6 +19,7 @@ import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.TimeMicroVector;
 import org.apache.arrow.vector.TimeMilliVector;
@@ -62,6 +63,7 @@ public class LanceArrowColumnVector extends ColumnVector {
   private LanceMapAccessor mapAccessor;
   private LanceLargeArrayAccessor largeArrayAccessor;
   private LargeVarCharAccessor largeVarCharAccessor;
+  private LargeVarBinaryAccessor largeVarBinaryAccessor;
   private Float2Accessor float2Accessor;
   private DateMilliAccessor dateMilliAccessor;
   private TimestampUnitAccessor timestampUnitAccessor;
@@ -113,6 +115,8 @@ public class LanceArrowColumnVector extends ColumnVector {
       largeArrayAccessor = new LanceLargeArrayAccessor((LargeListVector) vector);
     } else if (vector instanceof LargeVarCharVector) {
       largeVarCharAccessor = new LargeVarCharAccessor((LargeVarCharVector) vector);
+    } else if (vector instanceof LargeVarBinaryVector) {
+      largeVarBinaryAccessor = new LargeVarBinaryAccessor((LargeVarBinaryVector) vector);
     } else if (vector instanceof TimeStampSecVector) {
       timestampUnitAccessor =
           new TimestampUnitAccessor((TimeStampSecVector) vector, 1_000_000L, 1L);
@@ -188,6 +192,9 @@ public class LanceArrowColumnVector extends ColumnVector {
     if (largeArrayAccessor != null) {
       largeArrayAccessor.close();
     }
+    if (largeVarBinaryAccessor != null) {
+      largeVarBinaryAccessor.close();
+    }
     if (largeVarCharAccessor != null) {
       largeVarCharAccessor.close();
     }
@@ -245,6 +252,9 @@ public class LanceArrowColumnVector extends ColumnVector {
     }
     if (largeArrayAccessor != null) {
       return largeArrayAccessor.getNullCount() > 0;
+    }
+    if (largeVarBinaryAccessor != null) {
+      return largeVarBinaryAccessor.getNullCount() > 0;
     }
     if (largeVarCharAccessor != null) {
       return largeVarCharAccessor.getNullCount() > 0;
@@ -305,6 +315,9 @@ public class LanceArrowColumnVector extends ColumnVector {
     if (largeArrayAccessor != null) {
       return largeArrayAccessor.getNullCount();
     }
+    if (largeVarBinaryAccessor != null) {
+      return largeVarBinaryAccessor.getNullCount();
+    }
     if (largeVarCharAccessor != null) {
       return largeVarCharAccessor.getNullCount();
     }
@@ -363,6 +376,9 @@ public class LanceArrowColumnVector extends ColumnVector {
     }
     if (largeArrayAccessor != null) {
       return largeArrayAccessor.isNullAt(rowId);
+    }
+    if (largeVarBinaryAccessor != null) {
+      return largeVarBinaryAccessor.isNullAt(rowId);
     }
     if (largeVarCharAccessor != null) {
       return largeVarCharAccessor.isNullAt(rowId);
@@ -525,6 +541,9 @@ public class LanceArrowColumnVector extends ColumnVector {
   public byte[] getBinary(int rowId) {
     if (fixedSizeBinaryAccessor != null) {
       return fixedSizeBinaryAccessor.getBinary(rowId);
+    }
+    if (largeVarBinaryAccessor != null) {
+      return largeVarBinaryAccessor.getBinary(rowId);
     }
     if (blobStructAccessor != null) {
       return blobStructAccessor.getBlobReference(rowId);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LargeVarBinaryAccessor.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/vectorized/LargeVarBinaryAccessor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.vectorized;
+
+import org.apache.arrow.vector.LargeVarBinaryVector;
+
+/**
+ * Accessor for large binary values (LargeBinary). Maps to Spark BinaryType. This accessor supports
+ * byte arrays with 64-bit offsets, allowing for larger individual values and total buffer sizes
+ * than the standard VarBinaryVector.
+ *
+ * <p>Handling LargeBinary here rather than delegating to Spark's {@code ArrowColumnVector} is
+ * required on Spark 3.4, whose {@code ArrowUtils.fromArrowType} rejects LargeBinary with
+ * UNSUPPORTED_ARROWTYPE. This mirrors {@link LargeVarCharAccessor}, which exists for the same
+ * reason on LargeUtf8.
+ */
+public class LargeVarBinaryAccessor {
+  private final LargeVarBinaryVector accessor;
+
+  LargeVarBinaryAccessor(LargeVarBinaryVector vector) {
+    this.accessor = vector;
+  }
+
+  final byte[] getBinary(int rowId) {
+    return accessor.get(rowId);
+  }
+
+  final boolean isNullAt(int rowId) {
+    return accessor.isNull(rowId);
+  }
+
+  final int getNullCount() {
+    return accessor.getNullCount();
+  }
+
+  final void close() {
+    accessor.close();
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceArrowUtils.scala
@@ -30,7 +30,7 @@ import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
 import org.apache.spark.{SparkException, SparkUnsupportedOperationException}
 import org.apache.spark.sql.types._
 import org.lance.spark.LanceConstant
-import org.lance.spark.utils.{BlobUtils, DateMilliUtils, FixedSizeBinaryUtils, Float16Utils, LargeVarCharUtils, ListChildUtils, VectorUtils}
+import org.lance.spark.utils.{BlobUtils, DateMilliUtils, FixedSizeBinaryUtils, Float16Utils, LargeVarBinaryUtils, LargeVarCharUtils, ListChildUtils, VectorUtils}
 
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicInteger
@@ -47,6 +47,7 @@ object LanceArrowUtils {
   val ARROW_EXT_NAME_KEY = BlobUtils.ARROW_EXTENSION_NAME_KEY
   val BLOB_V2_EXT_NAME = BlobUtils.ARROW_EXTENSION_BLOB_V2
   val ARROW_LARGE_VAR_CHAR_KEY = LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_KEY
+  val ARROW_LARGE_VAR_BINARY_KEY = LargeVarBinaryUtils.ARROW_LARGE_VAR_BINARY_KEY
   val ARROW_DATE_MILLISECOND_KEY = DateMilliUtils.ARROW_DATE_MILLISECOND_KEY
   val ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY =
     FixedSizeBinaryUtils.ARROW_FIXED_SIZE_BINARY_BYTE_WIDTH_KEY
@@ -244,6 +245,17 @@ object LanceArrowUtils {
         }
       case _: ArrowType.LargeUtf8 =>
         builder.putString(ARROW_LARGE_VAR_CHAR_KEY, LargeVarCharUtils.ARROW_LARGE_VAR_CHAR_VALUE)
+      // Spark has a single BinaryType covering both Arrow Binary (32-bit offsets) and LargeBinary
+      // (64-bit offsets), so record which one this field was. Without the marker a Lance
+      // LargeBinary column is silently narrowed to Binary whenever a Spark operation round-trips
+      // the schema (UPDATE, ADD COLUMNS FROM, or simply read -> transform -> write), and the
+      // resulting write fails type validation against the existing Lance schema.
+      // Blob columns are excluded: they are already LargeBinary-backed via the blob marker, which
+      // toArrowField honors on its own.
+      case _: ArrowType.LargeBinary if !isBlobField(field) =>
+        builder.putString(
+          ARROW_LARGE_VAR_BINARY_KEY,
+          LargeVarBinaryUtils.ARROW_LARGE_VAR_BINARY_VALUE)
       case date: ArrowType.Date if date.getUnit == DateUnit.MILLISECOND =>
         builder.putString(ARROW_DATE_MILLISECOND_KEY, DateMilliUtils.ARROW_DATE_MILLISECOND_VALUE)
       case fsb: ArrowType.FixedSizeBinary =>
@@ -349,6 +361,14 @@ object LanceArrowUtils {
       }
       if (metadata.contains(ARROW_LARGE_VAR_CHAR_KEY)
         && metadata.getString(ARROW_LARGE_VAR_CHAR_KEY).equalsIgnoreCase("true")) {
+        large = true
+      }
+      // Restore 64-bit offsets for a BinaryType that came from an Arrow LargeBinary column.
+      // Gated on dt == BinaryType so the marker cannot leak onto an unrelated type if the
+      // metadata is copied across columns by a Spark transform.
+      if (dt == BinaryType
+        && metadata.contains(ARROW_LARGE_VAR_BINARY_KEY)
+        && metadata.getString(ARROW_LARGE_VAR_BINARY_KEY).equalsIgnoreCase("true")) {
         large = true
       }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BaseSparkConnectorWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/BaseSparkConnectorWriteTest.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.spark.sql.functions.col;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -741,6 +742,66 @@ public abstract class BaseSparkConnectorWriteTest {
           idField.getType(),
           "id field should be LargeUtf8 when use_large_var_types=true on createOrReplace path");
     }
+  }
+
+  /**
+   * Regression: reading a Lance table with a LargeBinary column, transforming it in Spark, and
+   * writing back must not fail. Spark maps both Arrow Binary and LargeBinary onto its single
+   * BinaryType, so without a metadata marker the round trip silently narrows LargeBinary -> Binary
+   * and the append is rejected by Lance's schema validation.
+   */
+  @Test
+  public void appendAfterTransformPreservesLargeBinary(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String path = TestUtils.getDatasetUri(dbPath.toString(), datasetName);
+
+    StructType schema =
+        new StructType().add("id", DataTypes.IntegerType).add("image_bytes", DataTypes.BinaryType);
+    Dataset<Row> data =
+        spark.createDataFrame(
+            Arrays.asList(
+                RowFactory.create(1, new byte[] {1, 2, 3}),
+                RowFactory.create(2, new byte[] {4, 5, 6})),
+            schema);
+    data.writeTo("lance.`" + path + "`")
+        .using("lance")
+        .option("use_large_var_types", "true")
+        .create();
+
+    // Read back, apply a transform that leaves image_bytes untouched, and append.
+    // This is the exact shape of the reported failure.
+    Dataset<Row> transformed =
+        spark
+            .read()
+            .format(LanceDataSource.name)
+            .option(LanceSparkReadOptions.CONFIG_DATASET_URI, path)
+            .load()
+            .withColumn("id", col("id").plus(10));
+
+    transformed.writeTo("lance.`" + path + "`").append();
+
+    // The on-disk Arrow type must still be LargeBinary, not silently narrowed to Binary.
+    try (org.lance.Dataset ds =
+        org.lance.Dataset.open().allocator(LanceRuntime.allocator()).uri(path).build()) {
+      assertEquals(
+          org.apache.arrow.vector.types.pojo.ArrowType.LargeBinary.INSTANCE,
+          ds.getSchema().findField("image_bytes").getType(),
+          "image_bytes must remain LargeBinary after a read -> transform -> write round trip");
+    }
+
+    List<Row> rows =
+        spark
+            .read()
+            .format(LanceDataSource.name)
+            .option(LanceSparkReadOptions.CONFIG_DATASET_URI, path)
+            .load()
+            .orderBy("id")
+            .collectAsList();
+    assertEquals(4, rows.size());
+    assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) rows.get(0).get(1));
+    assertArrayEquals(new byte[] {4, 5, 6}, (byte[]) rows.get(1).get(1));
+    assertArrayEquals(new byte[] {1, 2, 3}, (byte[]) rows.get(2).get(1));
+    assertArrayEquals(new byte[] {4, 5, 6}, (byte[]) rows.get(3).get(1));
   }
 
   /**

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/util/LanceArrowUtilsSuite.scala
@@ -838,4 +838,40 @@ class LanceArrowUtilsSuite extends AnyFunSuite {
     assert(roundtripField.getType.isInstanceOf[ArrowType.FixedSizeBinary])
     assert(roundtripField.getType.asInstanceOf[ArrowType.FixedSizeBinary].getByteWidth === 32)
   }
+
+  test("LargeBinary roundtrip preserves 64-bit offsets") {
+    // Spark represents both Arrow Binary and LargeBinary as BinaryType. The metadata marker must
+    // retain the distinction so a read -> transform -> write round trip through Spark does not
+    // silently narrow a Lance LargeBinary column to Binary and fail schema validation.
+    val arrowSchema = new Schema(java.util.Arrays.asList(
+      primitiveField("image_bytes", ArrowType.LargeBinary.INSTANCE),
+      primitiveField("small_bytes", ArrowType.Binary.INSTANCE)))
+
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrowSchema)
+    assert(sparkSchema("image_bytes").dataType === BinaryType)
+    assert(sparkSchema("small_bytes").dataType === BinaryType)
+    assert(sparkSchema("image_bytes").metadata.contains(
+      LanceArrowUtils.ARROW_LARGE_VAR_BINARY_KEY))
+    assert(!sparkSchema("small_bytes").metadata.contains(
+      LanceArrowUtils.ARROW_LARGE_VAR_BINARY_KEY))
+
+    val roundtrip = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    assert(roundtrip.findField("image_bytes").getType === ArrowType.LargeBinary.INSTANCE)
+    // A plain Binary column must NOT be widened by the marker on its sibling.
+    assert(roundtrip.findField("small_bytes").getType === ArrowType.Binary.INSTANCE)
+  }
+
+  test("LargeBinary inside Array roundtrips to LargeBinary") {
+    val arrow = new Schema(java.util.Arrays.asList(listField(
+      "arr",
+      primitiveField("element", ArrowType.LargeBinary.INSTANCE))))
+    val sparkSchema = LanceArrowUtils.fromArrowSchema(arrow)
+    assert(sparkSchema("arr").dataType === ArrayType(BinaryType, containsNull = true))
+
+    val arrowBack = LanceArrowUtils.toArrowSchema(sparkSchema, "UTC", false)
+    val elementType = arrowBack.findField("arr").getChildren.get(0).getType
+    assert(
+      elementType === ArrowType.LargeBinary.INSTANCE,
+      s"Array element should remain LargeBinary, got $elementType")
+  }
 }


### PR DESCRIPTION
## Problem

Spark has a single `BinaryType` that covers both Arrow `Binary` (32-bit offsets) and Arrow `LargeBinary` (64-bit offsets). #413 fixed the **write** path so `use_large_var_types` produces `LargeBinary`, but the **read** path still drops the distinction: a Lance `LargeBinary` column comes back as a plain `BinaryType` with no marker, so writing that DataFrame back narrows the column to `Binary` and the append is rejected by Lance's schema validation.

This bites any read → transform → write round trip, which is the common shape for backfills:

```python
df = spark.read...load()                       # LARGE_BINARY -> BINARY
df = df.withColumn("md5", md5("image_bytes"))  # image_bytes untouched
df.writeTo(table).append()                     # BINARY != LARGE_BINARY -> fail
```

It also affects `UPDATE` and `ALTER TABLE ... ADD COLUMNS FROM`, which round-trip the table schema through Spark internally.

The asymmetry is visible in `LanceArrowUtils`:

- write (`toArrowType`): `case BinaryType if largeVarTypes => ArrowType.LargeBinary.INSTANCE` ✅
- read (`convertArrowFieldType`): `case _: ArrowType.LargeBinary => BinaryType`, and `augmentTypeMarkers` had **no `LargeBinary` case** — so the 64-bit-offset information was discarded.

`LargeUtf8` already gets a marker (`arrow:large-var-char`), and `FixedSizeBinary` already preserves its byte width. `LargeBinary` was the one that got missed.

## Fix

Record the 64-bit-offset marker in Spark field metadata on read and honor it on writeback, mirroring what `LargeVarCharUtils` already does for `LargeUtf8`.

- New `LargeVarBinaryUtils` holds the key, alongside the existing `LargeVarCharUtils` / `FixedSizeBinaryUtils`.
- The writeback check is gated on `dt == BinaryType`, so a stray copied metadata key cannot widen an unrelated column.
- The read-side marker skips blob columns (`if !isBlobField(field)`) — those are already `LargeBinary`-backed via their own marker, which `toArrowField` honors on its own.

## Second commit: Spark 3.4 read path

Adding the end-to-end test surfaced a second, pre-existing instance of the same omission one layer down. Spark 3.4's `ArrowUtils.fromArrowType` rejects `LargeBinary` with `UNSUPPORTED_ARROWTYPE`, and `LanceArrowColumnVector` was delegating `LargeVarBinaryVector` to Spark's `ArrowColumnVector`:

```
UNSUPPORTED_ARROWTYPE: Unsupported arrow type LargeBinary
  at org.apache.spark.sql.util.ArrowUtils$.fromArrowType(ArrowUtils.scala:82)
  at org.apache.spark.sql.vectorized.ArrowColumnVector.<init>(ArrowColumnVector.java:140)
  at org.lance.spark.vectorized.LanceArrowColumnVector.<init>(LanceArrowColumnVector.java:152)
```

`LanceArrowColumnVector` already routes `LargeVarCharVector` to a dedicated accessor for exactly this reason on `LargeUtf8` — `LargeBinary` was missing the equivalent. Added `LargeVarBinaryAccessor`, mirroring `LargeVarCharAccessor`.

This gap broke **any** read of a LargeBinary Lance table on Spark 3.4, independent of the metadata change here; this branch's test is simply the first coverage to exercise that path on 3.4.

## Tests

Three new tests, each verified to **fail without the fix and pass with it**:

| Test | Without fix |
|---|---|
| `LargeBinary roundtrip preserves 64-bit offsets` | FAILED |
| `LargeBinary inside Array roundtrips to LargeBinary` | FAILED |
| `appendAfterTransformPreservesLargeBinary` (end-to-end) | `RuntimeException: Failed to write data to lance` |

The unit test also asserts that a **sibling plain `Binary` column is not widened**, guarding the main regression risk. The end-to-end test reproduces the reported scenario (read → `withColumn` → `append`) and its failure without the fix matches the reported error exactly.

Verified on Temurin JDK 17 (matching CI). Removing just the accessor wiring reproduces the CI
error exactly, confirming that line is what fixes it. Full suites green: `lance-spark-base_2.12`
(573 tests), `lance-spark-3.4_2.12` (1127 tests), `lance-spark-3.5_2.12` (1266 tests, including
all blob tests), and checkstyle.

Reported by Ryan Stuart, who also root-caused the read/write asymmetry and supplied the initial patch that this PR builds on — thank you!

Co-authored-by: Ryan Stuart <ryanstuart@microsoft.com>
