### PR TITLE
feat: support branch reads

### DIFF
--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -579,6 +579,17 @@ The parent configuration effectively "anchors" your Spark catalog at a specific 
 hierarchy, making the extra levels transparent to Spark users while maintaining compatibility with the underlying
 namespace implementation.
 
+## Branch Read Option
+
+Set `branch` to read the current head of a named branch. Do not set `version` on the same read.
+
+```python
+df = spark.read \
+    .format("lance") \
+    .option("branch", "audit") \
+    .load("/path/to/dataset.lance")
+```
+
 ## Memory Configuration
 
 Lance Spark uses Arrow for data transfer between native code and Spark, and maintains caches for improved performance.

--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -239,6 +239,54 @@ Use `VERSION AS OF` with a quoted tag name to query the snapshot referenced by a
 Tag queries are read-only. `UPDATE`, `DELETE`, `INSERT`, `MERGE INTO`, `ADD COLUMNS`, and
 `UPDATE COLUMNS` operations cannot target a tagged snapshot.
 
+### Query by Branch
+
+Read the current head of a named branch. Do not set `branch` and `version` on the same read.
+
+=== "SQL"
+    ```sql
+    SELECT * FROM catalog.db.users.branch_audit;
+    ```
+
+=== "Python"
+    ```python
+    audit = spark.read.option("branch", "audit").table("catalog.db.users")
+
+    audit_path = spark.read \
+        .format("lance") \
+        .option("branch", "audit") \
+        .load("/path/to/dataset.lance")
+    ```
+
+=== "Scala"
+    ```scala
+    val audit = spark.read.option("branch", "audit").table("catalog.db.users")
+
+    val auditPath = spark.read
+        .format("lance")
+        .option("branch", "audit")
+        .load("/path/to/dataset.lance")
+    ```
+
+=== "Java"
+    ```java
+    Dataset<Row> audit = spark.read()
+        .option("branch", "audit")
+        .table("catalog.db.users");
+
+    Dataset<Row> auditPath = spark.read()
+        .format("lance")
+        .option("branch", "audit")
+        .load("/path/to/dataset.lance");
+    ```
+
+If a table named `users.branch_audit` already exists, Spark reads that table. Otherwise the last
+segment is a branch on the parent table. Do not add `VERSION AS OF` or `TIMESTAMP AS OF`. Branch
+identifiers are read-only.
+
+`.option("branch").table(...)` applies the branch at scan time. Spark still analyzes with the table
+schema. Use `table.branch_name` when the branch schema differs from the table.
+
 ### Query by Timestamp
 
 Use `TIMESTAMP AS OF` to query the table as it existed at a specific point in time:
@@ -279,6 +327,7 @@ These options control how data is read from Lance datasets. They can be set usin
 | `batch_size`          | Integer | `8192`  | Number of rows to read per batch during scanning. Larger values may improve throughput but increase memory usage. |
 | `use_scalar_index`    | Boolean | `true`  | Whether to use scalar indices (e.g. btree) for filter acceleration during scanning.                               |
 | `version`             | Integer | Latest  | Specific dataset version to read. If not specified, reads the latest version.                                     |
+| `branch`              | String  | Main    | Named branch to read. Reads the current head. Do not set with `version`.                                          |
 | `block_size`          | Integer | -       | Block size in bytes for reading data.                                                                             |
 | `index_cache_size`    | Integer | -       | Size of the index cache in number of entries.                                                                     |
 | `metadata_cache_size` | Integer | -       | Size of the metadata cache in number of entries.                                                                  |

--- a/docs/src/operations/dql/select.md
+++ b/docs/src/operations/dql/select.md
@@ -282,7 +282,7 @@ Read the current head of a named branch. Do not set `branch` and `version` on th
 
 If a table named `users.branch_audit` already exists, Spark reads that table. Otherwise the last
 segment is a branch on the parent table. Do not add `VERSION AS OF` or `TIMESTAMP AS OF`. Branch
-identifiers are read-only.
+identifiers are read-only; mutating commands are rejected.
 
 `.option("branch").table(...)` applies the branch at scan time. Spark still analyzes with the table
 schema. Use `table.branch_name` when the branch schema differs from the table.

--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2804,6 +2804,101 @@ class TestDQLTimeTravel:
         assert len(result) == 3
 
 
+class TestDQLBranchRead:
+    def test_branch_reference_matches_iceberg_read_surfaces(self, spark):
+        spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
+        spark.sql(
+            "INSERT INTO default.test_table VALUES (1, 'a'), (2, 'b')"
+        )
+        expected = [(1, "a"), (2, "b")]
+        spark.sql(
+            "ALTER TABLE default.test_table CREATE BRANCH test_branch"
+        )
+        spark.sql(
+            "INSERT INTO default.test_table VALUES (3, 'c'), (4, 'd')"
+        )
+
+        identifier = spark.sql(
+            "SELECT * FROM default.test_table.branch_test_branch ORDER BY id"
+        ).collect()
+        option_table = (
+            spark.read.option("branch", "test_branch")
+            .table("default.test_table")
+            .orderBy("id")
+            .collect()
+        )
+        option_path = (
+            spark.read.format("lance")
+            .option("branch", "test_branch")
+            .load(_table_location(spark, "default.test_table"))
+            .orderBy("id")
+            .collect()
+        )
+        main = spark.sql(
+            "SELECT * FROM default.test_table ORDER BY id"
+        ).collect()
+
+        assert [(row.id, row.name) for row in identifier] == expected
+        assert [(row.id, row.name) for row in option_table] == expected
+        assert [(row.id, row.name) for row in option_path] == expected
+        assert [(row.id, row.name) for row in main] == expected + [(3, "c"), (4, "d")]
+
+    def test_branch_identifier_rejects_as_of_and_conflicting_options(self, spark):
+        spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'main')")
+        spark.sql("ALTER TABLE default.test_table CREATE BRANCH audit")
+
+        with pytest.raises(Exception, match="Cannot combine"):
+            spark.sql(
+                "SELECT * FROM default.test_table.branch_audit VERSION AS OF 1"
+            ).collect()
+        with pytest.raises(Exception, match="Cannot combine"):
+            spark.sql(
+                "SELECT * FROM default.test_table.branch_audit TIMESTAMP AS OF now()"
+            ).collect()
+        with pytest.raises(Exception):
+            spark.read.option("branch", "audit").option("version", "1").table(
+                "default.test_table"
+            ).collect()
+        with pytest.raises(Exception, match="no_such_branch"):
+            spark.read.option("branch", "no_such_branch").table(
+                "default.test_table"
+            ).collect()
+
+    def test_branch_identifier_is_read_only(self, spark):
+        spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'main')")
+        spark.sql("ALTER TABLE default.test_table CREATE BRANCH audit")
+
+        with pytest.raises(Exception):
+            spark.sql(
+                "INSERT INTO default.test_table.branch_audit VALUES (2, 'branch')"
+            ).collect()
+
+        assert spark.table("default.test_table").count() == 1
+        assert spark.table("default.test_table.branch_audit").count() == 1
+
+    def test_existing_table_wins_over_branch_identifier(self, spark):
+        spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
+        spark.sql("INSERT INTO default.test_table VALUES (1, 'branch_row')")
+        spark.sql("ALTER TABLE default.test_table CREATE BRANCH audit")
+        spark.sql(
+            "CREATE TABLE default.test_table.branch_audit (id INT, name STRING)"
+        )
+        spark.sql(
+            "INSERT INTO default.test_table.branch_audit VALUES (99, 'literal')"
+        )
+
+        rows = spark.table("default.test_table.branch_audit").collect()
+        assert [(row.id, row.name) for row in rows] == [(99, "literal")]
+        assert [
+            row.id
+            for row in spark.read.option("branch", "audit")
+            .table("default.test_table")
+            .collect()
+        ] == [1]
+
+
 @requires_update_or_merge
 class TestDMLMergeDelete:
     """Test MERGE INTO with WHEN MATCHED THEN DELETE."""

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -79,6 +79,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,6 +117,8 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
   private static final String CONFIG_PARENT_DELIMITER = "parent_delimiter";
   private static final String CONFIG_PARENT_DELIMITER_DEFAULT = ".";
