### PR TITLE
fix: treat empty DataFrame writes as noop on immediate-commit path

### DIFF
--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2115,6 +2115,33 @@ class TestDMLInsert:
 
         assert spark.read.format("lance").load(str(tmp_path)).count() == 0
 
+    def test_append_empty_dataframe_to_existing_path_is_noop(self, spark, tmp_path):
+        """Empty DataFrame append to an existing Lance path must be a noop (not raise).
+
+        Regression guard for the immediate-append path: ``empty_df.write.format('lance')
+        .mode('append').save(path)`` against an existing Lance table must route through
+        ``LanceBatchWrite.commit()`` (immediate-commit path, ``stagedCommit == null``),
+        hit the empty-append guard, and return without raising. Seed rows must remain
+        unchanged.
+        """
+        from pyspark.sql.types import StructType, StructField, IntegerType
+
+        schema = StructType([StructField("id", IntegerType())])
+
+        # Step 1: Seed an existing Lance path with 3 rows.
+        rows = spark.createDataFrame([(1,), (2,), (3,)], schema)
+        rows.write.format("lance").save(str(tmp_path))
+        assert spark.read.format("lance").load(str(tmp_path)).count() == 3
+
+        # Step 2: empty append to the existing path — this exercises
+        # LanceBatchWrite.commit() with stagedCommit == null and !isOverwrite,
+        # hitting the new guard.
+        empty_df = spark.createDataFrame([], schema)
+        empty_df.write.format("lance").mode("append").save(str(tmp_path))
+
+        # Step 3: existing rows remain unchanged.
+        assert spark.read.format("lance").load(str(tmp_path)).count() == 3
+
 
 @requires_update_or_merge
 class TestDMLUpdate:

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2075,6 +2075,27 @@ class TestDMLInsert:
         count = spark.table("default.test_table").count()
         assert count == 4
 
+    def test_write_empty_dataframe_is_noop(self, spark, tmp_path):
+        """Empty DataFrame writes should succeed as a noop rather than raise.
+
+        Repro for empty upstream in a Spark pipeline: a filter/aggregate that
+        produces zero rows followed by ``df.write.format('lance').save(...)``
+        used to fail with ``IllegalArgumentException: fragments cannot be null
+        or empty``. Per Spark sink contract, the write should succeed silently
+        (no table is created when there is no data to commit).
+        """
+        from pyspark.sql.types import StructType, StructField, IntegerType, StringType
+
+        schema = StructType(
+            [StructField("id", IntegerType()), StructField("name", StringType())]
+        )
+        empty_df = spark.createDataFrame([], schema)
+
+        # Empty df must not raise; this exercises LanceBatchWrite.commit
+        # directly via the v1 DataFrameWriter API path. No table should be
+        # created because there is nothing to commit.
+        empty_df.write.format("lance").save(str(tmp_path))
+
 
 @requires_update_or_merge
 class TestDMLUpdate:

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2096,6 +2096,25 @@ class TestDMLInsert:
         # created because there is nothing to commit.
         empty_df.write.format("lance").save(str(tmp_path))
 
