### PR TITLE
feat: support blob v2 columns in add columns

### DIFF
--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -27,6 +27,36 @@ ALTER TABLE users ADD COLUMNS name_hash FROM tmp_view;
 
 No table rewrite, no data movement—just a new column that is instantly queryable.
 
+## Adding a Blob v2 Column
+
+To add a blob v2 column, declare the future `BINARY` column's blob encoding when creating the
+target table and use Lance file format version `2.2` or higher. The column property may refer to a
+column that will be added later.
+
+```sql
+CREATE TABLE users (
+    id INT,
+    name STRING
+) USING lance
+TBLPROPERTIES (
+    'content.lance.encoding' = 'blob',
+    'file_format_version' = '2.2'
+);
+
+CREATE TEMPORARY VIEW content_backfill AS
+SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content
+FROM users;
+
+ALTER TABLE users ADD COLUMNS content FROM content_backfill;
+```
+
+The source column must have Spark type `BINARY`. After the operation, reads expose `content` as a
+blob v2 descriptor struct, so descriptor fields can be queried without loading the bytes:
+
+```sql
+SELECT id, content.size, content.kind FROM users;
+```
+
 !!! note
     Because we use `_rowaddr` and `_fragid` to address the target dataset's rows for the new column's data, 
     the temporary view should contain `_rowaddr` and `_fragid`.

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -52,10 +52,12 @@ FROM users;
 ALTER TABLE users ADD COLUMNS content FROM content_backfill;
 ```
 
-The source column must have Spark type `BINARY`. Without the encoding property, `ADD COLUMNS`
-still succeeds and writes a plain `BINARY` column. With the encoding property set to `blob`, after
-the operation, reads expose `content` as a blob v2 descriptor struct, so descriptor fields can be
-queried without loading the bytes:
+The source column must have Spark type `BINARY`. The `content.lance.encoding` property must be
+persisted before `ADD COLUMNS` runs. If it is omitted, `ADD COLUMNS` still succeeds but writes a
+plain `BINARY` column. Setting the property after the column has been added does not retroactively
+convert that column to blob v2, so descriptor access such as `content.size` is not available.
+When the property is set to `blob` before the operation, reads expose `content` as a blob v2
+descriptor struct, so descriptor fields can be queried without loading the bytes:
 
 ```sql
 SELECT id, content.size, content.kind FROM users;

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -29,9 +29,9 @@ No table rewrite, no data movement—just a new column that is instantly queryab
 
 ## Adding a Blob v2 Column
 
-To add a blob v2 column, declare the future `BINARY` column's blob encoding when creating the
-target table and use Lance file format version `2.2` or higher. The column property may refer to a
-column that will be added later.
+To add a blob v2 column, create the target table with Lance file format version `2.2` or higher,
+then persist the future `BINARY` column's blob encoding with `ALTER TABLE SET TBLPROPERTIES` before
+adding the column.
 
 ```sql
 CREATE TABLE users (
@@ -39,9 +39,11 @@ CREATE TABLE users (
     name STRING
 ) USING lance
 TBLPROPERTIES (
-    'content.lance.encoding' = 'blob',
     'file_format_version' = '2.2'
 );
+
+ALTER TABLE users
+SET TBLPROPERTIES ('content.lance.encoding' = 'blob');
 
 CREATE TEMPORARY VIEW content_backfill AS
 SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -27,6 +27,10 @@ ALTER TABLE users ADD COLUMNS name_hash FROM tmp_view;
 
 No table rewrite, no data movement—just a new column that is instantly queryable.
 
+!!! note
+    Because we use `_rowaddr` and `_fragid` to address the target dataset's rows for the new column's data,
+    the temporary view should contain `_rowaddr` and `_fragid`.
+
 ## Adding a Blob v2 Column
 
 To add a blob v2 column, create the target table with Lance file format version `2.2` or higher,
@@ -72,7 +76,3 @@ descriptor struct, so descriptor fields can be queried without loading the bytes
 ```sql
 SELECT id, content.size, content.kind FROM users;
 ```
-
-!!! note
-    Because we use `_rowaddr` and `_fragid` to address the target dataset's rows for the new column's data, 
-    the temporary view should contain `_rowaddr` and `_fragid`.

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -52,8 +52,10 @@ FROM users;
 ALTER TABLE users ADD COLUMNS content FROM content_backfill;
 ```
 