+
+  private static final Pattern BRANCH_SUFFIX = Pattern.compile("branch_(.+)");
 
   private boolean pathBasedOnly = false;
 
@@ -596,17 +599,60 @@ public abstract class BaseLanceNamespaceSparkCatalog
 
   @Override
   public Table loadTable(Identifier ident) throws NoSuchTableException {
-    return loadTableInternal(ident, Optional.empty(), Optional.empty());
+    return loadTableOrBranchSelector(ident, Optional.empty(), Optional.empty());
   }
 
   @Override
   public Table loadTable(Identifier ident, String version) throws NoSuchTableException {
-    return loadTableInternal(ident, Optional.empty(), Optional.of(version));
+    return loadTableOrBranchSelector(ident, Optional.empty(), Optional.of(version));
   }
 
   @Override
   public Table loadTable(Identifier ident, long timestamp) throws NoSuchTableException {
-    return loadTableInternal(ident, Optional.of(timestamp), Optional.empty());
+    return loadTableOrBranchSelector(ident, Optional.of(timestamp), Optional.empty());
+  }
+
+  private Table loadTableOrBranchSelector(
+      Identifier ident, Optional<Long> timestamp, Optional<String> version)
+      throws NoSuchTableException {
+    Optional<LanceRef> branch = branchSelector(ident);
+    try {
+      return loadTableInternal(ident, timestamp, version, Optional.empty());
+    } catch (NoSuchTableException e) {
+      if (!branch.isPresent()) {
+        throw e;
+      }
+      return loadBranchSelector(ident, timestamp, version, branch.get());
+    } catch (LanceNamespaceException e) {
+      if (!branch.isPresent() || e.getErrorCode() != ErrorCode.NAMESPACE_NOT_FOUND) {
+        throw e;
+      }
+      return loadBranchSelector(ident, timestamp, version, branch.get());
+    }
+  }
+
+  private Table loadBranchSelector(
+      Identifier ident, Optional<Long> timestamp, Optional<String> version, LanceRef branch)
+      throws NoSuchTableException {
+    if (timestamp.isPresent() || version.isPresent()) {
+      throw new IllegalArgumentException(
+          "Cannot combine a branch identifier with VERSION AS OF or TIMESTAMP AS OF");
+    }
+    return loadTableInternal(parentIdent(ident), timestamp, version, Optional.of(branch));
+  }
+
+  private static Optional<LanceRef> branchSelector(Identifier ident) {
+    if (ident.namespace().length == 0) {
+      return Optional.empty();
+    }
+    Matcher matcher = BRANCH_SUFFIX.matcher(ident.name());
+    return matcher.matches() ? Optional.of(LanceRef.ofBranch(matcher.group(1))) : Optional.empty();
+  }
+
+  private static Identifier parentIdent(Identifier ident) {
+    String[] namespace = ident.namespace();
+    return Identifier.of(
+        Arrays.copyOf(namespace, namespace.length - 1), namespace[namespace.length - 1]);
   }
 
   @Override
