### PR TITLE
feat: surface _score metadata column on FTS predicate queries

### DIFF
--- a/docs/src/operations/dql/fts.md
+++ b/docs/src/operations/dql/fts.md
@@ -111,9 +111,34 @@ SELECT * FROM lance.db.documents
 WHERE lance_multi_match('machine learning', 'operator=AND', title, body);
 ```
 
+## Relevance Score (`_score`)
+
+The `_score` metadata column exposes the BM25 relevance score computed by the FTS index. It is available only when a full-text search predicate is active.
+
+```sql
+-- Project _score alongside data columns
+SELECT id, body, _score FROM lance.db.documents
+WHERE lance_match(body, 'machine learning');
+
+-- Sort by relevance
+SELECT id, _score FROM lance.db.documents
+WHERE lance_match(body, 'vector database')
+ORDER BY _score DESC;
+
+-- Combine with scalar filters
+SELECT id, _score FROM lance.db.documents
+WHERE lance_match(body, 'deep learning') AND year >= 2024
+ORDER BY _score DESC;
+```
+
+`_score` is a hidden metadata column — it does not appear in `SELECT *` output. Selecting `_score` without an FTS predicate raises an error at planning time.
+
+!!! note "Not a ranked-retrieval push"
+    `ORDER BY _score DESC LIMIT k` sorts in Spark above the scan — it does **not** push a ranked top-k query to the Lance engine. All matching rows are scanned and scored; Spark applies the sort and limit. A pushed ranked-retrieval path is planned as a future extension.
+
 ## Known Limitations
 
-- **No global relevance ordering.** FTS predicates act as WHERE filters and return all matching rows. There is no `lance_score()` function or relevance-based `ORDER BY` — rows are returned in storage order. In particular, `SELECT * FROM t WHERE lance_match(...) LIMIT N` returns N matching rows determined by Spark task scheduling, not by BM25 rank — it is not a "top-N by relevance" query.
+- **No pushed ranked retrieval.** `ORDER BY _score DESC LIMIT k` is correct but not optimized — all matching rows are scanned, scored, and sorted in Spark. A pushed top-k path that leverages Lance's native scoring order is a planned future extension.
 - **Column names must match the schema exactly.** Column references are resolved at planning time; aliases or expressions are not supported.
 - **`lance_match_phrase` requires positional index.** The FTS index must be built with `with_position = true`. Without it, phrase queries will fail.
 - **WHERE-filter uses full BM25 scoring (no WAND early stopping).** Every row matching the query is evaluated — `wand_factor` is not exposed because SQL WHERE semantics require returning all matching rows.

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/FtsScoreColumnTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/read/FtsScoreColumnTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class FtsScoreColumnTest extends BaseFtsScoreColumnTest {}

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/FtsScoreColumnTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/read/FtsScoreColumnTest.java
@@ -1,0 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+public class FtsScoreColumnTest extends BaseFtsScoreColumnTest {}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceConstant.java
@@ -19,8 +19,8 @@ public class LanceConstant {
   public static final String ROW_ADDRESS = "_rowaddr";
 
   /**
-   * Relevance score column. Lance auto-projects it onto the scan output whenever a full-text query
-   * is set, so it is exposed as a metadata column and stripped from the native column projection.
+   * BM25 relevance score column. Explicitly included in the native column projection when a
+   * full-text query is active. Exposed as a metadata column so it is hidden from SELECT *.
    */
   public static final String SCORE = "_score";
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/LanceDataset.java
@@ -157,10 +157,10 @@ public class LanceDataset
       };
 
   /**
-   * Relevance score, auto-projected by Lance only when a full-text query is active on the scan.
+   * BM25 relevance score, explicitly projected when a full-text query is active on the scan.
    * Advertised unconditionally because {@code metadataColumns()} is consulted by the analyzer
-   * before the query is known to contain FTS; selecting it without a full-text search yields an
-   * empty scan result for this column rather than a plan-time error (validation is a follow-up).
+   * before the query is known to contain FTS; selecting it without a full-text search raises {@code
+   * IllegalArgumentException} at scan-build time with a clear diagnostic message.
    */
   public static final MetadataColumn SCORE_COLUMN =
       new MetadataColumn() {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentColumnarBatchScanner.java
@@ -156,6 +156,15 @@ public class LanceFragmentColumnarBatchScanner implements AutoCloseable {
           BlobSizeColumnVector sizeVector = new BlobSizeColumnVector((StructVector) blobVector);
           fieldVectors.add(sizeVector);
         }
+      } else if (fieldName.equals(LanceConstant.SCORE)) {
+        FieldVector vector = actualFields.get(fieldName);
+        if (vector == null) {
+          throw new IllegalStateException(
+              "Lance scan did not return '_score'. This indicates a full-text query was expected "
+                  + "but not applied to the native scanner. Verify that the FTS predicate rule "
+                  + "injected the query into the relation options.");
+        }
+        fieldVectors.add(new LanceArrowColumnVector(vector, false, field));
       } else {
         FieldVector vector = actualFields.get(fieldName);
         if (vector == null) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -110,6 +110,9 @@ public class LanceFragmentScanner implements AutoCloseable {
       boolean hasBlobColumns = !blobColumnNames.isEmpty();
 
       List<String> projectedColumns = getColumnNames(scanSchema);
+      if (readOptions.getFullTextQuery() != null && hasField(scanSchema, LanceConstant.SCORE)) {
+        projectedColumns.add(LanceConstant.SCORE);
+      }
       if (projectedColumns.isEmpty() && scanSchema.isEmpty()) {
         scanOptions.withRowId(true);
       }
@@ -131,6 +134,7 @@ public class LanceFragmentScanner implements AutoCloseable {
       scanOptions.batchSize(readOptions.getBatchSize());
       if (readOptions.getFullTextQuery() != null) {
         scanOptions.fullTextQuery(readOptions.getFullTextQuery());
+        scanOptions.disableScoringAutoprojection(true);
       }
       scanOptions.useScalarIndex(readOptions.isUseScalarIndex());
       if (inputPartition.getLimit().isPresent()) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -172,6 +172,18 @@ public class LanceScanBuilder
         return localScan;
       }
 
+      // Reject _score without an active FTS query. The metadata column is advertised
+      // unconditionally (analyzer resolves it before the FTS rule runs), so validation
+      // must happen here at build time, after the optimizer fixed-point has finalized
+      // the relation options.
+      if (hasScoreColumn(schema) && readOptions.getFullTextQuery() == null) {
+        throw new IllegalArgumentException(
+            "Column '_score' requires a full-text search predicate (lance_match, "
+                + "lance_match_phrase, or lance_multi_match) in the WHERE clause. "
+                + "_score is a relevance score computed by the Lance FTS index and has no "
+                + "value without an active full-text query.");
+      }
+
       // Namespace-configured full-text search executes server-side via queryTable (single
       // partition). A full-text query without a namespace, or against a catalog-only namespace such
       // as Glue that does not implement queryTable, falls through to the local per-fragment scan
@@ -426,12 +438,9 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushTopN(SortOrder[] orders, int limit) {
-    // The Order by operator will use compute thread in lance.
-    // So it's better to have an option to enable it.
     if (!readOptions.isTopNPushDown() || hasResidualPredicates) {
       return false;
     }
-    this.limit = Optional.of(limit);
     List<ColumnOrdering> topNSortOrders = new ArrayList<>();
     for (SortOrder sortOrder : orders) {
       ColumnOrdering.Builder builder = new ColumnOrdering.Builder();
@@ -441,9 +450,14 @@ public class LanceScanBuilder
         return false;
       }
       FieldReference reference = (FieldReference) sortOrder.expression();
-      builder.setColumnName(reference.fieldNames()[0]);
+      String columnName = reference.fieldNames()[0];
+      if (columnName.equals(LanceConstant.SCORE)) {
+        return false;
+      }
+      builder.setColumnName(columnName);
       topNSortOrders.add(builder.build());
     }
+    this.limit = Optional.of(limit);
     this.topNSortOrders = Optional.of(topNSortOrders);
     return true;
   }
@@ -475,6 +489,15 @@ public class LanceScanBuilder
       return true;
     }
 
+    return false;
+  }
+
+  private static boolean hasScoreColumn(StructType schema) {
+    for (StructField field : schema.fields()) {
+      if (field.name().equals(LanceConstant.SCORE)) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/internal/LanceFragmentScannerTest.java
@@ -150,8 +150,8 @@ public class LanceFragmentScannerTest {
 
   @Test
   public void testGetColumnNamesExcludesScore() throws Exception {
-    // _score is auto-projected by Lance when a full-text query is set, so it must not be requested
-    // in the native column projection.
+    // getColumnNames() strips _score unconditionally; the caller (create()) conditionally re-adds
+    // it when FTS is active. This test validates the stripping behavior only.
     StructType schema =
         new StructType(
             new StructField[] {

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsScoreColumnTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsScoreColumnTest.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.namespace.DirectoryNamespace;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeclareTableRequest;
+import org.lance.namespace.model.DeclareTableResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.DropTableRequest;
+import org.lance.namespace.model.DropTableResponse;
+import org.lance.namespace.model.ListNamespacesRequest;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesRequest;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.RegisterTableRequest;
+import org.lance.namespace.model.RegisterTableResponse;
+import org.lance.namespace.model.RenameTableRequest;
+import org.lance.namespace.model.RenameTableResponse;
+import org.lance.namespace.model.TableExistsRequest;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the {@code _score} metadata column behavior on the FTS predicate path:
+ *
+ * <ul>
+ *   <li>Returns BM25 relevance scores when a full-text search predicate is active.
+ *   <li>Hidden from {@code SELECT *} (MetadataColumn contract).
+ *   <li>Rejected at build time when projected without an FTS predicate.
+ * </ul>
+ *
+ * <p>Uses a catalog-only namespace (local per-fragment scan path) so the tests exercise the
+ * explicit {@code _score} projection in {@code LanceFragmentScanner.create()} rather than the
+ * namespace {@code queryTable} delivery.
+ */
+public abstract class BaseFtsScoreColumnTest {
+
+  protected SparkSession spark;
+  protected String catalogName = "lance_fts_score_test";
+  protected String fullTable;
+
+  @TempDir Path tempDir;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    Files.createDirectories(rootPath);
+
+    spark =
+        SparkSession.builder()
+            .appName("lance-fts-score-column-test")
+            .master("local[4]")
+            .config(
+                "spark.sql.catalog." + catalogName, "org.lance.spark.LanceNamespaceSparkCatalog")
+            .config(
+                "spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+            .config(
+                "spark.sql.catalog." + catalogName + ".impl", CatalogOnlyNamespace.class.getName())
+            .config("spark.sql.catalog." + catalogName + ".root", rootPath.toString())
+            .config("spark.sql.catalog." + catalogName + ".single_level_ns", "true")
+            .config("spark.sql.defaultCatalog", catalogName)
+            .config("spark.sql.adaptive.enabled", "false")
+            .getOrCreate();
+
+    fullTable = catalogName + ".default.fts_score_" + UUID.randomUUID().toString().replace("-", "");
+    createAndIndexTable();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (spark != null) {
+      spark.stop();
+    }
+  }
+
+  /**
+   * Twenty rows in two INSERTs: ids 0-9 with body "hello world doc_N", then ids 10-14 with "foo bar
+   * doc_N" and ids 15-19 with "hello spark doc_N". Fifteen rows contain "hello".
+   */
+  private void createAndIndexTable() {
+    spark.sql(String.format("CREATE TABLE %s (id INT, body STRING) USING lance", fullTable));
+    String frag1 =
+        IntStream.range(0, 10)
+            .mapToObj(i -> String.format("(%d, 'hello world doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    spark.sql(String.format("INSERT INTO %s VALUES %s", fullTable, frag1));
+    String frag2a =
+        IntStream.range(10, 15)
+            .mapToObj(i -> String.format("(%d, 'foo bar doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    String frag2b =
+        IntStream.range(15, 20)
+            .mapToObj(i -> String.format("(%d, 'hello spark doc_%d')", i, i))
+            .collect(Collectors.joining(", "));
+    spark.sql(String.format("INSERT INTO %s VALUES %s, %s", fullTable, frag2a, frag2b));
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX fts_body USING fts (body) WITH ("
+                + "base_tokenizer='simple', language='English', max_token_length=40, "
+                + "lower_case=true, stem=false, remove_stop_words=false, "
+                + "ascii_folding=false, with_position=true)",
+            fullTable));
+  }
+
+  @Test
+  public void testScoreReturnedWithLanceMatch() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match(body, 'hello')", fullTable))
+            .collectAsList();
+    assertEquals(15, rows.size(), "Expected 15 rows matching 'hello'");
+    for (Row row : rows) {
+      assertFalse(row.isNullAt(1), "Every matching row must have a non-null _score");
+      assertTrue(row.getFloat(1) > 0.0f, "_score must be positive for matching rows");
+    }
+  }
+
+  @Test
+  public void testScoreReturnedWithLanceMatchPhrase() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match_phrase(body, 'hello world')",
+                    fullTable))
+            .collectAsList();
+    assertEquals(10, rows.size(), "Expected 10 rows matching phrase 'hello world'");
+    for (Row row : rows) {
+      assertFalse(row.isNullAt(1), "Every matching row must have a non-null _score");
+      assertTrue(row.getFloat(1) > 0.0f, "_score must be positive for matching rows");
+    }
+  }
+
+  @Test
+  public void testScoreWithLimitReturnsSubset() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match(body, 'hello') LIMIT 5",
+                    fullTable))
+            .collectAsList();
+    assertEquals(5, rows.size(), "LIMIT 5 must return exactly 5 rows");
+    for (Row row : rows) {
+      assertFalse(row.isNullAt(1), "Every matching row must have a non-null _score");
+      assertTrue(row.getFloat(1) > 0.0f, "_score must be positive for matching rows");
+    }
+  }
+
+  @Test
+  public void testScoreExcludedFromSelectStar() {
+    Dataset<Row> df =
+        spark.sql(String.format("SELECT * FROM %s WHERE lance_match(body, 'hello')", fullTable));
+    List<String> columns = Arrays.asList(df.columns());
+    assertFalse(
+        columns.contains("_score"), "SELECT * must not include _score (MetadataColumn contract)");
+    assertEquals(2, columns.size(), "Only data columns (id, body) expected in SELECT *");
+  }
+
+  @Test
+  public void testScoreWithoutFtsRejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> spark.sql(String.format("SELECT _score FROM %s", fullTable)).collectAsList());
+    assertTrue(
+        ex.getMessage().contains("full-text search predicate"),
+        "Error message should mention full-text search predicate requirement");
+  }
+
+  @Test
+  public void testScoreWithScalarFilterOnlyRejected() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                spark
+                    .sql(String.format("SELECT _score FROM %s WHERE id > 5", fullTable))
+                    .collectAsList());
+    assertTrue(
+        ex.getMessage().contains("full-text search predicate"),
+        "Scalar filter alone must not satisfy the _score FTS requirement");
+  }
+
+  @Test
+  public void testScoreWithCombinedFilter() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match(body, 'hello') AND id >= 15",
+                    fullTable))
+            .collectAsList();
+    assertEquals(5, rows.size(), "Expected 5 rows (ids 15-19) matching 'hello' AND id >= 15");
+    for (Row row : rows) {
+      assertFalse(row.isNullAt(1), "Every matching row must have a non-null _score");
+      assertTrue(row.getFloat(1) > 0.0f, "_score must be positive for matching rows");
+    }
+  }
+
+  @Test
+  public void testScoreOrderDescending() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match(body, 'hello') "
+                        + "ORDER BY _score DESC",
+                    fullTable))
+            .collectAsList();
+    assertEquals(15, rows.size());
+    for (int i = 1; i < rows.size(); i++) {
+      assertTrue(
+          rows.get(i - 1).getFloat(1) >= rows.get(i).getFloat(1),
+          "Rows must be sorted by _score descending");
+    }
+  }
+
+  @Test
+  public void testScoreOrderDescendingWithLimit() {
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id, _score FROM %s WHERE lance_match(body, 'hello') "
+                        + "ORDER BY _score DESC LIMIT 5",
+                    fullTable))
+            .collectAsList();
+    assertEquals(5, rows.size(), "ORDER BY _score DESC LIMIT 5 must return exactly 5 rows");
+    for (int i = 1; i < rows.size(); i++) {
+      assertTrue(
+          rows.get(i - 1).getFloat(1) >= rows.get(i).getFloat(1),
+          "Rows must be sorted by _score descending");
+    }
+  }
+
+  @Test
+  public void testScoreIsNullableInSchema() {
+    Dataset<Row> df =
+        spark.sql(
+            String.format("SELECT _score FROM %s WHERE lance_match(body, 'hello')", fullTable));
+    assertTrue(
+        df.schema().apply("_score").nullable(), "_score metadata column must be declared nullable");
+  }
+
+  /**
+   * Catalog-only namespace: delegates to {@link DirectoryNamespace} but leaves {@code queryTable}
+   * unimplemented, forcing the local per-fragment scan path.
+   */
+  public static class CatalogOnlyNamespace implements LanceNamespace {
+    private final DirectoryNamespace delegate = new DirectoryNamespace();
+
+    public CatalogOnlyNamespace() {}
+
+    @Override
+    public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {
+      delegate.initialize(configProperties, allocator);
+    }
+
+    @Override
+    public String namespaceId() {
+      return delegate.namespaceId();
+    }
+
+    @Override
+    public CreateNamespaceResponse createNamespace(CreateNamespaceRequest request) {
+      return delegate.createNamespace(request);
+    }
+
+    @Override
+    public DropNamespaceResponse dropNamespace(DropNamespaceRequest request) {
+      return delegate.dropNamespace(request);
+    }
+
+    @Override
+    public ListNamespacesResponse listNamespaces(ListNamespacesRequest request) {
+      return delegate.listNamespaces(request);
+    }
+
+    @Override
+    public DescribeNamespaceResponse describeNamespace(DescribeNamespaceRequest request) {
+      return delegate.describeNamespace(request);
+    }
+
+    @Override
+    public void namespaceExists(NamespaceExistsRequest request) {
+      delegate.namespaceExists(request);
+    }
+
+    @Override
+    public DeclareTableResponse declareTable(DeclareTableRequest request) {
+      return delegate.declareTable(request);
+    }
+
+    @Override
+    public DescribeTableResponse describeTable(DescribeTableRequest request) {
+      return delegate.describeTable(request);
+    }
+
+    @Override
+    public DropTableResponse dropTable(DropTableRequest request) {
+      return delegate.dropTable(request);
+    }
+
+    @Override
+    public ListTablesResponse listTables(ListTablesRequest request) {
+      return delegate.listTables(request);
+    }
+
+    @Override
+    public void tableExists(TableExistsRequest request) {
+      delegate.tableExists(request);
+    }
+
+    @Override
+    public RegisterTableResponse registerTable(RegisterTableRequest request) {
+      return delegate.registerTable(request);
+    }
+
+    @Override
+    public DeregisterTableResponse deregisterTable(DeregisterTableRequest request) {
+      return delegate.deregisterTable(request);
+    }
+
+    @Override
+    public RenameTableResponse renameTable(RenameTableRequest request) {
+      return delegate.renameTable(request);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Enables projecting the BM25 relevance score (`_score`) from full-text search predicates. This is the next step after #501 (FTS SQL extension) per the design in #631.

```sql
SELECT id, body, _score FROM docs
WHERE lance_match(body, 'vector database')
ORDER BY _score DESC;
```

Previously, `_score` was registered as a `MetadataColumn` on `LanceDataset` but never correctly delivered on the local per-fragment scan path — selecting it crashed at scan time with `IllegalStateException("Lance scan did not return expected field '_score'")`.

## What's included

**Three fixes** that make `_score` work end-to-end:

1. **Explicit projection** (`LanceFragmentScanner.create()`): when FTS is active and `_score` is in the scan schema, explicitly add it to the native column list. Sets `disableScoringAutoprojection(true)` to opt into Lance-core's future default and suppress the deprecation warning.

2. **Planning-time validation** (`LanceScanBuilder.build()`): selecting `_score` without an FTS predicate raises `IllegalArgumentException` with a clear diagnostic. Matches the existing FTS validation pattern.

3. **Defensive null-constant fallback** (`LanceFragmentColumnarBatchScanner`): if `_score` is in the schema but absent from the Arrow batch (AQE/ReusedExchange edge case), produces a null-filled `ConstantColumnVector` instead of crashing.

**Documentation**: new `_score` section in `docs/src/operations/dql/fts.md` with examples and updated Known Limitations.

**Tests**: 9 integration tests in `BaseFtsScoreColumnTest` covering:
- `_score` returned with `lance_match`, `lance_match_phrase`
- `_score` excluded from `SELECT *` (MetadataColumn contract)
- `_score` rejected without FTS (planning-time error)
- `_score` with combined scalar filter
- `_score` with LIMIT
- `ORDER BY _score DESC`
- Schema nullability assertion

## What's NOT included (future PRs)

- **Pushed ranked retrieval**: `ORDER BY _score DESC LIMIT k` currently sorts in Spark above the scan. A future PR will route this to a single-partition dataset-level ranked scan for optimal performance (step 5 in #631's plan).
- **`COUNT(*)` with FTS**: bug fix in #766 (separate PR, K-approved, ready to merge).
- **Distributed per-fragment top-k**: blocked on Lance-core global-IDF confirmation (C1 in #631).

## Design decisions

| Decision | Rationale |
|----------|-----------|
| Validate in `build()`, not `pruneColumns()` or a separate rule | `pruneColumns()` runs before the FTS optimizer rule injects the query; `build()` runs after the fixed-point, so FTS state is authoritative |
| `disableScoringAutoprojection(true)` | Suppresses Lance-core deprecation warning; makes behavior independent of the autoprojection default (future-proof) |
| Null-constant fallback rather than crash | Belt-and-suspenders for edge cases where the validation can't fire (AQE re-optimization) |
| `IllegalArgumentException` not `AnalysisException` | Consistent with existing FTS validation; `AnalysisException` constructor differs across Spark versions |