### PR TITLE
feat: support configurable cache backends

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -68,9 +68,89 @@ and namespace-specific options:
 | `spark.sql.catalog.{name}`                  | String | ✓        | Set to `org.lance.spark.LanceNamespaceSparkCatalog`                                                                        |
 | `spark.sql.catalog.{name}.impl`             | String | ✓        | Namespace implementation, short name like `dir`, `rest`, `hive3`, `glue` or full Java implementation class                 |
 | `spark.sql.catalog.{name}.storage.*`        | -      | ✗        | Lance IO storage options. See [Lance Object Store Guide](https://lance.org/guide/object_store) for all available options.  |
+| `spark.sql.catalog.{name}.index_cache_backend` | String | ✗     | Registered native index cache backend URI, for example `moka://?capacity=6442450944`. |
+| `spark.sql.catalog.{name}.metadata_cache_backend` | String | ✗  | Registered native metadata cache backend URI, for example `moka://?capacity=1073741824`. |
 | `spark.sql.catalog.{name}.single_level_ns`  | Boolean | ✗       | Enable single-level mode with virtual "default" namespace. Default: `false`. See [Note on Namespace Levels](#note-on-namespace-levels). |
 | `spark.sql.catalog.{name}.parent`           | String | ✗        | Parent prefix for multi-level namespaces. See [Note on Namespace Levels](#note-on-namespace-levels).                             |
 | `spark.sql.catalog.{name}.parent_delimiter` | String | ✗        | Delimiter for parent prefix (default: `.`). See [Note on Namespace Levels](#note-on-namespace-levels).                           |
+
+## Cache Backends
+
+Each Spark catalog owns an isolated Lance `Session`. Select registered native cache backends for
+the index and metadata cache independently by setting backend URIs:
+
+```python
+spark = SparkSession.builder \
+    .config("spark.sql.catalog.lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
+    .config("spark.sql.catalog.lance.impl", "dir") \
+    .config("spark.sql.catalog.lance.root", "/path/to/lance/database") \
+    .config(
+        "spark.sql.catalog.lance.index_cache_backend",
+        "moka://?capacity=6442450944",
+    ) \
+    .config(
+        "spark.sql.catalog.lance.metadata_cache_backend",
+        "moka://?capacity=1073741824",
+    ) \
+    .getOrCreate()
+```
+
+`moka` is registered by Lance Core. Other backend kinds must already be registered by the native
+Lance runtime packaged with the application. These options select a registered backend; they do
+not register a Java cache implementation.
+
+The connector serializes the backend URIs with its read and write options, so driver and executor
+JVMs create equivalent process-local sessions. A catalog's session is fixed when that catalog is
+first used. To switch backends in one Spark application, configure a second catalog:
+
+```python
+spark = SparkSession.builder \
+    .config("spark.sql.catalog.memory_lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
+    .config("spark.sql.catalog.memory_lance.impl", "dir") \
+    .config("spark.sql.catalog.memory_lance.root", "/path/to/lance/database") \
+    .config(
+        "spark.sql.catalog.memory_lance.index_cache_backend",
+        "moka://?capacity=6442450944",
+    ) \
+    .config("spark.sql.catalog.other_lance", "org.lance.spark.LanceNamespaceSparkCatalog") \
+    .config("spark.sql.catalog.other_lance.impl", "dir") \
+    .config("spark.sql.catalog.other_lance.root", "/path/to/lance/database") \
+    .config(
+        "spark.sql.catalog.other_lance.index_cache_backend",
+        "other://?option=value",
+    ) \
+    .getOrCreate()
+```
+
+For structured Java SDK configuration, build a `Session` with `CacheBackendConfig` and register it
+before the catalog is first used:
+
+```java
+import org.lance.CacheBackendConfig;
+import org.lance.Session;
+import org.lance.spark.LanceRuntime;
+
+Session session = Session.builder()
+    .indexCacheBackend(
+        CacheBackendConfig.builder("moka")
+            .option("capacity", "6442450944")
+            .build())
+    .metadataCacheBackend(
+        CacheBackendConfig.builder("moka")
+            .option("capacity", "1073741824")
+            .build())
+    .build();
+LanceRuntime.registerSession("lance", session);
+```
+
+Registration transfers session ownership to `LanceRuntime`; do not close it directly. In cluster
+mode, programmatic registration must run in every JVM that accesses Lance. Catalog URI options are
+recommended when the same configuration should be distributed automatically.
+
+The corresponding environment fallbacks are `LANCE_INDEX_CACHE_BACKEND` and
+`LANCE_METADATA_CACHE_BACKEND`. Per-catalog URIs take precedence over environment backend URIs.
+Backend URIs take precedence over the legacy `LANCE_INDEX_CACHE_SIZE` and
+`LANCE_METADATA_CACHE_SIZE` settings for the same cache tier.
 
 ## OpenTelemetry Metrics
 

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -217,6 +217,18 @@ Lance Spark implements two levels of caching:
     - All workers read the same version for snapshot isolation
     - Fragments are pre-loaded and cached per dataset
 
+### Cache Backend
+
+The index and metadata cache backend can be selected independently for each Spark catalog. For
+example:
+
+```bash
+--conf 'spark.sql.catalog.lance.index_cache_backend=moka://?capacity=8589934592' \
+--conf 'spark.sql.catalog.lance.metadata_cache_backend=moka://?capacity=2147483648'
+```
+
+See [Cache Backends](config.md#cache-backends) for backend registration, switching, and precedence.
+
 ### Index Cache Size
 
 Set via environment variable `LANCE_INDEX_CACHE_SIZE` (default: 6GB from Lance native).

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -258,6 +258,14 @@ def spark(request):
             "spark.sql.extensions",
             "org.lance.spark.extensions.LanceSparkSessionExtensions",
         )
+        .config(
+            f"spark.sql.catalog.{CATALOG}.index_cache_backend",
+            "moka://?capacity=16777216",
+        )
+        .config(
+            f"spark.sql.catalog.{CATALOG}.metadata_cache_backend",
+            "moka://?capacity=8388608",
+        )
     )
 
     if backend == "lancedb":

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -1839,6 +1839,17 @@ class TestDQLSearchTableFunctions:
 class TestDQLSelect:
     """Test DQL SELECT operations."""
 
+    def test_cache_backend_catalog_session_reads_written_table(self, spark, test_table):
+        """Verify catalog cache backends are used by a real Spark write/read path."""
+        spark.sql(f"CREATE TABLE {test_table} (id INT, value STRING)")
+        spark.createDataFrame([(1, "one"), (2, "two")], ["id", "value"]) \
+            .writeTo(test_table).append()
+
+        jvm = spark._jvm
+        runtime_session = jvm.org.lance.spark.LanceRuntime.session(LANCE_CATALOG)
+        assert not runtime_session.isClosed()
+        assert spark.sql(f"SELECT id FROM {test_table} ORDER BY id").collect() == [(1,), (2,)]
+
     def test_select_all(self, spark):
         """Test SELECT * query."""
         spark.sql("""

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -90,7 +90,10 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
             .datasetUri(readOptions.getDatasetUri())
             .storageOptions(readOptions.getStorageOptions())
             .namespace(readOptions.getNamespace())
-            .tableId(readOptions.getTableId());
+            .tableId(readOptions.getTableId())
+            .catalogName(readOptions.getCatalogName())
+            .indexCacheBackend(readOptions.getIndexCacheBackend())
+            .metadataCacheBackend(readOptions.getMetadataCacheBackend());
     if (fileFormatVersion != null) {
       writeOptionsBuilder.fileFormatVersion(fileFormatVersion);
     }

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -15,6 +15,8 @@ package org.lance.spark.write;
 
 import org.lance.Dataset;
 import org.lance.WriteParams;
+import org.lance.spark.LancePositionDeltaOperation;
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.TestUtils;
 
@@ -25,7 +27,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.connector.write.DeltaBatchWrite;
+import org.apache.spark.sql.connector.write.DeltaWriteBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.sql.util.LanceArrowUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -34,6 +40,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -69,5 +76,59 @@ public class SparkPositionDeltaWriteTest {
           "Position delta writes must explicitly override Spark's commit coordinator default");
       assertFalse(batchWrite.useCommitCoordinator());
     }
+  }
+
+  @Test
+  public void newWriteBuilderPropagatesCacheBackendConfiguration() throws Exception {
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri("file:///unused")
+            .catalogName("configured-catalog")
+            .indexCacheBackend("moka://?capacity=1048576")
+            .metadataCacheBackend("moka://?capacity=524288")
+            .build();
+    StructType schema = new StructType();
+    LancePositionDeltaOperation operation =
+        new LancePositionDeltaOperation(
+            RowLevelOperation.Command.DELETE,
+            schema,
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            false,
+            null,
+            Collections.emptyMap());
+    LogicalWriteInfo info =
+        new LogicalWriteInfo() {
+          @Override
+          public String queryId() {
+            return "probe";
+          }
+
+          @Override
+          public StructType schema() {
+            return schema;
+          }
+
+          @Override
+          public CaseInsensitiveStringMap options() {
+            return new CaseInsensitiveStringMap(Collections.emptyMap());
+          }
+        };
+
+    DeltaWriteBuilder builder = operation.newWriteBuilder(info);
+    LanceSparkWriteOptions writeOptions = extractWriteOptions(builder);
+    assertEquals("configured-catalog", writeOptions.getCatalogName());
+    assertEquals("moka://?capacity=1048576", writeOptions.getIndexCacheBackend());
+    assertEquals("moka://?capacity=524288", writeOptions.getMetadataCacheBackend());
+  }
+
+  private static LanceSparkWriteOptions extractWriteOptions(DeltaWriteBuilder builder)
+      throws Exception {
+    // Fully qualified to avoid clashing with the Arrow Field import used above.
+    java.lang.reflect.Field field = builder.getClass().getDeclaredField("writeOptions");
+    field.setAccessible(true);
+    return (LanceSparkWriteOptions) field.get(builder);
   }
 }

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaOperation.java
@@ -136,7 +136,10 @@ public class LancePositionDeltaOperation implements RowLevelOperation, SupportsD
             .datasetUri(readOptions.getDatasetUri())
             .storageOptions(readOptions.getStorageOptions())
             .namespace(readOptions.getNamespace())
-            .tableId(readOptions.getTableId());
+            .tableId(readOptions.getTableId())
+            .catalogName(readOptions.getCatalogName())
+            .indexCacheBackend(readOptions.getIndexCacheBackend())
+            .metadataCacheBackend(readOptions.getMetadataCacheBackend());
     if (fileFormatVersion != null) {
       writeOptionsBuilder.fileFormatVersion(fileFormatVersion);
     }

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/write/SparkPositionDeltaWriteTest.java
@@ -15,6 +15,8 @@ package org.lance.spark.write;
 
 import org.lance.Dataset;
 import org.lance.WriteParams;
+import org.lance.spark.LancePositionDeltaOperation;
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.LanceSparkWriteOptions;
 import org.lance.spark.TestUtils;
 
@@ -25,7 +27,11 @@ import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.connector.write.DeltaBatchWrite;
+import org.apache.spark.sql.connector.write.DeltaWriteBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.RowLevelOperation;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.sql.util.LanceArrowUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -77,5 +83,59 @@ public class SparkPositionDeltaWriteTest {
           "Position delta writes must explicitly override Spark's commit coordinator default");
       assertFalse(batchWrite.useCommitCoordinator());
     }
+  }
+
+  @Test
+  public void newWriteBuilderPropagatesCacheBackendConfiguration() throws Exception {
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri("file:///unused")
+            .catalogName("configured-catalog")
+            .indexCacheBackend("moka://?capacity=1048576")
+            .metadataCacheBackend("moka://?capacity=524288")
+            .build();
+    StructType schema = new StructType();
+    LancePositionDeltaOperation operation =
+        new LancePositionDeltaOperation(
+            RowLevelOperation.Command.DELETE,
+            schema,
+            readOptions,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            false,
+            null,
+            Collections.emptyMap());
+    LogicalWriteInfo info =
+        new LogicalWriteInfo() {
+          @Override
+          public String queryId() {
+            return "probe";
+          }
+
+          @Override
+          public StructType schema() {
+            return schema;
+          }
+
+          @Override
+          public CaseInsensitiveStringMap options() {
+            return new CaseInsensitiveStringMap(Collections.emptyMap());
+          }
+        };
+
+    DeltaWriteBuilder builder = operation.newWriteBuilder(info);
+    LanceSparkWriteOptions writeOptions = extractWriteOptions(builder);
+    assertEquals("configured-catalog", writeOptions.getCatalogName());
+    assertEquals("moka://?capacity=1048576", writeOptions.getIndexCacheBackend());
+    assertEquals("moka://?capacity=524288", writeOptions.getMetadataCacheBackend());
+  }
+
+  private static LanceSparkWriteOptions extractWriteOptions(DeltaWriteBuilder builder)
+      throws Exception {
+    // Fully qualified to avoid clashing with the Arrow Field import used above.
+    java.lang.reflect.Field field = builder.getClass().getDeclaredField("writeOptions");
+    field.setAccessible(true);
+    return (LanceSparkWriteOptions) field.get(builder);
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -209,6 +209,11 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
     // Parse catalog configuration
     this.catalogConfig = LanceSparkCatalogConfig.from(this.storageOptions);
+    if (catalogConfig.getIndexCacheBackend() != null
+        || catalogConfig.getMetadataCacheBackend() != null) {
+      LanceRuntime.session(
+          name, catalogConfig.getIndexCacheBackend(), catalogConfig.getMetadataCacheBackend());
+    }
 
     // impl is optional - if not provided, catalog operates in path-based only mode
     if (!options.containsKey(CONFIG_IMPL)) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -317,6 +317,9 @@ public class LanceDataset
               .datasetUri(readOptions.getDatasetUri())
               .namespace(readOptions.getNamespace())
               .tableId(readOptions.getTableId())
+              .catalogName(readOptions.getCatalogName())
+              .indexCacheBackend(readOptions.getIndexCacheBackend())
+              .metadataCacheBackend(readOptions.getMetadataCacheBackend())
               .fromOptions(mergedOptions)
               .build();
     }
@@ -373,6 +376,9 @@ public class LanceDataset
             .datasetUri(readOptions.getDatasetUri())
             .namespace(readOptions.getNamespace())
             .tableId(readOptions.getTableId())
+            .catalogName(readOptions.getCatalogName())
+            .indexCacheBackend(readOptions.getIndexCacheBackend())
+            .metadataCacheBackend(readOptions.getMetadataCacheBackend())
             .fromOptions(mergedOptions);
     // Use table's file format version if not explicitly set in write options
     if (!mergedOptions.containsKey(LanceSparkWriteOptions.CONFIG_FILE_FORMAT_VERSION)

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRuntime.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,8 +43,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>Session cache sizes can be configured via environment variables:
  *
  * <ul>
- *   <li>{@code LANCE_INDEX_CACHE_SIZE} - Index cache size in bytes (default: 256MB)
- *   <li>{@code LANCE_METADATA_CACHE_SIZE} - Metadata cache size in bytes (default: 256MB)
+ *   <li>{@code LANCE_INDEX_CACHE_SIZE} - Index cache size in bytes
+ *   <li>{@code LANCE_METADATA_CACHE_SIZE} - Metadata cache size in bytes
+ *   <li>{@code LANCE_INDEX_CACHE_BACKEND} - Registered index cache backend URI
+ *   <li>{@code LANCE_METADATA_CACHE_BACKEND} - Registered metadata cache backend URI
  * </ul>
  *
  * <p>Usage:
@@ -66,6 +69,12 @@ public final class LanceRuntime {
   /** Environment variable for metadata cache size in bytes. */
   public static final String ENV_METADATA_CACHE_SIZE = "LANCE_METADATA_CACHE_SIZE";
 
+  /** Environment variable for the registered index cache backend URI. */
+  public static final String ENV_INDEX_CACHE_BACKEND = "LANCE_INDEX_CACHE_BACKEND";
+
+  /** Environment variable for the registered metadata cache backend URI. */
+  public static final String ENV_METADATA_CACHE_BACKEND = "LANCE_METADATA_CACHE_BACKEND";
+
   /** Spark configuration key that enables Lance OpenTelemetry metrics in each JVM. */
   public static final String SPARK_CONF_OPEN_TELEMETRY_ENABLED = "spark.lance.otel.enabled";
 
@@ -82,7 +91,7 @@ public final class LanceRuntime {
   private static volatile BufferAllocator GLOBAL_ALLOCATOR;
 
   /** Per-catalog sessions for cache isolation (lazy initialized). */
-  private static final Map<String, Session> CATALOG_SESSIONS = new ConcurrentHashMap<>();
+  private static final Map<String, CatalogSession> CATALOG_SESSIONS = new ConcurrentHashMap<>();
 
   /** External namespace implementation aliases used by Spark catalog configuration. */
   private static final Map<String, String> EXTERNAL_NAMESPACE_IMPLS =
@@ -222,7 +231,91 @@ public final class LanceRuntime {
    */
   public static Session session(String catalogName) {
     String key = catalogName != null ? catalogName : DEFAULT_CATALOG;
-    return CATALOG_SESSIONS.computeIfAbsent(key, k -> createSession());
+    return CATALOG_SESSIONS.computeIfAbsent(
+            key, k -> CatalogSession.managed(createSessionConfiguration(null, null)))
+        .session;
+  }
+
+  /**
+   * Returns the session for a catalog with registered cache backends selected by URI.
+   *
+   * <p>The first call for a catalog creates its process-local session. Later calls must request the
+   * same backend configuration. Cache backends cannot be changed after the session has been used;
+   * use a different catalog or restart the JVM to switch an existing catalog.
+   *
+   * <p>Catalog backend URIs take precedence over the corresponding environment backend and cache
+   * size settings. A {@code null} URI falls back to {@link #ENV_INDEX_CACHE_BACKEND} or {@link
+   * #ENV_METADATA_CACHE_BACKEND}, then to the legacy cache size environment variable.
+   *
+   * @param catalogName the catalog name for cache isolation
+   * @param indexCacheBackendUri index cache backend URI, or null for the environment/default
+   * @param metadataCacheBackendUri metadata cache backend URI, or null for the environment/default
+   * @return the session for the specified catalog
+   */
+  public static Session session(
+      String catalogName, String indexCacheBackendUri, String metadataCacheBackendUri) {
+    validateOptionalBackendUri(indexCacheBackendUri, "indexCacheBackendUri");
+    validateOptionalBackendUri(metadataCacheBackendUri, "metadataCacheBackendUri");
+    if (!hasText(indexCacheBackendUri) && !hasText(metadataCacheBackendUri)) {
+      return session(catalogName);
+    }
+
+    String key = catalogName != null ? catalogName : DEFAULT_CATALOG;
+    SessionConfiguration requested =
+        createSessionConfiguration(indexCacheBackendUri, metadataCacheBackendUri);
+    return CATALOG_SESSIONS.compute(
+            key,
+            (ignored, current) -> {
+              if (current == null) {
+                return CatalogSession.managed(requested);
+              }
+              if (!requested.equals(current.configuration)) {
+                throw new IllegalStateException(
+                    "Lance session for catalog '"
+                        + key
+                        + "' is already initialized with a different cache configuration");
+              }
+              return current;
+            })
+        .session;
+  }
+
+  /**
+   * Registers a Java SDK session for a Spark catalog.
+   *
+   * <p>Use this when the session was built programmatically, for example with structured {@code
+   * CacheBackendConfig} instances. Registration must happen before the catalog is first used in
+   * each driver or executor JVM. Ownership transfers to {@code LanceRuntime}; callers must not
+   * close the session after registration.
+   *
+   * @param catalogName the catalog that should use the session
+   * @param session the open Java SDK session to register
+   */
+  public static void registerSession(String catalogName, Session session) {
+    Objects.requireNonNull(session, "session must not be null");
+    if (session.isClosed()) {
+      throw new IllegalArgumentException("session must be open");
+    }
+
+    String key = catalogName != null ? catalogName : DEFAULT_CATALOG;
+    CATALOG_SESSIONS.compute(
+        key,
+        (ignored, current) -> {
+          if (current == null) {
+            return CatalogSession.registered(session);
+          }
+          if (current.session.isSameAs(session)) {
+            return current;
+          }
+          throw new IllegalStateException(
+              "Lance session for catalog '" + key + "' is already initialized");
+        });
+  }
+
+  private static void validateOptionalBackendUri(String backendUri, String name) {
+    if (backendUri != null && !hasText(backendUri)) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
   }
 
   /**
@@ -322,20 +415,44 @@ public final class LanceRuntime {
     return value != null && !value.trim().isEmpty();
   }
 
-  private static Session createSession() {
+  private static SessionConfiguration createSessionConfiguration(
+      String indexCacheBackendUri, String metadataCacheBackendUri) {
+    String indexBackend =
+        firstNonBlank(indexCacheBackendUri, System.getenv(ENV_INDEX_CACHE_BACKEND));
+    String metadataBackend =
+        firstNonBlank(metadataCacheBackendUri, System.getenv(ENV_METADATA_CACHE_BACKEND));
+    Long indexCacheSize = indexBackend == null ? getEnvLong(ENV_INDEX_CACHE_SIZE) : null;
+    Long metadataCacheSize = metadataBackend == null ? getEnvLong(ENV_METADATA_CACHE_SIZE) : null;
+    return new SessionConfiguration(
+        indexBackend, metadataBackend, indexCacheSize, metadataCacheSize);
+  }
+
+  private static Session createSession(SessionConfiguration configuration) {
     Session.Builder builder = Session.builder();
 
-    Long indexCacheSize = getEnvLong(ENV_INDEX_CACHE_SIZE);
-    if (indexCacheSize != null) {
-      builder.indexCacheSizeBytes(indexCacheSize);
+    if (configuration.indexCacheBackendUri != null) {
+      builder.indexCacheBackend(configuration.indexCacheBackendUri);
+    } else if (configuration.indexCacheSize != null) {
+      builder.indexCacheSizeBytes(configuration.indexCacheSize);
     }
 
-    Long metadataCacheSize = getEnvLong(ENV_METADATA_CACHE_SIZE);
-    if (metadataCacheSize != null) {
-      builder.metadataCacheSizeBytes(metadataCacheSize);
+    if (configuration.metadataCacheBackendUri != null) {
+      builder.metadataCacheBackend(configuration.metadataCacheBackendUri);
+    } else if (configuration.metadataCacheSize != null) {
+      builder.metadataCacheSizeBytes(configuration.metadataCacheSize);
     }
 
     return builder.build();
+  }
+
+  private static String firstNonBlank(String primary, String fallback) {
+    if (hasText(primary)) {
+      return primary.trim();
+    }
+    if (hasText(fallback)) {
+      return fallback.trim();
+    }
+    return null;
   }
 
   /**
@@ -394,8 +511,8 @@ public final class LanceRuntime {
    */
   static void clearGlobalSession() {
     synchronized (LanceRuntime.class) {
-      for (Session session : CATALOG_SESSIONS.values()) {
-        session.close();
+      for (CatalogSession catalogSession : CATALOG_SESSIONS.values()) {
+        catalogSession.session.close();
       }
       CATALOG_SESSIONS.clear();
     }
@@ -414,6 +531,63 @@ public final class LanceRuntime {
     NOT_ATTEMPTED,
     INSTALLED,
     FAILED
+  }
+
+  private static final class CatalogSession {
+    private final Session session;
+    private final SessionConfiguration configuration;
+
+    private CatalogSession(Session session, SessionConfiguration configuration) {
+      this.session = session;
+      this.configuration = configuration;
+    }
+
+    private static CatalogSession managed(SessionConfiguration configuration) {
+      return new CatalogSession(createSession(configuration), configuration);
+    }
+
+    private static CatalogSession registered(Session session) {
+      return new CatalogSession(session, null);
+    }
+  }
+
+  private static final class SessionConfiguration {
+    private final String indexCacheBackendUri;
+    private final String metadataCacheBackendUri;
+    private final Long indexCacheSize;
+    private final Long metadataCacheSize;
+
+    private SessionConfiguration(
+        String indexCacheBackendUri,
+        String metadataCacheBackendUri,
+        Long indexCacheSize,
+        Long metadataCacheSize) {
+      this.indexCacheBackendUri = indexCacheBackendUri;
+      this.metadataCacheBackendUri = metadataCacheBackendUri;
+      this.indexCacheSize = indexCacheSize;
+      this.metadataCacheSize = metadataCacheSize;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof SessionConfiguration)) {
+        return false;
+      }
+      SessionConfiguration that = (SessionConfiguration) other;
+      return Objects.equals(indexCacheBackendUri, that.indexCacheBackendUri)
+          && Objects.equals(metadataCacheBackendUri, that.metadataCacheBackendUri)
+          && Objects.equals(indexCacheSize, that.indexCacheSize)
+          && Objects.equals(metadataCacheSize, that.metadataCacheSize);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          indexCacheBackendUri, metadataCacheBackendUri, indexCacheSize, metadataCacheSize);
+    }
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkCatalogConfig.java
@@ -47,12 +47,22 @@ public class LanceSparkCatalogConfig {
 
   public static final String TABLE_OPT_FILE_FORMAT_VERSION = "file_format_version";
 
+  /** Catalog option selecting the registered index cache backend by URI. */
+  public static final String CACHE_OPT_INDEX_BACKEND = "index_cache_backend";
+
+  /** Catalog option selecting the registered metadata cache backend by URI. */
+  public static final String CACHE_OPT_METADATA_BACKEND = "metadata_cache_backend";
+
   private final Map<String, String> storageOptions;
   private final Map<String, String> tableOptions;
+  private final String indexCacheBackend;
+  private final String metadataCacheBackend;
 
   private LanceSparkCatalogConfig(Builder builder) {
     this.storageOptions = Collections.unmodifiableMap(new HashMap<>(builder.storageOptions));
     this.tableOptions = Collections.unmodifiableMap(new HashMap<>(builder.tableOptions));
+    this.indexCacheBackend = builder.indexCacheBackend;
+    this.metadataCacheBackend = builder.metadataCacheBackend;
   }
 
   /** Creates a new builder for LanceSparkCatalogConfig. */
@@ -82,8 +92,7 @@ public class LanceSparkCatalogConfig {
       if (fullKey.startsWith(STORAGE_PREFIX)) {
         String nativeKey = fullKey.substring(STORAGE_PREFIX.length());
         nativeOptions.put(nativeKey, value);
-      } else if (!TABLE_OPT_ENABLE_STABLE_ROW_IDS.equals(fullKey)
-          && !TABLE_OPT_FILE_FORMAT_VERSION.equals(fullKey)) {
+      } else if (!isConnectorOption(fullKey)) {
         // Keep table options out of storageOptions, as writes merge those in.
         nativeOptions.put(fullKey, value);
       }
@@ -99,7 +108,19 @@ public class LanceSparkCatalogConfig {
       tableOpts.put(TABLE_OPT_FILE_FORMAT_VERSION, fileFormatVersion);
     }
 
-    return builder().storageOptions(nativeOptions).tableOptions(tableOpts).build();
+    return builder()
+        .storageOptions(nativeOptions)
+        .tableOptions(tableOpts)
+        .indexCacheBackend(catalogOptions.get(CACHE_OPT_INDEX_BACKEND))
+        .metadataCacheBackend(catalogOptions.get(CACHE_OPT_METADATA_BACKEND))
+        .build();
+  }
+
+  private static boolean isConnectorOption(String key) {
+    return TABLE_OPT_ENABLE_STABLE_ROW_IDS.equals(key)
+        || TABLE_OPT_FILE_FORMAT_VERSION.equals(key)
+        || CACHE_OPT_INDEX_BACKEND.equals(key)
+        || CACHE_OPT_METADATA_BACKEND.equals(key);
   }
 
   /**
@@ -118,6 +139,16 @@ public class LanceSparkCatalogConfig {
    */
   public Map<String, String> getTableOptions() {
     return tableOptions;
+  }
+
+  /** Returns the registered index cache backend URI, or null if not configured. */
+  public String getIndexCacheBackend() {
+    return indexCacheBackend;
+  }
+
+  /** Returns the registered metadata cache backend URI, or null if not configured. */
+  public String getMetadataCacheBackend() {
+    return metadataCacheBackend;
   }
 
   /**
@@ -159,18 +190,22 @@ public class LanceSparkCatalogConfig {
     if (o == null || getClass() != o.getClass()) return false;
     LanceSparkCatalogConfig that = (LanceSparkCatalogConfig) o;
     return Objects.equals(storageOptions, that.storageOptions)
-        && Objects.equals(tableOptions, that.tableOptions);
+        && Objects.equals(tableOptions, that.tableOptions)
+        && Objects.equals(indexCacheBackend, that.indexCacheBackend)
+        && Objects.equals(metadataCacheBackend, that.metadataCacheBackend);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(storageOptions, tableOptions);
+    return Objects.hash(storageOptions, tableOptions, indexCacheBackend, metadataCacheBackend);
   }
 
   /** Builder for creating LanceSparkCatalogConfig instances. */
   public static class Builder {
     private Map<String, String> storageOptions = new HashMap<>();
     private Map<String, String> tableOptions = new HashMap<>();
+    private String indexCacheBackend;
+    private String metadataCacheBackend;
 
     private Builder() {}
 
@@ -193,6 +228,18 @@ public class LanceSparkCatalogConfig {
      */
     public Builder tableOptions(Map<String, String> tableOptions) {
       this.tableOptions = new HashMap<>(tableOptions);
+      return this;
+    }
+
+    /** Sets the registered index cache backend URI. */
+    public Builder indexCacheBackend(String indexCacheBackend) {
+      this.indexCacheBackend = indexCacheBackend;
+      return this;
+    }
+
+    /** Sets the registered metadata cache backend URI. */
+    public Builder metadataCacheBackend(String metadataCacheBackend) {
+      this.metadataCacheBackend = metadataCacheBackend;
       return this;
     }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -127,6 +127,11 @@ public class LanceSparkReadOptions implements Serializable {
   /** The catalog name for cache isolation when multiple catalogs are configured. */
   private final String catalogName;
 
+  /** Registered cache backend URIs for the process-local catalog session. */
+  private final String indexCacheBackend;
+
+  private final String metadataCacheBackend;
+
   /**
    * Whether executors should rebuild the namespace client for credential refresh. See {@link
    * #CONFIG_EXECUTOR_CREDENTIAL_REFRESH} for details.
@@ -151,6 +156,8 @@ public class LanceSparkReadOptions implements Serializable {
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
     this.catalogName = builder.catalogName;
+    this.indexCacheBackend = builder.indexCacheBackend;
+    this.metadataCacheBackend = builder.metadataCacheBackend;
     this.executorCredentialRefresh = builder.executorCredentialRefresh;
   }
 
@@ -286,6 +293,14 @@ public class LanceSparkReadOptions implements Serializable {
     return catalogName;
   }
 
+  public String getIndexCacheBackend() {
+    return indexCacheBackend;
+  }
+
+  public String getMetadataCacheBackend() {
+    return metadataCacheBackend;
+  }
+
   /**
    * Returns whether executors should rebuild the namespace client and route the dataset open
    * through the namespace path (for credential refresh). See {@link
@@ -332,6 +347,8 @@ public class LanceSparkReadOptions implements Serializable {
         .namespace(this.namespace)
         .tableId(this.tableId)
         .catalogName(this.catalogName)
+        .indexCacheBackend(this.indexCacheBackend)
+        .metadataCacheBackend(this.metadataCacheBackend)
         .executorCredentialRefresh(this.executorCredentialRefresh)
         .build();
   }
@@ -343,7 +360,7 @@ public class LanceSparkReadOptions implements Serializable {
    */
   public ReadOptions toReadOptions() {
     ReadOptions.Builder builder = new ReadOptions.Builder();
-    builder.setSession(LanceRuntime.session());
+    builder.setSession(LanceRuntime.session(catalogName, indexCacheBackend, metadataCacheBackend));
     if (blockSize != null) {
       builder.setBlockSize(blockSize);
     }
@@ -392,7 +409,9 @@ public class LanceSparkReadOptions implements Serializable {
         && Objects.equals(metadataCacheSize, that.metadataCacheSize)
         && Objects.equals(storageOptions, that.storageOptions)
         && Objects.equals(tableId, that.tableId)
-        && Objects.equals(catalogName, that.catalogName);
+        && Objects.equals(catalogName, that.catalogName)
+        && Objects.equals(indexCacheBackend, that.indexCacheBackend)
+        && Objects.equals(metadataCacheBackend, that.metadataCacheBackend);
   }
 
   @Override
@@ -411,6 +430,8 @@ public class LanceSparkReadOptions implements Serializable {
         storageOptions,
         tableId,
         catalogName,
+        indexCacheBackend,
+        metadataCacheBackend,
         executorCredentialRefresh);
   }
 
@@ -430,6 +451,8 @@ public class LanceSparkReadOptions implements Serializable {
     private LanceNamespace namespace;
     private List<String> tableId;
     private String catalogName;
+    private String indexCacheBackend;
+    private String metadataCacheBackend;
     private boolean executorCredentialRefresh = DEFAULT_EXECUTOR_CREDENTIAL_REFRESH;
 
     private Builder() {}
@@ -504,6 +527,16 @@ public class LanceSparkReadOptions implements Serializable {
       return this;
     }
 
+    public Builder indexCacheBackend(String indexCacheBackend) {
+      this.indexCacheBackend = indexCacheBackend;
+      return this;
+    }
+
+    public Builder metadataCacheBackend(String metadataCacheBackend) {
+      this.metadataCacheBackend = metadataCacheBackend;
+      return this;
+    }
+
     public Builder executorCredentialRefresh(boolean executorCredentialRefresh) {
       this.executorCredentialRefresh = executorCredentialRefresh;
       return this;
@@ -536,6 +569,8 @@ public class LanceSparkReadOptions implements Serializable {
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
+      this.indexCacheBackend = catalogConfig.getIndexCacheBackend();
+      this.metadataCacheBackend = catalogConfig.getMetadataCacheBackend();
       return fromOptions(merged);
     }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -99,6 +99,13 @@ public class LanceSparkWriteOptions implements Serializable {
   /** Use this version to open the dataset and apply write if set. */
   private final Long version;
 
+  /** Catalog and cache backend configuration for process-local session reuse. */
+  private final String catalogName;
+
+  private final String indexCacheBackend;
+
+  private final String metadataCacheBackend;
+
   private LanceSparkWriteOptions(Builder builder) {
     this.datasetUri = builder.datasetUri;
     this.writeMode = builder.writeMode;
@@ -117,6 +124,9 @@ public class LanceSparkWriteOptions implements Serializable {
     this.namespace = builder.namespace;
     this.tableId = builder.tableId;
     this.version = builder.version;
+    this.catalogName = builder.catalogName;
+    this.indexCacheBackend = builder.indexCacheBackend;
+    this.metadataCacheBackend = builder.metadataCacheBackend;
   }
 
   /** Creates a new builder for LanceSparkWriteOptions. */
@@ -217,6 +227,18 @@ public class LanceSparkWriteOptions implements Serializable {
     return version;
   }
 
+  public String getCatalogName() {
+    return catalogName;
+  }
+
+  public String getIndexCacheBackend() {
+    return indexCacheBackend;
+  }
+
+  public String getMetadataCacheBackend() {
+    return metadataCacheBackend;
+  }
+
   /** Returns a builder pre-populated with all fields from this instance. */
   public Builder toBuilder() {
     return builder()
@@ -236,7 +258,10 @@ public class LanceSparkWriteOptions implements Serializable {
         .storageOptions(storageOptions)
         .namespace(namespace)
         .tableId(tableId)
-        .version(version);
+        .version(version)
+        .catalogName(catalogName)
+        .indexCacheBackend(indexCacheBackend)
+        .metadataCacheBackend(metadataCacheBackend);
   }
 
   /** Returns a copy of these options with version set to the given version. */
@@ -328,7 +353,10 @@ public class LanceSparkWriteOptions implements Serializable {
         && Objects.equals(blobPackFileSizeThreshold, that.blobPackFileSizeThreshold)
         && Objects.equals(storageOptions, that.storageOptions)
         && Objects.equals(tableId, that.tableId)
-        && Objects.equals(version, that.version);
+        && Objects.equals(version, that.version)
+        && Objects.equals(catalogName, that.catalogName)
+        && Objects.equals(indexCacheBackend, that.indexCacheBackend)
+        && Objects.equals(metadataCacheBackend, that.metadataCacheBackend);
   }
 
   @Override
@@ -349,7 +377,10 @@ public class LanceSparkWriteOptions implements Serializable {
         blobPackFileSizeThreshold,
         storageOptions,
         tableId,
-        version);
+        version,
+        catalogName,
+        indexCacheBackend,
+        metadataCacheBackend);
   }
 
   /** Builder for creating LanceSparkWriteOptions instances. */
@@ -371,6 +402,9 @@ public class LanceSparkWriteOptions implements Serializable {
     private LanceNamespace namespace;
     private List<String> tableId;
     private Long version;
+    private String catalogName;
+    private String indexCacheBackend;
+    private String metadataCacheBackend;
 
     private Builder() {}
 
@@ -464,6 +498,21 @@ public class LanceSparkWriteOptions implements Serializable {
       return this;
     }
 
+    public Builder catalogName(String catalogName) {
+      this.catalogName = catalogName;
+      return this;
+    }
+
+    public Builder indexCacheBackend(String indexCacheBackend) {
+      this.indexCacheBackend = indexCacheBackend;
+      return this;
+    }
+
+    public Builder metadataCacheBackend(String metadataCacheBackend) {
+      this.metadataCacheBackend = metadataCacheBackend;
+      return this;
+    }
+
     /**
      * Parses options from a map, extracting write-specific settings.
      *
@@ -538,6 +587,8 @@ public class LanceSparkWriteOptions implements Serializable {
       // Merge storage options: catalog options are defaults, current options override
       Map<String, String> merged = new HashMap<>(catalogConfig.getStorageOptions());
       merged.putAll(this.storageOptions);
+      this.indexCacheBackend = catalogConfig.getIndexCacheBackend();
+      this.metadataCacheBackend = catalogConfig.getMetadataCacheBackend();
       return fromOptions(merged);
     }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -72,6 +72,8 @@ public class Utils {
     private final List<String> tableId;
     private final Map<String, String> storageOptions;
     private final String catalogName;
+    private final String indexCacheBackend;
+    private final String metadataCacheBackend;
     private final Long version;
     private final Integer blockSize;
     private final Integer indexCacheSize;
@@ -87,6 +89,8 @@ public class Utils {
       this.storageOptions = opts.getStorageOptions();
       this.version = opts.getVersion();
       this.catalogName = opts.getCatalogName();
+      this.indexCacheBackend = opts.getIndexCacheBackend();
+      this.metadataCacheBackend = opts.getMetadataCacheBackend();
       this.namespace = opts.getNamespace();
       this.tableId = opts.getTableId();
       this.blockSize = opts.getBlockSize();
@@ -99,7 +103,9 @@ public class Utils {
       this.storageOptions = opts.getStorageOptions();
       this.namespace = opts.getNamespace();
       this.tableId = opts.getTableId();
-      this.catalogName = null;
+      this.catalogName = opts.getCatalogName();
+      this.indexCacheBackend = opts.getIndexCacheBackend();
+      this.metadataCacheBackend = opts.getMetadataCacheBackend();
       this.version = opts.getVersion();
       this.blockSize = null;
       this.indexCacheSize = null;
@@ -131,7 +137,7 @@ public class Utils {
           new ReadOptions.Builder()
               .setStorageOptions(merged)
               .setSession(
-                  catalogName != null ? LanceRuntime.session(catalogName) : LanceRuntime.session());
+                  LanceRuntime.session(catalogName, indexCacheBackend, metadataCacheBackend));
       if (version != null) {
         roBuilder.setVersion(version);
       }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeCacheBackendTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeCacheBackendTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark;
+
+import org.lance.CacheBackendConfig;
+import org.lance.Dataset;
+import org.lance.Session;
+import org.lance.spark.utils.Utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LanceRuntimeCacheBackendTest {
+
+  @AfterEach
+  void clearSessions() {
+    LanceRuntime.clearGlobalSession();
+  }
+
+  @Test
+  void createsAndReusesSessionFromBackendUris() {
+    Session session =
+        LanceRuntime.session("cache-uri", "moka://?capacity=1048576", "moka://?capacity=524288");
+
+    assertSame(
+        session,
+        LanceRuntime.session("cache-uri", "moka://?capacity=1048576", "moka://?capacity=524288"));
+  }
+
+  @Test
+  void rejectsChangingBackendAfterCatalogSessionIsCreated() {
+    LanceRuntime.session("cache-switch", "moka://?capacity=1048576", "moka://?capacity=524288");
+
+    IllegalStateException error =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                LanceRuntime.session(
+                    "cache-switch", "moka://?capacity=2097152", "moka://?capacity=524288"));
+
+    assertTrue(error.getMessage().contains("already initialized"));
+  }
+
+  @Test
+  void switchesBackendConfigurationByCatalog() {
+    Session smallCache =
+        LanceRuntime.session("small-cache", "moka://?capacity=1048576", "moka://?capacity=524288");
+    Session largeCache =
+        LanceRuntime.session("large-cache", "moka://?capacity=2097152", "moka://?capacity=1048576");
+
+    assertFalse(smallCache.isSameAs(largeCache));
+  }
+
+  @Test
+  void configuredSessionIsUsedToOpenRealDataset() {
+    String indexBackend = "moka://?capacity=1048576";
+    String metadataBackend = "moka://?capacity=524288";
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri(TestUtils.TestTable1Config.datasetUri)
+            .catalogName("dataset-cache")
+            .indexCacheBackend(indexBackend)
+            .metadataCacheBackend(metadataBackend)
+            .build();
+
+    try (Dataset dataset = Utils.openDatasetBuilder(readOptions).build()) {
+      assertEquals(TestUtils.TestTable1Config.expectedValues.size(), dataset.countRows());
+      assertTrue(
+          dataset
+              .session()
+              .isSameAs(LanceRuntime.session("dataset-cache", indexBackend, metadataBackend)));
+    }
+  }
+
+  @Test
+  void registersStructuredJavaSdkSession() {
+    Session registered =
+        Session.builder()
+            .indexCacheBackend(
+                CacheBackendConfig.builder("moka").option("capacity", "1048576").build())
+            .metadataCacheBackend(
+                CacheBackendConfig.builder("moka").option("capacity", "524288").build())
+            .build();
+
+    LanceRuntime.registerSession("structured-cache", registered);
+
+    assertSame(registered, LanceRuntime.session("structured-cache"));
+  }
+
+  @Test
+  void rejectsReplacingRegisteredSession() {
+    Session first = Session.builder().build();
+    Session second = Session.builder().build();
+    try {
+      LanceRuntime.registerSession("registered-cache", first);
+      IllegalStateException error =
+          assertThrows(
+              IllegalStateException.class,
+              () -> LanceRuntime.registerSession("registered-cache", second));
+      assertTrue(error.getMessage().contains("already initialized"));
+    } finally {
+      second.close();
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkCatalogConfigTest.java
@@ -59,6 +59,22 @@ public class LanceSparkCatalogConfigTest {
   }
 
   @Test
+  public void testFromExtractsCacheBackendOptions() {
+    Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("index_cache_backend", "moka://?capacity=1048576");
+    catalogOptions.put("metadata_cache_backend", "moka://?capacity=524288");
+    catalogOptions.put("storage.region", "us-west-2");
+
+    LanceSparkCatalogConfig config = LanceSparkCatalogConfig.from(catalogOptions);
+
+    assertEquals("moka://?capacity=1048576", config.getIndexCacheBackend());
+    assertEquals("moka://?capacity=524288", config.getMetadataCacheBackend());
+    assertFalse(config.getStorageOptions().containsKey("index_cache_backend"));
+    assertFalse(config.getStorageOptions().containsKey("metadata_cache_backend"));
+    assertEquals("us-west-2", config.getStorageOptions().get("region"));
+  }
+
+  @Test
   public void testFromIgnoresNullKeysOrValues() {
     Map<String, String> catalogOptions = new HashMap<>();
     catalogOptions.put("storage.region", "us-west-2");

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
@@ -247,6 +247,52 @@ public class LanceSparkReadOptionsSerializationTest {
   }
 
   @Test
+  public void testCacheBackendConfigurationSurvivesSerialization()
+      throws IOException, ClassNotFoundException {
+    Map<String, String> catalogOpts = new HashMap<>();
+    catalogOpts.put("index_cache_backend", "moka://?capacity=1048576");
+    catalogOpts.put("metadata_cache_backend", "moka://?capacity=524288");
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .catalogName("cache-catalog")
+            .withCatalogDefaults(LanceSparkCatalogConfig.from(catalogOpts))
+            .build();
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    try (ObjectOutputStream objectOutput = new ObjectOutputStream(output)) {
+      objectOutput.writeObject(options);
+    }
+
+    LanceSparkReadOptions deserialized;
+    try (ObjectInputStream objectInput =
+        new ObjectInputStream(new ByteArrayInputStream(output.toByteArray()))) {
+      deserialized = (LanceSparkReadOptions) objectInput.readObject();
+    }
+
+    Assertions.assertEquals("cache-catalog", deserialized.getCatalogName());
+    Assertions.assertEquals("moka://?capacity=1048576", deserialized.getIndexCacheBackend());
+    Assertions.assertEquals("moka://?capacity=524288", deserialized.getMetadataCacheBackend());
+  }
+
+  @Test
+  public void testWithVersionPreservesCacheBackendConfiguration() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri("s3://bucket/path")
+            .catalogName("cache-catalog")
+            .indexCacheBackend("moka://?capacity=1048576")
+            .metadataCacheBackend("moka://?capacity=524288")
+            .build();
+
+    LanceSparkReadOptions pinned = options.withVersion(7);
+
+    Assertions.assertEquals("cache-catalog", pinned.getCatalogName());
+    Assertions.assertEquals("moka://?capacity=1048576", pinned.getIndexCacheBackend());
+    Assertions.assertEquals("moka://?capacity=524288", pinned.getMetadataCacheBackend());
+  }
+
+  @Test
   public void testExecutorCredentialRefreshPreservedByWithVersion() {
     LanceSparkReadOptions options =
         LanceSparkReadOptions.builder()

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -68,10 +68,19 @@ public class LanceSparkWriteOptionsTest {
 
   @Test
   public void withVersionCopiesOptions() {
-    LanceSparkWriteOptions base = LanceSparkWriteOptions.from(TEMP_URL);
+    LanceSparkWriteOptions base =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .catalogName("cache-catalog")
+            .indexCacheBackend("moka://?capacity=1048576")
+            .metadataCacheBackend("moka://?capacity=524288")
+            .build();
     LanceSparkWriteOptions pinned = base.withVersion(3L);
     assertEquals(3L, pinned.getVersion());
     assertNull(base.getVersion());
+    assertEquals("cache-catalog", pinned.getCatalogName());
+    assertEquals("moka://?capacity=1048576", pinned.getIndexCacheBackend());
+    assertEquals("moka://?capacity=524288", pinned.getMetadataCacheBackend());
   }
 
   @Test
@@ -181,6 +190,26 @@ public class LanceSparkWriteOptionsTest {
     // Catalog keys are carried into storage options as well as typed fields.
     assertEquals("512", writeOptions.getStorageOptions().get("batch_size"));
     assertEquals("8192", writeOptions.getStorageOptions().get("blob_pack_file_size_threshold"));
+  }
+
+  @Test
+  public void testWithCatalogDefaultsCopiesCacheBackends() {
+    final Map<String, String> catalogOptions = new HashMap<>();
+    catalogOptions.put("index_cache_backend", "moka://?capacity=1048576");
+    catalogOptions.put("metadata_cache_backend", "moka://?capacity=524288");
+
+    final LanceSparkWriteOptions writeOptions =
+        LanceSparkWriteOptions.builder()
+            .datasetUri(TEMP_URL)
+            .catalogName("cache-catalog")
+            .withCatalogDefaults(LanceSparkCatalogConfig.from(catalogOptions))
+            .build();
+
+    assertEquals("cache-catalog", writeOptions.getCatalogName());
+    assertEquals("moka://?capacity=1048576", writeOptions.getIndexCacheBackend());
+    assertEquals("moka://?capacity=524288", writeOptions.getMetadataCacheBackend());
+    assertFalse(writeOptions.getStorageOptions().containsKey("index_cache_backend"));
+    assertFalse(writeOptions.getStorageOptions().containsKey("metadata_cache_backend"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.7.1</lance-spark.version>
-        <lance.version>11.0.0-beta.3</lance.version>
+        <lance.version>11.0.0-beta.10</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Summary

- Add per-catalog configuration for index and metadata cache backend URIs.
- Propagate cache backend settings to executor-side read and write paths.
- Support registering a preconfigured Java `Session` through `LanceRuntime.registerSession`.
- Upgrade Lance Core to `11.0.0-beta.10`.
- Add documentation and integration tests for backend registration and switching.

## Testing

- `./mvnw spotless:check checkstyle:check`
- Cache backend and configuration tests
- `SparkConnectorReadTest`
- Spark 3.4/3.5 compilation with Scala 2.12 and 2.13

Spark 4.x compilation was not run locally because it requires JDK 17, while the current environment has JDK 11.