+    def test_write_empty_dataframe_overwrite_clears_table(self, spark, tmp_path):
+        """Empty DataFrame overwrite on a populated table must truncate (not raise, not no-op).
+
+        Regression guard for the immediate-commit path: an empty overwrite still goes through
+        Overwrite.builder() so the table is truncated and the pinned-version transaction is
+        recorded, matching what mode("overwrite").save(...) expects.
+        """
+        from pyspark.sql.types import StructType, StructField, IntegerType
+
+        schema = StructType([StructField("id", IntegerType())])
+        rows = spark.createDataFrame([(1,), (2,), (3,)], schema)
+        rows.write.format("lance").save(str(tmp_path))
+        assert spark.read.format("lance").load(str(tmp_path)).count() == 3
+
+        empty_df = spark.createDataFrame([], schema)
+        empty_df.write.format("lance").mode("overwrite").save(str(tmp_path))
+
+        assert spark.read.format("lance").load(str(tmp_path)).count() == 0
+
 
 @requires_update_or_merge
 class TestDMLUpdate:

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -163,6 +163,14 @@ public class LanceBatchWrite implements BatchWrite {
             .flatMap(List::stream)
             .collect(Collectors.toList());
 
+    // Spark sink contract: empty DataFrame writes should be a noop (not raise).
+    // Lance-Java Append rejects empty fragments, so skip building the operation.
+    // StagedCommit goes through Overwrite which does not enforce this check, so we
+    // only short-circuit the non-staged (immediate-commit) path.
+    if (stagedCommit == null && fragments.isEmpty()) {
+      return;
+    }
+
     Schema arrowSchema =
         LanceArrowUtils.toArrowSchema(schema, "UTC", true, writeOptions.isUseLargeVarTypes());
     boolean isOverwrite = overwrite || writeOptions.isOverwrite();

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/write/LanceBatchWrite.java
@@ -163,17 +163,18 @@ public class LanceBatchWrite implements BatchWrite {
             .flatMap(List::stream)
             .collect(Collectors.toList());
 
-    // Spark sink contract: empty DataFrame writes should be a noop (not raise).
-    // Lance-Java Append rejects empty fragments, so skip building the operation.
-    // StagedCommit goes through Overwrite which does not enforce this check, so we
-    // only short-circuit the non-staged (immediate-commit) path.
-    if (stagedCommit == null && fragments.isEmpty()) {
-      return;
-    }
-
     Schema arrowSchema =
         LanceArrowUtils.toArrowSchema(schema, "UTC", true, writeOptions.isUseLargeVarTypes());
     boolean isOverwrite = overwrite || writeOptions.isOverwrite();
+
+    // Spark sink contract: empty immediate append writes should be a noop (not raise).
+    // Lance-Java Append rejects empty fragments, so skip building the operation.
+    // StagedCommit goes through Overwrite which does not enforce this check, so we
+    // only short-circuit the non-staged path. Empty overwrites must still go through
+    // Overwrite.builder() so the table is truncated and OCC is enforced.
+    if (stagedCommit == null && !isOverwrite && fragments.isEmpty()) {
+      return;
+    }
 
     // Boxed: null means unset (inherit in lance-core); see LanceSparkWriteOptions.
     final Boolean enableStableRowIds = writeOptions.getEnableStableRowIds();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -121,6 +121,59 @@ public class LanceBatchWriteTest {
     }
   }
 
+  /**
+   * Empty overwrite on a populated table must still go through {@code Overwrite.builder()} so the
+   * table is truncated (rows removed) and the pinned-version transaction is recorded. Guards
+   * against over-broad short-circuits that would leave stale rows in place.
+   */
+  @Test
+  public void testCommitEmptyOverwriteTruncatesTable(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Collections.singletonList(field));
+      StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+      LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+
+      // Seed the table with 10 rows via the standard writeRows helper.
+      Dataset.create(allocator, datasetUri, schema, new WriteParams.Builder().build()).close();
+      LanceBatchWrite seedWriter =
+          new LanceBatchWrite(
+              sparkSchema,
+              writeOptions,
+              false,
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null, // tableId
+              false, // managedVersioning
+              null); // stagedCommit (null -> immediate-commit path)
+      seedWriter.commit(new WriterCommitMessage[] {writeRows(seedWriter, sparkSchema, 10, 0)});
+      try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+        assertEquals(10, dataset.countRows());
+      }
+
+      // Empty overwrite must go through Overwrite.builder() and clear the rows.
+      LanceBatchWrite overwriteWriter =
+          new LanceBatchWrite(
+              sparkSchema,
+              writeOptions,
+              true, // overwrite=true
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null, // tableId
+              false, // managedVersioning
+              null); // stagedCommit (null -> immediate-commit path)
+      overwriteWriter.commit(new WriterCommitMessage[0]);
+
+      try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+        assertEquals(0, dataset.countRows());
+      }
+    }
+  }
+
   @Test
   public void testLanceDataWriter(TestInfo testInfo) throws Exception {
     String datasetName = testInfo.getTestMethod().get().getName();

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/write/LanceBatchWriteTest.java
@@ -51,6 +51,76 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class LanceBatchWriteTest {
   @TempDir static Path tempDir;
 
+  /**
+   * Empty DataFrame writes should be a noop on the immediate-commit path: when a Spark DataFrame
+   * pipeline produces zero rows, {@code df.write.format("lance").save(uri)} used to fail with
+   * {@code IllegalArgumentException: fragments cannot be null or empty}. Per the Spark sink
+   * contract, the write should succeed silently.
+   */
+  @Test
+  public void testCommitEmptyFragmentsIsNoop(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+    try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Schema schema = new Schema(Collections.singletonList(field));
+      Dataset.create(allocator, datasetUri, schema, new WriteParams.Builder().build()).close();
+
+      LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+      StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+      LanceBatchWrite lanceBatchWrite =
+          new LanceBatchWrite(
+              sparkSchema,
+              writeOptions,
+              false,
+              null, // initialStorageOptions
+              null, // namespaceImpl
+              null, // namespaceProperties
+              null, // tableId
+              false, // managedVersioning
+              null); // stagedCommit (null -> immediate-commit path)
+      lanceBatchWrite.commit(new WriterCommitMessage[0]);
+    }
+  }
+
+  /**
+   * Empty DataFrame writes go through the staged path: {@link LanceBatchWrite#commit} should
+   * populate the {@link StagedCommit} without raising, and the subsequent {@link
+   * StagedCommit#commit()} should succeed at creating an empty table (path-based staged create).
+   */
+  @Test
+  public void testCommitEmptyFragmentsStagedIsNoop(TestInfo testInfo) throws Exception {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String datasetUri = TestUtils.getDatasetUri(tempDir.toString(), datasetName);
+
+    Field field = new Field("column1", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    Schema schema = new Schema(Collections.singletonList(field));
+    StructType sparkSchema = LanceArrowUtils.fromArrowSchema(schema);
+    LanceSparkWriteOptions writeOptions = LanceSparkWriteOptions.from(datasetUri);
+
+    StagedCommit stagedCommit =
+        StagedCommit.forNewTable(
+            schema, datasetUri, StagedCommitOptions.pathBased(Collections.emptyMap(), false, null));
+
+    LanceBatchWrite batchWrite =
+        new LanceBatchWrite(
+            sparkSchema,
+            writeOptions,
+            false,
+            null, // initialStorageOptions
+            null, // namespaceImpl
+            null, // namespaceProperties
+            null, // tableId
+            false, // managedVersioning
+            stagedCommit);
+
+    batchWrite.commit(new WriterCommitMessage[0]);
+    stagedCommit.commit();
+    try (Dataset dataset = Dataset.open(datasetUri, LanceRuntime.allocator())) {
+      assertEquals(0, dataset.countRows());
+    }
+  }
+
   @Test
   public void testLanceDataWriter(TestInfo testInfo) throws Exception {
     String datasetName = testInfo.getTestMethod().get().getName();


### PR DESCRIPTION
## Summary

When a Spark DataFrame pipeline produces zero rows upstream, `df.write.format("lance").save(uri)` currently fails with `IllegalArgumentException: fragments cannot be null or empty`. This PR makes the immediate-commit path of `LanceBatchWrite.commit()` a no-op on empty fragments.

The staged-commit path (Spark v2 DataFrameWriter's CTAS-style API, i.e. `df.writeTo("t").create()`) already accepts empty fragments via `Operation::Overwrite` and is the canonical way to create an empty table — that path is intentionally left untouched.

## Fix

Short-circuit `LanceBatchWrite.commit()` on the immediate-commit path:

```java
// Spark sink contract: empty immediate append writes should be a noop (not raise).
// Lance-Java Append rejects empty fragments, so skip building the operation.
// StagedCommit goes through Overwrite which does not enforce this check, so we
// only short-circuit the non-staged path. Empty overwrites must still go through
// Overwrite.builder() so the table is truncated and OCC is enforced.
if (stagedCommit == null && !isOverwrite && fragments.isEmpty()) {
  return;
}
```

## Tests

- `LanceBatchWriteTest.testCommitEmptyFragmentsIsNoop` — unit test reproducing the bug on the immediate-commit path.
- `LanceBatchWriteTest.testCommitEmptyFragmentsStagedIsNoop` — unit test guarding the staged-commit path (path-based staged create of an empty table).
- `LanceBatchWriteTest.testCommitEmptyOverwriteTruncatesTable` — regression guard for the empty overwrite truncate path.
- `integration-tests/test_lance_spark.py::TestDMLInsert::test_write_empty_dataframe_is_noop` — pyspark end-to-end test mirroring the original repro.
- `integration-tests/test_lance_spark.py::TestDMLInsert::test_write_empty_dataframe_overwrite_clears_table` — pyspark end-to-end test for the empty overwrite truncate (local filesystem backend).
- `integration-tests/test_lance_spark.py::TestDMLInsert::test_append_empty_dataframe_to_existing_path_is_noop` — pyspark end-to-end test exercising the immediate-append guard on an existing Lance path (seed → empty append → seed rows unchanged).

Validation:
- `LanceBatchWriteTest`: 586 / 586 tests pass on `lance-spark-base_2.12`.
- `spotless:check` / `checkstyle:check` clean.
- `git diff --check` clean.
- Manually reverted the fix to confirm `testCommitEmptyFragmentsIsNoop` fails with the same `IllegalArgumentException` (`fragments cannot be null or empty`) at `LanceBatchWrite.commit` → `Append.<init>` (the `Preconditions.checkArgument(!isEmpty())` guard), matching the original bug report.

## Diff

```
 integration-tests/test_lance_spark.py              |  67 +++++++++++
 .../org/lance/spark/write/LanceBatchWrite.java     |   9 ++
 .../org/lance/spark/write/LanceBatchWriteTest.java | 123 +++++++++++++++++++++
 3 files changed, 80 insertions(+), 7 deletions(-)
```

Closes #768