@@ -1662,19 +1708,22 @@ public abstract class BaseLanceNamespaceSparkCatalog
   }
 
   private Table loadTableInternal(
-      Identifier ident, Optional<Long> timestamp, Optional<String> version)
+      Identifier ident,
+      Optional<Long> timestamp,
+      Optional<String> version,
+      Optional<LanceRef> branchRef)
       throws NoSuchTableException {
 
     // Handle path-based access
     if (isPathBasedIdentifier(ident)) {
-      return loadTableFromPath(ident, timestamp, version);
+      return loadTableFromPath(ident, timestamp, version, branchRef);
     }
 
     ResolvedTable resolved = resolveIdentifier(ident);
     DescribeTableResponse describeResponse = resolved.describeResponse;
     Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
 
-    Optional<LanceRef> ref = Optional.empty();
+    Optional<LanceRef> ref = branchRef;
     if (timestamp.isPresent()) {
       try (Dataset dataset = Utils.openDatasetBuilder(resolved.readOptions).build()) {
         ref =
@@ -1698,6 +1747,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
       schema = LanceArrowUtils.fromArrowSchema(dataset.getSchema());
       fileFormatVersion = dataset.getLanceFileFormatVersion();
       tableProperties = dataset.getConfig();
+      readOptions = pinLoadedBranch(readOptions, dataset);
     }
 
     // Create read options with namespace support
@@ -1743,14 +1793,17 @@ public abstract class BaseLanceNamespaceSparkCatalog
    * spark.read.format("lance").load(path).
    */
   private Table loadTableFromPath(
-      Identifier ident, Optional<Long> timestamp, Optional<String> version)
+      Identifier ident,
+      Optional<Long> timestamp,
+      Optional<String> version,
+      Optional<LanceRef> branchRef)
       throws NoSuchTableException {
     String datasetUri = getDatasetUri(ident);
 
     LanceSparkReadOptions baseReadOptions =
         createReadOptions(
             datasetUri, catalogConfig, Optional.empty(), Optional.empty(), Optional.empty(), name);
-    Optional<LanceRef> ref = Optional.empty();
+    Optional<LanceRef> ref = branchRef;
     if (version.isPresent()) {
       ref = Optional.of(parseVersionRef(version.get()));
     } else if (timestamp.isPresent()) {
@@ -1774,12 +1827,22 @@ public abstract class BaseLanceNamespaceSparkCatalog
       schema = LanceArrowUtils.fromArrowSchema(dataset.getSchema());
       fileFormatVersion = dataset.getLanceFileFormatVersion();
       tableProperties = dataset.getConfig();
+      readOptions = pinLoadedBranch(readOptions, dataset);
     } catch (IllegalArgumentException e) {
       throw new NoSuchTableException(ident);
     }
 
     return createDataset(
         readOptions, schema, null, null, null, false, fileFormatVersion, tableProperties, null);
+  }
+
+  private static LanceSparkReadOptions pinLoadedBranch(
+      LanceSparkReadOptions readOptions, Dataset dataset) {
+    LanceRef ref = readOptions.getRef();
+    if (ref == null || !ref.isBranch()) {
+      return readOptions;
+    }
+    return readOptions.withRef(Utils.pinOpenedRef(dataset, ref));
   }
 
   public abstract LanceDataset createDataset(

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
+import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCapability;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.write.LogicalWriteInfo;
@@ -405,6 +406,15 @@ public class LanceDataset
       return READ_ONLY_CAPABILITIES;
     }
     return BlobUtils.hasBlobV2Fields(sparkSchema) ? CAPABILITIES_WITH_BLOB_V2 : CAPABILITIES;
+  }
+
+  public static LanceDataset requireWritable(Table table, String command) {
+    if (!(table instanceof LanceDataset)) {
+      throw new UnsupportedOperationException(command + " only supports LanceDataset");
+    }
+    LanceDataset dataset = (LanceDataset) table;
+    dataset.ensureWritable();
+    return dataset;
   }
 
   protected void ensureWritable() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -13,16 +13,19 @@
  */
 package org.lance.spark;
 
+import org.lance.Dataset;
 import org.lance.memwal.ShardingSpec;
 import org.lance.spark.read.LanceScanBuilder;
 import org.lance.spark.utils.BlobSourceContext;
 import org.lance.spark.utils.BlobUtils;
+import org.lance.spark.utils.Utils;
 import org.lance.spark.write.AddColumnsBackfillWrite;
 import org.lance.spark.write.LanceWriteSchemaValidator;
 import org.lance.spark.write.SparkWrite;
 import org.lance.spark.write.StagedCommit;
 import org.lance.spark.write.UpdateColumnsBackfillWrite;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import org.apache.spark.sql.connector.catalog.MetadataColumn;
 import org.apache.spark.sql.connector.catalog.StagedTable;
@@ -38,6 +41,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.apache.spark.sql.util.LanceArrowUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -309,31 +313,70 @@ public class LanceDataset
   }
 
   @Override
