### PR TITLE
feat!: show index segment count and size

### DIFF
--- a/docs/src/operations/ddl/show-indexes.md
+++ b/docs/src/operations/ddl/show-indexes.md
@@ -7,7 +7,7 @@ List all indexes defined on a Lance table.
 
 ## Overview
 
-The `SHOW INDEXES` command returns one row for each index on a Lance table. The information is retrieved using the `Dataset.describeIndices` method, and the output columns align with the attributes of `org.lance.index.IndexDescription`, excluding the per-segment metadata list.
+The `SHOW INDEXES` command returns one row for each logical index on a Lance table. It groups the raw segment metadata returned by `Dataset.getIndexes()` to calculate segment count and total size, while the existing type and coverage fields continue to come from `Dataset.getIndexStatistics(name)`.
 
 This command is useful for inspecting existing indexes, verifying index creation, and understanding the high-level properties of each index.
 
@@ -45,15 +45,17 @@ You can also use the `IN` keyword or the singular `INDEX` spelling:
 
 The `SHOW INDEXES` command returns the following columns:
 
-| Column                  | Type          | Description                                                        |
-|-------------------------|---------------|--------------------------------------------------------------------|
-| `name`                  | string        | Logical name of the index.                                         |
-| `fields`                | array<string> | List of column names included in the index.                        |
-| `index_type`            | string        | Human-readable index type (for example `btree`).                   |
-| `num_indexed_fragments` | long          | Number of fragments fully or partially covered by the index.       |
-| `num_indexed_rows`      | long          | Approximate number of rows covered by the index.                   |
-| `num_unindexed_fragments` | long        | Number of fragments that are not yet indexed.                      |
-| `num_unindexed_rows`    | long          | Approximate number of rows that are not yet covered by the index.  |
+| Column                    | Type          | Description                                                          |
+|---------------------------|---------------|----------------------------------------------------------------------|
+| `name`                    | string        | Logical name of the index.                                           |
+| `fields`                  | array<string> | List of column names included in the index.                          |
+| `index_type`              | string        | Human-readable index type (for example `btree`).                     |
+| `segment_count`           | long          | Number of physical segments in the logical index.                    |
+| `total_size_bytes`        | long          | Sum of all segment file sizes, or `NULL` if any size is unavailable. |
+| `num_indexed_fragments`   | long          | Number of fragments fully or partially covered by the index.         |
+| `num_indexed_rows`        | long          | Approximate number of rows covered by the index.                     |
+| `num_unindexed_fragments` | long          | Number of fragments that are not yet indexed.                        |
+| `num_unindexed_rows`      | long          | Approximate number of rows that are not yet covered by the index.    |
 
 ## Notes
 

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -864,14 +864,19 @@ class TestDDLIndex:
             )
         """)
 
-        data = [(i, f"Name{i}", float(i * 10)) for i in range(100)]
-        df = spark.createDataFrame(data, ["id", "name", "value"])
-        df.writeTo("default.test_table").append()
+        first_batch = [(i, f"Name{i}", float(i * 10)) for i in range(50)]
+        second_batch = [(i, f"Name{i}", float(i * 10)) for i in range(50, 100)]
+        spark.createDataFrame(first_batch, ["id", "name", "value"]).writeTo(
+            "default.test_table"
+        ).append()
+        spark.createDataFrame(second_batch, ["id", "name", "value"]).writeTo(
+            "default.test_table"
+        ).append()
 
         result = spark.sql("""
             ALTER TABLE default.test_table
             CREATE INDEX idx_id_zonemap USING zonemap (id)
-            WITH (rows_per_zone = 8)
+            WITH (rows_per_zone = 8, num_segments = 2)
         """).collect()
 
         assert len(result) == 1
@@ -881,8 +886,10 @@ class TestDDLIndex:
             SHOW INDEXES IN default.test_table
         """).collect()
         zonemap_rows = [row for row in indexes if row["name"] == "idx_id_zonemap"]
-        assert len(zonemap_rows) >= 1
+        assert len(zonemap_rows) == 1
         assert zonemap_rows[0]["index_type"] == "zonemap"
