### PR TITLE
feat: support DQL for specific tag

### DIFF
--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -230,6 +230,12 @@ Use `VERSION AS OF` with a quoted tag name to query the snapshot referenced by a
     spark.sql("SELECT * FROM users VERSION AS OF 'release_candidate'").show();
     ```
 
+!!! note
+    Tags whose names consist entirely of integer digits cannot be queried. Numeric values are
+    interpreted as table versions, even when quoted. For example, both `VERSION AS OF 123` and
+    `VERSION AS OF '123'` query table version 123 rather than a tag named `123`. Use a tag name that
+    contains at least one non-digit character.
+
 Tag queries are read-only. `UPDATE`, `DELETE`, `INSERT`, `MERGE INTO`, `ADD COLUMNS`, and
 `UPDATE COLUMNS` operations cannot target a tagged snapshot.
 

--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -199,6 +199,40 @@ Use `VERSION AS OF` to query a specific version of the table:
     df.show();
     ```
 
+### Query by Tag
+
+Use `VERSION AS OF` with a quoted tag name to query the snapshot referenced by a tag:
+
+=== "SQL"
+    ```sql
+    -- Query the snapshot referenced by the release_candidate tag
+    SELECT * FROM users VERSION AS OF 'release_candidate';
+
+    -- Query specific columns from a tagged snapshot
+    SELECT id, name FROM users VERSION AS OF 'v1.0';
+    ```
+
+=== "Python"
+    ```python
+    # Query a tag using SQL
+    spark.sql("SELECT * FROM users VERSION AS OF 'release_candidate'").show()
+    ```
+
+=== "Scala"
+    ```scala
+    // Query a tag using SQL
+    spark.sql("SELECT * FROM users VERSION AS OF 'release_candidate'").show()
+    ```
+
+=== "Java"
+    ```java
+    // Query a tag using SQL
+    spark.sql("SELECT * FROM users VERSION AS OF 'release_candidate'").show();
+    ```
+
+Tag queries are read-only. `UPDATE`, `DELETE`, `INSERT`, `MERGE INTO`, `ADD COLUMNS`, and
+`UPDATE COLUMNS` operations cannot target a tagged snapshot.
+
 ### Query by Timestamp
 
 Use `TIMESTAMP AS OF` to query the table as it existed at a specific point in time:

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2702,6 +2702,49 @@ class TestDQLTimeTravel:
         assert len(result) == 1
         assert result[0].id == 1
 
+    def test_tag_as_of_excludes_data_inserted_after_tag_creation(self, spark):
+        """Test that a tag remains on its snapshot after the main table advances."""
+        spark.sql("""
+            CREATE TABLE default.test_table (
+                id INT,
+                name STRING
+            )
+        """)
+        spark.sql("""
+            INSERT INTO default.test_table VALUES
+            (1, 'before_tag_1'),
+            (2, 'before_tag_2')
+        """)
+        spark.sql("ALTER TABLE default.test_table CREATE TAG stable")
+
+        spark.sql("""
+            INSERT INTO default.test_table VALUES
+            (3, 'after_tag_1'),
+            (4, 'after_tag_2')
+        """)
+
+        tagged = spark.sql("""
+            SELECT id, name
+            FROM default.test_table VERSION AS OF 'stable'
+            ORDER BY id
+        """).collect()
+        current = spark.sql("""
+            SELECT id, name
+            FROM default.test_table
+            ORDER BY id
+        """).collect()
+
+        assert [(row.id, row.name) for row in tagged] == [
+            (1, "before_tag_1"),
+            (2, "before_tag_2"),
+        ]
+        assert [(row.id, row.name) for row in current] == [
+            (1, "before_tag_1"),
+            (2, "before_tag_2"),
+            (3, "after_tag_1"),
+            (4, "after_tag_2"),
+        ]
+
     @requires_update_or_merge
     def test_version_as_of_after_update(self, spark):
         """Test VERSION AS OF returns data before an update."""