-The source column must have Spark type `BINARY`. After the operation, reads expose `content` as a
-blob v2 descriptor struct, so descriptor fields can be queried without loading the bytes:
+The source column must have Spark type `BINARY`. Without the encoding property, `ADD COLUMNS`
+still succeeds and writes a plain `BINARY` column. With the encoding property set to `blob`, after
+the operation, reads expose `content` as a blob v2 descriptor struct, so descriptor fields can be
+queried without loading the bytes:
 
 ```sql
 SELECT id, content.size, content.kind FROM users;

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -66,12 +66,15 @@ FROM users;
 ALTER TABLE users ADD COLUMNS content FROM content_backfill;
 ```
 
-The source column must have Spark type `BINARY`. The `content.lance.encoding` property must be
-persisted before `ADD COLUMNS` runs. If it is omitted, `ADD COLUMNS` still succeeds but writes a
-plain `BINARY` column. Setting the property after the column has been added does not retroactively
-convert that column to blob v2, so descriptor access such as `content.size` is not available.
-When the property is set to `blob` before the operation, reads expose `content` as a blob v2
-descriptor struct, so descriptor fields can be queried without loading the bytes:
+The source column must have Spark type `BINARY`. A blob v2 source column is not accepted because
+Spark reads it as a descriptor struct rather than `BINARY`; copy blob columns between existing
+tables with [INSERT INTO](insert-into.md#copying-blob-v2-columns) instead. The
+`content.lance.encoding` property must be persisted before `ADD COLUMNS` runs. If it is omitted,
+`ADD COLUMNS` still succeeds but writes a plain `BINARY` column. Setting the property after the
+column has been added does not retroactively convert that column to blob v2, so descriptor access
+such as `content.size` is not available. When the property is set to `blob` before the operation,
+reads expose `content` as a blob v2 descriptor struct, so descriptor fields can be queried without
+loading the bytes:
 
 ```sql
 SELECT id, content.size, content.kind FROM users;

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -33,6 +33,12 @@ To add a blob v2 column, create the target table with Lance file format version 
 then persist the future `BINARY` column's blob encoding with `ALTER TABLE SET TBLPROPERTIES` before
 adding the column.
 
+If the target table uses a file format below `2.2`, `ADD COLUMNS` still succeeds, but the `BINARY`
+column is written with legacy blob v1 encoding. Tables created without an explicit
+`file_format_version` may also use an older format, so set it to `2.2` or higher before adding the
+column. For more details, see
+[Blob v2 Writes](../../config.md#blob-v2-writes).
+
 ```sql
 CREATE TABLE users (
     id INT,

--- a/docs/src/operations/dml/add-columns.md
+++ b/docs/src/operations/dml/add-columns.md
@@ -45,6 +45,10 @@ TBLPROPERTIES (
 ALTER TABLE users
 SET TBLPROPERTIES ('content.lance.encoding' = 'blob');
 
+INSERT INTO users VALUES
+    (1, 'alpha'),
+    (2, 'bravo');
+
 CREATE TEMPORARY VIEW content_backfill AS
 SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content
 FROM users;

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2258,6 +2258,66 @@ class TestDMLMerge:
 class TestDMLAddColumn:
     """Test DML ADD COLUMN FROM operations for schema evolution with backfill."""
 
+    def test_add_blob_v2_binary_column(self, spark):
+        """Test adding a BINARY column with blob v2 encoding."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING
+            )
+            TBLPROPERTIES (
+                'content.lance.encoding' = 'blob',
+                'invalid_content.lance.encoding' = 'blob',
+                'file_format_version' = '2.2'
+            )
+        """)
+
+        spark.sql("""
+            INSERT INTO default.test_table VALUES
+            (1, 'alpha'),
+            (2, 'bravo')
+        """)
+
+        spark.sql("""
+            CREATE TEMPORARY VIEW tmp_view AS
+            SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content
+            FROM default.test_table
+        """)
+
+        spark.sql("""
+            ALTER TABLE default.test_table ADD COLUMNS content FROM tmp_view
+        """)
+
+        content_field = next(
+            row
+            for row in spark.sql("DESCRIBE default.test_table").collect()
+            if row.col_name == "content"
+        )
+        assert "struct" in content_field.data_type.lower()
+
+        rows = spark.sql("""
+            SELECT id, content.size, content.kind
+            FROM default.test_table
+            ORDER BY id
+        """).collect()
+
+        assert [(row.id, row.size, row.kind) for row in rows] == [
+            (1, len(b"alpha"), 0),
+            (2, len(b"bravo"), 0),
+        ]
+
+        spark.sql("""
+            CREATE OR REPLACE TEMPORARY VIEW tmp_view AS
+            SELECT _rowaddr, _fragid, name AS invalid_content
+            FROM default.test_table
+        """)
+
+        with pytest.raises(Exception, match="must have BINARY type"):
+            spark.sql("""
+                ALTER TABLE default.test_table
+                ADD COLUMNS invalid_content FROM tmp_view
+            """)
+
     def test_add_column_from_view(self, spark):
         """Test ALTER TABLE ADD COLUMNS FROM with single column."""
         spark.sql("""

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2266,9 +2266,15 @@ class TestDMLAddColumn:
                 name STRING
             )
             TBLPROPERTIES (
-                'content.lance.encoding' = 'blob',
-                'invalid_content.lance.encoding' = 'blob',
                 'file_format_version' = '2.2'
+            )
+        """)
+
+        spark.sql("""
+            ALTER TABLE default.test_table
+            SET TBLPROPERTIES (
+                'content.lance.encoding' = 'blob',
+                'invalid_content.lance.encoding' = 'blob'
             )
         """)
 
@@ -2317,6 +2323,9 @@ class TestDMLAddColumn:
                 ALTER TABLE default.test_table
                 ADD COLUMNS invalid_content FROM tmp_view
             """)
+
+        field_names = [field.name for field in spark.table("default.test_table").schema.fields]
+        assert "invalid_content" not in field_names
 
     def test_add_column_from_view(self, spark):
         """Test ALTER TABLE ADD COLUMNS FROM with single column."""

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2327,6 +2327,96 @@ class TestDMLAddColumn:
         field_names = [field.name for field in spark.table("default.test_table").schema.fields]
         assert "invalid_content" not in field_names
 
+    def test_add_blob_column_without_encoding_property_stays_binary(self, spark, test_table):
+        """Test that a blob column added without its encoding property stays BINARY."""
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
+                id INT,
+                name STRING
+            )
+            TBLPROPERTIES (
+                'file_format_version' = '2.2'
+            )
+        """)
+
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
+            (1, 'alpha'),
+            (2, 'bravo')
+        """)
+
+        spark.sql(f"""
+            CREATE TEMPORARY VIEW no_property_backfill AS
+            SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content
+            FROM {test_table}
+        """)
+
+        spark.sql(f"""
+            ALTER TABLE {test_table} ADD COLUMNS content FROM no_property_backfill
+        """)
+
+        content_type = next(
+            row.data_type
+            for row in spark.sql(f"DESCRIBE {test_table}").collect()
+            if row.col_name == "content"
+        )
+        assert content_type == "binary"
+
+        spark.sql(f"""
+            ALTER TABLE {test_table}
+            SET TBLPROPERTIES ('content.lance.encoding' = 'blob')
+        """)
+
+        content_type_after_property = next(
+            row.data_type
+            for row in spark.sql(f"DESCRIBE {test_table}").collect()
+            if row.col_name == "content"
+        )
+        assert content_type_after_property == "binary"
+
+    def test_add_blob_column_with_mismatched_encoding_property_stays_binary(
+        self, spark, test_table
+    ):
+        """Test that an encoding property must exactly match the added column name."""
+        spark.sql(f"""
+            CREATE TABLE {test_table} (
+                id INT,
+                name STRING
+            )
+            TBLPROPERTIES (
+                'file_format_version' = '2.2'
+            )
+        """)
+
+        spark.sql(f"""
+            ALTER TABLE {test_table}
+            SET TBLPROPERTIES ('content.lance.encoding' = 'blob')
+        """)
+
+        spark.sql(f"""
+            INSERT INTO {test_table} VALUES
+            (1, 'alpha'),
+            (2, 'bravo')
+        """)
+
+        spark.sql(f"""
+            CREATE TEMPORARY VIEW mismatched_property_backfill AS
+            SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content_bytes
+            FROM {test_table}
+        """)
+
+        spark.sql(f"""
+            ALTER TABLE {test_table}
+            ADD COLUMNS content_bytes FROM mismatched_property_backfill
+        """)
+
+        content_bytes_type = next(
+            row.data_type
+            for row in spark.sql(f"DESCRIBE {test_table}").collect()
+            if row.col_name == "content_bytes"
+        )
+        assert content_bytes_type == "binary"
+
     def test_add_column_from_view(self, spark):
         """Test ALTER TABLE ADD COLUMNS FROM with single column."""
         spark.sql("""

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2278,10 +2278,17 @@ class TestDMLAddColumn:
             )
         """)
 
+        first_content = b"alpha"
+        second_content = b"bravo-charlie"
+
         spark.sql("""
             INSERT INTO default.test_table VALUES
