### PR TITLE
feat: balance scalar index fragment batches

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -51,9 +51,9 @@ These options apply to all index methods:
 The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`,
 `rtree`, `fts` (or `inverted`), and `btree` with `build_mode = 'fragment'` supports:
 
-| Option         | Type    | Description                                                                                                                                                                                                 |
-|----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Each task covers a contiguous batch of fragments. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+| Option         | Type    | Description                                                                                                                                                                                                                                                                                  |
+|----------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Fragments are assigned by row count to balance estimated task workloads, so batches are not necessarily contiguous by fragment ID. Defaults to `min(fragment_count, spark.default.parallelism)`. |
 
 ### ZoneMap Options
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -51,9 +51,9 @@ These options apply to all index methods:
 The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloomfilter`,
 `rtree`, `fts` (or `inverted`), and `btree` with `build_mode = 'fragment'` supports:
 
-| Option         | Type    | Description                                                                                                                                                                                                                                                                                  |
-|----------------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Fragments are assigned by row count to balance estimated task workloads, so batches are not necessarily contiguous by fragment ID. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+| Option         | Type    | Description                                                                                                                                                                                                                        |
+|----------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Fragments are assigned by row count to balance estimated task workloads. Defaults to `min(fragment_count, spark.default.parallelism)`. |
 
 ### ZoneMap Options
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -40,6 +40,7 @@ import org.lance.spark.write.SingleBatchArrowReader
 import java.util.{Collections, Locale, UUID}
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable.{ArrayBuffer, PriorityQueue}
 import scala.reflect.ClassTag
 
 /**
@@ -90,7 +91,7 @@ case class AddIndexExec(
     val btreeBuildMode = IndexUtils.btreeBuildMode(indexType, args)
     val scalarSegmentIndexType = IndexUtils.scalarSegmentIndexType(method)
 
-    val (fragmentIds, canonicalColumns) = {
+    val (fragmentWorkloads, canonicalColumns) = {
       val ds = Utils.openDatasetBuilder(readOptions).build()
       try {
         val canonical = columns.map { column =>
@@ -98,12 +99,18 @@ case class AddIndexExec(
           FieldPathUtils.pathByFieldId(ds.getLanceSchema, field.getId)
         }
         (
-          ds.getFragments.asScala.map(_.getId).map(Integer.valueOf).toList,
+          ds.getFragments.asScala
+            .map(fragment =>
+              FragmentWorkload(
+                Integer.valueOf(fragment.getId),
+                fragment.metadata().getNumRows))
+            .toList,
           canonical)
       } finally {
         ds.close()
       }
     }
+    val fragmentIds = fragmentWorkloads.map(_.fragmentId)
 
     val train = IndexUtils.extractTrain(args)
 
@@ -183,7 +190,7 @@ case class AddIndexExec(
       val segmentJob = new ScalarSegmentIndexJob(
         this.copy(columns = canonicalColumns),
         readOptions,
-        fragmentIds,
+        fragmentWorkloads,
         validatedNumSegments,
         nsImpl,
         nsProps,
@@ -474,7 +481,7 @@ case class RangeBTreeIndexBuilder(
 class ScalarSegmentIndexJob(
     addIndexExec: AddIndexExec,
     readOptions: LanceSparkReadOptions,
-    fragmentIds: List[Integer],
+    fragmentWorkloads: List[FragmentWorkload],
     numSegments: Option[Int],
     nsImpl: Option[String],
     nsProps: Option[Map[String, String]],
@@ -490,7 +497,7 @@ class ScalarSegmentIndexJob(
     val columns = addIndexExec.columns.toList
     val argsJson = IndexUtils.toJson(addIndexExec.args)
     val fragmentBatches = IndexUtils.batchFragments(
-      fragmentIds,
+      fragmentWorkloads,
       numSegments,
       addIndexExec.session.sparkContext.defaultParallelism)
 
@@ -514,6 +521,8 @@ class ScalarSegmentIndexJob(
         "visible to readers and will not affect query correctness.")(_.execute())
   }
 }
+
+final private[v2] case class FragmentWorkload(fragmentId: Integer, numRows: Long)
 
 /**
  * A task to create a scalar index segment on a batch of fragments.
@@ -731,10 +740,10 @@ object IndexUtils extends Logging {
   }
 
   def batchFragments(
-      fragmentIds: List[Integer],
+      fragments: List[FragmentWorkload],
       numSegments: Option[Int],
       defaultParallelism: Int): Seq[List[Integer]] = {
-    val fragmentCount = fragmentIds.size
+    val fragmentCount = fragments.size
     if (fragmentCount == 0) {
       return Seq.empty
     }
@@ -751,11 +760,35 @@ object IndexUtils extends Logging {
       case None => math.max(1, math.min(fragmentCount, defaultParallelism))
     }
 
-    (0 until segmentCount).map { index =>
-      fragmentIds.slice(
-        (index.toLong * fragmentCount / segmentCount).toInt,
-        ((index.toLong + 1) * fragmentCount / segmentCount).toInt)
+    final class SegmentBatch(val index: Int) {
+      val fragmentIds: ArrayBuffer[Integer] = ArrayBuffer.empty
+      var numRows: Long = 0L
+
+      def add(fragment: FragmentWorkload): Unit = {
+        numRows = Math.addExact(numRows, fragment.numRows)
+        fragmentIds += fragment.fragmentId
+      }
     }
+
+    val segmentOrdering: Ordering[SegmentBatch] =
+      Ordering
+        .by[SegmentBatch, (Long, Int, Int)](segment =>
+          (segment.numRows, segment.fragmentIds.size, segment.index))
+        .reverse
+
+    val segments = PriorityQueue.empty[SegmentBatch](segmentOrdering)
+    (0 until segmentCount).foreach(index => segments.enqueue(new SegmentBatch(index)))
+
+    val sortedFragments = fragments.sortBy(fragment => (-fragment.numRows, fragment.fragmentId))
+    sortedFragments.foreach { fragment =>
+      val segment = segments.dequeue()
+      segment.add(fragment)
+      segments.enqueue(segment)
+    }
+
+    segments.toSeq
+      .sortBy(_.index)
+      .map(segment => segment.fragmentIds.sortBy(_.intValue()).toList)
   }
 
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -100,10 +100,7 @@ case class AddIndexExec(
         }
         (
           ds.getFragments.asScala
-            .map(fragment =>
-              FragmentWorkload(
-                Integer.valueOf(fragment.getId),
-                fragment.metadata().getNumRows))
+            .map(fragment => FragmentWorkload(fragment.getId, fragment.metadata().getNumRows))
             .toList,
           canonical)
       } finally {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -13,6 +13,7 @@
  */
 package org.lance.spark.update;
 
