### PR TITLE
feat: support blob v2 add columns

### DIFF
--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -27,6 +27,51 @@ ALTER TABLE users ADD COLUMNS name_hash FROM tmp_view;
 
 No table rewrite, no data movement—just a new column that is instantly queryable.
 
+## Blob v2 columns
+
+To add a blob v2 column, store the target blob encoding property on the table and
+use a Lance file format version that supports blob v2 before running
+`ADD COLUMNS FROM`:
+
+```sql
+CREATE TABLE media (
+  id INT
+) USING lance
+TBLPROPERTIES (
+  'file_format_version' = '2.2'
+);
+
+INSERT INTO media VALUES (1), (2);
+
+ALTER TABLE media SET TBLPROPERTIES ('content.lance.encoding' = 'blob');
+
+CREATE TEMPORARY VIEW content_backfill AS
+SELECT _rowaddr, _fragid, image_bytes AS content
+FROM media_with_bytes;
+
+ALTER TABLE media ADD COLUMNS content FROM content_backfill;
+```
+
+The source expression for the new column should be `BINARY`. When adding a new
+column from an existing blob v2 Lance table, a direct column select also works:
+
+```sql
+CREATE TEMPORARY VIEW copied_content AS
+SELECT target._rowaddr, target._fragid, source.content AS content
+FROM media target
+JOIN source_media source ON target.id = source.id;
+
+ALTER TABLE media ADD COLUMNS content FROM copied_content;
+```
+
+For an existing table that was already created with `file_format_version = '2.2'`
+or newer, set the new column's blob property before adding the column:
+
+```sql
+ALTER TABLE media SET TBLPROPERTIES ('content.lance.encoding' = 'blob');
+ALTER TABLE media ADD COLUMNS content FROM content_backfill;
+```
+
 !!! note
     Because we use `_rowaddr` and `_fragid` to address the target dataset's rows for the new column's data, 
     the temporary view should contain `_rowaddr` and `_fragid`.

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -45,9 +45,15 @@ INSERT INTO media VALUES (1), (2);
 
 ALTER TABLE media SET TBLPROPERTIES ('content.lance.encoding' = 'blob');
 
+CREATE TEMPORARY VIEW media_with_bytes AS
+SELECT 1 AS id, X'68656C6C6F' AS image_bytes
+UNION ALL
+SELECT 2 AS id, X'776F726C64' AS image_bytes;
+
 CREATE TEMPORARY VIEW content_backfill AS
 SELECT _rowaddr, _fragid, image_bytes AS content
