### PR TITLE
fix: support JDK immutable collections in the Kryo codec

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
+++ b/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
@@ -14,14 +14,19 @@
 package org.apache.spark.sql.util;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer;
 import com.esotericsoftware.kryo.serializers.MapSerializer;
+import com.esotericsoftware.kryo.util.MapReferenceResolver;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,16 +46,35 @@ import java.util.Set;
  * deserialization gadget surface that is dangerous here because {@code LanceSerializeUtil.decode}
  * is reachable from caller-controlled write options (a crafted payload's {@code readObject} would
  * run before the decoded value is even cast). Instead they keep every element on the Kryo path and
- * rebuild the collection through its public factory ({@code List.copyOf}/{@code Set.copyOf}/ {@code
+ * rebuild the collection through its public factory ({@code List.copyOf}/{@code Set.copyOf}/{@code
  * Map.copyOf}), preserving immutability. No {@code java.base}-internal reflection is used, so no
  * {@code --add-opens} is required, and immutable sub-lists are handled too because the collection
  * is rebuilt by iteration rather than reconstructed in place.
+ *
+ * <p><b>Reference identity.</b> Rebuilding a collection means the value returned to callers (the
+ * immutable copy) is not the object Kryo registered while reading (a mutable staging buffer). Left
+ * alone -- as in Kryo 5's own port -- a back-reference to an aliased collection would resolve to
+ * that throwaway buffer, so a decoded alias could be a mutable {@code ArrayList} (or the wrong type
+ * for a set/map). {@link ImmutableAwareReferenceResolver} closes that gap: each serializer arms the
+ * resolver immediately before delegating to {@code super.read}, which lets the resolver capture the
+ * id Kryo assigns to the collection and, once the immutable copy exists, swap it in so every later
+ * back-reference resolves to the immutable value. Aliased collections therefore round-trip to the
+ * same immutable instance.
+ *
+ * <p><b>Cyclic graphs.</b> A pure-immutable cycle is impossible (an immutable collection cannot
+ * contain itself -- it does not exist yet when its elements are chosen). A cycle can only form
+ * through a mutable object in the loop. When the immutable collection is <em>not</em> the object
+ * the cycle re-enters, it is fully supported (the mutable member is registered before its fields
+ * are read, so the back-reference resolves correctly). The one unsupportable shape is an immutable
+ * collection that a back-reference re-enters <em>while it is still being read</em> -- its immutable
+ * copy does not exist yet, so only the mutable buffer could be handed out. That case is detected
+ * and rejected with a clear {@link KryoException} rather than silently leaking the buffer.
  */
 public final class ImmutableCollectionsSerializers {
 
   private ImmutableCollectionsSerializers() {}
 
-  /** Registers the immutable-collection serializers on {@code kryo}. */
+  /** Registers the immutable-collection serializers and the identity-preserving resolver. */
   public static void register(Kryo kryo) {
     // Reach the package-private abstract bases via getSuperclass so no java.base-internal class is
     // named in source. List/Set/Map are distinct hierarchies, each rebuilt through its own factory;
@@ -59,14 +83,21 @@ public final class ImmutableCollectionsSerializers {
     Class<?> immutableList = List.copyOf(Collections.emptyList()).getClass().getSuperclass();
     Class<?> immutableSet = Set.copyOf(Collections.emptySet()).getClass().getSuperclass();
     Class<?> immutableMap = Map.of().getClass().getSuperclass();
-    kryo.addDefaultSerializer(immutableList, new ImmutableListSerializer());
-    kryo.addDefaultSerializer(immutableSet, new ImmutableSetSerializer());
-    kryo.addDefaultSerializer(immutableMap, new ImmutableMapSerializer());
+    // MapReferenceResolver is Kryo's default resolver, so subclassing it keeps all standard
+    // reference behavior for every other type; only the immutable-collection ids are rewritten.
+    ImmutableAwareReferenceResolver resolver = new ImmutableAwareReferenceResolver();
+    kryo.setReferenceResolver(resolver);
+    kryo.addDefaultSerializer(immutableList, new ImmutableListSerializer(resolver));
+    kryo.addDefaultSerializer(immutableSet, new ImmutableSetSerializer(resolver));
+    kryo.addDefaultSerializer(immutableMap, new ImmutableMapSerializer(resolver));
   }
 
   /** Reads elements onto a mutable buffer through Kryo, then rebuilds an immutable {@code List}. */
   private static final class ImmutableListSerializer extends CollectionSerializer {
-    ImmutableListSerializer() {
+    private final ImmutableAwareReferenceResolver resolver;
+
+    ImmutableListSerializer(ImmutableAwareReferenceResolver resolver) {
+      this.resolver = resolver;
       setElementsCanBeNull(false);
     }
 
@@ -77,14 +108,20 @@ public final class ImmutableCollectionsSerializers {
 
     @Override
     public Collection read(Kryo kryo, Input input, Class<Collection> type) {
+      resolver.arm();
       Collection buffer = super.read(kryo, input, type);
-      return buffer == null ? null : List.copyOf(buffer);
+      Collection immutable = buffer == null ? null : List.copyOf(buffer);
+      resolver.finish(immutable);
+      return immutable;
     }
   }
 
   /** Reads elements onto a mutable buffer through Kryo, then rebuilds an immutable {@code Set}. */
   private static final class ImmutableSetSerializer extends CollectionSerializer {
-    ImmutableSetSerializer() {
+    private final ImmutableAwareReferenceResolver resolver;
+
+    ImmutableSetSerializer(ImmutableAwareReferenceResolver resolver) {
+      this.resolver = resolver;
       setElementsCanBeNull(false);
     }
 
@@ -95,14 +132,20 @@ public final class ImmutableCollectionsSerializers {
 
     @Override
     public Collection read(Kryo kryo, Input input, Class<Collection> type) {
+      resolver.arm();
       Collection buffer = super.read(kryo, input, type);
-      return buffer == null ? null : Set.copyOf(buffer);
+      Collection immutable = buffer == null ? null : Set.copyOf(buffer);
+      resolver.finish(immutable);
+      return immutable;
     }
   }
 
   /** Reads entries onto a mutable buffer through Kryo, then rebuilds an immutable {@code Map}. */
   private static final class ImmutableMapSerializer extends MapSerializer {
-    ImmutableMapSerializer() {
+    private final ImmutableAwareReferenceResolver resolver;
+
+    ImmutableMapSerializer(ImmutableAwareReferenceResolver resolver) {
+      this.resolver = resolver;
       setKeysCanBeNull(false);
       setValuesCanBeNull(false);
     }
@@ -114,8 +157,84 @@ public final class ImmutableCollectionsSerializers {
 
     @Override
     public Map read(Kryo kryo, Input input, Class<Map> type) {
+      resolver.arm();
       Map buffer = super.read(kryo, input, type);
-      return buffer == null ? null : Map.copyOf(buffer);
+      Map immutable = buffer == null ? null : Map.copyOf(buffer);
+      resolver.finish(immutable);
+      return immutable;
+    }
+  }
+
+  /**
+   * A {@link MapReferenceResolver} that lets the immutable-collection serializers swap the mutable
+   * staging buffer Kryo registered while reading for the final immutable value, so back-references
+   * resolve to the immutable value returned to callers rather than the throwaway buffer.
+   *
+   * <p>Protocol: a serializer calls {@link #arm()} just before {@code super.read}. Kryo's {@code
+   * CollectionSerializer} / {@code MapSerializer} register the collection (via {@code
+   * kryo.reference}) right after {@code create()} and before reading elements, so the first {@link
+   * #setReadObject} that follows {@code arm()} is the collection's own registration; its id is
+   * captured. Nested reads re-arm and capture their own ids, forming a LIFO stack that matches read
+   * nesting. After the immutable copy is built the serializer calls {@link #finish(Object)} to
+   * rewrite that id. Until then the id is "pending"; a back-reference that resolves a pending id
+   * means the collection is being re-entered mid-read (an unsupportable cycle), which {@link
+   * #getReadObject} rejects.
+   */
+  static final class ImmutableAwareReferenceResolver extends MapReferenceResolver {
+    private final Deque<Integer> pendingStack = new ArrayDeque<>();
+    private final Set<Integer> pendingIds = new HashSet<>();
+    private boolean armed;
+
+    /** Arm the resolver so the next registered object's id is captured as a pending collection. */
+    void arm() {
+      armed = true;
+    }
+
+    /** Rewrite the just-read collection's reference id to point at its immutable copy. */
+    void finish(Object immutable) {
+      if (armed) {
+        // super.read registered no reference for this collection (e.g. references disabled), so
+        // there is nothing to rewrite; just clear the arm.
+        armed = false;
+        return;
+      }
+      if (pendingStack.isEmpty()) {
+        return;
+      }
+      int id = pendingStack.pop();
+      pendingIds.remove(id);
+      if (immutable != null) {
+        setReadObject(id, immutable);
+      }
+    }
+
+    @Override
+    public void setReadObject(int id, Object object) {
+      super.setReadObject(id, object);
+      if (armed) {
+        pendingStack.push(id);
+        pendingIds.add(id);
+        armed = false;
+      }
+    }
+
+    @Override
+    public Object getReadObject(Class type, int id) {
+      if (pendingIds.contains(id)) {
+        throw new KryoException(
+            "cyclic reference through an immutable collection is not supported: the collection is "
+                + "referenced again while it is still being deserialized, before its immutable "
+                + "value exists");
+      }
+      return super.getReadObject(type, id);
+    }
+
+    @Override
+    public void reset() {
+      super.reset();
+      pendingStack.clear();
+      pendingIds.clear();
+      armed = false;
     }
   }
 }

--- a/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
+++ b/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
@@ -21,7 +21,6 @@ import com.esotericsoftware.kryo.serializers.MapSerializer;
 import com.esotericsoftware.kryo.util.MapReferenceResolver;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
@@ -54,9 +53,9 @@ import java.util.Set;
  * <p><b>Reference identity.</b> Rebuilding a collection means the value returned to callers (the
  * immutable copy) is not the object Kryo registered while reading (a mutable staging buffer). Left
  * alone -- as in Kryo 5's own port -- a back-reference to an aliased collection would resolve to
- * that throwaway buffer, so a decoded alias could be a mutable {@code ArrayList} (or the wrong type
- * for a set/map). {@link ImmutableAwareReferenceResolver} closes that gap: each serializer arms the
- * resolver immediately before delegating to {@code super.read}, which lets the resolver capture the
+ * that throwaway buffer, so a decoded alias could be a mutable staging collection (or the wrong
+ * type for a set/map). {@link ImmutableAwareReferenceResolver} closes that gap: each serializer
+ * arms the resolver immediately before delegating to {@code super.read}, which lets it capture the
  * id Kryo assigns to the collection and, once the immutable copy exists, swap it in so every later
  * back-reference resolves to the immutable value. Aliased collections therefore round-trip to the
  * same immutable instance.
@@ -103,7 +102,11 @@ public final class ImmutableCollectionsSerializers {
 
     @Override
     protected Collection create(Kryo kryo, Input input, Class<Collection> type) {
-      return new ArrayList<>();
+      // ArrayDeque, not ArrayList: CollectionSerializer.read calls ArrayList.ensureCapacity
+      // with the wire-supplied length before any element is read, so a malformed huge length
+      // would eagerly allocate a giant array. decode() is reachable from caller-controlled write
+      // options, so a non-ArrayList buffer avoids that pre-allocation; ArrayDeque keeps order.
+      return new ArrayDeque<>();
     }
 
     @Override
@@ -127,7 +130,9 @@ public final class ImmutableCollectionsSerializers {
 
     @Override
     protected Collection create(Kryo kryo, Input input, Class<Collection> type) {
-      return new ArrayList<>();
+      // ArrayDeque for the same reason as the list serializer: avoid ArrayList.ensureCapacity
+      // pre-allocating from a hostile wire length. Element order is irrelevant to a set.
+      return new ArrayDeque<>();
     }
 
     @Override

--- a/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
+++ b/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
@@ -48,7 +48,11 @@ import java.util.Set;
  * rebuild the collection through its public factory ({@code List.copyOf}/{@code Set.copyOf}/{@code
  * Map.copyOf}), preserving immutability. No {@code java.base}-internal reflection is used, so no
  * {@code --add-opens} is required, and immutable sub-lists are handled too because the collection
- * is rebuilt by iteration rather than reconstructed in place.
+ * is rebuilt by iteration rather than reconstructed in place. A valid immutable collection never
+ * holds {@code null}, and a {@code null} smuggled in by a malformed payload is rejected by the
+ * {@code ArrayDeque} staging buffer and by {@code copyOf}, so no Kryo element-null flag is set (it
+ * would be inert here anyway: with no per-element serializer, Kryo takes its {@code
+ * writeClassAndObject}/{@code readClassAndObject} path, which never consults those flags).
  *
  * <p><b>Reference identity.</b> Rebuilding a collection means the value returned to callers (the
  * immutable copy) is not the object Kryo registered while reading (a mutable staging buffer). Left
@@ -97,7 +101,6 @@ public final class ImmutableCollectionsSerializers {
 
     ImmutableListSerializer(ImmutableAwareReferenceResolver resolver) {
       this.resolver = resolver;
-      setElementsCanBeNull(false);
     }
 
     @Override
@@ -125,7 +128,6 @@ public final class ImmutableCollectionsSerializers {
 
     ImmutableSetSerializer(ImmutableAwareReferenceResolver resolver) {
       this.resolver = resolver;
-      setElementsCanBeNull(false);
     }
 
     @Override
@@ -151,8 +153,6 @@ public final class ImmutableCollectionsSerializers {
 
     ImmutableMapSerializer(ImmutableAwareReferenceResolver resolver) {
       this.resolver = resolver;
-      setKeysCanBeNull(false);
-      setValuesCanBeNull(false);
     }
 
     @Override

--- a/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
+++ b/lance-spark-base_2.12/src/main/java/org/apache/spark/sql/util/ImmutableCollectionsSerializers.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.util;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+import com.esotericsoftware.kryo.serializers.MapSerializer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Kryo serializers for the JDK immutable collections ({@code List.of}/{@code copyOf}, {@code
+ * Set.of}, {@code Map.of}), backported from Kryo 5's {@code ImmutableCollectionsSerializers}
+ * (absent from the Kryo 4.0.2 that Spark bundles).
+ *
+ * <p>These collections have no no-arg constructor and keep their elements in a private, {@code
+ * java.base}-internal field, so the Objenesis-based instantiator {@link LanceSerializeUtil}
+ * configures produces an instance whose backing storage is never populated -- a decoded collection
+ * then throws (e.g. {@code UnsupportedOperationException} / NPE) the first time it is used.
+ *
+ * <p>These serializers deliberately do <b>not</b> delegate to Kryo's {@code JavaSerializer}: that
+ * would route every nested element through {@code ObjectInputStream.readObject}, a Java
+ * deserialization gadget surface that is dangerous here because {@code LanceSerializeUtil.decode}
+ * is reachable from caller-controlled write options (a crafted payload's {@code readObject} would
+ * run before the decoded value is even cast). Instead they keep every element on the Kryo path and
+ * rebuild the collection through its public factory ({@code List.copyOf}/{@code Set.copyOf}/ {@code
+ * Map.copyOf}), preserving immutability. No {@code java.base}-internal reflection is used, so no
+ * {@code --add-opens} is required, and immutable sub-lists are handled too because the collection
+ * is rebuilt by iteration rather than reconstructed in place.
+ */
+public final class ImmutableCollectionsSerializers {
+
+  private ImmutableCollectionsSerializers() {}
+
+  /** Registers the immutable-collection serializers on {@code kryo}. */
+  public static void register(Kryo kryo) {
+    // Reach the package-private abstract bases via getSuperclass so no java.base-internal class is
+    // named in source. List/Set/Map are distinct hierarchies, each rebuilt through its own factory;
+    // registering on the base covers every size variant (List12/ListN, Set12/SetN, Map1/MapN) and
+    // sub-lists. copyOf(empty*) sidesteps the overloaded of() factories.
+    Class<?> immutableList = List.copyOf(Collections.emptyList()).getClass().getSuperclass();
+    Class<?> immutableSet = Set.copyOf(Collections.emptySet()).getClass().getSuperclass();
+    Class<?> immutableMap = Map.of().getClass().getSuperclass();
+    kryo.addDefaultSerializer(immutableList, new ImmutableListSerializer());
+    kryo.addDefaultSerializer(immutableSet, new ImmutableSetSerializer());
+    kryo.addDefaultSerializer(immutableMap, new ImmutableMapSerializer());
+  }
+
+  /** Reads elements onto a mutable buffer through Kryo, then rebuilds an immutable {@code List}. */
+  private static final class ImmutableListSerializer extends CollectionSerializer {
+    ImmutableListSerializer() {
+      setElementsCanBeNull(false);
+    }
+
+    @Override
+    protected Collection create(Kryo kryo, Input input, Class<Collection> type) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public Collection read(Kryo kryo, Input input, Class<Collection> type) {
+      Collection buffer = super.read(kryo, input, type);
+      return buffer == null ? null : List.copyOf(buffer);
+    }
+  }
+
+  /** Reads elements onto a mutable buffer through Kryo, then rebuilds an immutable {@code Set}. */
+  private static final class ImmutableSetSerializer extends CollectionSerializer {
+    ImmutableSetSerializer() {
+      setElementsCanBeNull(false);
+    }
+
+    @Override
+    protected Collection create(Kryo kryo, Input input, Class<Collection> type) {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public Collection read(Kryo kryo, Input input, Class<Collection> type) {
+      Collection buffer = super.read(kryo, input, type);
+      return buffer == null ? null : Set.copyOf(buffer);
+    }
+  }
+
+  /** Reads entries onto a mutable buffer through Kryo, then rebuilds an immutable {@code Map}. */
+  private static final class ImmutableMapSerializer extends MapSerializer {
+    ImmutableMapSerializer() {
+      setKeysCanBeNull(false);
+      setValuesCanBeNull(false);
+    }
+
+    @Override
+    protected Map create(Kryo kryo, Input input, Class<Map> type) {
+      return new HashMap<>();
+    }
+
+    @Override
+    public Map read(Kryo kryo, Input input, Class<Map> type) {
+      Map buffer = super.read(kryo, input, type);
+      return buffer == null ? null : Map.copyOf(buffer);
+    }
+  }
+}

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceSerializeUtil.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/util/LanceSerializeUtil.scala
@@ -28,6 +28,13 @@ object LanceSerializeUtil {
       val kryo = new Kryo()
       kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy(new StdInstantiatorStrategy()))
       kryo.setClassLoader(Utils.getContextOrSparkClassLoader)
+      // The JDK immutable collections (List.of/copyOf, Set.of, Map.of) cannot be rebuilt by the
+      // Objenesis instantiator above -- they have no no-arg constructor and hold their storage in a
+      // java.base-internal field -- so a decoded collection would throw on first use. See
+      // ImmutableCollectionsSerializers for why these stay on the Kryo path rather than delegating
+      // to JavaSerializer (which would expose a deserialization gadget at this caller-controlled
+      // decode boundary).
+      ImmutableCollectionsSerializers.register(kryo)
       kryo
     }
   }

--- a/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
@@ -35,8 +35,8 @@ public class LanceSerializeUtilTest {
 
   // The JDK immutable collections (List.of/copyOf, Set.of, Map.of) have no no-arg constructor and
   // keep their storage in a java.base-internal field, so the codec's Objenesis instantiator could
-  // not reconstruct them: a decoded collection threw on first use. The size()/contents assertions
-  // below fail on the pre-fix codec and pass once the immutable classes delegate to JavaSerializer.
+  // not reconstruct them. The assertions below pass once dedicated Kryo serializers rebuild the
+  // collections through their public copyOf factories without invoking Java serialization.
   @Test
   public void roundtripsImmutableListOfEveryBackingShape() {
     List<List<Long>> cases =

--- a/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests that {@link LanceSerializeUtil}'s Kryo codec roundtrips JDK immutable collections. */
@@ -108,5 +110,80 @@ public class LanceSerializeUtilTest {
       in.defaultReadObject();
       executed = true;
     }
+  }
+
+  // The immutable collections are rebuilt via their public factory during decode, so the value
+  // returned to callers is not the mutable buffer Kryo registered while reading. Aliased
+  // collections (the same instance referenced twice) must still round-trip to a single immutable
+  // instance -- otherwise a back-reference could hand back the throwaway mutable ArrayList (or the
+  // wrong type for a set/map), which is exactly what an unfixed rebuild-on-read serializer does.
+  @Test
+  public void preservesReferenceIdentityOfAliasedImmutableCollections() {
+    List<Long> sharedList = List.copyOf(Arrays.asList(1L, 2L, 3L));
+    List<List<Long>> decodedList = roundtrip(List.of(sharedList, sharedList));
+    assertSame(decodedList.get(0), decodedList.get(1));
+    assertEquals(sharedList, decodedList.get(0));
+    assertThrows(UnsupportedOperationException.class, () -> decodedList.get(0).add(4L));
+
+    java.util.Set<Long> sharedSet = java.util.Set.of(9L, 8L, 7L);
+    List<java.util.Set<Long>> decodedSet = roundtrip(List.of(sharedSet, sharedSet));
+    assertSame(decodedSet.get(0), decodedSet.get(1));
+    assertEquals(sharedSet, decodedSet.get(0));
+    assertThrows(UnsupportedOperationException.class, () -> decodedSet.get(0).add(6L));
+
+    java.util.Map<String, Long> sharedMap = java.util.Map.of("a", 1L, "b", 2L);
+    List<java.util.Map<String, Long>> decodedMap = roundtrip(List.of(sharedMap, sharedMap));
+    assertSame(decodedMap.get(0), decodedMap.get(1));
+    assertEquals(sharedMap, decodedMap.get(0));
+    assertThrows(UnsupportedOperationException.class, () -> decodedMap.get(0).put("c", 3L));
+  }
+
+  // A cycle can only form through a mutable object in the loop (an immutable collection cannot
+  // contain itself). When the immutable collection is not the object the cycle re-enters, the
+  // mutable member is registered before its back-reference is read, so the graph decodes correctly
+  // and the collection is still immutable.
+  @Test
+  public void supportsCycleThroughAMutableObjectHoldingAnImmutableCollection() {
+    CycleHolder holder = new CycleHolder();
+    holder.tag = 42;
+    holder.ref = List.of(holder); // immutable list contains holder; holder points back at the list
+
+    CycleHolder decoded = roundtrip(holder);
+    assertEquals(42, decoded.tag);
+    assertTrue(decoded.ref instanceof List);
+    List<?> list = (List<?>) decoded.ref;
+    assertEquals(1, list.size());
+    assertSame(decoded, list.get(0));
+    assertThrows(UnsupportedOperationException.class, () -> ((List<Object>) decoded.ref).add(0));
+  }
+
+  // The one unsupportable shape: an immutable collection that a back-reference re-enters while it
+  // is still being read (here it is the graph root). Its immutable value does not exist yet, so
+  // rather than leak the mutable buffer the decode fails fast with a clear message.
+  @Test
+  public void rejectsCycleThatReentersAnImmutableCollectionStillBeingRead() {
+    CycleHolder holder = new CycleHolder();
+    holder.tag = 7;
+    List<CycleHolder> root = List.of(holder); // root is the immutable list itself
+    holder.ref = root;
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> roundtrip(root));
+    assertTrue(
+        messageChain(thrown).contains("cyclic reference through an immutable collection"),
+        messageChain(thrown));
+  }
+
+  private static String messageChain(Throwable t) {
+    StringBuilder sb = new StringBuilder();
+    for (Throwable cur = t; cur != null; cur = cur.getCause()) {
+      sb.append(cur.getMessage()).append('\n');
+    }
+    return sb.toString();
+  }
+
+  /** A mutable object that can hold a back-reference, used to build cyclic object graphs. */
+  public static final class CycleHolder {
+    public int tag;
+    public Object ref;
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
@@ -52,11 +52,17 @@ public class LanceSerializeUtilTest {
     }
   }
 
+  // Set.of(1-2 elems)/Map.of(1 entry) select the Set12/Map1 backing classes; the empty and larger
+  // variants select SetN/MapN. All extend the abstract base the serializers register on, so both
+  // shapes are exercised here rather than assumed.
   @Test
   public void roundtripsImmutableSetAndMap() {
     assertTrue(roundtrip(java.util.Set.of()).isEmpty());
+    assertEquals(java.util.Set.of("x"), roundtrip(java.util.Set.of("x")));
+    assertEquals(java.util.Set.of("x", "y"), roundtrip(java.util.Set.of("x", "y")));
     assertEquals(java.util.Set.of("a", "b", "c"), roundtrip(java.util.Set.of("a", "b", "c")));
     assertTrue(roundtrip(java.util.Map.of()).isEmpty());
+    assertEquals(java.util.Map.of("k", "v"), roundtrip(java.util.Map.of("k", "v")));
     assertEquals(
         java.util.Map.of("a", "b", "c", "d"), roundtrip(java.util.Map.of("a", "b", "c", "d")));
   }

--- a/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/apache/spark/sql/util/LanceSerializeUtilTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests that {@link LanceSerializeUtil}'s Kryo codec roundtrips JDK immutable collections. */
+public class LanceSerializeUtilTest {
+
+  private static <T> T roundtrip(T obj) {
+    return LanceSerializeUtil.decode(LanceSerializeUtil.encode(obj));
+  }
+
+  // The JDK immutable collections (List.of/copyOf, Set.of, Map.of) have no no-arg constructor and
+  // keep their storage in a java.base-internal field, so the codec's Objenesis instantiator could
+  // not reconstruct them: a decoded collection threw on first use. The size()/contents assertions
+  // below fail on the pre-fix codec and pass once the immutable classes delegate to JavaSerializer.
+  @Test
+  public void roundtripsImmutableListOfEveryBackingShape() {
+    List<List<Long>> cases =
+        Arrays.asList(
+            List.<Long>copyOf(Collections.emptyList()),
+            List.copyOf(Arrays.asList(7L)),
+            List.copyOf(Arrays.asList(1L, 2L, 3L)));
+    for (List<Long> src : cases) {
+      List<Long> decoded = roundtrip(src);
+      // size() is the call that dereferenced the (unpopulated) backing array before the fix.
+      assertEquals(src.size(), decoded.size());
+      assertEquals(src, decoded);
+    }
+  }
+
+  @Test
+  public void roundtripsImmutableSetAndMap() {
+    assertTrue(roundtrip(java.util.Set.of()).isEmpty());
+    assertEquals(java.util.Set.of("a", "b", "c"), roundtrip(java.util.Set.of("a", "b", "c")));
+    assertTrue(roundtrip(java.util.Map.of()).isEmpty());
+    assertEquals(
+        java.util.Map.of("a", "b", "c", "d"), roundtrip(java.util.Map.of("a", "b", "c", "d")));
+  }
+
+  // Mirrors the failing path in practice: a Serializable value object (e.g. a compaction task's
+  // options) that holds an immutable list built with List.copyOf(...) as a field. The codec used to
+  // throw "KryoException: UnsupportedOperationException" on that field when shipping the object to
+  // an executor.
+  @Test
+  public void roundtripsSerializableObjectHoldingAnImmutableListField() {
+    Holder src = new Holder(List.copyOf(Arrays.asList(10L, 20L, 30L)), "compact");
+    Holder decoded = roundtrip(src);
+    assertEquals(src.ids, decoded.ids);
+    assertEquals(src.name, decoded.name);
+  }
+
+  /** A minimal Serializable object carrying an immutable-list field, like CompactionOptions. */
+  public static final class Holder implements Serializable {
+    private final List<Long> ids;
+    private final String name;
+
+    Holder(List<Long> ids, String name) {
+      this.ids = ids;
+      this.name = name;
+    }
+  }
+
+  // Security regression: LanceSerializeUtil.decode() is reachable from caller-controlled write
+  // options, so element (de)serialization must stay on the Kryo path and must never invoke Java's
+  // readObject hook. Delegating immutable collections to JavaSerializer (an earlier candidate fix)
+  // ran every nested element through ObjectInputStream.readObject -- a deserialization gadget
+  // surface. Decoding an immutable collection carrying such an element must NOT run its readObject.
+  @Test
+  public void doesNotInvokeReadObjectOfNestedElements() {
+    GadgetProbe.executed = false;
+    List<GadgetProbe> decoded = roundtrip(List.of(new GadgetProbe()));
+    assertEquals(1, decoded.size());
+    assertFalse(
+        GadgetProbe.executed, "nested element readObject must not run during a Kryo decode");
+  }
+
+  /**
+   * A Serializable element whose readObject records execution -- a stand-in for a deserialization
+   * gadget. Kryo never calls readObject, so a Kryo decode must leave {@link #executed} false.
+   */
+  public static final class GadgetProbe implements Serializable {
+    static boolean executed;
+
+    private void readObject(java.io.ObjectInputStream in)
+        throws java.io.IOException, ClassNotFoundException {
+      in.defaultReadObject();
+      executed = true;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
     <properties>
         <lance-spark.version>0.8.0-beta.1</lance-spark.version>
-        <lance.version>11.0.0-beta.10</lance.version>
+        <lance.version>11.0.0-beta.21</lance.version>
         <lance-namespace.version>0.8.6</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 


### PR DESCRIPTION
## Problem

`LanceSerializeUtil` (used to ship compaction and index tasks to executors) configures Kryo with an Objenesis-based instantiator (`StdInstantiatorStrategy`), which constructs objects without calling their constructors. The JDK immutable collections — `List.of`/`List.copyOf`, `Set.of`, `Map.of` — have no no-arg constructor and keep their elements in a private, `java.base`-internal field. Kryo therefore produces an instance whose backing storage is never populated, and decoding such a collection throws on first use:

- `KryoException: java.lang.UnsupportedOperationException`
- `NullPointerException: Cannot read the array length because "this.elements" is null`

lance-core value objects passed through this codec carry such collections. Starting in `11.0.0-beta.21`, `CompactionOptions` stores `excludedFragmentIds` as `List.copyOf(...)`, so a compaction task fails to deserialize on the executor:

```
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException
Serialization trace:
excludedFragmentIds (org.lance.compaction.CompactionOptions)
```

This is what makes `OptimizeTest` / `VacuumTest` / `ShowIndexesTest` fail once lance-core is bumped past beta.10.

## Changes

1. **Bump lance-core `11.0.0-beta.10` → `11.0.0-beta.21`.** This is the version that introduces the `excludedFragmentIds` field, so it reproduces the failure — the PR's own CI now exercises the affected tests against the version that breaks.

2. **Fix the Kryo codec** with dedicated serializers for the JDK immutable collections (`ImmutableCollectionsSerializers`), ported from Kryo 5's `ImmutableCollectionsSerializers` — auto-wired by default there, but never backported to the Kryo 4.0.2 that Spark bundles. They are registered on the package-private abstract bases reached via `getSuperclass`, which covers every size variant (`List12`/`ListN`, `Set12`/`SetN`, `Map1`/`MapN`) without naming a `java.base`-internal class in source and without `--add-opens`. Each element is read onto a mutable staging buffer through Kryo and the collection is then rebuilt through its public factory (`List`/`Set`/`Map.copyOf`).

   - **No `JavaSerializer`.** `decode()` is reachable from caller-controlled write options, and `JavaSerializer` would route every nested element through `ObjectInputStream.readObject` — a Java deserialization gadget surface right at that entry point (a crafted payload's `readObject` would run before the decoded value is even cast). Keeping every element on the Kryo path avoids that. As a bonus, immutable sub-lists (`List.of(...).subList(...)`) are handled too, since the collection is rebuilt by iteration rather than reconstructed in place.

   - **Reference identity.** Rebuilding means the value returned to callers (the immutable copy) is not the object Kryo registered while reading (the mutable staging buffer). Left alone — as in Kryo 5's own port — a back-reference to an aliased collection resolves to that throwaway buffer, so a decoded alias could be a mutable collection (or the wrong type for a set/map). `ImmutableAwareReferenceResolver` rewrites each collection's Kryo reference id to its immutable copy once rebuilt, so aliased collections round-trip to the same immutable instance. This is stricter than Kryo 5, whose port does not fix aliasing.

   - **Cyclic graphs.** A pure-immutable cycle is impossible (a collection cannot contain itself). A cycle through a mutable object that merely holds an immutable collection is supported. The one unsupportable shape — a back-reference re-entering an immutable collection while it is still being read — is detected and rejected with a clear `KryoException` rather than silently leaking the mutable buffer.

   - **Hardened read buffer.** The list and set serializers stage elements in an `ArrayDeque`, not an `ArrayList`: `CollectionSerializer.read` calls `ArrayList.ensureCapacity` with the wire-supplied length before reading any element, so on this caller-reachable path a malformed huge length would eagerly allocate a giant backing array. `ArrayDeque` avoids that branch and preserves insertion order for the `List.copyOf` rebuild.

## Test

`LanceSerializeUtilTest` (JUnit 5, 7 cases):

- Round-trips `List` / `Set` / `Map` across the sizes that select the distinct backing classes, plus a `Serializable` object holding an immutable-list field — each throws on the pre-fix codec and passes with the fix.
- `doesNotInvokeReadObjectOfNestedElements` locks in the security property: a nested element's `readObject` must not run during a Kryo decode.
- `preservesReferenceIdentityOfAliasedImmutableCollections` asserts aliased list/set/map decode to a single immutable instance (and stay immutable).
- `supportsCycleThroughAMutableObjectHoldingAnImmutableCollection` and `rejectsCycleThatReentersAnImmutableCollectionStillBeingRead` cover the two cyclic-graph outcomes.

The pre-existing `OptimizeTest` / `VacuumTest` / `ShowIndexesTest` provide end-to-end coverage against beta.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
