### PR TITLE
fix: resolve branch identifiers through the parent table

### DIFF
--- a/integration-tests/test_lance_spark.py
+++ b/integration-tests/test_lance_spark.py
@@ -2805,7 +2805,7 @@ class TestDQLTimeTravel:
 
 
 class TestDQLBranchRead:
-    def test_branch_reference_matches_iceberg_read_surfaces(self, spark):
+    def test_branch_identifier_matches_option_and_path(self, spark):
         spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
         spark.sql(
             "INSERT INTO default.test_table VALUES (1, 'a'), (2, 'b')"
@@ -2879,6 +2879,8 @@ class TestDQLBranchRead:
         assert spark.table("default.test_table.branch_audit").count() == 1
 
     def test_existing_table_wins_over_branch_identifier(self, spark):
+        if getattr(spark, "_lance_backend", None) == "glue":
+            pytest.skip("Glue table identifiers are database.table")
         spark.sql("CREATE TABLE default.test_table (id INT, name STRING)")
         spark.sql("INSERT INTO default.test_table VALUES (1, 'branch_row')")
         spark.sql("ALTER TABLE default.test_table CREATE BRANCH audit")

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/BaseLanceNamespaceSparkCatalog.java
@@ -616,18 +616,27 @@ public abstract class BaseLanceNamespaceSparkCatalog
       Identifier ident, Optional<Long> timestamp, Optional<String> version)
       throws NoSuchTableException {
     Optional<LanceRef> branch = branchSelector(ident);
-    try {
+    if (!branch.isPresent()) {
       return loadTableInternal(ident, timestamp, version, Optional.empty());
+    }
+
+    try {
+      ResolvedTable literal = resolveLiteralTable(ident);
+      return loadResolvedTable(ident, literal, timestamp, version, Optional.empty());
     } catch (NoSuchTableException e) {
-      if (!branch.isPresent()) {
-        throw e;
-      }
       return loadBranchSelector(ident, timestamp, version, branch.get());
+    }
+  }
+
+  private ResolvedTable resolveLiteralTable(Identifier ident) throws NoSuchTableException {
+    try {
+      return resolveIdentifier(ident);
     } catch (LanceNamespaceException e) {
-      if (!branch.isPresent() || e.getErrorCode() != ErrorCode.NAMESPACE_NOT_FOUND) {
-        throw e;
+      ErrorCode code = e.getErrorCode();
+      if (code == ErrorCode.NAMESPACE_NOT_FOUND || code == ErrorCode.INVALID_INPUT) {
+        throw new NoSuchTableException(ident);
       }
-      return loadBranchSelector(ident, timestamp, version, branch.get());
+      throw e;
     }
   }
 
@@ -642,7 +651,7 @@ public abstract class BaseLanceNamespaceSparkCatalog
   }
 
   private static Optional<LanceRef> branchSelector(Identifier ident) {
-    if (ident.namespace().length == 0) {
+    if (ident.namespace().length == 0 || isPathBasedIdentifier(ident)) {
       return Optional.empty();
     }
     Matcher matcher = BRANCH_SUFFIX.matcher(ident.name());
@@ -1719,7 +1728,16 @@ public abstract class BaseLanceNamespaceSparkCatalog
       return loadTableFromPath(ident, timestamp, version, branchRef);
     }
 
-    ResolvedTable resolved = resolveIdentifier(ident);
+    return loadResolvedTable(ident, resolveIdentifier(ident), timestamp, version, branchRef);
+  }
+
+  private Table loadResolvedTable(
+      Identifier ident,
+      ResolvedTable resolved,
+      Optional<Long> timestamp,
+      Optional<String> version,
+      Optional<LanceRef> branchRef)
+      throws NoSuchTableException {
     DescribeTableResponse describeResponse = resolved.describeResponse;
     Map<String, String> initialStorageOptions = describeResponse.getStorageOptions();
 


### PR DESCRIPTION
Branch identifiers were failing on Glue because we first tried to resolve the full branch shaped identifier as a literal table. Glue only accepts database.table, so that lookup failed before we could fall back to the parent table and branch.

This changes branch identifier resolution so the literal table lookup is just a probe. If it does not resolve as a real table, we load the parent table and apply the branch instead. Literal tables still win on catalogs that support them.

The collision test is skipped on Glue since Glue cannot represent that table shape.