-FROM media_with_bytes;
+FROM media
+JOIN media_with_bytes USING (id);
 
 ALTER TABLE media ADD COLUMNS content FROM content_backfill;
 ```

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2432,6 +2432,131 @@ class TestDMLAddColumn:
         assert result[1].total_compensation == 69000   # 60000 + 9000
         assert result[2].total_compensation == 84000   # 70000 + 14000
 
+    def test_add_blob_v2_column_from_binary_view(self, spark, test_table):
+        """Test ADD COLUMNS FROM can add a blob v2 column from BINARY values."""
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
+                id INT,
+                name STRING
+            ) USING lance
+            TBLPROPERTIES (
+                'file_format_version' = '2.2'
+            )
+        """)
+        spark.sql(f"""
+            ALTER TABLE {test_table}
+            SET TBLPROPERTIES ('content.lance.encoding' = 'blob')
+        """)
+
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
+            (1, 'Alice'),
+            (2, 'Bob')
+        """)
+
+        first_content = b"blob added from binary view"
+        second_content = b"second blob from binary view"
+        view = f"tmp_add_blob_v2_binary_{int(time.time() * 1000)}"
+        spark.sql(f"""
+            CREATE TEMPORARY VIEW {view} AS
+            SELECT _rowaddr, _fragid,
+                   CASE
+                     WHEN id = 1 THEN {_sql_binary_literal(first_content)}
+                     ELSE {_sql_binary_literal(second_content)}
+                   END AS content
+            FROM {test_table}
+        """)
+
+        spark.sql(f"ALTER TABLE {test_table} ADD COLUMNS content FROM {view}")
+
+        describe_rows = spark.sql(f"DESCRIBE {test_table}").collect()
+        content_field = next(row for row in describe_rows if row.col_name == "content")
+        content_type = content_field.data_type.lower()
+        assert "struct" in content_type
+        assert "blob_uri" in content_type
+
+        rows = spark.sql(f"""
+            SELECT id, content.size, content.kind
+            FROM {test_table}
+            ORDER BY id
+        """).collect()
+
+        assert rows[0].size == len(first_content)
+        assert rows[0].kind == 0
+        assert rows[1].size == len(second_content)
+        assert rows[1].kind == 0
+
+        if spark._lance_backend == "local":
+            lance = pytest.importorskip("lance", reason="lance-python not installed")
+            ds = lance.dataset(_table_location(spark, test_table))
+            assert (
+                ds.schema.field("content").metadata.get(b"ARROW:extension:name")
+                == b"lance.blob.v2"
+            )
+
+    def test_add_blob_v2_column_from_blob_v2_source(self, spark, test_table):
+        """Test ADD COLUMNS FROM can copy an existing blob v2 source column."""
+        source = f"default.add_blob_v2_source_{int(time.time() * 1000)}"
+        try:
+            spark.sql(f"""
+                CREATE TABLE {source} (
+                    id INT,
+                    content BINARY
+                ) USING lance
+                TBLPROPERTIES (
+                    'content.lance.encoding' = 'blob',
+                    'file_format_version' = '2.2'
+                )
+            """)
+            spark.sql(f"""
+                CREATE TABLE {test_table} (
+                    id INT
+                ) USING lance
+                TBLPROPERTIES (
+                    'file_format_version' = '2.2'
+                )
+            """)
+            spark.sql(f"""
+                ALTER TABLE {test_table}
+                SET TBLPROPERTIES ('copied.lance.encoding' = 'blob')
+            """)
+
+            first_content = b"copied blob one"
+            second_content = b"copied blob two"
+            spark.sql(f"""
+                INSERT INTO {source} VALUES
+                (1, {_sql_binary_literal(first_content)}),
+                (2, {_sql_binary_literal(second_content)})
+            """)
+            spark.sql(f"""
+                INSERT INTO {test_table} VALUES
+                (1),
+                (2)
+            """)
+
+            view = f"tmp_add_blob_v2_copy_{int(time.time() * 1000)}"
+            spark.sql(f"""
+                CREATE TEMPORARY VIEW {view} AS
+                SELECT t._rowaddr, t._fragid, s.content AS copied
+                FROM {test_table} t
+                JOIN {source} s ON t.id = s.id
+            """)
+
+            spark.sql(f"ALTER TABLE {test_table} ADD COLUMNS copied FROM {view}")
+
+            rows = spark.sql(f"""
+                SELECT id, copied.size, copied.kind
+                FROM {test_table}
+                ORDER BY id
+            """).collect()
+
+            assert rows[0].size == len(first_content)
+            assert rows[0].kind == 0
+            assert rows[1].size == len(second_content)
+            assert rows[1].kind == 0
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {source}")
+
 
 class TestDMLUpdateColumn:
     """Test DML UPDATE COLUMNS FROM operations for updating existing columns via backfill."""

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -401,7 +401,8 @@ public class LanceDataset
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          readOptions.getTableId());
+          readOptions.getTableId(),
+          blobSourceContexts);
     }
 
     List<String> updateColumns =
@@ -418,7 +419,8 @@ public class LanceDataset
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          readOptions.getTableId());
+          readOptions.getTableId(),
+          blobSourceContexts);
     }
 
     SparkWrite.SparkWriteBuilder builder =

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobUtils.java
@@ -189,6 +189,25 @@ public class BlobUtils {
     return changed ? new StructType(fields) : schema;
   }
 
+  /** Rewrites read-side blob v2 descriptor columns back to the binary write schema. */
+  public static StructType applyBlobV2WriteSchema(StructType schema) {
+    StructField[] fields = new StructField[schema.fields().length];
+    boolean changed = false;
+    for (int i = 0; i < schema.fields().length; i++) {
+      StructField field = schema.fields()[i];
+      if (!isBlobV2SparkField(field) || !(field.dataType() instanceof StructType)) {
+        fields[i] = field;
+        continue;
+      }
+
+      fields[i] =
+          new StructField(field.name(), DataTypes.BinaryType, field.nullable(), field.metadata());
+      changed = true;
+    }
+
+    return changed ? new StructType(fields) : schema;
+  }
+
   /**
    * True when {@code fileFormatVersion} is numeric {@code major[.minor]} of {@value
    * #MIN_BLOB_V2_FILE_FORMAT_VERSION} or newer.

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
@@ -25,8 +25,6 @@ import org.lance.spark.utils.Utils;
 import org.apache.arrow.c.ArrowArrayStream;
 import org.apache.arrow.c.Data;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
 import org.apache.spark.sql.connector.write.WriterCommitMessage;
@@ -34,13 +32,15 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.LanceArrowUtils;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 
 /**
- * Abstract base class for backfill writers that buffer rows per fragment and then process each
- * fragment's data via a Lance fragment operation (merge or update).
+ * Abstract base class for backfill writers that stream rows for each fragment through bounded Arrow
+ * record batches and process the stream via a Lance fragment operation (merge or update).
  *
  * <p>Subclasses implement {@link #processFragment} to perform the specific operation and {@link
  * #buildCommitMessage} to construct the appropriate commit message.
@@ -50,21 +50,26 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
   private final StructType schema;
   private final int fragmentIdField;
   private final StructType writerSchema;
-  private final Map<Integer, FragmentBuffer> buffers = new HashMap<>();
+  private final int[] writerInputOrdinals;
 
   private final Map<String, String> initialStorageOptions;
   private final String namespaceImpl;
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
   private final BlobReferenceResolver blobResolver;
+  private Dataset dataset;
+  private FragmentStream currentStream;
+  private Integer lastCompletedFragmentId;
 
-  private static class FragmentBuffer {
-    final VectorSchemaRoot data;
-    final org.lance.spark.arrow.LanceArrowWriter writer;
+  private static class FragmentStream {
+    final int fragmentId;
+    final SemaphoreArrowBatchWriteBuffer buffer;
+    final FutureTask<Void> task;
 
-    FragmentBuffer(VectorSchemaRoot data, org.lance.spark.arrow.LanceArrowWriter writer) {
-      this.data = data;
-      this.writer = writer;
+    FragmentStream(int fragmentId, SemaphoreArrowBatchWriteBuffer buffer, FutureTask<Void> task) {
+      this.fragmentId = fragmentId;
+      this.buffer = buffer;
+      this.task = task;
     }
   }
 
@@ -94,47 +99,79 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
       }
     }
     this.writerSchema = ws;
+    this.writerInputOrdinals =
+        Arrays.stream(writerSchema.fields())
+            .mapToInt(field -> schema.fieldIndex(field.name()))
+            .toArray();
   }
 
   @Override
   public void write(InternalRow record) throws IOException {
     int fragId = record.getInt(fragmentIdField);
-
-    FragmentBuffer buffer =
-        buffers.computeIfAbsent(
-            fragId,
-            id -> {
-              BufferAllocator allocator = LanceRuntime.allocator();
-              VectorSchemaRoot data =
-                  VectorSchemaRoot.create(
-                      LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false), allocator);
-              org.lance.spark.arrow.LanceArrowWriter writer =
-                  org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(
-                      data, writerSchema, blobResolver);
-              return new FragmentBuffer(data, writer);
-            });
-
-    for (int i = 0; i < writerSchema.fields().length; i++) {
-      buffer.writer.field(i).write(record, schema.fieldIndex(writerSchema.fields()[i].name()));
+    if (currentStream == null || currentStream.fragmentId != fragId) {
+      finishCurrentFragment();
+      if (lastCompletedFragmentId != null && fragId <= lastCompletedFragmentId) {
+        throw new IOException(
+            "Backfill rows must be ordered by "
+                + LanceDataset.FRAGMENT_ID_COLUMN.name()
+                + "; saw fragment "
+                + fragId
+                + " after fragment "
+                + lastCompletedFragmentId);
+      }
+      currentStream = startFragment(fragId);
     }
+    currentStream.buffer.write(record);
   }
 
-  private void flushFragment(Dataset dataset, int fragmentId, FragmentBuffer buffer) {
+  private FragmentStream startFragment(int fragmentId) {
+    if (dataset == null) {
+      dataset =
+          Utils.openDatasetBuilder(writeOptions)
+              .initialStorageOptions(initialStorageOptions)
+              .build();
+    }
+    BufferAllocator allocator = LanceRuntime.allocator();
+    SemaphoreArrowBatchWriteBuffer buffer =
+        new SemaphoreArrowBatchWriteBuffer(
+            allocator,
+            LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false),
+            writerSchema,
+            writeOptions.getBatchSize(),
+            writeOptions.getMaxBatchBytes(),
+            blobResolver,
+            writerInputOrdinals);
+    FutureTask<Void> task =
+        buffer.createTrackedTask(
+            () -> {
+              try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+                Data.exportArrayStream(allocator, buffer, stream);
+                processFragment(new Fragment(dataset, fragmentId), stream);
+              }
+              return null;
+            });
+    Thread thread = new Thread(task, "lance-backfill-fragment-" + fragmentId);
+    thread.start();
+    return new FragmentStream(fragmentId, buffer, task);
+  }
+
+  private void finishCurrentFragment() throws IOException {
+    if (currentStream == null) {
+      return;
+    }
+    FragmentStream stream = currentStream;
+    currentStream = null;
+    stream.buffer.setFinished();
     try {
-      buffer.writer.finish();
-      BufferAllocator allocator = LanceRuntime.allocator();
-
-      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator);
-          ArrowReader reader = new SingleBatchArrowReader(allocator, buffer.data)) {
-        Data.exportArrayStream(allocator, reader, stream);
-
-        Fragment fragment = new Fragment(dataset, fragmentId);
-        processFragment(fragment, stream);
-      } catch (Exception e) {
-        throw new RuntimeException("Cannot read arrow stream.", e);
-      }
+      stream.task.get();
+      lastCompletedFragmentId = stream.fragmentId;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while backfilling fragment " + stream.fragmentId, e);
+    } catch (ExecutionException e) {
+      throw new IOException("Failed to backfill fragment " + stream.fragmentId, e.getCause());
     } finally {
-      buffer.data.close();
+      stream.buffer.close();
     }
   }
 
@@ -148,31 +185,35 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
   protected abstract WriterCommitMessage buildCommitMessage();
 
   @Override
-  public WriterCommitMessage commit() {
-    try (Dataset dataset =
-        Utils.openDatasetBuilder(writeOptions)
-            .initialStorageOptions(initialStorageOptions)
-            .build()) {
-      for (Map.Entry<Integer, FragmentBuffer> entry : buffers.entrySet()) {
-        flushFragment(dataset, entry.getKey(), entry.getValue());
-      }
-    }
-
+  public WriterCommitMessage commit() throws IOException {
+    finishCurrentFragment();
+    closeDataset();
     return buildCommitMessage();
   }
 
   @Override
-  public void abort() {}
+  public void abort() throws IOException {
+    finishCurrentFragment();
+    closeDataset();
+  }
 
   @Override
   public void close() throws IOException {
     try {
-      for (FragmentBuffer buffer : buffers.values()) {
-        buffer.data.close();
-      }
+      finishCurrentFragment();
     } finally {
-      blobResolver.close();
+      try {
+        closeDataset();
+      } finally {
+        blobResolver.close();
+      }
     }
-    buffers.clear();
+  }
+
+  private void closeDataset() {
+    if (dataset != null) {
+      dataset.close();
+      dataset = null;
+    }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AbstractBackfillWriter.java
@@ -18,6 +18,8 @@ import org.lance.Fragment;
 import org.lance.spark.LanceDataset;
 import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobReferenceResolver;
+import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.Utils;
 
 import org.apache.arrow.c.ArrowArrayStream;
@@ -54,6 +56,7 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
   private final String namespaceImpl;
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final BlobReferenceResolver blobResolver;
 
   private static class FragmentBuffer {
     final VectorSchemaRoot data;
@@ -72,7 +75,8 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.writeOptions = writeOptions;
     this.schema = schema;
     this.fragmentIdField = schema.fieldIndex(LanceDataset.FRAGMENT_ID_COLUMN.name());
@@ -80,6 +84,7 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.blobResolver = new BlobReferenceResolver(blobSourceContexts);
 
     StructType ws = new StructType();
     for (org.apache.spark.sql.types.StructField f : schema.fields()) {
@@ -104,7 +109,8 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
                   VectorSchemaRoot.create(
                       LanceArrowUtils.toArrowSchema(writerSchema, "UTC", false), allocator);
               org.lance.spark.arrow.LanceArrowWriter writer =
-                  org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(data, writerSchema);
+                  org.lance.spark.arrow.LanceArrowWriter$.MODULE$.create(
+                      data, writerSchema, blobResolver);
               return new FragmentBuffer(data, writer);
             });
 
@@ -160,8 +166,12 @@ public abstract class AbstractBackfillWriter implements DataWriter<InternalRow> 
 
   @Override
   public void close() throws IOException {
-    for (FragmentBuffer buffer : buffers.values()) {
-      buffer.data.close();
+    try {
+      for (FragmentBuffer buffer : buffers.values()) {
+        buffer.data.close();
+      }
+    } finally {
+      blobResolver.close();
     }
     buffers.clear();
   }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillBatchWrite.java
@@ -23,6 +23,7 @@ import org.lance.operation.Merge;
 import org.lance.spark.LanceDataset;
 import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.Utils;
 
 import org.apache.arrow.c.ArrowArrayStream;
@@ -64,6 +65,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final Map<String, BlobSourceContext> blobSourceContexts;
 
   public AddColumnsBackfillBatchWrite(
       StructType schema,
@@ -72,7 +74,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.schema = schema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
       this.writeOptions = writeOptions.withVersion(ds.version());
@@ -83,6 +86,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   @Override
@@ -94,7 +98,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
-        tableId);
+        tableId,
+        blobSourceContexts);
   }
 
   @Override
@@ -173,7 +178,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       super(
           writeOptions,
           schema,
@@ -181,7 +187,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
 
     @Override
@@ -218,6 +225,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
 
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
+    private final Map<String, BlobSourceContext> blobSourceContexts;
 
     protected AddColumnsWriterFactory(
         StructType schema,
@@ -226,7 +234,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       // Everything passed to writer factory should be serializable
       this.schema = schema;
       this.writeOptions = writeOptions;
@@ -235,6 +244,7 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
       this.namespaceImpl = namespaceImpl;
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
+      this.blobSourceContexts = blobSourceContexts;
     }
 
     @Override
@@ -248,7 +258,8 @@ public class AddColumnsBackfillBatchWrite implements BatchWrite {
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
@@ -21,6 +21,8 @@ import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.Distributions;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.NullOrdering;
+import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering;
@@ -96,7 +98,12 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
 
   @Override
   public SortOrder[] requiredOrdering() {
-    return new SortOrder[0];
+    return new SortOrder[] {
+      Expressions.sort(
+          Expressions.column(LanceConstant.FRAGMENT_ID),
+          SortDirection.ASCENDING,
+          NullOrdering.NULLS_FIRST)
+    };
   }
 
   /** Task commit. */

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/AddColumnsBackfillWrite.java
@@ -15,6 +15,7 @@ package org.lance.spark.write;
 
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobSourceContext;
 
 import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.Distributions;
@@ -48,6 +49,7 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final Map<String, BlobSourceContext> blobSourceContexts;
 
   AddColumnsBackfillWrite(
       StructType schema,
@@ -56,7 +58,8 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.schema = schema;
     this.writeOptions = writeOptions;
     this.newColumns = newColumns;
@@ -64,6 +67,7 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   @Override
@@ -75,7 +79,8 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
-        tableId);
+        tableId,
+        blobSourceContexts);
   }
 
   @Override
@@ -111,6 +116,7 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
 
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
+    private final Map<String, BlobSourceContext> blobSourceContexts;
 
     public AddColumnsWriteBuilder(
         StructType schema,
@@ -119,7 +125,8 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       this.schema = schema;
       this.writeOptions = writeOptions;
       this.newColumns = newColumns;
@@ -127,6 +134,7 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
       this.namespaceImpl = namespaceImpl;
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
+      this.blobSourceContexts = blobSourceContexts;
     }
 
     @Override
@@ -138,7 +146,8 @@ public class AddColumnsBackfillWrite implements Write, RequiresDistributionAndOr
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/SemaphoreArrowBatchWriteBuffer.java
@@ -83,6 +83,9 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
   /** Resolves blob references during writes; null when blob resolution is not needed. */
   private final BlobReferenceResolver resolver;
 
+  /** Optional source-row ordinals for streams that omit routing-only input columns. */
+  private final int[] inputOrdinals;
+
   public SemaphoreArrowBatchWriteBuffer(
       BufferAllocator allocator,
       Schema schema,
@@ -90,6 +93,17 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
       int batchSize,
       long maxBatchBytes,
       BlobReferenceResolver resolver) {
+    this(allocator, schema, sparkSchema, batchSize, maxBatchBytes, resolver, null);
+  }
+
+  SemaphoreArrowBatchWriteBuffer(
+      BufferAllocator allocator,
+      Schema schema,
+      StructType sparkSchema,
+      int batchSize,
+      long maxBatchBytes,
+      BlobReferenceResolver resolver,
+      int[] inputOrdinals) {
     // Pass a child allocator to ArrowReader so VectorSchemaRoot allocation is tracked
     super(allocator.newChildAllocator("semaphore-buffer", 0, Long.MAX_VALUE));
     Preconditions.checkNotNull(schema);
@@ -100,6 +114,7 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
     this.batchSize = batchSize;
     this.maxBatchBytes = maxBatchBytes;
     this.resolver = resolver;
+    this.inputOrdinals = inputOrdinals;
     // Start with count = batchSize so the writer blocks on canWrite.await() until the
     // reader's prepareLoadNextBatch() initializes arrowWriter and resets count to 0.
     this.count = batchSize;
@@ -185,7 +200,11 @@ public class SemaphoreArrowBatchWriteBuffer extends ArrowBatchWriteBuffer {
         checkForError();
       }
 
-      arrowWriter.write(row);
+      if (inputOrdinals == null) {
+        arrowWriter.write(row);
+      } else {
+        arrowWriter.write(row, inputOrdinals);
+      }
       // Add bytes buffered outside the vectors (unresolved blob references resolve to far larger
       // bytes on finish); without this the guard would size the ~200-byte references and let the
       // batch grow until resolution OOMs the executor.

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillBatchWrite.java
@@ -23,6 +23,7 @@ import org.lance.operation.Update;
 import org.lance.spark.LanceDataset;
 import org.lance.spark.LanceRuntime;
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.Utils;
 
 import org.apache.arrow.c.ArrowArrayStream;
@@ -72,6 +73,7 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final Map<String, BlobSourceContext> blobSourceContexts;
 
   public UpdateColumnsBackfillBatchWrite(
       StructType schema,
@@ -80,7 +82,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.schema = schema;
     try (Dataset ds = Utils.openDatasetBuilder(writeOptions).build()) {
       this.writeOptions = writeOptions.withVersion(ds.version());
@@ -92,6 +95,7 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   @Override
@@ -103,7 +107,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
-        tableId);
+        tableId,
+        blobSourceContexts);
   }
 
   @Override
@@ -180,7 +185,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       super(
           writeOptions,
           schema,
@@ -188,7 +194,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
 
     @Override
@@ -224,6 +231,7 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
 
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
+    private final Map<String, BlobSourceContext> blobSourceContexts;
 
     protected UpdateColumnsWriterFactory(
         StructType schema,
@@ -232,7 +240,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       // Everything passed to writer factory should be serializable
       this.schema = schema;
       this.writeOptions = writeOptions;
@@ -241,6 +250,7 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
       this.namespaceImpl = namespaceImpl;
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
+      this.blobSourceContexts = blobSourceContexts;
     }
 
     @Override
@@ -254,7 +264,8 @@ public class UpdateColumnsBackfillBatchWrite implements BatchWrite {
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
   }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillWrite.java
@@ -15,6 +15,7 @@ package org.lance.spark.write;
 
 import org.lance.spark.LanceConstant;
 import org.lance.spark.LanceSparkWriteOptions;
+import org.lance.spark.utils.BlobSourceContext;
 
 import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.Distributions;
@@ -54,6 +55,7 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
 
   private final Map<String, String> namespaceProperties;
   private final List<String> tableId;
+  private final Map<String, BlobSourceContext> blobSourceContexts;
 
   UpdateColumnsBackfillWrite(
       StructType schema,
@@ -62,7 +64,8 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
       Map<String, String> initialStorageOptions,
       String namespaceImpl,
       Map<String, String> namespaceProperties,
-      List<String> tableId) {
+      List<String> tableId,
+      Map<String, BlobSourceContext> blobSourceContexts) {
     this.schema = schema;
     this.writeOptions = writeOptions;
     this.updateColumns = updateColumns;
@@ -70,6 +73,7 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
     this.namespaceImpl = namespaceImpl;
     this.namespaceProperties = namespaceProperties;
     this.tableId = tableId;
+    this.blobSourceContexts = blobSourceContexts;
   }
 
   @Override
@@ -81,7 +85,8 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
-        tableId);
+        tableId,
+        blobSourceContexts);
   }
 
   @Override
@@ -117,6 +122,7 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
 
     private final Map<String, String> namespaceProperties;
     private final List<String> tableId;
+    private final Map<String, BlobSourceContext> blobSourceContexts;
 
     public UpdateColumnsWriteBuilder(
         StructType schema,
@@ -125,7 +131,8 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
         Map<String, String> initialStorageOptions,
         String namespaceImpl,
         Map<String, String> namespaceProperties,
-        List<String> tableId) {
+        List<String> tableId,
+        Map<String, BlobSourceContext> blobSourceContexts) {
       this.schema = schema;
       this.writeOptions = writeOptions;
       this.updateColumns = updateColumns;
@@ -133,6 +140,7 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
       this.namespaceImpl = namespaceImpl;
       this.namespaceProperties = namespaceProperties;
       this.tableId = tableId;
+      this.blobSourceContexts = blobSourceContexts;
     }
 
     @Override
@@ -144,7 +152,8 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
           initialStorageOptions,
           namespaceImpl,
           namespaceProperties,
-          tableId);
+          tableId,
+          blobSourceContexts);
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/UpdateColumnsBackfillWrite.java
@@ -21,6 +21,8 @@ import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.Distributions;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.expressions.NullOrdering;
+import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.write.BatchWrite;
 import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering;
@@ -102,7 +104,12 @@ public class UpdateColumnsBackfillWrite implements Write, RequiresDistributionAn
 
   @Override
   public SortOrder[] requiredOrdering() {
-    return new SortOrder[0];
+    return new SortOrder[] {
+      Expressions.sort(
+          Expressions.column(LanceConstant.FRAGMENT_ID),
+          SortDirection.ASCENDING,
+          NullOrdering.NULLS_FIRST)
+    };
   }
 
   /** Write builder for UPDATE COLUMNS FROM command. */

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -16,13 +16,14 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias, View}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias, View}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util._
+import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.Metadata
-import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceConstant}
-import org.lance.spark.utils.BlobUtils
+import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceConstant, LanceDataset}
+import org.lance.spark.utils.{BlobUtils, SchemaConverter}
 
 /**
  * Rewrites direct blob v2 reads in Lance writes into [[LanceBlobV2CopyRef]] tokens so writes see
@@ -48,6 +49,14 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
       }
     case command @ V2BlobWrite(write) if write.query.resolved =>
       rewriteForExistingTarget(write.table, write.query).map(write.withQuery).getOrElse(command)
+    case a @ AddColumnsBackfill(
+          ResolvedIdentifier(catalog: TableCatalog, ident),
+          columnNames,
+          source) if source.resolved =>
+      targetBlobV2Columns(catalog, ident, columnNames, source)
+        .flatMap(names => rewriteGuarded(source, Some(names)))
+        .map(rewritten => a.copy(source = rewritten))
+        .getOrElse(a)
   }
 
   private def rewriteGuarded(
@@ -88,6 +97,26 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     case LanceRelation(_, ds) =>
       val names =
         ds.schema().fields.collect { case f if BlobUtils.isBlobV2SparkField(f) => f.name }.toSet
+      if (names.isEmpty) None else Some(names)
+    case _ => None
+  }
+
+  private def targetBlobV2Columns(
+      catalog: TableCatalog,
+      ident: Identifier,
+      columnNames: Seq[String],
+      source: LogicalPlan): Option[Set[String]] = catalog.loadTable(ident) match {
+    case ds: LanceDataset =>
+      val requestedColumns = columnNames.toSet
+      val writeSchema = SchemaConverter.processSchemaWithProperties(
+        BlobUtils.applyBlobV2WriteSchema(source.schema),
+        ds.properties(),
+        ds.getFileFormatVersion)
+      val names =
+        writeSchema.fields.collect {
+          case f if requestedColumns.contains(f.name) && BlobUtils.isBlobV2SparkField(f) =>
+            f.name
+        }.toSet
       if (names.isEmpty) None else Some(names)
     case _ => None
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -14,7 +14,7 @@
 package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier}
-import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Cast, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias, View}
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -241,9 +241,19 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     sourceColumnId(e).filter(id =>
       admittedColumn(id) && targetBlobColumns.forall(_.contains(e.name)))
 
-  private def sourceColumnId(e: NamedExpression): Option[ExprId] = e match {
-    case a: AttributeReference => Some(a.exprId)
-    case Alias(a: AttributeReference, _) => Some(a.exprId)
+  private def sourceColumnId(e: NamedExpression): Option[ExprId] =
+    directSourceAttribute(e).map(_.exprId)
+
+  private def directSourceAttribute(e: NamedExpression): Option[AttributeReference] = e match {
+    case a: AttributeReference => Some(a)
+    case Alias(a: AttributeReference, _) => Some(a)
+    // Spark normalizes view output with Alias(Cast(attribute)) even when the cast does not change
+    // the type. It is still a direct reference and is safe to copy through.
+    case Alias(c: Cast, _) =>
+      c.child match {
+        case a: AttributeReference if a.dataType == c.dataType => Some(a)
+        case _ => None
+      }
     case _ => None
   }
 
@@ -254,6 +264,7 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     if (admittedSourceId(e, bindingById.contains, targetBlobColumns).isEmpty) {
       return e
     }
+    val source = directSourceAttribute(e).get
     e match {
       case a: AttributeReference =>
         copyRefAlias(
@@ -264,15 +275,15 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
           a.metadata,
           bindingById(a.exprId).rowAddress,
           bindingById(a.exprId).datasetUri)
-      case alias @ Alias(a: AttributeReference, name) =>
+      case alias: Alias =>
         copyRefAlias(
-          a,
-          name,
+          source,
+          alias.name,
           alias.exprId,
           alias.qualifier,
-          a.metadata,
-          bindingById(a.exprId).rowAddress,
-          bindingById(a.exprId).datasetUri)
+          source.metadata,
+          bindingById(source.exprId).rowAddress,
+          bindingById(source.exprId).datasetUri)
       case other => other
     }
   }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
-import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias}
+import org.apache.spark.sql.catalyst.plans.logical.{CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias, View}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -110,6 +110,8 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
       rewriteQuery(o.child, targetBlobColumns).map(rewritten => o.copy(child = rewritten))
     case a: SubqueryAlias =>
       rewriteQuery(a.child, targetBlobColumns).map(rewritten => a.copy(child = rewritten))
+    case v: View =>
+      rewriteQuery(v.child, targetBlobColumns).map(rewritten => v.withNewChildInternal(rewritten))
     // A bare table read (e.g. spark.table(...).writeTo(...).append()) has no projection to
     // rewrite. Synthesize the identity projection so the DataFrame API matches the SQL path.
     case LanceRelation(relation, _) =>

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -16,7 +16,7 @@ package org.apache.spark.sql.catalyst.optimizer
 import org.apache.spark.sql.catalyst.analysis.{NamedRelation, ResolvedIdentifier}
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, Cast, Expression, ExprId, LanceBlobV2CopyRef, NamedExpression, SortOrder}
 import org.apache.spark.sql.catalyst.optimizer.BlobPlanUtils.{LanceRelation, V2BlobWrite}
-import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, CreateTableAsSelect, GlobalLimit, LocalLimit, LogicalPlan, Offset, Project, ReplaceTableAsSelect, Sort, SubqueryAlias, View}
+import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, CreateTableAsSelect, Filter, GlobalLimit, Join, LocalLimit, LogicalPlan, Offset, Project, Repartition, RepartitionByExpression, ReplaceTableAsSelect, Sample, Sort, SubqueryAlias, View, Window}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
@@ -24,8 +24,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.Metadata
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceConstant, LanceDataset}
 import org.lance.spark.utils.{BlobUtils, SchemaConverter}
-
-import scala.collection.mutable
 
 /**
  * Rewrites direct blob v2 reads in Lance writes into [[LanceBlobV2CopyRef]] tokens so writes see
@@ -161,20 +159,14 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
       project: Project,
       targetBlobColumns: Option[Set[String]]): Option[LogicalPlan] = {
     val Project(projectList, child) = project
-    val lanceRelations = child.collect { case LanceRelation(relation, ds) => relation -> ds }
-    if (lanceRelations.isEmpty) {
-      return None
-    }
-    val datasetByRelation = lanceRelations.toMap
-    val blobColumns = blobColumnBindings(child, lanceRelations.map(_._1))
+    val blobColumns = blobColumnBindings(child)
     val rewrittenIds =
       projectList.flatMap(e => admittedSourceId(e, blobColumns.contains, targetBlobColumns)).toSet
     if (rewrittenIds.isEmpty) {
       return None
     }
-    val contributingRelations =
-      rewrittenIds.map(blobColumns).toSeq.distinct
-    val bindingByRelation: Map[DataSourceV2Relation, SourceBlobBinding] =
+    val contributingRelations = rewrittenIds.map(id => blobColumns(id).relation).toSeq.distinct
+    val bindingByRelation: Map[DataSourceV2Relation, SourceRelationBinding] =
       contributingRelations.map { relation =>
         // markAsAllowAnyAccess lets AddMetadataColumns thread _rowaddr through nested SELECTs.
         val rowAddress = relation.metadataOutput
@@ -183,11 +175,19 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
           .getOrElse(throw new IllegalStateException(
             s"blob v2 copy-through requires the '${LanceConstant.ROW_ADDRESS}' metadata column " +
               s"on '${relation.table.name()}', but the Lance relation did not expose it"))
-        val datasetUri = datasetByRelation(relation).readOptions().getDatasetUri
-        relation -> SourceBlobBinding(rowAddress, datasetUri)
+        val datasetUri = rewrittenIds.iterator
+          .map(blobColumns)
+          .find(_.relation == relation)
+          .map(_.datasetUri)
+          .get
+        relation -> SourceRelationBinding(rowAddress, datasetUri)
       }.toMap
     val bindingById: Map[ExprId, SourceBlobBinding] =
-      rewrittenIds.map(id => id -> bindingByRelation(blobColumns(id))).toMap
+      rewrittenIds.map { id =>
+        val column = blobColumns(id)
+        val relation = bindingByRelation(column.relation)
+        id -> SourceBlobBinding(relation.rowAddress, relation.datasetUri, column.sourceColumnName)
+      }.toMap
     val newChild = child.resolveOperatorsDown {
       case r: DataSourceV2Relation if bindingByRelation.contains(r) => r.withMetadataColumns()
     }
@@ -197,42 +197,68 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
   }
 
   /**
-   * Tracks direct blob references through simple projection aliases.
+   * Tracks direct blob references through validated pass-through ancestry.
    *
    * A resolved temporary view is wrapped in an outer identity Project. Its output attribute keeps
    * the ExprId of the alias inside the view, not the ExprId of the underlying Lance column. Carry
-   * the source relation binding through those aliases so the outer write projection can still be
-   * rewritten without admitting transformed descriptor expressions.
+   * the source relation and physical column name through those aliases so the outer write
+   * projection can still be rewritten without admitting transformed descriptor expressions.
+   * Operators that collapse or combine row identity (for example DISTINCT, aggregate, or UNION)
+   * deliberately fall through to the empty binding below.
    */
-  private def blobColumnBindings(
-      child: LogicalPlan,
-      lanceRelations: Seq[DataSourceV2Relation]): Map[ExprId, DataSourceV2Relation] = {
-    val bindings = mutable.Map.empty[ExprId, DataSourceV2Relation]
-    lanceRelations.foreach { relation =>
-      relation.output.foreach {
+  private def blobColumnBindings(plan: LogicalPlan): Map[ExprId, BlobColumnBinding] = plan match {
+    case LanceRelation(relation, ds) =>
+      relation.output.collect {
         case a: AttributeReference if BlobUtils.isBlobV2SparkMetadata(a.metadata) =>
-          bindings.put(a.exprId, relation)
-        case _ =>
+          a.exprId -> BlobColumnBinding(relation, ds.readOptions().getDatasetUri, a.name)
+      }.toMap
+    case p: Project =>
+      val childBindings = blobColumnBindings(p.child)
+      p.projectList.flatMap { expression =>
+        directSourceAttribute(expression)
+          .flatMap(source => childBindings.get(source.exprId))
+          .map(expression.exprId -> _)
+      }.toMap
+    case s: Sort =>
+      val childBindings = blobColumnBindings(s.child)
+      if (s.order.exists(_.references.exists(a => childBindings.contains(a.exprId)))) {
+        Map.empty
+      } else {
+        retainOutputBindings(s, childBindings)
       }
-    }
-
-    val projections = child.collect { case p: Project => p.projectList }.flatten
-    var changed = true
-    while (changed) {
-      changed = false
-      projections.foreach { expression =>
-        if (!bindings.contains(expression.exprId)) {
-          sourceColumnId(expression).flatMap(bindings.get).foreach { relation =>
-            bindings.put(expression.exprId, relation)
-            changed = true
-          }
-        }
-      }
-    }
-    bindings.toMap
+    case f: Filter => retainOutputBindings(f, blobColumnBindings(f.child))
+    case l: GlobalLimit => retainOutputBindings(l, blobColumnBindings(l.child))
+    case l: LocalLimit => retainOutputBindings(l, blobColumnBindings(l.child))
+    case o: Offset => retainOutputBindings(o, blobColumnBindings(o.child))
+    case a: SubqueryAlias => retainOutputBindings(a, blobColumnBindings(a.child))
+    case v: View => retainOutputBindings(v, blobColumnBindings(v.child))
+    case s: Sample => retainOutputBindings(s, blobColumnBindings(s.child))
+    case r: Repartition => retainOutputBindings(r, blobColumnBindings(r.child))
+    case r: RepartitionByExpression => retainOutputBindings(r, blobColumnBindings(r.child))
+    case w: Window => retainOutputBindings(w, blobColumnBindings(w.child))
+    case j: Join =>
+      retainOutputBindings(j, blobColumnBindings(j.left) ++ blobColumnBindings(j.right))
+    case _ => Map.empty
   }
 
-  private case class SourceBlobBinding(rowAddress: Expression, datasetUri: String)
+  private def retainOutputBindings(
+      plan: LogicalPlan,
+      childBindings: Map[ExprId, BlobColumnBinding]): Map[ExprId, BlobColumnBinding] =
+    plan.output.flatMap { output =>
+      childBindings.get(output.exprId).map(output.exprId -> _)
+    }.toMap
+
+  private case class BlobColumnBinding(
+      relation: DataSourceV2Relation,
+      datasetUri: String,
+      sourceColumnName: String)
+
+  private case class SourceRelationBinding(rowAddress: Expression, datasetUri: String)
+
+  private case class SourceBlobBinding(
+      rowAddress: Expression,
+      datasetUri: String,
+      sourceColumnName: String)
 
   private def admittedSourceId(
       e: NamedExpression,
@@ -274,7 +300,8 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
           a.qualifier,
           a.metadata,
           bindingById(a.exprId).rowAddress,
-          bindingById(a.exprId).datasetUri)
+          bindingById(a.exprId).datasetUri,
+          bindingById(a.exprId).sourceColumnName)
       case alias: Alias =>
         copyRefAlias(
           source,
@@ -283,7 +310,8 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
           alias.qualifier,
           source.metadata,
           bindingById(source.exprId).rowAddress,
-          bindingById(source.exprId).datasetUri)
+          bindingById(source.exprId).datasetUri,
+          bindingById(source.exprId).sourceColumnName)
       case other => other
     }
   }
@@ -295,8 +323,9 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
       qualifier: Seq[String],
       metadata: Metadata,
       rowAddress: Expression,
-      datasetUri: String): Alias =
-    Alias(LanceBlobV2CopyRef(source, rowAddress, datasetUri, source.name), outputName)(
+      datasetUri: String,
+      sourceColumnName: String): Alias =
+    Alias(LanceBlobV2CopyRef(source, rowAddress, datasetUri, sourceColumnName), outputName)(
       exprId = exprId,
       qualifier = qualifier,
       explicitMetadata = Some(metadata))

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -232,3 +232,11 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     case _ => false
   }
 }
+
+object LanceBlobV2CopyThroughRule {
+
+  private[sql] def rewriteForTargetBlobColumns(
+      query: LogicalPlan,
+      targetBlobColumns: Set[String]): Option[LogicalPlan] =
+    LanceBlobV2CopyThroughRule().rewriteGuarded(query, Some(targetBlobColumns))
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -25,6 +25,8 @@ import org.apache.spark.sql.types.Metadata
 import org.lance.spark.{BaseLanceNamespaceSparkCatalog, LanceConstant, LanceDataset}
 import org.lance.spark.utils.{BlobUtils, SchemaConverter}
 
+import scala.collection.mutable
+
 /**
  * Rewrites direct blob v2 reads in Lance writes into [[LanceBlobV2CopyRef]] tokens so writes see
  * BINARY instead of descriptor structs.
@@ -164,13 +166,7 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
       return None
     }
     val datasetByRelation = lanceRelations.toMap
-    val blobColumns: Map[ExprId, DataSourceV2Relation] = lanceRelations.flatMap {
-      case (relation, _) =>
-        relation.output.collect {
-          case a: AttributeReference if BlobUtils.isBlobV2SparkMetadata(a.metadata) =>
-            a.exprId -> relation
-        }
-    }.toMap
+    val blobColumns = blobColumnBindings(child, lanceRelations.map(_._1))
     val rewrittenIds =
       projectList.flatMap(e => admittedSourceId(e, blobColumns.contains, targetBlobColumns)).toSet
     if (rewrittenIds.isEmpty) {
@@ -198,6 +194,42 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     val newProjectList =
       projectList.map(e => rewriteProjection(e, bindingById, targetBlobColumns))
     Some(Project(newProjectList, newChild))
+  }
+
+  /**
+   * Tracks direct blob references through simple projection aliases.
+   *
+   * A resolved temporary view is wrapped in an outer identity Project. Its output attribute keeps
+   * the ExprId of the alias inside the view, not the ExprId of the underlying Lance column. Carry
+   * the source relation binding through those aliases so the outer write projection can still be
+   * rewritten without admitting transformed descriptor expressions.
+   */
+  private def blobColumnBindings(
+      child: LogicalPlan,
+      lanceRelations: Seq[DataSourceV2Relation]): Map[ExprId, DataSourceV2Relation] = {
+    val bindings = mutable.Map.empty[ExprId, DataSourceV2Relation]
+    lanceRelations.foreach { relation =>
+      relation.output.foreach {
+        case a: AttributeReference if BlobUtils.isBlobV2SparkMetadata(a.metadata) =>
+          bindings.put(a.exprId, relation)
+        case _ =>
+      }
+    }
+
+    val projections = child.collect { case p: Project => p.projectList }.flatten
+    var changed = true
+    while (changed) {
+      changed = false
+      projections.foreach { expression =>
+        if (!bindings.contains(expression.exprId)) {
+          sourceColumnId(expression).flatMap(bindings.get).foreach { relation =>
+            bindings.put(expression.exprId, relation)
+            changed = true
+          }
+        }
+      }
+    }
+    bindings.toMap
   }
 
   private case class SourceBlobBinding(rowAddress: Expression, datasetUri: String)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/optimizer/LanceBlobV2CopyThroughRule.scala
@@ -111,7 +111,7 @@ case class LanceBlobV2CopyThroughRule() extends Rule[LogicalPlan] {
     case a: SubqueryAlias =>
       rewriteQuery(a.child, targetBlobColumns).map(rewritten => a.copy(child = rewritten))
     case v: View =>
-      rewriteQuery(v.child, targetBlobColumns).map(rewritten => v.withNewChildInternal(rewritten))
+      rewriteQuery(v.child, targetBlobColumns).map(rewritten => v.withNewChildren(Seq(rewritten)))
     // A bare table read (e.g. spark.table(...).writeTo(...).append()) has no projection to
     // rewrite. Synthesize the identity projection so the DataFrame API matches the SQL path.
     case LanceRelation(relation, _) =>

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -15,6 +15,8 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.optimizer.LanceBlobSourceContextRule
+import org.apache.spark.sql.catalyst.optimizer.LanceBlobV2CopyThroughRule
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, Project}
 import org.apache.spark.sql.connector.catalog._
 import org.lance.spark.{LanceConstant, LanceDataset}
@@ -83,11 +85,25 @@ case class AddColumnsBackfillExec(
       Some(catalog),
       Some(ident))
 
+    val blobColumns =
+      backfillSchema.fields.collect { case f if BlobUtils.isBlobV2SparkField(f) => f.name }.toSet
+    val rewrittenQuery =
+      if (blobColumns.nonEmpty) {
+        LanceBlobV2CopyThroughRule
+          .rewriteForTargetBlobColumns(actualQuery, blobColumns)
+          .getOrElse(actualQuery)
+      } else {
+        actualQuery
+      }
+    val writeOptions = LanceBlobSourceContextRule.annotateWriteOptions(
+      actualQuery,
+      Map(LanceConstant.BACKFILL_COLUMNS_KEY -> columnNames.mkString(",")))
+
     val append =
       AppendData.byPosition(
         relation,
-        actualQuery,
-        Map(LanceConstant.BACKFILL_COLUMNS_KEY -> columnNames.mkString(",")))
+        rewrittenQuery,
+        writeOptions)
     val qe = session.sessionState.executePlan(append)
     qe.assertCommandExecuted()
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -18,6 +18,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, Project}
 import org.apache.spark.sql.connector.catalog._
 import org.lance.spark.{LanceConstant, LanceDataset}
+import org.lance.spark.utils.{BlobUtils, SchemaConverter}
 
 case class AddColumnsBackfillExec(
     catalog: TableCatalog,
@@ -55,10 +56,25 @@ case class AddColumnsBackfillExec(
       query
     }
 
+    val backfillSchema =
+      SchemaConverter.processSchemaWithProperties(
+        BlobUtils.applyBlobV2WriteSchema(actualQuery.schema),
+        originalTable.properties(),
+        originalTable.getFileFormatVersion)
+
+    if (BlobUtils.hasBlobV2Fields(backfillSchema)
+      && !BlobUtils.fileFormatSupportsBlobV2(originalTable.getFileFormatVersion)) {
+      throw new IllegalArgumentException(
+        s"Blob v2 ADD COLUMNS requires Lance file_format_version " +
+          s"${BlobUtils.MIN_BLOB_V2_FILE_FORMAT_VERSION} or newer. " +
+          s"Table '${ident.toString}' uses file_format_version " +
+          s"'${originalTable.getFileFormatVersion}'.")
+    }
+
     val relation = DataSourceV2Relation.create(
       new LanceDataset(
         originalTable.readOptions(),
-        actualQuery.schema,
+        backfillSchema,
         originalTable.getInitialStorageOptions,
         originalTable.getNamespaceImpl,
         originalTable.getNamespaceProperties,

--- a/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/lance/spark/arrow/LanceArrowWriter.scala
@@ -170,6 +170,18 @@ class LanceArrowWriter(root: VectorSchemaRoot, fields: Array[LanceArrowFieldWrit
     }
   }
 
+  /** Writes fields from selected input ordinals, used when a stream omits routing columns. */
+  def write(row: InternalRow, inputOrdinals: Array[Int]): Unit = {
+    require(
+      inputOrdinals.length == fields.length,
+      s"Expected ${fields.length} input ordinals, got ${inputOrdinals.length}")
+    var i = 0
+    while (i < fields.length) {
+      fields(i).write(row, inputOrdinals(i))
+      i += 1
+    }
+  }
+
   def finish(): Unit = {
     fields.foreach(_.finish())
     root.setRowCount(fields(0).count)
@@ -520,6 +532,8 @@ private[arrow] class BlobV2StructWriter(
       i += 1
     }
   }
+
+  override def estimatedBufferedBytes: Long = dataWriter.estimatedBufferedBytes
 
   override def reset(): Unit = {
     super.reset()

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2CopyTest.java
@@ -127,6 +127,64 @@ public abstract class BaseBlobV2CopyTest extends AbstractBlobV2CopyTest {
   }
 
   @Test
+  public void insertSelectThroughRenamedAlias_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_alias_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_alias_tgt_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(173, 64), deterministicBlob(174, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    createV2BlobTable(fqTgt);
+    try {
+      spark.sql(
+          "INSERT INTO "
+              + fqTgt
+              + " SELECT id, copied AS data FROM "
+              + "(SELECT id, data AS copied FROM "
+              + fqSrc
+              + ") q");
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), blobs);
+    } finally {
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void addColumnsFromRenamedBlobSource_copiesBlobBytes() throws Exception {
+    String src = "v2_e2e_add_alias_src_" + System.currentTimeMillis();
+    String tgt = "v2_e2e_add_alias_tgt_" + System.currentTimeMillis();
+    String view = "v2_e2e_add_alias_view_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    byte[][] blobs = {deterministicBlob(175, 64), deterministicBlob(176, 4096)};
+    createV2BlobSource(fqSrc, row(1, blobs[0]), row(2, blobs[1]));
+    spark.sql(
+        "CREATE TABLE "
+            + fqTgt
+            + " (id INT NOT NULL) USING lance "
+            + "TBLPROPERTIES ('file_format_version' = '2.2')");
+    spark.sql("INSERT INTO " + fqTgt + " VALUES (1), (2)");
+    spark.sql("ALTER TABLE " + fqTgt + " SET TBLPROPERTIES ('copied.lance.encoding' = 'blob')");
+    spark.sql(
+        "CREATE TEMPORARY VIEW "
+            + view
+            + " AS SELECT t._rowaddr, t._fragid, s.data AS copied FROM "
+            + fqTgt
+            + " t JOIN "
+            + fqSrc
+            + " s ON t.id = s.id");
+    try {
+      spark.sql("ALTER TABLE " + fqTgt + " ADD COLUMNS copied FROM " + view);
+      assertTargetBlobBytes(datasetUriOf(tgt), rowAddressesOf(fqTgt), "copied", blobs);
+    } finally {
+      spark.sql("DROP VIEW IF EXISTS " + view);
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
   public void ctas_copiesBlobBytes() throws Exception {
     String src = "v2_e2e_ctas_src_" + System.currentTimeMillis();
     String tgt = "v2_e2e_ctas_tgt_" + System.currentTimeMillis();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
@@ -72,6 +72,45 @@ public abstract class BaseBlobV2PlanShapeTest extends AbstractBlobV2CopyTest {
   }
 
   @Test
+  public void addColumnsFromView_injectsCopyRefThroughViewAlias() throws Exception {
+    String src = "v2_plan_add_view_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_add_view_tgt_" + System.currentTimeMillis();
+    String view = "v2_plan_add_view_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(171, 16)));
+    spark.sql(
+        "CREATE TABLE "
+            + fqTgt
+            + " (id INT NOT NULL) USING lance "
+            + "TBLPROPERTIES ('file_format_version' = '2.2')");
+    spark.sql(
+        "ALTER TABLE "
+            + fqTgt
+            + " SET TBLPROPERTIES ('copied.lance.encoding' = 'blob')");
+    spark.sql(
+        "CREATE TEMPORARY VIEW "
+            + view
+            + " AS SELECT t._rowaddr, t._fragid, s.data AS copied FROM "
+            + fqTgt
+            + " t JOIN "
+            + fqSrc
+            + " s ON t.id = s.id");
+    try {
+      LogicalPlan plan =
+          analyzePlan("ALTER TABLE " + fqTgt + " ADD COLUMNS copied FROM " + view);
+      assertEquals(
+          1,
+          countCopyRefs(plan),
+          "expected the blob view alias to be rewritten\nplan:\n" + plan);
+    } finally {
+      spark.sql("DROP VIEW IF EXISTS " + view);
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
   public void ctas_injectsCopyRef() throws Exception {
     String src = "v2_plan_ctas_src_" + System.currentTimeMillis();
     String tgt = "v2_plan_ctas_tgt_" + System.currentTimeMillis();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
@@ -97,6 +97,32 @@ public abstract class BaseBlobV2PlanShapeTest extends AbstractBlobV2CopyTest {
       LogicalPlan plan = analyzePlan("ALTER TABLE " + fqTgt + " ADD COLUMNS copied FROM " + view);
       assertEquals(
           1, countCopyRefs(plan), "expected the blob view alias to be rewritten\nplan:\n" + plan);
+      assertEquals(
+          Collections.singletonList("data"),
+          BlobPlanProbe.copyRefSourceColumnNames(plan),
+          "the copy reference must retain the physical source column across aliases\nplan:\n"
+              + plan);
+    } finally {
+      spark.sql("DROP VIEW IF EXISTS " + view);
+      spark.sql("DROP TABLE IF EXISTS " + fqSrc);
+      spark.sql("DROP TABLE IF EXISTS " + fqTgt);
+    }
+  }
+
+  @Test
+  public void nestedDistinctView_noCopyRef() throws Exception {
+    String src = "v2_plan_distinct_view_src_" + System.currentTimeMillis();
+    String tgt = "v2_plan_distinct_view_tgt_" + System.currentTimeMillis();
+    String view = "v2_plan_distinct_view_" + System.currentTimeMillis();
+    String fqSrc = fq(src);
+    String fqTgt = fq(tgt);
+    createV2BlobSource(fqSrc, row(1, deterministicBlob(172, 16)));
+    createV2BlobTable(fqTgt);
+    spark.sql("CREATE TEMPORARY VIEW " + view + " AS SELECT DISTINCT id, data FROM " + fqSrc);
+    try {
+      LogicalPlan plan = analyzePlan("INSERT INTO " + fqTgt + " SELECT id, data FROM " + view);
+      assertEquals(
+          0, countCopyRefs(plan), "provenance must stop at DISTINCT inside a view\nplan:\n" + plan);
     } finally {
       spark.sql("DROP VIEW IF EXISTS " + view);
       spark.sql("DROP TABLE IF EXISTS " + fqSrc);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/BaseBlobV2PlanShapeTest.java
@@ -84,10 +84,7 @@ public abstract class BaseBlobV2PlanShapeTest extends AbstractBlobV2CopyTest {
             + fqTgt
             + " (id INT NOT NULL) USING lance "
             + "TBLPROPERTIES ('file_format_version' = '2.2')");
-    spark.sql(
-        "ALTER TABLE "
-            + fqTgt
-            + " SET TBLPROPERTIES ('copied.lance.encoding' = 'blob')");
+    spark.sql("ALTER TABLE " + fqTgt + " SET TBLPROPERTIES ('copied.lance.encoding' = 'blob')");
     spark.sql(
         "CREATE TEMPORARY VIEW "
             + view
@@ -97,12 +94,9 @@ public abstract class BaseBlobV2PlanShapeTest extends AbstractBlobV2CopyTest {
             + fqSrc
             + " s ON t.id = s.id");
     try {
-      LogicalPlan plan =
-          analyzePlan("ALTER TABLE " + fqTgt + " ADD COLUMNS copied FROM " + view);
+      LogicalPlan plan = analyzePlan("ALTER TABLE " + fqTgt + " ADD COLUMNS copied FROM " + view);
       assertEquals(
-          1,
-          countCopyRefs(plan),
-          "expected the blob view alias to be rewritten\nplan:\n" + plan);
+          1, countCopyRefs(plan), "expected the blob view alias to be rewritten\nplan:\n" + plan);
     } finally {
       spark.sql("DROP VIEW IF EXISTS " + view);
       spark.sql("DROP TABLE IF EXISTS " + fqSrc);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddColumnsBackfillTest.java
@@ -304,7 +304,14 @@ public abstract class BaseAddColumnsBackfillTest {
 
       AddColumnsBackfillBatchWrite backfillWrite =
           new AddColumnsBackfillBatchWrite(
-              backfillSchema, writeOptions, newColumns, null, null, null, null);
+              backfillSchema,
+              writeOptions,
+              newColumns,
+              null,
+              null,
+              null,
+              null,
+              Collections.emptyMap());
 
       DataWriterFactory factory = backfillWrite.createBatchWriterFactory(() -> 1);
       WriterCommitMessage backfillMsg;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseUpdateColumnsBackfillTest.java
@@ -429,7 +429,14 @@ public abstract class BaseUpdateColumnsBackfillTest {
 
       UpdateColumnsBackfillBatchWrite updateWrite =
           new UpdateColumnsBackfillBatchWrite(
-              updateSchema, writeOptions, updateColumns, null, null, null, null);
+              updateSchema,
+              writeOptions,
+              updateColumns,
+              null,
+              null,
+              null,
+              null,
+              Collections.emptyMap());
 
       DataWriterFactory factory = updateWrite.createBatchWriterFactory(() -> 1);
       WriterCommitMessage updateMsg;

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/utils/BlobUtilsTest.java
@@ -138,6 +138,33 @@ public class BlobUtilsTest {
   }
 
   @Test
+  public void testBlobV2WriteSchemaRewrite() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              field("id", DataTypes.IntegerType), blobV2DescriptorField(),
+            });
+    StructType rewritten = BlobUtils.applyBlobV2WriteSchema(schema);
+    StructField payload = rewritten.apply("payload");
+    assertEquals(DataTypes.BinaryType, payload.dataType());
+    assertTrue(BlobUtils.isBlobV2SparkField(payload));
+  }
+
+  @Test
+  public void testBlobV2WriteSchemaPreservesBinaryAndV1Fields() {
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              blobV2Field(), blobV1Field("legacy"),
+            });
+    StructType rewritten = BlobUtils.applyBlobV2WriteSchema(schema);
+    assertEquals(DataTypes.BinaryType, rewritten.fields()[0].dataType());
+    assertTrue(BlobUtils.isBlobV2SparkField(rewritten.fields()[0]));
+    assertEquals(DataTypes.BinaryType, rewritten.fields()[1].dataType());
+    assertTrue(BlobUtils.isBlobSparkField(rewritten.fields()[1]));
+  }
+
+  @Test
   public void fileFormatSupportsBlobV2AcceptsTwoTwoAndNewer() {
     assertTrue(BlobUtils.fileFormatSupportsBlobV2("2.2"));
     assertTrue(BlobUtils.fileFormatSupportsBlobV2("2.10"));
@@ -174,11 +201,23 @@ public class BlobUtilsTest {
     return new StructField("payload", DataTypes.BinaryType, true, md);
   }
 
+  private static StructField blobV2DescriptorField() {
+    Metadata md =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
+    return new StructField("payload", BlobUtils.BLOB_DESCRIPTOR_STRUCT, true, md);
+  }
+
   private static StructField blobV1Field() {
+    return blobV1Field("payload");
+  }
+
+  private static StructField blobV1Field(String name) {
     Metadata md =
         new MetadataBuilder()
             .putString(BlobUtils.LANCE_ENCODING_BLOB_KEY, BlobUtils.LANCE_ENCODING_BLOB_VALUE)
             .build();
-    return new StructField("payload", DataTypes.BinaryType, true, md);
+    return new StructField(name, DataTypes.BinaryType, true, md);
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/AbstractBackfillWriterTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/AbstractBackfillWriterTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.write;
+
+import org.lance.Dataset;
+import org.lance.Fragment;
+import org.lance.WriteParams;
+import org.lance.spark.LanceConstant;
+import org.lance.spark.LanceRuntime;
+import org.lance.spark.LanceSparkWriteOptions;
+
+import org.apache.arrow.c.ArrowArrayStream;
+import org.apache.arrow.c.Data;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AbstractBackfillWriterTest {
+  @TempDir Path tempDir;
+
+  @Test
+  public void streamsFragmentInMaxBatchByteBoundedBatches() throws Exception {
+    String datasetUri = tempDir.resolve("bounded-backfill.lance").toString();
+    Schema datasetSchema =
+        new Schema(
+            Collections.singletonList(
+                new Field("id", FieldType.nullable(new ArrowType.Int(32, true)), null)));
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        Dataset ignored =
+            Dataset.create(
+                allocator, datasetUri, datasetSchema, new WriteParams.Builder().build())) {
+      // The dataset only needs to exist so the backfill writer can open its pinned target.
+    }
+
+    StructType inputSchema =
+        new StructType()
+            .add(LanceConstant.ROW_ADDRESS, DataTypes.LongType, false)
+            .add(LanceConstant.FRAGMENT_ID, DataTypes.IntegerType, false)
+            .add("value", DataTypes.BinaryType, true);
+    LanceSparkWriteOptions options =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(datasetUri)
+            .batchSize(100)
+            .maxBatchBytes(1)
+            .build();
+
+    CountingBackfillWriter writer = new CountingBackfillWriter(options, inputSchema);
+    try {
+      writer.write(new GenericInternalRow(new Object[] {0L, 0, new byte[1024 * 1024]}));
+      writer.write(new GenericInternalRow(new Object[] {1L, 0, new byte[1024 * 1024]}));
+      writer.commit();
+
+      assertEquals(2, writer.batchCount.get());
+      assertEquals(1, writer.maxRowsPerBatch.get());
+    } finally {
+      writer.close();
+    }
+  }
+
+  private static class CountingBackfillWriter extends AbstractBackfillWriter {
+    final AtomicInteger batchCount = new AtomicInteger();
+    final AtomicInteger maxRowsPerBatch = new AtomicInteger();
+
+    CountingBackfillWriter(LanceSparkWriteOptions options, StructType schema) {
+      super(
+          options,
+          schema,
+          Collections.singletonList("value"),
+          Collections.emptyMap(),
+          null,
+          Collections.emptyMap(),
+          Collections.emptyList(),
+          Collections.emptyMap());
+    }
+
+    @Override
+    protected void processFragment(Fragment fragment, ArrowArrayStream stream) {
+      try (ArrowReader reader = Data.importArrayStream(LanceRuntime.allocator(), stream)) {
+        while (reader.loadNextBatch()) {
+          batchCount.incrementAndGet();
+          maxRowsPerBatch.accumulateAndGet(reader.getVectorSchemaRoot().getRowCount(), Math::max);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    protected WriterCommitMessage buildCommitMessage() {
+      return new TestCommitMessage();
+    }
+  }
+
+  private static class TestCommitMessage implements WriterCommitMessage {}
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/SemaphoreArrowBatchWriteBufferTest.java
@@ -15,11 +15,13 @@ package org.lance.spark.write;
 
 import org.lance.spark.utils.BlobReference;
 import org.lance.spark.utils.BlobReferenceResolver;
+import org.lance.spark.utils.BlobUtils;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -27,8 +29,11 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.LanceArrowUtils;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -295,18 +300,16 @@ public class SemaphoreArrowBatchWriteBufferTest {
   }
 
   private Schema createBlobSchema() {
-    Field field =
-        new Field(
-            "blob",
-            FieldType.nullable(
-                org.apache.arrow.vector.types.Types.MinorType.LARGEVARBINARY.getType()),
-            null);
-    return new Schema(Collections.singletonList(field));
+    return LanceArrowUtils.toArrowSchema(createBlobSparkSchema(), "UTC", false);
   }
 
   private StructType createBlobSparkSchema() {
+    Metadata metadata =
+        new MetadataBuilder()
+            .putString(BlobUtils.ARROW_EXTENSION_NAME_KEY, BlobUtils.ARROW_EXTENSION_BLOB_V2)
+            .build();
     return new StructType(
-        new StructField[] {DataTypes.createStructField("blob", DataTypes.BinaryType, true)});
+        new StructField[] {new StructField("blob", DataTypes.BinaryType, true, metadata)});
   }
 
   /** Resolver that fabricates {@code size} bytes per reference — no source dataset needed. */
@@ -363,9 +366,10 @@ public class SemaphoreArrowBatchWriteBufferTest {
             while (writeBuffer.loadNextBatch()) {
               VectorSchemaRoot root = writeBuffer.getVectorSchemaRoot();
               int rowCount = root.getRowCount();
+              StructVector blobVector = (StructVector) root.getVector("blob");
               for (int i = 0; i < rowCount; i++) {
                 // Each placeholder reference must have resolved to a full-size blob in the vector.
-                byte[] resolved = (byte[]) root.getVector("blob").getObject(i);
+                byte[] resolved = (byte[]) blobVector.getChild("data").getObject(i);
                 assertEquals(blobSize, resolved.length);
               }
               rowsRead.addAndGet(rowCount);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/UpdateColumnsConflictTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/UpdateColumnsConflictTest.java
@@ -103,7 +103,14 @@ public class UpdateColumnsConflictTest {
 
       UpdateColumnsBackfillBatchWrite updateWrite =
           new UpdateColumnsBackfillBatchWrite(
-              updateSchema, writeOptions, updateColumns, null, null, null, null);
+              updateSchema,
+              writeOptions,
+              updateColumns,
+              null,
+              null,
+              null,
+              null,
+              Collections.emptyMap());
 
       // Simulate executor work: write updated column values
       DataWriterFactory factory = updateWrite.createBatchWriterFactory(() -> 1);

--- a/lance-spark-base_2.12/src/test/scala/org/lance/spark/BlobPlanProbe.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/lance/spark/BlobPlanProbe.scala
@@ -32,6 +32,12 @@ object BlobPlanProbe {
     names
   }
 
+  def copyRefSourceColumnNames(plan: LogicalPlan): java.util.List[String] = {
+    val names = new java.util.ArrayList[String]()
+    allExpressions(plan).flatMap(copyRefsInExpr).foreach(ref => names.add(ref.columnName))
+    names
+  }
+
   /** The dataset version each encoded blob source context would resolve against; null = latest. */
   def blobSourceContextVersions(plan: LogicalPlan): java.util.Map[String, java.lang.Long] = {
     val versions = new java.util.HashMap[String, java.lang.Long]()


### PR DESCRIPTION
## Summary

Add blob v2 support to `ALTER TABLE ... ADD COLUMNS ... FROM` backfill writes.

## Changes

- Apply the target table's column metadata properties to the backfill write schema so a newly added `BINARY` column with `<column>.lance.encoding = blob` is written as blob v2 when the table uses Lance file format `2.2` or newer.
- Add a blob v2 write-schema helper that converts read-side descriptor structs back into the binary write schema while preserving `lance.blob.v2` metadata. This lets direct blob v2 source-column copy-through work for newly added columns.
- Reject blob v2 ADD COLUMNS attempts on tables whose Lance file format version cannot store blob v2 columns.
- Document the supported SQL flow for adding blob v2 columns.

## Tests

- Added unit coverage for converting blob v2 descriptor schemas back to write schemas.
- Added integration coverage for adding a blob v2 column from raw `BINARY` values.
- Added integration coverage for adding a blob v2 column from an existing blob v2 Lance source column.

Local validation:

- `./mvnw spotless:apply`
- `git diff --check`

Per Lance workflow, local compile/test runs were not executed; GitHub Actions is the validation gate.
