### PR TITLE
fix: normalize WITH-clause option names at the parser boundary

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -38,6 +38,8 @@ The following index methods are supported:
 
 The `CREATE INDEX` command supports options via the `WITH` clause to control index creation. These options are specific to the chosen index method.
 
+Option names are case-insensitive: `WITH (TRAIN = false)` and `WITH (train = false)` are the same option.
+
 ### Common Options
 
 These options apply to all index methods:

--- a/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.4_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -19,12 +19,25 @@ import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceCreateTag, LanceDropBranch, LanceDropIndex, LanceDropTag, LanceNamedArgument, LanceShowBranches, LanceShowTags, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {
 
   private def cleanIdentifier(text: String): String = ParserUtils.cleanIdentifier(text)
+
+  /**
+   * A WITH-clause option name, normalized to lower case.
+   *
+   * ANTLR reports identifier text as written, and every command matches its option names against
+   * lower-case literals, so without normalizing here `WITH (TRAIN = false)` parses into an option
+   * no command recognizes: the index is trained anyway, and the name leaks to Lance as an index
+   * parameter.
+   */
+  private def normalizedOptionName(text: String): String =
+    cleanIdentifier(text).toLowerCase(Locale.ROOT)
 
   override def visitSingleStatement(ctx: LanceSqlExtensionsParser.SingleStatementContext)
       : LogicalPlan = {
@@ -73,7 +86,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -84,7 +97,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -98,7 +111,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val columns = visitFieldPathList(ctx.fieldPathList())
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 

--- a/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
+++ b/lance-spark-3.4_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
@@ -143,6 +143,26 @@ public class LanceSqlExtensionsAstBuilderTest {
   }
 
   @Test
+  public void testCreateIndexNormalizesOptionNames() {
+    // Keywords must be uppercase here: the grammar's LETTER fragment is [A-Z], and this test
+    // feeds the lexer a raw stream rather than the UpperCaseCharStream the session parser uses.
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE DB.T CREATE INDEX IDX USING ZONEMAP (ID) "
+                + "WITH (TRAIN = FALSE, ROWS_PER_ZONE = 4)");
+    AddIndex plan = (AddIndex) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    // Option names are normalized at parse time: the commands match lower-case literals, so an
+    // upper-case spelling must reach them as the option it looks like rather than an unknown one
+    // that is silently ignored and forwarded to Lance as an index parameter.
+    assertEquals(2, plan.args().size());
+    assertEquals("train", plan.args().apply(0).name());
+    assertEquals(Boolean.FALSE, plan.args().apply(0).value());
+    assertEquals("rows_per_zone", plan.args().apply(1).name());
+    assertEquals(4L, plan.args().apply(1).value());
+  }
+
+  @Test
   public void testOptimizeWithBacktickedTableName() {
     LanceSqlExtensionsParser parser = createParser("OPTIMIZE `my-catalog`.`my-table`");
     Optimize plan = (Optimize) astBuilder.visitSingleStatement(parser.singleStatement());
@@ -150,6 +170,16 @@ public class LanceSqlExtensionsAstBuilderTest {
     UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
     assertEquals(
         List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
+
+  @Test
+  public void testOptimizeNormalizesOptionNames() {
+    LanceSqlExtensionsParser parser =
+        createParser("OPTIMIZE DB.T WITH (TARGET_ROWS_PER_FRAGMENT = 100)");
+    Optimize plan = (Optimize) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    assertEquals(1, plan.args().size());
+    assertEquals("target_rows_per_fragment", plan.args().apply(0).name());
   }
 
   @Test
@@ -188,6 +218,15 @@ public class LanceSqlExtensionsAstBuilderTest {
     UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
     assertEquals(
         List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
+
+  @Test
+  public void testVacuumNormalizesOptionNames() {
+    LanceSqlExtensionsParser parser = createParser("VACUUM DB.T WITH (BEFORE_VERSION = 3)");
+    Vacuum plan = (Vacuum) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    assertEquals(1, plan.args().size());
+    assertEquals("before_version", plan.args().apply(0).name());
   }
 
   @Test

--- a/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-3.5_2.12/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -19,12 +19,25 @@ import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceCreateTag, LanceDropBranch, LanceDropIndex, LanceDropTag, LanceNamedArgument, LanceShowBranches, LanceShowTags, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
+import java.util.Locale
+
 import scala.collection.JavaConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {
 
   private def cleanIdentifier(text: String): String = ParserUtils.cleanIdentifier(text)
+
+  /**
+   * A WITH-clause option name, normalized to lower case.
+   *
+   * ANTLR reports identifier text as written, and every command matches its option names against
+   * lower-case literals, so without normalizing here `WITH (TRAIN = false)` parses into an option
+   * no command recognizes: the index is trained anyway, and the name leaks to Lance as an index
+   * parameter.
+   */
+  private def normalizedOptionName(text: String): String =
+    cleanIdentifier(text).toLowerCase(Locale.ROOT)
 
   override def visitSingleStatement(ctx: LanceSqlExtensionsParser.SingleStatementContext)
       : LogicalPlan = {
@@ -73,7 +86,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -84,7 +97,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -98,7 +111,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val columns = visitFieldPathList(ctx.fieldPathList())
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 

--- a/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
+++ b/lance-spark-3.5_2.12/src/test/java/org/lance/spark/update/LanceSqlExtensionsAstBuilderTest.java
@@ -167,6 +167,26 @@ public class LanceSqlExtensionsAstBuilderTest {
   }
 
   @Test
+  public void testCreateIndexNormalizesOptionNames() {
+    // Keywords must be uppercase here: the grammar's LETTER fragment is [A-Z], and this test
+    // feeds the lexer a raw stream rather than the UpperCaseCharStream the session parser uses.
+    LanceSqlExtensionsParser parser =
+        createParser(
+            "ALTER TABLE DB.T CREATE INDEX IDX USING ZONEMAP (ID) "
+                + "WITH (TRAIN = FALSE, ROWS_PER_ZONE = 4)");
+    AddIndex plan = (AddIndex) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    // Option names are normalized at parse time: the commands match lower-case literals, so an
+    // upper-case spelling must reach them as the option it looks like rather than an unknown one
+    // that is silently ignored and forwarded to Lance as an index parameter.
+    assertEquals(2, plan.args().size());
+    assertEquals("train", plan.args().apply(0).name());
+    assertEquals(Boolean.FALSE, plan.args().apply(0).value());
+    assertEquals("rows_per_zone", plan.args().apply(1).name());
+    assertEquals(4L, plan.args().apply(1).value());
+  }
+
+  @Test
   public void testOptimizeWithBacktickedTableName() {
     LanceSqlExtensionsParser parser = createParser("OPTIMIZE `my-catalog`.`my-table`");
     Optimize plan = (Optimize) astBuilder.visitSingleStatement(parser.singleStatement());
@@ -174,6 +194,16 @@ public class LanceSqlExtensionsAstBuilderTest {
     UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
     assertEquals(
         List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
+
+  @Test
+  public void testOptimizeNormalizesOptionNames() {
+    LanceSqlExtensionsParser parser =
+        createParser("OPTIMIZE DB.T WITH (TARGET_ROWS_PER_FRAGMENT = 100)");
+    Optimize plan = (Optimize) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    assertEquals(1, plan.args().size());
+    assertEquals("target_rows_per_fragment", plan.args().apply(0).name());
   }
 
   @Test
@@ -212,6 +242,15 @@ public class LanceSqlExtensionsAstBuilderTest {
     UnresolvedIdentifier table = (UnresolvedIdentifier) plan.table();
     assertEquals(
         List.of("my-catalog", "my-table"), JavaConverters.seqAsJavaList(table.nameParts()));
+  }
+
+  @Test
+  public void testVacuumNormalizesOptionNames() {
+    LanceSqlExtensionsParser parser = createParser("VACUUM DB.T WITH (BEFORE_VERSION = 3)");
+    Vacuum plan = (Vacuum) astBuilder.visitSingleStatement(parser.singleStatement());
+
+    assertEquals(1, plan.args().size());
+    assertEquals("before_version", plan.args().apply(0).name());
   }
 
   @Test

--- a/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.0_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -19,12 +19,25 @@ import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceCreateTag, LanceDropBranch, LanceDropIndex, LanceDropTag, LanceNamedArgument, LanceShowBranches, LanceShowTags, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
+import java.util.Locale
+
 import scala.jdk.CollectionConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {
 
   private def cleanIdentifier(text: String): String = ParserUtils.cleanIdentifier(text)
+
+  /**
+   * A WITH-clause option name, normalized to lower case.
+   *
+   * ANTLR reports identifier text as written, and every command matches its option names against
+   * lower-case literals, so without normalizing here `WITH (TRAIN = false)` parses into an option
+   * no command recognizes: the index is trained anyway, and the name leaks to Lance as an index
+   * parameter.
+   */
+  private def normalizedOptionName(text: String): String =
+    cleanIdentifier(text).toLowerCase(Locale.ROOT)
 
   override def visitSingleStatement(ctx: LanceSqlExtensionsParser.SingleStatementContext)
       : LogicalPlan = {
@@ -73,7 +86,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -84,7 +97,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -98,7 +111,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val columns = visitFieldPathList(ctx.fieldPathList())
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 

--- a/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.1_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -19,12 +19,25 @@ import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceCreateTag, LanceDropBranch, LanceDropIndex, LanceDropTag, LanceNamedArgument, LanceShowBranches, LanceShowTags, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
+import java.util.Locale
+
 import scala.jdk.CollectionConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {
 
   private def cleanIdentifier(text: String): String = ParserUtils.cleanIdentifier(text)
+
+  /**
+   * A WITH-clause option name, normalized to lower case.
+   *
+   * ANTLR reports identifier text as written, and every command matches its option names against
+   * lower-case literals, so without normalizing here `WITH (TRAIN = false)` parses into an option
+   * no command recognizes: the index is trained anyway, and the name leaks to Lance as an index
+   * parameter.
+   */
+  private def normalizedOptionName(text: String): String =
+    cleanIdentifier(text).toLowerCase(Locale.ROOT)
 
   override def visitSingleStatement(ctx: LanceSqlExtensionsParser.SingleStatementContext)
       : LogicalPlan = {
@@ -73,7 +86,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -84,7 +97,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -98,7 +111,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val columns = visitFieldPathList(ctx.fieldPathList())
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 

--- a/lance-spark-4.2_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
+++ b/lance-spark-4.2_2.13/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/LanceSqlExtensionsAstBuilder.scala
@@ -19,12 +19,25 @@ import org.apache.spark.sql.catalyst.parser.{ParseException, ParserInterface}
 import org.apache.spark.sql.catalyst.plans.logical.{AddColumnsBackfill, AddIndex, LanceCreateBranch, LanceCreateTag, LanceDropBranch, LanceDropIndex, LanceDropTag, LanceNamedArgument, LanceShowBranches, LanceShowTags, LogicalPlan, Optimize, SetUnenforcedPrimaryKey, ShowIndexes, UpdateColumnsBackfill, Vacuum}
 import org.lance.spark.utils.{FieldPathUtils, ParserUtils}
 
+import java.util.Locale
+
 import scala.jdk.CollectionConverters._
 
 class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
   extends LanceSqlExtensionsBaseVisitor[AnyRef] {
 
   private def cleanIdentifier(text: String): String = ParserUtils.cleanIdentifier(text)
+
+  /**
+   * A WITH-clause option name, normalized to lower case.
+   *
+   * ANTLR reports identifier text as written, and every command matches its option names against
+   * lower-case literals, so without normalizing here `WITH (TRAIN = false)` parses into an option
+   * no command recognizes: the index is trained anyway, and the name leaks to Lance as an index
+   * parameter.
+   */
+  private def normalizedOptionName(text: String): String =
+    cleanIdentifier(text).toLowerCase(Locale.ROOT)
 
   override def visitSingleStatement(ctx: LanceSqlExtensionsParser.SingleStatementContext)
       : LogicalPlan = {
@@ -73,7 +86,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -84,7 +97,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val table = UnresolvedIdentifier(visitMultipartIdentifier(ctx.multipartIdentifier()))
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 
@@ -98,7 +111,7 @@ class LanceSqlExtensionsAstBuilder(delegate: ParserInterface)
     val columns = visitFieldPathList(ctx.fieldPathList())
     val args = ctx.namedArgument().asScala.map(a =>
       LanceNamedArgument(
-        cleanIdentifier(a.identifier().getText),
+        normalizedOptionName(a.identifier().getText),
         a.constant().accept(this)))
       .toSeq
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -801,6 +801,46 @@ public abstract class BaseAddIndexTest {
   }
 
   /**
+   * WITH-clause option names are normalized at parse time, so an upper-case {@code TRAIN} defers
+   * the build exactly as the lower-case spelling does. Without that normalization the option is not
+   * the one any command recognizes: the index is trained anyway, and the name reaches Lance as an
+   * index parameter.
+   */
+  @Test
+  public void testCreateZonemapIndexDeferredWithUpperCaseOptionName() {
+    prepareDataset();
+
+    Dataset<Row> result =
+        spark.sql(
+            String.format(
+                "alter table %s create index idx_upper_defer using zonemap (id) "
+                    + "with (TRAIN = false)",
+                fullTable));
+
+    Row row = result.collectAsList().get(0);
+    Assertions.assertEquals(0L, row.getLong(0), "Deferred create should index zero fragments");
+    Assertions.assertEquals("idx_upper_defer", row.getString(1));
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      List<Index> deferred =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "idx_upper_defer".equals(index.name()))
+              .collect(Collectors.toList());
+
+      Assertions.assertEquals(
+          1, deferred.size(), "Deferred zonemap should commit a single empty index");
+      Assertions.assertEquals(IndexType.ZONEMAP, deferred.get(0).indexType());
+      Assertions.assertEquals(
+          0,
+          deferred.get(0).fragments().orElse(Collections.emptyList()).size(),
+          "Deferred zonemap should cover no fragments");
+    } finally {
+      lanceDataset.close();
+    }
+  }
+
+  /**
    * A deferred ZONEMAP can be populated by re-running CREATE INDEX (eager): the distributed segment
    * build replaces the empty index and covers all fragments.
    */


### PR DESCRIPTION
Part of #789.

## What

WITH-clause option names are compared case-sensitively, while the parser hands back the identifier exactly as written. ANTLR reports the raw text and `UpperCaseCharStream` upcases only `LA()`, not `getText()`, so an uppercase option name is not the option it looks like.

Every consumer matches lower-case literals, so today:

```sql
ALTER TABLE t CREATE INDEX i USING zonemap (id) WITH (TRAIN = false);
```

builds a **trained** index rather than a deferred one, and `TRAIN` additionally leaks to the Lance index backend as an index parameter, because the `SparkOnlyOptions` filter is case-sensitive too. `OPTIMIZE` and `VACUUM` have the same gap on their own options.

## Change

Normalize the option name once, where it is constructed: a `normalizedOptionName` helper next to `cleanIdentifier` in each `LanceSqlExtensionsAstBuilder`, lower-casing with `Locale.ROOT`. That covers all three named-argument sites (`CREATE INDEX`, `OPTIMIZE`, `VACUUM`) in one place per module, so no consumer can be missed. Normalizing at the boundary rather than at each read site is deliberate: the read sites are spread across several execs and a new one would silently reintroduce the bug.

Note that this lower-cases backtick-quoted option names too. Option names are not column identifiers, so that is the intended behaviour.