--- a/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
+++ b/lance-spark-3.4_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
@@ -74,6 +74,7 @@ public class LancePositionDeltaDataset extends LanceDataset implements SupportsR
   @Override
   public RowLevelOperationBuilder newRowLevelOperationBuilder(
       RowLevelOperationInfo rowLevelOperationInfo) {
+    ensureWritable();
     return new LanceRowLevelOperationBuilder(
         rowLevelOperationInfo.command(),
         sparkSchema,

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/tag/TagDQLTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/tag/TagDQLTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.tag;
+
+public class TagDQLTest extends BaseTagDQLTest {}

--- a/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
+++ b/lance-spark-3.5_2.12/src/main/java/org/lance/spark/LancePositionDeltaDataset.java
@@ -74,6 +74,7 @@ public class LancePositionDeltaDataset extends LanceDataset implements SupportsR
   @Override
   public RowLevelOperationBuilder newRowLevelOperationBuilder(
       RowLevelOperationInfo rowLevelOperationInfo) {
+    ensureWritable();
     return new LanceRowLevelOperationBuilder(
         rowLevelOperationInfo.command(),
         sparkSchema,

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/tag/TagDQLTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/tag/TagDQLTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.tag;
+
+public class TagDQLTest extends BaseTagDQLTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -1653,6 +1653,14 @@ public abstract class BaseLanceNamespaceSparkCatalog
     }
   }
 
+  private LanceRef parseVersionRef(String version) {
+    try {
+      return LanceRef.ofMain(Utils.parseVersion(version));
+    } catch (NumberFormatException e) {
+      return LanceRef.ofTag(version);
+    }
+  }
+
   private Table loadTableInternal(
       Identifier ident, Optional<Long> timestamp, Optional<String> version)
       throws NoSuchTableException {
@@ -1666,31 +1674,21 @@ public abstract class BaseLanceNamespaceSparkCatalog
     DescribeTableResponse describeResponse = resolved.describeResponse;
     Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
 
-    Optional<Long> versionId = Optional.empty();
+    Optional<LanceRef> ref = Optional.empty();
     if (timestamp.isPresent()) {
       try (Dataset dataset = Utils.openDatasetBuilder(resolved.readOptions).build()) {
-        versionId = Optional.of(Utils.findVersion(dataset.listVersions(), timestamp.get()));
+        ref =
+            Optional.of(
+                LanceRef.ofMain(Utils.findVersion(dataset.listVersions(), timestamp.get())));
       } catch (TableNotFoundException e) {
         throw new NoSuchTableException(ident);
       }
     } else if (version.isPresent()) {
-      versionId = Optional.of(Utils.parseVersion(version.get()));
+      ref = Optional.of(parseVersionRef(version.get()));
     }
 
-    // If time travel requested, rebuild readOptions with the resolved version
-    LanceSparkReadOptions readOptions;
-    if (versionId.isPresent()) {
-      readOptions =
-          createReadOptions(
-              describeResponse.getLocation(),
-              catalogConfig,
-              versionId,
-              Optional.of(namespace),
-              Optional.of(resolved.tableIdList),
-              name);
-    } else {
-      readOptions = resolved.readOptions;
-    }
+    LanceSparkReadOptions readOptions =
+        ref.isPresent() ? resolved.readOptions.withRef(ref.get()) : resolved.readOptions;
 
     // Read schema, file format version, and config from the dataset
     String fileFormatVersion;
@@ -1749,28 +1747,24 @@ public abstract class BaseLanceNamespaceSparkCatalog
       throws NoSuchTableException {
     String datasetUri = getDatasetUri(ident);
 
-    Optional<Long> versionId = Optional.empty();
+    LanceSparkReadOptions baseReadOptions =
+        createReadOptions(
+            datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
+    Optional<LanceRef> ref = Optional.empty();
     if (version.isPresent()) {
-      versionId = Optional.of(Utils.parseVersion(version.get()));
+      ref = Optional.of(parseVersionRef(version.get()));
     } else if (timestamp.isPresent()) {
-      LanceSparkReadOptions readOptions =
-          createReadOptions(
-              datasetUri,
-              catalogConfig,
-              Optional.empty(),
-              Optional.empty(),
-              Optional.empty(),
-              name);
-      try (Dataset dataset = Utils.openDatasetBuilder(readOptions).build()) {
-        versionId = Optional.of(Utils.findVersion(dataset.listVersions(), timestamp.get()));
+      try (Dataset dataset = Utils.openDatasetBuilder(baseReadOptions).build()) {
+        ref =
+            Optional.of(
+                LanceRef.ofMain(Utils.findVersion(dataset.listVersions(), timestamp.get())));
       } catch (IllegalArgumentException e) {
         throw new NoSuchTableException(ident);
       }
     }
 
     LanceSparkReadOptions readOptions =
-        createReadOptions(
-            datasetUri, catalogConfig, versionId, Optional.empty(), Optional.empty(), name);
+        ref.isPresent() ? baseReadOptions.withRef(ref.get()) : baseReadOptions;
 
     // Read schema, file format version, and config from the dataset
     String fileFormatVersion;

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -56,6 +56,9 @@ public class LanceDataset
 
   private static final Logger LOG = LoggerFactory.getLogger(LanceDataset.class);
 
+  private static final Set<TableCapability> READ_ONLY_CAPABILITIES =
+      ImmutableSet.of(TableCapability.BATCH_READ);
+
   private static final Set<TableCapability> CAPABILITIES =
       ImmutableSet.of(
           TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.TRUNCATE);
@@ -321,6 +324,7 @@ public class LanceDataset
               .indexCacheBackend(readOptions.getIndexCacheBackend())
               .metadataCacheBackend(readOptions.getMetadataCacheBackend())
               .fromOptions(mergedOptions)
+              .ref(readOptions.getRef())
               .build();
     }
     return new LanceScanBuilder(
@@ -354,11 +358,26 @@ public class LanceDataset
 
   @Override
   public Set<TableCapability> capabilities() {
+    if (isTagReference()) {
+      return READ_ONLY_CAPABILITIES;
+    }
     return BlobUtils.hasBlobV2Fields(sparkSchema) ? CAPABILITIES_WITH_BLOB_V2 : CAPABILITIES;
+  }
+
+  protected void ensureWritable() {
+    if (isTagReference()) {
+      throw new UnsupportedOperationException(
+          "Writes are not supported for tag: " + readOptions.getRef().getTagName().get());
+    }
+  }
+
+  private boolean isTagReference() {
+    return readOptions.getRef() != null && readOptions.getRef().getTagName().isPresent();
   }
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
+    ensureWritable();
     if (capabilities().contains(TableCapability.ACCEPT_ANY_SCHEMA)) {
       LanceWriteSchemaValidator.validate(sparkSchema, logicalWriteInfo.schema());
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -176,9 +176,7 @@ public class LanceScanBuilder
       // partition). A full-text query without a namespace, or against a catalog-only namespace such
       // as Glue that does not implement queryTable, falls through to the local per-fragment scan
       // below. COUNT(*) is excluded because countTableRows has no full-text field.
-      if (readOptions.getFullTextQuery() != null
-          && LanceRuntime.supportsQueryTable(namespaceImpl)
-          && !pushedAggregation.isPresent()) {
+      if (shouldNamespaceFtsScan()) {
         return buildNamespaceFtsScan();
       }
 
@@ -296,6 +294,19 @@ public class LanceScanBuilder
     } finally {
       closeLazyDataset();
     }
+  }
+
+  boolean shouldNamespaceFtsScan() {
+    LanceRef ref = readOptions.getRef();
+    boolean hasTag = ref != null && ref.getTagName().isPresent();
+    if (hasTag) {
+      return false;
+    }
+
+    return readOptions.getFullTextQuery() != null
+        && LanceRuntime.supportsQueryTable(namespaceImpl)
+        && !pushedAggregation.isPresent()
+        && !hasTag;
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -266,9 +266,8 @@ public class LanceScanBuilder
       // the resolved version onto the read options shipped to workers, providing snapshot
       // isolation across all tasks of this query. The version is kept as a long end-to-end so
       // long-lived high-write-frequency datasets do not silently truncate to a wrong version.
-      LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset);
-      LanceSparkReadOptions resolvedReadOptions =
-          readOptions.withRef(LanceRef.ofMain(scanPlan.getResolvedVersion()));
+      LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset, readOptions);
+      LanceSparkReadOptions resolvedReadOptions = readOptions.withRef(scanPlan.getRef());
 
       Optional<String> whereCondition =
           FilterPushDown.compileFiltersToSqlWhereClause(pushedPredicates);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -15,6 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.Dataset;
 import org.lance.Fragment;
+import org.lance.Tag;
 import org.lance.spark.LanceRef;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Utils;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 public class LanceSplit implements Serializable {
   private static final long serialVersionUID = 2983749283749283749L;
@@ -104,6 +106,21 @@ public class LanceSplit implements Serializable {
     LanceRef ref = readOptions.getRef();
     if (ref != null && ref.getBranchName().isPresent()) {
       plannedRef = LanceRef.ofBranch(ref.getBranchName().get(), dataset.getVersion().getId());
+    } else if (ref != null && ref.getTagName().isPresent()) {
+      Optional<Tag> tag =
+          dataset.tags().list().stream()
+              .filter(t -> t.getName().equals(ref.getTagName().get()))
+              .findFirst();
+      if (tag.isEmpty()) {
+        throw new RuntimeException("No existed tag with name:" + ref.getTagName().get());
+      }
+
+      Optional<String> tagBranch = tag.get().getBranch();
+      if (tagBranch.isEmpty()) {
+        plannedRef = LanceRef.ofMain(dataset.getVersion().getId());
+      } else {
+        plannedRef = LanceRef.ofBranch(tagBranch.get(), dataset.version());
+      }
     } else {
       plannedRef = LanceRef.ofMain(dataset.getVersion().getId());
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -99,12 +99,16 @@ public class LanceSplit implements Serializable {
       fragmentRowCounts.put(id, fragment.metadata().getNumRows());
     }
 
+    LanceRef plannedRef;
+
     LanceRef ref = readOptions.getRef();
-    if (ref == null || (ref.getTagName().isEmpty() && ref.getBranchName().isEmpty())) {
-      ref = LanceRef.ofMain(dataset.getVersion().getId());
+    if (ref != null && ref.getBranchName().isPresent()) {
+      plannedRef = LanceRef.ofBranch(ref.getBranchName().get(), dataset.getVersion().getId());
+    } else {
+      plannedRef = LanceRef.ofMain(dataset.getVersion().getId());
     }
 
-    return new ScanPlanResult(splits, ref, fragmentRowCounts);
+    return new ScanPlanResult(splits, plannedRef, fragmentRowCounts);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -15,6 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.Dataset;
 import org.lance.Fragment;
+import org.lance.spark.LanceRef;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Utils;
 
@@ -41,15 +42,15 @@ public class LanceSplit implements Serializable {
   /** Result of scan planning containing splits, resolved version, and per-fragment row counts. */
   public static class ScanPlanResult {
     private final List<LanceSplit> splits;
-    private final long resolvedVersion;
+    private final LanceRef ref;
 
     /** Per-fragment logical row counts (after deletions). Key is fragment ID. */
     private final Map<Integer, Long> fragmentRowCounts;
 
     public ScanPlanResult(
-        List<LanceSplit> splits, long resolvedVersion, Map<Integer, Long> fragmentRowCounts) {
+        List<LanceSplit> splits, LanceRef ref, Map<Integer, Long> fragmentRowCounts) {
       this.splits = splits;
-      this.resolvedVersion = resolvedVersion;
+      this.ref = ref;
       this.fragmentRowCounts = fragmentRowCounts;
     }
 
@@ -57,8 +58,8 @@ public class LanceSplit implements Serializable {
       return splits;
     }
 
-    public long getResolvedVersion() {
-      return resolvedVersion;
+    public LanceRef getRef() {
+      return ref;
     }
 
     public Map<Integer, Long> getFragmentRowCounts() {
@@ -75,7 +76,7 @@ public class LanceSplit implements Serializable {
    */
   public static ScanPlanResult planScan(LanceSparkReadOptions readOptions) {
     try (Dataset dataset = Utils.openDatasetBuilder(readOptions).build()) {
-      return planScan(dataset);
+      return planScan(dataset, readOptions);
     }
   }
 
@@ -88,7 +89,7 @@ public class LanceSplit implements Serializable {
    *
    * <p>The caller retains ownership of the dataset; this method does not close it.
    */
-  public static ScanPlanResult planScan(Dataset dataset) {
+  public static ScanPlanResult planScan(Dataset dataset, LanceSparkReadOptions readOptions) {
     List<Fragment> fragments = dataset.getFragments();
     List<LanceSplit> splits = new ArrayList<>(fragments.size());
     Map<Integer, Long> fragmentRowCounts = new HashMap<>(fragments.size());
@@ -97,8 +98,13 @@ public class LanceSplit implements Serializable {
       splits.add(new LanceSplit(Collections.singletonList(id)));
       fragmentRowCounts.put(id, fragment.metadata().getNumRows());
     }
-    long resolvedVersion = dataset.getVersion().getId();
-    return new ScanPlanResult(splits, resolvedVersion, fragmentRowCounts);
+
+    LanceRef ref = readOptions.getRef();
+    if (ref == null || (ref.getTagName().isEmpty() && ref.getBranchName().isEmpty())) {
+      ref = LanceRef.ofMain(dataset.getVersion().getId());
+    }
+
+    return new ScanPlanResult(splits, ref, fragmentRowCounts);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Optional.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Optional.java
@@ -80,8 +80,4 @@ public class Optional<T> implements Serializable {
     Optional<?> other = (Optional<?>) obj;
     return Objects.equals(value, other.value);
   }
-
-  public boolean gett() {
-    return false;
-  }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Optional.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Optional.java
@@ -80,4 +80,8 @@ public class Optional<T> implements Serializable {
     Optional<?> other = (Optional<?>) obj;
     return Objects.equals(value, other.value);
   }
+
+  public boolean gett() {
+    return false;
+  }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -15,6 +15,7 @@ package org.lance.spark.utils;
 
 import org.lance.Dataset;
 import org.lance.ReadOptions;
+import org.lance.Ref;
 import org.lance.Version;
 import org.lance.namespace.LanceNamespace;
 import org.lance.spark.LanceRef;
@@ -129,6 +130,30 @@ public class Utils {
     }
 
     public Dataset build() {
+      if (ref != null && (ref.getTagName().isPresent() || ref.getBranchName().isPresent())) {
+        // Open specific tag or branch/version
+        Dataset main = openMain(null);
+        try {
+          if (ref.getTagName().isPresent()) {
+            return main.checkout(Ref.ofTag(ref.getTagName().get()));
+          } else {
+            return ref.getVersionNumber().isPresent()
+                ? main.checkout(
+                    Ref.ofBranch(ref.getBranchName().get(), ref.getVersionNumber().get()))
+                : main.checkout(Ref.ofBranch(ref.getBranchName().get()));
+          }
+        } finally {
+          main.close();
+        }
+      } else {
+        return openMain(
+            ref != null && ref.getVersionNumber().isPresent()
+                ? ref.getVersionNumber().get()
+                : null);
+      }
+    }
+
+    private Dataset openMain(Long version) {
       LanceRuntime.enableOpenTelemetry();
 
       Map<String, String> base = storageOptions != null ? storageOptions : Collections.emptyMap();
@@ -139,8 +164,8 @@ public class Utils {
               .setStorageOptions(merged)
               .setSession(
                   LanceRuntime.session(catalogName, indexCacheBackend, metadataCacheBackend));
-      if (ref != null && ref.getVersionNumber().isPresent()) {
-        builder.setVersion(ref.getVersionNumber().get());
+      if (version != null) {
+        builder.setVersion(version);
       }
       if (blockSize != null) {
         builder.setBlockSize(blockSize);
@@ -152,17 +177,7 @@ public class Utils {
         builder.setMetadataCacheSize(metadataCacheSize);
       }
 
-      Dataset dataset = open(builder.build());
-
-      if (ref != null && ref.getTagName().isPresent()) {
-        Dataset baseDataset = dataset;
-        try {
-          dataset = baseDataset.checkoutTag(ref.getTagName().get());
-        } finally {
-          baseDataset.close();
-        }
-      }
-      return dataset;
+      return open(builder.build());
     }
 
     private Dataset open(ReadOptions readOptions) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -134,30 +134,44 @@ public class Utils {
       Map<String, String> base = storageOptions != null ? storageOptions : Collections.emptyMap();
       Map<String, String> merged = LanceRuntime.mergeStorageOptions(base, initialStorageOptions);
 
-      ReadOptions.Builder roBuilder =
+      ReadOptions.Builder builder =
           new ReadOptions.Builder()
               .setStorageOptions(merged)
               .setSession(
                   LanceRuntime.session(catalogName, indexCacheBackend, metadataCacheBackend));
-      if (ref != null) {
-        ref.getVersionNumber().ifPresent(roBuilder::setVersion);
+      if (ref != null && ref.getVersionNumber().isPresent()) {
+        builder.setVersion(ref.getVersionNumber().get());
       }
       if (blockSize != null) {
-        roBuilder.setBlockSize(blockSize);
+        builder.setBlockSize(blockSize);
       }
       if (indexCacheSize != null) {
-        roBuilder.setIndexCacheSize(indexCacheSize);
+        builder.setIndexCacheSize(indexCacheSize);
       }
       if (metadataCacheSize != null) {
-        roBuilder.setMetadataCacheSize(metadataCacheSize);
+        builder.setMetadataCacheSize(metadataCacheSize);
       }
 
+      Dataset dataset = open(builder.build());
+
+      if (ref != null && ref.getTagName().isPresent()) {
+        Dataset baseDataset = dataset;
+        try {
+          dataset = baseDataset.checkoutTag(ref.getTagName().get());
+        } finally {
+          baseDataset.close();
+        }
+      }
+      return dataset;
+    }
+
+    private Dataset open(ReadOptions readOptions) {
       if (namespace != null && tableId != null) {
         return Dataset.open()
             .allocator(LanceRuntime.allocator())
             .namespaceClient(namespace)
             .tableId(tableId)
-            .readOptions(roBuilder.build())
+            .readOptions(readOptions)
             .build();
       }
       if (runtimeNamespaceImpl != null) {
@@ -169,14 +183,14 @@ public class Utils {
               .allocator(LanceRuntime.allocator())
               .namespaceClient(runtimeNamespace)
               .tableId(effectiveTableId)
-              .readOptions(roBuilder.build())
+              .readOptions(readOptions)
               .build();
         }
       }
       return Dataset.open()
           .allocator(LanceRuntime.allocator())
           .uri(uri)
-          .readOptions(roBuilder.build())
+          .readOptions(readOptions)
           .build();
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
@@ -13,6 +13,7 @@
  */
 package org.lance.spark.read;
 
+import org.lance.ipc.FullTextQuery;
 import org.lance.spark.LanceRef;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
@@ -352,6 +353,21 @@ public class LanceScanBuilderTest {
     LanceRef pinned = first.getReadOptions().getRef();
     assertNotNull(pinned, "build() must pin the resolved version onto readOptions");
     assertTrue(pinned.getVersionNumber().get() > 0);
+  }
+
+  @Test
+  public void testTagFullTextQueryDoesNotUseNamespaceScan() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri(TestUtils.TestTable1Config.datasetUri)
+            .ref(LanceRef.ofTag("stable"))
+            .fullTextQuery(FullTextQuery.match("hello", "b"))
+            .build();
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            TEST_SCHEMA, options, Collections.emptyMap(), "dir", Collections.emptyMap());
+
+    assertFalse(builder.shouldNamespaceFtsScan());
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceSplitTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceSplitTest.java
@@ -14,6 +14,7 @@
 package org.lance.spark.read;
 
 import org.lance.Dataset;
+import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
 import org.lance.spark.utils.Utils;
 
@@ -29,7 +30,7 @@ public class LanceSplitTest {
   public void testPlanScanReturnsNonEmptySplits() {
     LanceSplit.ScanPlanResult result = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
     assertFalse(result.getSplits().isEmpty());
-    assertTrue(result.getResolvedVersion() > 0);
+    assertTrue(result.getRef().getVersionNumber().get() > 0);
   }
 
   @Test
@@ -58,15 +59,16 @@ public class LanceSplitTest {
   }
 
   /**
-   * Contract test: {@link LanceSplit#planScan(Dataset)} must not close the externally-owned dataset
-   * handle. {@link LanceScanBuilder#build()} relies on this so it can keep using the single open
-   * handle for both manifest/zonemap loading and split planning.
+   * Contract test: {@link LanceSplit#planScan(Dataset, LanceSparkReadOptions)} must not close the
+   * externally-owned dataset handle. {@link LanceScanBuilder#build()} relies on this so it can keep
+   * using the single open handle for both manifest/zonemap loading and split planning.
    */
   @Test
   public void testPlanScanWithDatasetDoesNotCloseExternalDataset() {
     try (Dataset dataset =
         Utils.openDatasetBuilder(TestUtils.TestTable1Config.readOptions).build()) {
-      LanceSplit.ScanPlanResult result = LanceSplit.planScan(dataset);
+      LanceSplit.ScanPlanResult result =
+          LanceSplit.planScan(dataset, TestUtils.TestTable1Config.readOptions);
       assertFalse(result.getSplits().isEmpty());
 
       // If planScan(Dataset) accidentally closed the handle, subsequent native calls would
@@ -77,15 +79,15 @@ public class LanceSplitTest {
   }
 
   /**
-   * Contract test: the long-typed resolved version returned by {@link LanceSplit#planScan(Dataset)}
-   * must round-trip through {@link org.lance.spark.LanceSparkReadOptions} as a LanceRef without
-   * truncation. This guards against silently casting to {@code int}, which would corrupt the
-   * snapshot-isolation guarantee for long-lived high-write-frequency datasets.
+   * Contract test: the long-typed resolved version returned by {@link LanceSplit#planScan(Dataset,
+   * LanceSparkReadOptions)} must round-trip through {@link org.lance.spark.LanceSparkReadOptions}
+   * as a LanceRef without truncation. This guards against silently casting to {@code int}, which
+   * would corrupt the snapshot-isolation guarantee for long-lived high-write-frequency datasets.
    */
   @Test
   public void testResolvedVersionRoundTripsAsLong() {
     LanceSplit.ScanPlanResult result = LanceSplit.planScan(TestUtils.TestTable1Config.readOptions);
-    long resolved = result.getResolvedVersion();
+    long resolved = result.getRef().getVersionNumber().get();
     assertEquals(
         resolved,
         TestUtils.TestTable1Config.readOptions

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
@@ -97,6 +97,27 @@ public abstract class BaseTagDQLTest {
   }
 
   @Test
+  public void testQueryTagCreatedFromBranchAfterMainAdvances() {
+    spark.sql(String.format("create table %s (id int, text string) using lance", fullTable));
+    insertRange(0, 5);
+
+    String branch = "source_branch";
+    String tag = "branch_snapshot";
+    spark.sql(String.format("alter table %s create branch %s", fullTable, branch));
+    spark.sql(
+        String.format("alter table %s create tag %s as of branch %s", fullTable, tag, branch));
+
+    insertRange(5, 10);
+
+    String taggedTable = String.format("%s version as of '%s'", fullTable, tag);
+    Assertions.assertEquals(5, spark.sql("select * from " + taggedTable).count());
+    Assertions.assertEquals(
+        0, spark.sql("select * from " + taggedTable + " where id >= 5").count());
+    Assertions.assertEquals(10, spark.table(fullTable).count());
+    Assertions.assertEquals(5, spark.sql("select * from " + fullTable + " where id >= 5").count());
+  }
+
+  @Test
   public void testQueryNonexistentTagThrowsException() {
     spark.sql(String.format("create table %s (id int, text string) using lance", fullTable));
     insertRange(0, 5);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.tag;
+
+import org.lance.Ref;
+import org.lance.spark.LanceDataset;
+import org.lance.spark.LanceRef;
+
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** Base tests for querying tagged table snapshots. */
+public abstract class BaseTagDQLTest {
+  private static final String CATALOG_NAME = "lance_test";
+
+  private SparkSession spark;
+  private String tableName;
+  private String fullTable;
+  private String tableDir;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+    String testRoot = rootPath.toString();
+    spark =
+        SparkSession.builder()
+            .appName("lance-tag-dql-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + CATALOG_NAME, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".impl", "dir")
+            .config("spark.sql.catalog." + CATALOG_NAME + ".root", testRoot)
+            .config("spark.sql.catalog." + CATALOG_NAME + ".single_level_ns", "true")
+            .getOrCreate();
+    tableName = "tag_dql_test_" + UUID.randomUUID().toString().replace("-", "");
+    fullTable = CATALOG_NAME + ".default." + tableName;
+    tableDir = FileSystems.getDefault().getPath(testRoot, tableName + ".lance").toString();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  @Test
+  public void testTagSnapshotDoesNotIncludeDataWrittenAfterTagCreation() {
+    spark.sql(String.format("create table %s (id int, text string) using lance", fullTable));
+    insertRange(0, 5);
+    String tag = "snapshot_before_new_data";
+    createTag(tag);
+
+    insertRange(5, 10);
+
+    String taggedTable = String.format("%s version as of '%s'", fullTable, tag);
+
+    Assertions.assertEquals(5, spark.sql("select * from " + taggedTable).count());
+    Assertions.assertEquals(
+        0, spark.sql("select * from " + taggedTable + " where id >= 5").count());
+
+    Assertions.assertEquals(10, spark.table(fullTable).count());
+    Assertions.assertEquals(5, spark.sql("select * from " + fullTable + " where id >= 5").count());
+  }
+
+  @Test
+  public void testTagTableUsesTagReferenceAndIsReadOnly() throws Exception {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(CATALOG_NAME);
+
+    Table taggedTable =
+        catalog.loadTable(
+            Identifier.of(new String[] {"default"}, tableName), versions.firstInsertTag);
+    LanceRef ref = ((LanceDataset) taggedTable).readOptions().getRef();
+
+    Assertions.assertEquals(versions.firstInsertTag, ref.getTagName().get());
+    Assertions.assertTrue(ref.getVersionNumber().isEmpty());
+    Assertions.assertEquals(
+        Collections.singleton(TableCapability.BATCH_READ), taggedTable.capabilities());
+  }
+
+  @Test
+  public void testRejectWritesToTag() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    String taggedTable = String.format("%s version as of '%s'", fullTable, versions.firstInsertTag);
+    spark.sql(
+        String.format(
+            "create temporary view tag_write_source as "
+                + "select id, text, _rowaddr, _fragid from %s",
+            taggedTable));
+
+    String[] statements = {
+      String.format("update %s set text = 'updated' where id = 0", taggedTable),
+      String.format("delete from %s where id = 0", taggedTable),
+      String.format("insert into %s values (10, 'inserted')", taggedTable),
+      String.format(
+          "merge into %s t using tag_write_source s on t.id = s.id "
+              + "when matched then update set text = s.text",
+          taggedTable),
+      String.format("alter table %s add columns copied_text from tag_write_source", taggedTable),
+      String.format("alter table %s update columns text from tag_write_source", taggedTable)
+    };
+
+    for (String statement : statements) {
+      Assertions.assertThrows(
+          Exception.class, () -> spark.sql(statement).collectAsList(), statement);
+    }
+    Assertions.assertEquals(10, spark.table(fullTable).count());
+    Assertions.assertEquals(2, spark.table(fullTable).schema().size());
+  }
+
+  private DatasetVersions prepareDatasetWithHistory() {
+    spark.sql(String.format("create table %s (id int, text string) using lance", fullTable));
+    insertRange(0, 5);
+    long firstInsertVersion = currentVersion();
+    String firstInsertTag = "tag_" + firstInsertVersion;
+    createTag(firstInsertTag);
+    insertRange(5, 10);
+    return new DatasetVersions(firstInsertTag);
+  }
+
+  private void insertRange(int startInclusive, int endExclusive) {
+    spark.sql(
+        String.format(
+            "insert into %s (id, text) values %s",
+            fullTable,
+            IntStream.range(startInclusive, endExclusive)
+                .boxed()
+                .map(i -> String.format("(%d, 'text_%d')", i, i))
+                .collect(Collectors.joining(","))));
+  }
+
+  private long currentVersion() {
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      return dataset.getVersion().getId();
+    }
+  }
+
+  private void createTag(String tag) {
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(tableDir).build()) {
+      dataset.tags().create(tag, Ref.ofMain());
+    }
+  }
+
+  private static final class DatasetVersions {
+    private final String firstInsertTag;
+
+    private DatasetVersions(String firstInsertTag) {
+      this.firstInsertTag = firstInsertTag;
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/tag/BaseTagDQLTest.java
@@ -97,6 +97,16 @@ public abstract class BaseTagDQLTest {
   }
 
   @Test
+  public void testQueryNonexistentTagThrowsException() {
+    spark.sql(String.format("create table %s (id int, text string) using lance", fullTable));
+    insertRange(0, 5);
+
+    String query = String.format("select * from %s version as of 'nonexistent_tag'", fullTable);
+
+    Assertions.assertThrows(Exception.class, () -> spark.sql(query).collectAsList());
+  }
+
+  @Test
   public void testTagTableUsesTagReferenceAndIsReadOnly() throws Exception {
     DatasetVersions versions = prepareDatasetWithHistory();
     TableCatalog catalog =


### PR DESCRIPTION
Related https://github.com/lance-format/lance-spark/issues/713

# Motivation

In some use cases, users need to run DQL against a specific tag rather than relying on the default resolution behavior. Tags are read-only. Tags could just stay on time travel.

# How to query

```SQL
SELECT * FROM lance.users VERSION AS OF 'specific_tag';
```

# Changes

* Add support for executing DQL against a specific tag.
* Enable more explicit tag-scoped reads in query workflows.
* Improve flexibility for scenarios where users need to access data from a designated tag.

# Testing

* Added/updated tests for DQL queries with a specific tag.
* Verified that existing query behavior remains unchanged when no tag is specified.
* Validated the new tag-specific query path works as expected.