+import org.lance.Fragment;
 import org.lance.index.Index;
 import org.lance.index.IndexCriteria;
 import org.lance.index.IndexDescription;
@@ -55,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -123,6 +125,27 @@ public abstract class BaseAddIndexTest {
                 .boxed()
                 .map(i -> String.format("(%d, 'text_%d')", i, i))
                 .collect(Collectors.joining(","))));
+  }
+
+  private void prepareUnevenFragmentDataset() throws Exception {
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("text", DataTypes.StringType, false)
+            });
+    int nextId = 0;
+    for (int rowCount : Arrays.asList(80, 50, 30, 20)) {
+      int startId = nextId;
+      List<Row> rows =
+          IntStream.range(startId, startId + rowCount)
+              .boxed()
+              .map(i -> RowFactory.create(i, String.format("text_%d", i)))
+              .collect(Collectors.toList());
+      spark.createDataFrame(rows, schema).coalesce(1).writeTo(fullTable).append();
+      nextId += rowCount;
+    }
   }
 
   private void prepareNestedDataset() {
@@ -379,6 +402,51 @@ public abstract class BaseAddIndexTest {
           "Expected committed segments to cover all fragments exactly once");
     } finally {
       lanceDataset.close();
+    }
+  }
+
+  @Test
+  public void testScalarSegmentBatchesBalanceByRowCount() throws Exception {
+    prepareUnevenFragmentDataset();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index balanced_segments using zonemap (id) with (num_segments = 2)",
+                fullTable))
+        .collectAsList();
+
+    try (org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      Map<Integer, Long> fragmentRows =
+          lanceDataset.getFragments().stream()
+              .collect(
+                  Collectors.toMap(Fragment::getId, fragment -> fragment.metadata().getNumRows()));
+      Assertions.assertEquals(
+          Arrays.asList(20L, 30L, 50L, 80L),
+          fragmentRows.values().stream().sorted().collect(Collectors.toList()),
+          "Expected four source fragments with intentionally uneven row counts");
+
+      List<Index> segments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "balanced_segments".equals(index.name()))
+              .collect(Collectors.toList());
+      Assertions.assertEquals(2, segments.size());
+
+      Set<Integer> coveredFragments = new HashSet<>();
+      List<Long> segmentWorkloads = new ArrayList<>();
+      for (Index segment : segments) {
+        List<Integer> segmentFragments = segment.fragments().orElse(Collections.emptyList());
+        long workload = segmentFragments.stream().mapToLong(fragmentRows::get).sum();
+        segmentWorkloads.add(workload);
+        coveredFragments.addAll(segmentFragments);
+      }
+      Collections.sort(segmentWorkloads);
+
+      Assertions.assertEquals(
+          Arrays.asList(80L, 100L),
+          segmentWorkloads,
+          "Expected row-count batching to avoid the 130/50 workload split produced by count batching");
+      Assertions.assertEquals(fragmentRows.keySet(), coveredFragments);
     }
   }
 

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
@@ -26,6 +26,11 @@ import org.lance.index.IndexType
  */
 class IndexUtilsTest {
 
+  private def fragmentWorkloads(rows: Long*): List[FragmentWorkload] =
+    rows.zipWithIndex.map { case (rowCount, fragmentId) =>
+      FragmentWorkload(java.lang.Integer.valueOf(fragmentId), rowCount)
+    }.toList
+
   // ── extractTrain ──────────────────────────────────────────────────────────
 
   @Test
@@ -213,23 +218,43 @@ class IndexUtilsTest {
 
   @Test
   def batchFragments_respectsNumSegmentsAndDefaults(): Unit = {
-    val ids = (0 until 4).map(java.lang.Integer.valueOf).toList
+    val fragments = fragmentWorkloads(1, 1, 1, 1)
 
-    assertEquals(Seq(2, 2), IndexUtils.batchFragments(ids, Some(2), 4).map(_.size))
-    assertEquals(4, IndexUtils.batchFragments(ids, Some(10), 4).size)
-    assertEquals(4, IndexUtils.batchFragments(ids, None, 8).size)
-    assertEquals(2, IndexUtils.batchFragments(ids, None, 2).size)
+    assertEquals(Seq(2, 2), IndexUtils.batchFragments(fragments, Some(2), 4).map(_.size))
+    assertEquals(4, IndexUtils.batchFragments(fragments, Some(4), 4).size)
+    assertEquals(4, IndexUtils.batchFragments(fragments, Some(10), 4).size)
+    assertEquals(4, IndexUtils.batchFragments(fragments, None, 8).size)
+    assertEquals(2, IndexUtils.batchFragments(fragments, None, 2).size)
     assertEquals(Seq.empty, IndexUtils.batchFragments(Nil, None, 4))
   }
 
   @Test
-  def batchFragments_coversAllFragmentsExactlyOnce(): Unit = {
-    val ids = (0 until 7).map(java.lang.Integer.valueOf).toList
-    val batches = IndexUtils.batchFragments(ids, Some(3), 4)
+  def batchFragments_balancesRowsDeterministically(): Unit = {
+    val fragments = fragmentWorkloads(80, 50, 30, 20)
+    val expected = Seq(
+      List(java.lang.Integer.valueOf(0), java.lang.Integer.valueOf(3)),
+      List(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2)))
 
-    assertEquals(Seq(2, 2, 3), batches.map(_.size))
-    assertEquals(ids, batches.flatten)
-    assertEquals(ids.size, batches.flatten.distinct.size)
-    assertTrue(batches.forall(_.nonEmpty))
+    assertEquals(expected, IndexUtils.batchFragments(fragments, Some(2), 4))
+    assertEquals(expected, IndexUtils.batchFragments(fragments.reverse, Some(2), 4))
+  }
+
+  @Test
+  def batchFragments_distributesZeroRowFragmentsAcrossSegments(): Unit = {
+    val fragments = fragmentWorkloads(0, 0, 0, 0).reverse
+
+    assertEquals(
+      Seq(
+        List(java.lang.Integer.valueOf(0), java.lang.Integer.valueOf(3)),
+        List(java.lang.Integer.valueOf(1)),
+        List(java.lang.Integer.valueOf(2))),
+      IndexUtils.batchFragments(fragments, Some(3), 4))
+  }
+
+  @Test
+  def batchFragments_rejectsWorkloadOverflow(): Unit = {
+    assertThrows(
+      classOf[ArithmeticException],
+      () => IndexUtils.batchFragments(fragmentWorkloads(Long.MaxValue, 1), Some(1), 1))
   }
 }


### PR DESCRIPTION
## Summary

- Balance scalar index fragment batches using fragment row counts.
- Keep assignments deterministic and document the non-contiguous batching behavior.

## Testing

- Spark 3.5 / Scala 2.12: AddIndexTest (48 tests)
- Scala 2.12 and 2.13: IndexUtilsTest (26 tests each)

Closes #757