-            (1, 'alpha'),
-            (2, 'bravo')
+            (1, 'alpha')
+        """)
+
+        spark.sql("""
+            INSERT INTO default.test_table VALUES
+            (2, 'bravo-charlie')
         """)
 
         spark.sql("""
@@ -2299,7 +2306,10 @@ class TestDMLAddColumn:
             for row in spark.sql("DESCRIBE default.test_table").collect()
             if row.col_name == "content"
         )
-        assert "struct" in content_field.data_type.lower()
+        content_type = content_field.data_type.lower()
+        assert "struct" in content_type
+        assert "kind" in content_type
+        assert "blob_uri" in content_type
 
         rows = spark.sql("""
             SELECT id, content.size, content.kind
@@ -2308,8 +2318,8 @@ class TestDMLAddColumn:
         """).collect()
 
         assert [(row.id, row.size, row.kind) for row in rows] == [
-            (1, len(b"alpha"), 0),
-            (2, len(b"bravo"), 0),
+            (1, len(first_content), 0),
+            (2, len(second_content), 0),
         ]
 
         spark.sql("""

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -18,6 +18,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.plans.logical.{AppendData, LogicalPlan, Project}
 import org.apache.spark.sql.connector.catalog._
 import org.lance.spark.{LanceConstant, LanceDataset}
+import org.lance.spark.utils.SchemaConverter
 
 case class AddColumnsBackfillExec(
     catalog: TableCatalog,
@@ -55,15 +56,24 @@ case class AddColumnsBackfillExec(
       query
     }
 
+    val tableProperties = originalTable.properties()
+    val backfillSchema = SchemaConverter.processSchemaWithProperties(
+      actualQuery.schema,
+      tableProperties,
+      originalTable.getFileFormatVersion)
+
     val relation = DataSourceV2Relation.create(
       new LanceDataset(
         originalTable.readOptions(),
-        actualQuery.schema,
+        backfillSchema,
         originalTable.getInitialStorageOptions,
         originalTable.getNamespaceImpl,
         originalTable.getNamespaceProperties,
         originalTable.getManagedVersioning,
-        originalTable.getFileFormatVersion),
+        null,
+        originalTable.getFileFormatVersion,
+        tableProperties,
+        null),
       Some(catalog),
       Some(ident))
 


### PR DESCRIPTION
## Summary

- apply the target table's persisted column properties and actual Lance file format version to `ADD COLUMNS ... FROM` backfill schemas
- support adding and backfilling a blob v2 `BINARY` column on file format 2.2+ tables
- validate configured blob columns are `BINARY` before append
- document the supported workflow and add integration coverage for success and error paths

## Usage

Persist the future column's blob encoding before running the backfill:

```sql
CREATE TABLE users (
    id INT,
    name STRING
) USING lance
TBLPROPERTIES ('file_format_version' = '2.2');

ALTER TABLE users
SET TBLPROPERTIES ('content.lance.encoding' = 'blob');

CREATE TEMPORARY VIEW content_backfill AS
SELECT _rowaddr, _fragid, CAST(name AS BINARY) AS content
FROM users;

ALTER TABLE users ADD COLUMNS content FROM content_backfill;
```

After the operation, reads expose `content` as the existing blob v2 descriptor struct, including fields such as `size` and `kind`.

## Why

The add-columns backfill path previously used the source view's raw Spark schema. As a result, a new `BINARY` column did not receive the `lance.blob.v2` Arrow extension metadata from the target table's persisted properties and was written as plain binary.

Using `ALTER TABLE ... SET TBLPROPERTIES` ensures the future column's encoding is persisted for both managed and unmanaged catalogs before `ADD COLUMNS` reloads the target table.

## Validation

- GitHub Actions: all checks passed
- integration coverage verifies blob v2 descriptor values after a successful `BINARY` backfill
- integration coverage verifies non-`BINARY` inputs fail before the invalid column is added
- existing non-blob add-columns scenarios remain covered

Local Maven, pytest, lint, and format checks were intentionally not run per the Lance repository workflow; GitHub Actions was used as the validation environment.