-  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap caseInsensitiveStringMap) {
-    // Merge scan-time options with the existing read options
-    LanceSparkReadOptions scanOptions = readOptions;
-    if (!caseInsensitiveStringMap.isEmpty()) {
-      Map<String, String> mergedOptions = new HashMap<>(readOptions.getStorageOptions());
-      mergedOptions.putAll(caseInsensitiveStringMap.asCaseSensitiveMap());
-      scanOptions =
-          LanceSparkReadOptions.builder()
-              .datasetUri(readOptions.getDatasetUri())
-              .namespace(readOptions.getNamespace())
-              .tableId(readOptions.getTableId())
-              .catalogName(readOptions.getCatalogName())
-              .indexCacheBackend(readOptions.getIndexCacheBackend())
-              .metadataCacheBackend(readOptions.getMetadataCacheBackend())
-              .fromOptions(mergedOptions)
-              .ref(readOptions.getRef())
-              .build();
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap scanMap) {
+    LanceSparkReadOptions scanOptions = mergeScanOptions(scanMap);
+    StructType scanSchema = sparkSchema;
+    LanceRef scanRef = scanOptions.getRef();
+    if (scanRef != null && scanRef.isBranch() && scanRef.getVersionNumber().isEmpty()) {
+      try (Dataset dataset =
+          Utils.openDatasetBuilder(scanOptions)
+              .initialStorageOptions(initialStorageOptions)
+              .runtimeNamespace(namespaceImpl, namespaceProperties, readOptions.getTableId())
+              .build()) {
+        scanOptions = scanOptions.withRef(Utils.pinOpenedRef(dataset, scanRef));
+        scanSchema = LanceArrowUtils.fromArrowSchema(dataset.getSchema());
+      }
     }
     return new LanceScanBuilder(
-        sparkSchema,
+        scanSchema,
         scanOptions,
         initialStorageOptions,
         namespaceImpl,
         namespaceProperties,
         shardingSpec);
+  }
+
+  private LanceSparkReadOptions mergeScanOptions(CaseInsensitiveStringMap scanMap) {
+    if (scanMap.isEmpty()) {
+      return readOptions;
+    }
+    LanceRef tableRef = readOptions.getRef();
+    boolean scanSetsBranchOrVersion =
+        scanMap.containsKey(LanceSparkReadOptions.CONFIG_VERSION)
+            || scanMap.containsKey(LanceSparkReadOptions.CONFIG_BRANCH);
+    Map<String, String> merged = new HashMap<>(readOptions.getStorageOptions());
+    // Stored options can still hold version/branch keys. Strip them so fromOptions cannot
+    // overwrite the table ref with a leftover key.
+    merged.remove(LanceSparkReadOptions.CONFIG_VERSION);
+    merged.remove(LanceSparkReadOptions.CONFIG_BRANCH);
+    merged.putAll(scanMap.asCaseSensitiveMap());
+    LanceSparkReadOptions scanOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri(readOptions.getDatasetUri())
+            .namespace(readOptions.getNamespace())
+            .tableId(readOptions.getTableId())
+            .catalogName(readOptions.getCatalogName())
+            .indexCacheBackend(readOptions.getIndexCacheBackend())
+            .metadataCacheBackend(readOptions.getMetadataCacheBackend())
+            .ref(tableRef)
+            .fromOptions(merged)
+            .build();
+    if (tableRef != null && scanSetsBranchOrVersion) {
+      LanceRef scanRef = scanOptions.getRef();
+      if (sameNamedBranch(tableRef, scanRef)) {
+        return scanOptions.withRef(tableRef);
+      }
+      Preconditions.checkArgument(
+          tableRef.equals(scanRef), "Cannot combine %s with %s", tableRef, scanRef);
+    }
+    return scanOptions;
+  }
+
+  private static boolean sameNamedBranch(LanceRef tableRef, LanceRef scanRef) {
+    return tableRef.isBranch()
+        && scanRef != null
+        && scanRef.isBranch()
+        && tableRef.getBranchName().equals(scanRef.getBranchName());
   }
 
   @Override
@@ -358,21 +401,21 @@ public class LanceDataset
 
   @Override
   public Set<TableCapability> capabilities() {
-    if (isTagReference()) {
+    if (isBranchOrTag()) {
       return READ_ONLY_CAPABILITIES;
     }
     return BlobUtils.hasBlobV2Fields(sparkSchema) ? CAPABILITIES_WITH_BLOB_V2 : CAPABILITIES;
   }
 
   protected void ensureWritable() {
-    if (isTagReference()) {
+    if (isBranchOrTag()) {
       throw new UnsupportedOperationException(
-          "Writes are not supported for tag: " + readOptions.getRef().getTagName().get());
+          "Writes are not supported for " + readOptions.getRef());
     }
   }
 
-  private boolean isTagReference() {
-    return readOptions.getRef() != null && readOptions.getRef().getTagName().isPresent();
+  private boolean isBranchOrTag() {
+    return readOptions.getRef() != null && readOptions.getRef().isBranchOrTag();
   }
 
   @Override

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRef.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceRef.java
@@ -34,18 +34,6 @@ public class LanceRef implements Serializable {
     this.tagName = tagName;
   }
 
-  public Optional<Long> getVersionNumber() {
-    return versionNumber;
-  }
-
-  public Optional<String> getBranchName() {
-    return branchName;
-  }
-
-  public Optional<String> getTagName() {
-    return tagName;
-  }
-
   public static LanceRef ofMain(long versionNumber) {
     Preconditions.checkArgument(versionNumber > 0, "versionNumber must be greater than 0");
     return new LanceRef(Optional.of(versionNumber), Optional.empty(), Optional.empty());
@@ -73,6 +61,34 @@ public class LanceRef implements Serializable {
     return new LanceRef(Optional.empty(), Optional.empty(), Optional.of(tagName));
   }
 
+  public Optional<Long> getVersionNumber() {
+    return versionNumber;
+  }
+
+  public Optional<String> getBranchName() {
+    return branchName;
+  }
+
+  public Optional<String> getTagName() {
+    return tagName;
+  }
+
+  public boolean isMain() {
+    return branchName.isEmpty() && tagName.isEmpty();
+  }
+
+  public boolean isBranch() {
+    return branchName.isPresent();
+  }
+
+  public boolean isTag() {
+    return tagName.isPresent();
+  }
+
+  public boolean isBranchOrTag() {
+    return isBranch() || isTag();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,13 +110,18 @@ public class LanceRef implements Serializable {
 
   @Override
   public String toString() {
-    return "LanceRef{"
-        + "versionNumber="
-        + (versionNumber.isPresent() ? versionNumber.get() : null)
-        + ", branchName="
-        + (branchName.isPresent() ? branchName.get() : null)
-        + ", tagName="
-        + (tagName.isPresent() ? tagName.get() : null)
-        + '}';
+    if (isTag()) {
+      return "tag " + tagName.get();
+    }
+    if (isBranch() && versionNumber.isPresent()) {
+      return "branch " + branchName.get() + " version " + versionNumber.get();
+    }
+    if (isBranch()) {
+      return "branch " + branchName.get();
+    }
+    if (versionNumber.isPresent()) {
+      return "version " + versionNumber.get();
+    }
+    return "main";
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkReadOptions.java
@@ -53,6 +53,7 @@ public class LanceSparkReadOptions implements Serializable {
   public static final String CONFIG_PUSH_DOWN_FILTERS = "pushDownFilters";
   public static final String CONFIG_BLOCK_SIZE = "block_size";
   public static final String CONFIG_VERSION = "version";
+  public static final String CONFIG_BRANCH = "branch";
   public static final String CONFIG_INDEX_CACHE_SIZE = "index_cache_size";
   public static final String CONFIG_METADATA_CACHE_SIZE = "metadata_cache_size";
   public static final String CONFIG_BATCH_SIZE = "batch_size";
@@ -364,7 +365,7 @@ public class LanceSparkReadOptions implements Serializable {
     if (blockSize != null) {
       builder.setBlockSize(blockSize);
     }
-    if (ref != null) {
+    if (ref != null && ref.isMain()) {
       ref.getVersionNumber().ifPresent(builder::setVersion);
     }
     if (indexCacheSize != null) {
@@ -583,6 +584,9 @@ public class LanceSparkReadOptions implements Serializable {
       Preconditions.checkArgument(
           !opts.containsKey(CONFIG_NEAREST),
           "The nearest read option is no longer supported; use VECTOR_SEARCH table function");
+      Preconditions.checkArgument(
+          !(opts.containsKey(CONFIG_VERSION) && opts.containsKey(CONFIG_BRANCH)),
+          "Specify only one of branch or version");
       if (opts.containsKey(CONFIG_PUSH_DOWN_FILTERS)) {
         this.pushDownFilters = Boolean.parseBoolean(opts.get(CONFIG_PUSH_DOWN_FILTERS));
       }
@@ -591,6 +595,8 @@ public class LanceSparkReadOptions implements Serializable {
       }
       if (opts.containsKey(CONFIG_VERSION)) {
         this.ref = LanceRef.ofMain(Long.parseLong(opts.get(CONFIG_VERSION)));
+      } else if (opts.containsKey(CONFIG_BRANCH)) {
+        this.ref = LanceRef.ofBranch(opts.get(CONFIG_BRANCH));
       }
       if (opts.containsKey(CONFIG_INDEX_CACHE_SIZE)) {
         this.indexCacheSize = Integer.parseInt(opts.get(CONFIG_INDEX_CACHE_SIZE));

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceSparkWriteOptions.java
@@ -520,6 +520,9 @@ public class LanceSparkWriteOptions implements Serializable {
      * @return this builder
      */
     public Builder fromOptions(Map<String, String> options) {
+      Preconditions.checkArgument(
+          !options.containsKey(LanceSparkReadOptions.CONFIG_BRANCH),
+          "The branch option is read-only");
       this.storageOptions = new HashMap<>(options);
       if (options.containsKey(CONFIG_WRITE_MODE)) {
         this.writeMode = WriteMode.valueOf(options.get(CONFIG_WRITE_MODE).toUpperCase());

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -297,15 +297,13 @@ public class LanceScanBuilder
 
   boolean shouldNamespaceFtsScan() {
     LanceRef ref = readOptions.getRef();
-    boolean hasTag = ref != null && ref.getTagName().isPresent();
-    if (hasTag) {
+    if (ref != null && ref.isBranchOrTag()) {
       return false;
     }
 
     return readOptions.getFullTextQuery() != null
         && LanceRuntime.supportsQueryTable(namespaceImpl)
-        && !pushedAggregation.isPresent()
-        && !hasTag;
+        && !pushedAggregation.isPresent();
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -15,7 +15,6 @@ package org.lance.spark.read;
 
 import org.lance.Dataset;
 import org.lance.Fragment;
-import org.lance.Tag;
 import org.lance.spark.LanceRef;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Utils;
@@ -26,7 +25,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 public class LanceSplit implements Serializable {
   private static final long serialVersionUID = 2983749283749283749L;
@@ -101,31 +99,8 @@ public class LanceSplit implements Serializable {
       fragmentRowCounts.put(id, fragment.metadata().getNumRows());
     }
 
-    LanceRef plannedRef;
-
-    LanceRef ref = readOptions.getRef();
-    if (ref != null && ref.getBranchName().isPresent()) {
-      plannedRef = LanceRef.ofBranch(ref.getBranchName().get(), dataset.getVersion().getId());
-    } else if (ref != null && ref.getTagName().isPresent()) {
-      Optional<Tag> tag =
-          dataset.tags().list().stream()
-              .filter(t -> t.getName().equals(ref.getTagName().get()))
-              .findFirst();
-      if (tag.isEmpty()) {
-        throw new RuntimeException("No existed tag with name:" + ref.getTagName().get());
-      }
-
-      Optional<String> tagBranch = tag.get().getBranch();
-      if (tagBranch.isEmpty()) {
-        plannedRef = LanceRef.ofMain(dataset.getVersion().getId());
-      } else {
-        plannedRef = LanceRef.ofBranch(tagBranch.get(), dataset.version());
-      }
-    } else {
-      plannedRef = LanceRef.ofMain(dataset.getVersion().getId());
-    }
-
-    return new ScanPlanResult(splits, plannedRef, fragmentRowCounts);
+    LanceRef ref = Utils.pinOpenedRef(dataset, readOptions.getRef());
+    return new ScanPlanResult(splits, ref, fragmentRowCounts);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/Utils.java
@@ -16,6 +16,7 @@ package org.lance.spark.utils;
 import org.lance.Dataset;
 import org.lance.ReadOptions;
 import org.lance.Ref;
+import org.lance.Tag;
 import org.lance.Version;
 import org.lance.namespace.LanceNamespace;
 import org.lance.spark.LanceRef;
@@ -33,6 +34,28 @@ public class Utils {
 
   public static long parseVersion(String version) {
     return Long.parseUnsignedLong(version);
+  }
+
+  // Tag names and branch heads move. Store the opened version, and the branch if a tag points at
+  // one.
+  public static LanceRef pinOpenedRef(Dataset dataset, LanceRef requested) {
+    long version = dataset.getVersion().getId();
+    if (requested != null && requested.isTag()) {
+      String tagName = requested.getTagName().get();
+      for (Tag tag : dataset.tags().list()) {
+        if (tag.getName().equals(tagName)) {
+          if (tag.getBranch().isPresent()) {
+            return LanceRef.ofBranch(tag.getBranch().get(), version);
+          }
+          return LanceRef.ofMain(version);
+        }
+      }
+      throw new RuntimeException("Tag not found: " + tagName);
+    }
+    if (requested != null && requested.isBranch()) {
+      return LanceRef.ofBranch(requested.getBranchName().get(), version);
+    }
+    return LanceRef.ofMain(version);
   }
 
   public static long findVersion(List<Version> versions, long timestamp) {

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddColumnsBackfillExec.scala
@@ -29,11 +29,8 @@ case class AddColumnsBackfillExec(
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    val originalTable = catalog.loadTable(ident) match {
-      case lanceTable: LanceDataset => lanceTable
-      case _ =>
-        throw new UnsupportedOperationException("AddColumnsBackfill only supports for LanceDataset")
-    }
+    val originalTable =
+      LanceDataset.requireWritable(catalog.loadTable(ident), "AddColumnsBackfill")
 
     // Check the added columns must not exist
     val originalFields = originalTable.schema().fieldNames.toSet

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -80,10 +80,7 @@ case class AddIndexExec(
   override def output: Seq[Attribute] = AddIndexOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case d: LanceDataset => d
-      case _ => throw new UnsupportedOperationException("AddIndex only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "AddIndex")
 
     val readOptions = lanceDataset.readOptions()
     val indexType = IndexUtils.buildIndexType(method)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropIndexExec.scala
@@ -35,11 +35,7 @@ case class LanceDropIndexExec(
   override def output: Seq[Attribute] = LanceDropIndexOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case ds: LanceDataset => ds
-      case _ =>
-        throw new UnsupportedOperationException("DropIndex only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "DropIndex")
 
     val readOptions = lanceDataset.readOptions()
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateBranchExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateBranchExec.scala
@@ -33,10 +33,7 @@ case class LanceCreateBranchExec(
   override def output: Seq[Attribute] = LanceCreateBranchOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case d: LanceDataset => d
-      case _ => throw new UnsupportedOperationException("CreateBranch only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "CreateBranch")
 
     val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
       .initialStorageOptions(lanceDataset.getInitialStorageOptions)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateTagExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceCreateTagExec.scala
@@ -33,10 +33,7 @@ case class LanceCreateTagExec(
   override def output: Seq[Attribute] = LanceCreateTagOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case d: LanceDataset => d
-      case _ => throw new UnsupportedOperationException("CreateTag only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "CreateTag")
 
     val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
       .initialStorageOptions(lanceDataset.getInitialStorageOptions)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropBranchExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropBranchExec.scala
@@ -32,10 +32,7 @@ case class LanceDropBranchExec(
   override def output: Seq[Attribute] = LanceDropBranchOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case d: LanceDataset => d
-      case _ => throw new UnsupportedOperationException("DropBranch only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "DropBranch")
 
     val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
       .initialStorageOptions(lanceDataset.getInitialStorageOptions)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropTagExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/LanceDropTagExec.scala
@@ -32,10 +32,7 @@ case class LanceDropTagExec(
   override def output: Seq[Attribute] = LanceDropTagOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case d: LanceDataset => d
-      case _ => throw new UnsupportedOperationException("DropTag only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "DropTag")
 
     val dataset = Utils.openDatasetBuilder(lanceDataset.readOptions())
       .initialStorageOptions(lanceDataset.getInitialStorageOptions)

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/OptimizeExec.scala
@@ -56,11 +56,7 @@ case class OptimizeExec(
   }
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case lanceDataset: LanceDataset => lanceDataset
-      case _ =>
-        throw new UnsupportedOperationException("Optimize only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "Optimize")
 
     // Build compaction options from arguments
     val options = buildOptions()

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetUnenforcedPrimaryKeyExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetUnenforcedPrimaryKeyExec.scala
@@ -39,12 +39,8 @@ case class SetUnenforcedPrimaryKeyExec(
   override def output: Seq[Attribute] = SetUnenforcedPrimaryKeyOutputType.SCHEMA
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case ds: LanceDataset => ds
-      case _ =>
-        throw new UnsupportedOperationException(
-          "SET UNENFORCED PRIMARY KEY only supports LanceDataset")
-    }
+    val lanceDataset =
+      LanceDataset.requireWritable(catalog.loadTable(ident), "SET UNENFORCED PRIMARY KEY")
 
     val readOptions = lanceDataset.readOptions()
     val dataset = Utils.openDatasetBuilder(readOptions).build()

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/UpdateColumnsBackfillExec.scala
@@ -37,12 +37,8 @@ case class UpdateColumnsBackfillExec(
   override def output: Seq[Attribute] = Seq.empty
 
   override protected def run(): Seq[InternalRow] = {
-    val originalTable = catalog.loadTable(ident) match {
-      case lanceTable: LanceDataset => lanceTable
-      case _ =>
-        throw new UnsupportedOperationException(
-          "UpdateColumnsBackfill only supports LanceDataset")
-    }
+    val originalTable =
+      LanceDataset.requireWritable(catalog.loadTable(ident), "UpdateColumnsBackfill")
 
     // Check the updated columns must exist
     val originalFields = originalTable.schema().fieldNames.toSet

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VacuumExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/VacuumExec.scala
@@ -48,11 +48,7 @@ case class VacuumExec(
   }
 
   override protected def run(): Seq[InternalRow] = {
-    val lanceDataset = catalog.loadTable(ident) match {
-      case lanceDataset: LanceDataset => lanceDataset
-      case _ =>
-        throw new UnsupportedOperationException("Vacuum only supports LanceDataset")
-    }
+    val lanceDataset = LanceDataset.requireWritable(catalog.loadTable(ident), "Vacuum")
 
     val policy = buildPolicy()
     val readOptions = lanceDataset.readOptions()

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRefTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRefTest.java
@@ -16,7 +16,9 @@ package org.lance.spark;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LanceRefTest {
 
@@ -31,6 +33,23 @@ public class LanceRefTest {
     assertNotEquals(LanceRef.ofMain(7), LanceRef.ofMain(8));
     assertNotEquals(LanceRef.ofBranch("dev"), LanceRef.ofBranch("prod"));
     assertNotEquals(LanceRef.ofTag("release"), LanceRef.ofTag("latest"));
+  }
+
+  @Test
+  public void testRefKind() {
+    assertTrue(LanceRef.ofMain().isMain());
+    assertFalse(LanceRef.ofMain().isBranch());
+    assertTrue(LanceRef.ofBranch("dev").isBranch());
+    assertFalse(LanceRef.ofBranch("dev").isMain());
+    assertTrue(LanceRef.ofTag("release").isTag());
+    assertTrue(LanceRef.ofBranch("dev").isBranchOrTag());
+    assertTrue(LanceRef.ofTag("release").isBranchOrTag());
+    assertFalse(LanceRef.ofMain().isBranchOrTag());
+    assertEquals("branch audit", LanceRef.ofBranch("audit").toString());
+    assertEquals("branch audit version 2", LanceRef.ofBranch("audit", 2).toString());
+    assertEquals("tag release", LanceRef.ofTag("release").toString());
+    assertEquals("version 7", LanceRef.ofMain(7).toString());
+    assertEquals("main", LanceRef.ofMain().toString());
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkReadOptionsSerializationTest.java
@@ -76,6 +76,30 @@ public class LanceSparkReadOptionsSerializationTest {
   }
 
   @Test
+  public void testFromOptionsParsesBranch() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.from(
+            Collections.singletonMap(LanceSparkReadOptions.CONFIG_BRANCH, "audit"),
+            "s3://bucket/path");
+
+    Assertions.assertEquals(LanceRef.ofBranch("audit"), options.getRef());
+  }
+
+  @Test
+  public void testFromOptionsRejectsBranchAndVersion() {
+    Map<String, String> options = new HashMap<>();
+    options.put(LanceSparkReadOptions.CONFIG_BRANCH, "audit");
+    options.put(LanceSparkReadOptions.CONFIG_VERSION, "2");
+
+    IllegalArgumentException exception =
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> LanceSparkReadOptions.from(options, "s3://bucket/path"));
+    Assertions.assertTrue(exception.getMessage().contains("branch"));
+    Assertions.assertTrue(exception.getMessage().contains("version"));
+  }
+
+  @Test
   public void testFromOptionsParsesFtsSubtype() {
     FullTextQuery original = FullTextQuery.phrase("hello world", "body", 0);
     String json = org.lance.spark.utils.FullTextQueryUtils.fullTextQueryToString(original);

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceSparkWriteOptionsTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link LanceSparkWriteOptions}. */
@@ -47,6 +48,20 @@ public class LanceSparkWriteOptionsTest {
     LanceSparkWriteOptions opts =
         LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).ref(LanceRef.ofMain(7L)).build();
     assertEquals(7L, opts.getRef().getVersionNumber().get());
+  }
+
+  @Test
+  public void testWriteOptionsRejectBranch() {
+    Map<String, String> options = new HashMap<>();
+    options.put(LanceSparkReadOptions.CONFIG_BRANCH, "audit");
+
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                LanceSparkWriteOptions.builder().datasetUri(TEMP_URL).fromOptions(options).build());
+
+    assertTrue(exception.getMessage().contains("read-only"));
   }
 
   @Test

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
@@ -14,10 +14,18 @@
 package org.lance.spark.branch;
 
 import org.lance.Ref;
+import org.lance.spark.LanceDataset;
+import org.lance.spark.LanceRef;
+import org.lance.spark.LanceSparkReadOptions;
+import org.lance.spark.read.LanceInputPartition;
+import org.lance.spark.read.LanceSplit;
 
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +36,9 @@ import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -379,6 +389,292 @@ public abstract class BaseBranchDDLTest {
         showBranches(String.format("show branches from %s", fullTable));
     Assertions.assertTrue(
         branches.containsKey(branchName), "Expected backtick-quoted branch to be returned");
+  }
+
+  @Test
+  public void testBranchReadUsesBranchSchemaAfterMainAddsColumn() throws Exception {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+    spark.sql(
+        String.format(
+            "create temporary view extra_cols as select _rowaddr, _fragid, 1 as extra from %s",
+            fullTable));
+    spark.sql(String.format("alter table %s add columns extra from extra_cols", fullTable));
+
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    List<String> expectedBranchSchema =
+        columnNames(
+            spark.sql(
+                "select * from " + fullTable + " version as of " + versions.firstInsertVersion));
+    List<String> catalogSchema =
+        Arrays.asList(
+            catalog
+                .loadTable(Identifier.of(new String[] {"default", tableName}, "branch_audit"))
+                .schema()
+                .fieldNames());
+    List<String> identifierSchema = columnNames(spark.table(fullTable + ".branch_audit"));
+
+    Assertions.assertEquals(expectedBranchSchema, catalogSchema);
+    Assertions.assertEquals(expectedBranchSchema, identifierSchema);
+  }
+
+  @Test
+  public void testBranchIdentifierPinsVersionOnLoad() throws Exception {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    LanceDataset table =
+        (LanceDataset)
+            catalog.loadTable(Identifier.of(new String[] {"default", tableName}, "branch_audit"));
+    LanceRef ref = table.readOptions().getRef();
+
+    Assertions.assertEquals("audit", ref.getBranchName().get());
+    Assertions.assertEquals(versions.firstInsertVersion, ref.getVersionNumber().get());
+  }
+
+  @Test
+  public void testBranchOptionPinsVersionOnScan() throws Exception {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    LanceDataset table =
+        (LanceDataset) catalog.loadTable(Identifier.of(new String[] {"default"}, tableName));
+    Map<String, String> options = new HashMap<>();
+    options.put("branch", "audit");
+    LanceInputPartition partition =
+        (LanceInputPartition)
+            table
+                .newScanBuilder(new CaseInsensitiveStringMap(options))
+                .build()
+                .toBatch()
+                .planInputPartitions()[0];
+    LanceRef ref = partition.getReadOptions().getRef();
+
+    Assertions.assertEquals("audit", ref.getBranchName().get());
+    Assertions.assertEquals(versions.firstInsertVersion, ref.getVersionNumber().get());
+  }
+
+  @Test
+  public void testTagScanPinsVersionNotName() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri(tableDir)
+            .ref(LanceRef.ofTag(versions.firstInsertTag))
+            .build();
+
+    LanceRef plannedRef = LanceSplit.planScan(readOptions).getRef();
+
+    Assertions.assertTrue(plannedRef.getTagName().isEmpty());
+    Assertions.assertEquals(versions.firstInsertVersion, plannedRef.getVersionNumber().get());
+  }
+
+  @Test
+  public void testReadBranchByOptionPathAndIdentifier() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+    insertRange(10, 15);
+
+    Assertions.assertEquals(15, spark.table(fullTable).count());
+    Assertions.assertEquals(5, spark.read().option("branch", "audit").table(fullTable).count());
+    Assertions.assertEquals(
+        5, spark.read().format("lance").option("branch", "audit").load(tableDir).count());
+    Assertions.assertEquals(5, spark.table(fullTable + ".branch_audit").count());
+    Assertions.assertEquals(
+        5, spark.read().option("branch", "audit").table(fullTable + ".branch_audit").count());
+  }
+
+  @Test
+  public void testExistingTableWinsOverBranchIdentifier() throws Exception {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    String literalTable = fullTable + ".branch_audit";
+    spark.sql("create table " + literalTable + " (id int, text string) using lance");
+    spark.sql("insert into " + literalTable + " values (99, 'literal')");
+
+    Assertions.assertEquals(1, spark.table(literalTable).count());
+    Assertions.assertEquals(99, spark.table(literalTable).collectAsList().get(0).getInt(0));
+    Assertions.assertEquals(5, spark.read().option("branch", "audit").table(fullTable).count());
+
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    LanceDataset table =
+        (LanceDataset)
+            catalog.loadTable(Identifier.of(new String[] {"default", tableName}, "branch_audit"));
+    LanceRef ref = table.readOptions().getRef();
+    Assertions.assertTrue(ref == null || ref.isMain());
+  }
+
+  @Test
+  public void testBranchIdentifierKeepsRowsWhenBatchSizeIsSet() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+    insertRange(10, 15);
+
+    Assertions.assertEquals(
+        5, spark.read().option("batch_size", "1024").table(fullTable + ".branch_audit").count());
+  }
+
+  @Test
+  public void testBranchScanPinsBranchAndVersion() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+    LanceSparkReadOptions readOptions =
+        LanceSparkReadOptions.builder()
+            .datasetUri(tableDir)
+            .ref(LanceRef.ofBranch("audit"))
+            .build();
+
+    LanceRef plannedRef = LanceSplit.planScan(readOptions).getRef();
+
+    Assertions.assertEquals("audit", plannedRef.getBranchName().get());
+    Assertions.assertTrue(plannedRef.getVersionNumber().isPresent());
+    Assertions.assertEquals(versions.firstInsertVersion, plannedRef.getVersionNumber().get());
+  }
+
+  @Test
+  public void testMissingBranchFails() {
+    prepareDatasetWithHistory();
+
+    Exception missing =
+        Assertions.assertThrows(
+            Exception.class,
+            () -> spark.read().option("branch", "no_such_branch").table(fullTable).collectAsList());
+    Assertions.assertTrue(exceptionChainMessages(missing).contains("no_such_branch"));
+  }
+
+  @Test
+  public void testBranchAndVersionOptionsFail() {
+    prepareDatasetWithHistory();
+
+    Exception conflicting =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .read()
+                    .option("branch", "audit")
+                    .option("version", "1")
+                    .table(fullTable)
+                    .collectAsList());
+    String conflictMessages = exceptionChainMessages(conflicting);
+    Assertions.assertTrue(conflictMessages.contains("branch"));
+    Assertions.assertTrue(conflictMessages.contains("version"));
+  }
+
+  @Test
+  public void testBranchIdentifierRejectsVersionAsOf() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    Exception asOf =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql("select * from " + fullTable + ".branch_audit version as of 1")
+                    .collectAsList());
+    Assertions.assertTrue(exceptionChainMessages(asOf).contains("Cannot combine"));
+
+    Exception timestampAsOf =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql("select * from " + fullTable + ".branch_audit timestamp as of now()")
+                    .collectAsList());
+    Assertions.assertTrue(exceptionChainMessages(timestampAsOf).contains("Cannot combine"));
+  }
+
+  @Test
+  public void testBranchIdentifierRejectsDifferentBranchOption() {
+    DatasetVersions versions = prepareDatasetWithHistory();
+    spark.sql(
+        String.format(
+            "alter table %s create branch audit as of version %d",
+            fullTable, versions.firstInsertVersion));
+
+    Exception mismatch =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .read()
+                    .option("branch", "other")
+                    .table(fullTable + ".branch_audit")
+                    .collectAsList());
+    String mismatchMessages = exceptionChainMessages(mismatch);
+    Assertions.assertTrue(mismatchMessages.contains("audit"));
+    Assertions.assertTrue(mismatchMessages.contains("other"));
+  }
+
+  @Test
+  public void testInsertIntoBranchIdentifierFails() {
+    prepareDatasetWithHistory();
+    spark.sql(String.format("alter table %s create branch audit", fullTable));
+
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql("insert into " + fullTable + ".branch_audit values (99, 'branch')")
+                .collectAsList());
+    Assertions.assertThrows(
+        Exception.class,
+        () ->
+            spark
+                .sql("select 99 as id, 'branch' as text")
+                .write()
+                .format("lance")
+                .option("branch", "audit")
+                .mode("append")
+                .save(tableDir));
+    Assertions.assertEquals(10, spark.table(fullTable).count());
+    Assertions.assertEquals(10, spark.table(fullTable + ".branch_audit").count());
+  }
+
+  private static String exceptionChainMessages(Throwable throwable) {
+    StringBuilder messages = new StringBuilder();
+    for (Throwable current = throwable; current != null; current = current.getCause()) {
+      if (current.getMessage() != null) {
+        messages.append(current.getMessage()).append('\n');
+      }
+    }
+    return messages.toString();
+  }
+
+  private static List<String> columnNames(Dataset<Row> rows) {
+    return Arrays.asList(rows.columns());
   }
 
   private DatasetVersions prepareDatasetWithHistory() {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/branch/BaseBranchDDLTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /** Base tests for BRANCH DDL commands. */
 public abstract class BaseBranchDDLTest {
@@ -661,6 +662,63 @@ public abstract class BaseBranchDDLTest {
                 .save(tableDir));
     Assertions.assertEquals(10, spark.table(fullTable).count());
     Assertions.assertEquals(10, spark.table(fullTable + ".branch_audit").count());
+  }
+
+  @Test
+  public void testBranchIdentifierRejectsCreateIndexAndVacuum() throws Exception {
+    prepareDatasetWithHistory();
+    spark.sql(String.format("alter table %s create branch audit", fullTable));
+
+    TableCatalog catalog =
+        (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    Identifier branchIdentifier =
+        Identifier.of(new String[] {"default", tableName}, "branch_audit");
+    long branchVersionBefore =
+        ((LanceDataset) catalog.loadTable(branchIdentifier))
+            .readOptions()
+            .getRef()
+            .getVersionNumber()
+            .get();
+    long fileCountBefore = datasetFileCount();
+
+    Exception createIndex =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql(
+                        "alter table "
+                            + fullTable
+                            + ".branch_audit create index id_idx using zonemap (id) "
+                            + "with (train=false)")
+                    .collectAsList());
+    Assertions.assertTrue(exceptionChainMessages(createIndex).contains("Writes are not supported"));
+
+    Exception vacuum =
+        Assertions.assertThrows(
+            Exception.class,
+            () ->
+                spark
+                    .sql("vacuum " + fullTable + ".branch_audit with (before_version=1000000)")
+                    .collectAsList());
+    Assertions.assertTrue(exceptionChainMessages(vacuum).contains("Writes are not supported"));
+
+    long branchVersionAfter =
+        ((LanceDataset) catalog.loadTable(branchIdentifier))
+            .readOptions()
+            .getRef()
+            .getVersionNumber()
+            .get();
+    Assertions.assertEquals(branchVersionBefore, branchVersionAfter);
+    Assertions.assertEquals(fileCountBefore, datasetFileCount());
+    Assertions.assertEquals(10, spark.table(fullTable).count());
+    Assertions.assertEquals(10, spark.table(fullTable + ".branch_audit").count());
+  }
+
+  private long datasetFileCount() throws IOException {
+    try (Stream<Path> files = Files.walk(FileSystems.getDefault().getPath(tableDir))) {
+      return files.filter(Files::isRegularFile).count();
+    }
   }
 
   private static String exceptionChainMessages(Throwable throwable) {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanBuilderTest.java
@@ -371,6 +371,21 @@ public class LanceScanBuilderTest {
   }
 
   @Test
+  public void testBranchFullTextQueryDoesNotUseNamespaceScan() {
+    LanceSparkReadOptions options =
+        LanceSparkReadOptions.builder()
+            .datasetUri(TestUtils.TestTable1Config.datasetUri)
+            .ref(LanceRef.ofBranch("audit"))
+            .fullTextQuery(FullTextQuery.match("hello", "b"))
+            .build();
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            TEST_SCHEMA, options, Collections.emptyMap(), "dir", Collections.emptyMap());
+
+    assertFalse(builder.shouldNamespaceFtsScan());
+  }
+
+  @Test
   public void testBuildWithCountStarReturnsLocalScan() {
     LanceScanBuilder builder = createBuilder();
     Aggregation countStar =


### PR DESCRIPTION
related to #713

#773 added tag reads through `VERSION AS OF`. This is the branch reads follow up.

You can read a named branch the same way other Spark projects do:

```sql
SELECT * FROM catalog.db.users.branch_audit;
```

```scala
spark.read.option("branch", "audit").table("catalog.db.users")
```

```python
spark.read.format("lance") \
    .option("branch", "audit") \
    .load("/path/to/dataset.lance")
````

In this case table.branch_audit is the real branch table, including that branch's schema. .option("branch") is scan time convenience and Spark still analyzes with the current table schema, so use the identifier when the branch schema has diverged.

If a real table named users.branch_audit already exists, that table wins. Don't combine a branch identifier with VERSION AS OF / TIMESTAMP AS OF, and don't set branch and version on the same read. Current;y Branches are read only here. Writes stay a follow-up. 

cc: @fangbo 