+        assert zonemap_rows[0]["segment_count"] == 2
+        assert zonemap_rows[0]["total_size_bytes"] > 0
 
         query_result = spark.sql("""
             SELECT * FROM default.test_table WHERE id = 50

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ShowIndexes.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ShowIndexes.scala
@@ -44,6 +44,8 @@ object ShowIndexesOutputType {
         DataTypes.createArrayType(DataTypes.StringType, true),
         nullable = true),
       StructField("index_type", DataTypes.StringType, nullable = true),
+      StructField("segment_count", DataTypes.LongType, nullable = false),
+      StructField("total_size_bytes", DataTypes.LongType, nullable = true),
       StructField("num_indexed_fragments", DataTypes.LongType, nullable = true),
       StructField("num_indexed_rows", DataTypes.LongType, nullable = true),
       StructField("num_unindexed_fragments", DataTypes.LongType, nullable = true),

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExec.scala
@@ -19,6 +19,7 @@ import org.apache.spark.sql.catalyst.plans.logical.ShowIndexesOutputType
 import org.apache.spark.sql.catalyst.util.GenericArrayData
 import org.apache.spark.sql.connector.catalog.{Identifier, TableCatalog}
 import org.apache.spark.unsafe.types.UTF8String
+import org.lance.index.Index
 import org.lance.spark.LanceDataset
 import org.lance.spark.utils.{FieldPathUtils, Utils}
 
@@ -29,6 +30,14 @@ object ShowIndexesExec {
 
   private def isSystemIndex(indexName: String): Boolean =
     indexName != null && SystemIndexNames.exists(_.equalsIgnoreCase(indexName))
+
+  private[v2] def totalSizeBytes(indexes: Seq[Index]): java.lang.Long = {
+    if (indexes.exists(index => !index.getSizeBytes.isPresent)) {
+      null
+    } else {
+      java.lang.Long.valueOf(indexes.map(_.getSizeBytes.get().longValue()).sum)
+    }
+  }
 }
 
 /**
@@ -53,15 +62,15 @@ case class ShowIndexesExec(
 
     val dataset = Utils.openDatasetBuilder(readOptions).build()
     try {
-      val indexes = dataset.getIndexes.asScala.toSeq
+      val indexGroups = dataset.getIndexes.asScala.toSeq
         .filterNot(idx => ShowIndexesExec.isSystemIndex(idx.name()))
         .groupBy(_.name())
         .toSeq
         .sortBy(_._1)
-        .map(_._2.head)
       val lanceSchema = dataset.getLanceSchema()
 
-      indexes.map { idx =>
+      indexGroups.map { case (name, indexSegments) =>
+        val idx = indexSegments.head
         val fieldIds = idx.fields()
         val fieldNamesArray =
           if (fieldIds == null) {
@@ -75,7 +84,6 @@ case class ShowIndexesExec(
             new GenericArrayData(names.toArray[AnyRef])
           }
 
-        val name = idx.name()
         val stats = dataset.getIndexStatistics(name)
         val indexTypeValue = stats.get("index_type")
         val indexTypeUtf8 =
@@ -102,6 +110,8 @@ case class ShowIndexesExec(
           UTF8String.fromString(name),
           fieldNamesArray,
           indexTypeUtf8,
+          indexSegments.size.toLong,
+          ShowIndexesExec.totalSizeBytes(indexSegments),
           numIndexedFragments,
           numIndexedRows,
           numUnindexedFragments,

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseShowIndexesTest.java
@@ -107,16 +107,20 @@ public abstract class BaseShowIndexesTest {
     prepareDataset();
 
     // Create a B-tree index on id
-    spark.sql(String.format("alter table %s create index test_index using btree (id)", fullTable));
+    spark.sql(
+        String.format(
+            "alter table %s create index test_index using btree (id) "
+                + "with (build_mode='fragment', num_segments=2)",
+            fullTable));
 
     Dataset<Row> result = spark.sql(String.format("show indexes from %s", fullTable));
 
     Assertions.assertEquals(
-        "StructType(StructField(name,StringType,true),StructField(fields,ArrayType(StringType,true),true),StructField(index_type,StringType,true),StructField(num_indexed_fragments,LongType,true),StructField(num_indexed_rows,LongType,true),StructField(num_unindexed_fragments,LongType,true),StructField(num_unindexed_rows,LongType,true))",
+        "StructType(StructField(name,StringType,true),StructField(fields,ArrayType(StringType,true),true),StructField(index_type,StringType,true),StructField(segment_count,LongType,false),StructField(total_size_bytes,LongType,true),StructField(num_indexed_fragments,LongType,true),StructField(num_indexed_rows,LongType,true),StructField(num_unindexed_fragments,LongType,true),StructField(num_unindexed_rows,LongType,true))",
         result.schema().toString());
 
     List<Row> rows = result.collectAsList();
-    Assertions.assertFalse(rows.isEmpty(), "Expected at least one index row");
+    Assertions.assertEquals(1, rows.size(), "Expected one logical index row");
 
     Row row = rows.get(0);
 
@@ -131,12 +135,33 @@ public abstract class BaseShowIndexesTest {
     // index_type should be btree
     Assertions.assertEquals("btree", row.getString(2));
 
+    List<org.lance.index.Index> segments;
+    try (var dataset =
+        Utils.openDatasetBuilder(LanceSparkReadOptions.builder().datasetUri(tableDir).build())
+            .build()) {
+      segments =
+          dataset.getIndexes().stream()
+              .filter(index -> "test_index".equals(index.name()))
+              .collect(Collectors.toList());
+    }
+    Assertions.assertEquals(2, segments.size(), "Expected two physical index segments");
+    Assertions.assertEquals((long) segments.size(), row.getLong(3));
+    long expectedTotalSize =
+        segments.stream()
+            .mapToLong(
+                segment ->
+                    segment
+                        .getSizeBytes()
+                        .orElseThrow(() -> new AssertionError("Expected segment size metadata")))
+            .sum();
+    Assertions.assertEquals(expectedTotalSize, row.getLong(4));
+
     // num_indexed_fragments should be at least 1
-    long numIndexedFragments = row.getLong(3);
+    long numIndexedFragments = row.getLong(5);
     Assertions.assertTrue(numIndexedFragments >= 1L, "num_indexed_fragments should be at least 1");
 
     // num_indexed_rows should be at least 1
-    long numIndexedRows = row.getLong(4);
+    long numIndexedRows = row.getLong(6);
     Assertions.assertTrue(numIndexedRows >= 1L, "num_indexed_rows should be at least 1");
   }
 
@@ -164,7 +189,9 @@ public abstract class BaseShowIndexesTest {
     Assertions.assertEquals("test_index", row.getString(0));
     Assertions.assertEquals("btree", row.getString(2));
     Assertions.assertTrue(row.getLong(3) >= 1L);
-    Assertions.assertTrue(row.getLong(4) >= 1L);
+    Assertions.assertTrue(row.getLong(4) > 0L);
+    Assertions.assertTrue(row.getLong(5) >= 1L);
+    Assertions.assertTrue(row.getLong(6) >= 1L);
   }
 
   @Test
@@ -205,5 +232,7 @@ public abstract class BaseShowIndexesTest {
     Assertions.assertEquals(1, rows.size());
     Assertions.assertEquals("test_index", rows.get(0).getString(0));
     Assertions.assertEquals("btree", rows.get(0).getString(2));
+    Assertions.assertEquals(1L, rows.get(0).getLong(3));
+    Assertions.assertTrue(rows.get(0).getLong(4) > 0L);
   }
 }

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExecTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/ShowIndexesExecTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.junit.jupiter.api.Assertions.{assertEquals, assertNull}
+import org.junit.jupiter.api.Test
+import org.lance.index.Index
+
+class ShowIndexesExecTest {
+
+  @Test
+  def totalSizeBytes_sumsAllSegments(): Unit = {
+    val indexes = Seq(indexWithSize(10L), indexWithSize(20L))
+
+    assertEquals(java.lang.Long.valueOf(30L), ShowIndexesExec.totalSizeBytes(indexes))
+  }
+
+  @Test
+  def totalSizeBytes_returnsNullWhenAnySegmentSizeIsMissing(): Unit = {
+    val indexes = Seq(indexWithSize(10L), Index.builder().build())
+
+    assertNull(ShowIndexesExec.totalSizeBytes(indexes))
+  }
+
+  private def indexWithSize(sizeBytes: Long): Index =
+    Index.builder().sizeBytes(java.lang.Long.valueOf(sizeBytes)).build()
+}


### PR DESCRIPTION
## What changed

- Add `segment_count` and `total_size_bytes` to `SHOW INDEXES`.
- Return `NULL` for total size when any segment size is missing.

## Tests

- `./mvnw test -pl lance-spark-3.5_2.12 -am -Dtest=ShowIndexesExecTest,ShowIndexesTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw test -pl lance-spark-3.5_2.13 -am -Dtest=ShowIndexesExecTest,ShowIndexesTest -Dsurefire.failIfNoSpecifiedTests=false`
- `./mvnw spotless:check`