### PR TITLE
fix: keep index segment fragment coverage contiguous

### DIFF
--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -53,7 +53,11 @@ The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloom
 
 | Option         | Type    | Description                                                                                                                                                                                                                        |
 |----------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `num_segments` | Integer | Target number of parallel build tasks (upper bound; clamped to fragment count when larger). Fragments are assigned by row count to balance estimated task workloads. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+| `num_segments` | Integer | Number of parallel build tasks, and so of index segments created (clamped to fragment count when larger). Each task takes a contiguous run of fragments, and the runs are chosen so the heaviest task is as light as any contiguous split allows. Defaults to `min(fragment_count, spark.default.parallelism)`. |
+
+Contiguous coverage matters beyond parallelism: [OPTIMIZE](./optimize.md) can only group fragments
+that the identical set of index segments covers, so segments whose fragment ids interleave leave it
+nothing to coalesce.
 
 ### ZoneMap Options
 

--- a/docs/src/operations/ddl/create-index.md
+++ b/docs/src/operations/ddl/create-index.md
@@ -56,8 +56,9 @@ The distributed build used by `zonemap`, `bitmap`, `label_list`, `ngram`, `bloom
 | `num_segments` | Integer | Number of parallel build tasks, and so of index segments created (clamped to fragment count when larger). Each task takes a contiguous run of fragments, and the runs are chosen so the heaviest task is as light as any contiguous split allows. Defaults to `min(fragment_count, spark.default.parallelism)`. |
 
 Contiguous coverage matters beyond parallelism: [OPTIMIZE](./optimize.md) can only group fragments
-that the identical set of index segments covers, so segments whose fragment ids interleave leave it
-nothing to coalesce.
+that the identical set of index segments covers. Interleaved segments leave it nothing to coalesce at
+all, while contiguous ones let it coalesce within each segment's run. A segment boundary is still a
+boundary, so `num_segments` also bounds how far compaction can get.
 
 ### ZoneMap Options
 

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -733,6 +733,20 @@ object IndexUtils extends Logging {
     }
   }
 
+  /**
+   * Splits `fragments` into `numSegments` batches, each a contiguous run of fragment ids, chosen so
+   * that the heaviest batch is as light as possible.
+   *
+   * Contiguity is not cosmetic. Lance's compaction planner only groups fragments that are covered by
+   * the identical set of index segments, so batches whose fragment ids interleave leave every
+   * adjacent pair of fragments in a different group and make OPTIMIZE a no-op for the whole table.
+   * Balance is not sacrificed to get it: the optimal contiguous partition is found exactly, so a
+   * workload that the previous least-loaded-first assignment balanced perfectly still is.
+   *
+   * Assignment is deterministic: the same fragments and segment count always produce the same
+   * batches, whatever order `fragments` arrives in. Every batch holds at least one fragment, so the
+   * result always has exactly `segmentCount` entries.
+   */
   def batchFragments(
       fragments: List[FragmentWorkload],
       numSegments: Option[Int],
@@ -754,35 +768,139 @@ object IndexUtils extends Logging {
       case None => math.max(1, math.min(fragmentCount, defaultParallelism))
     }
 
-    final class SegmentBatch(val index: Int) {
-      val fragmentIds: ArrayBuffer[Integer] = ArrayBuffer.empty
-      var numRows: Long = 0L
+    val ordered = fragments.sortBy(_.fragmentId.intValue)
+    // Prefix sums drive the search. addExact rejects a workload that cannot be summed rather than
+    // balancing against a wrapped total.
+    val rowsUpTo = new Array[Long](fragmentCount + 1)
+    ordered.iterator.zipWithIndex.foreach { case (fragment, index) =>
+      rowsUpTo(index + 1) = Math.addExact(rowsUpTo(index), fragment.numRows)
+    }
 
-      def add(fragment: FragmentWorkload): Unit = {
-        numRows = Math.addExact(numRows, fragment.numRows)
-        fragmentIds += fragment.fragmentId
+    var offset = 0
+    balancedRunLengths(rowsUpTo, segmentCount).map { length =>
+      val batch = ordered.slice(offset, offset + length).map(_.fragmentId)
+      offset += length
+      batch
+    }
+  }
+
+  /**
+   * Lengths of exactly `segmentCount` contiguous runs over `rowsUpTo`, minimising the heaviest run.
+   *
+   * The smallest row budget a contiguous packing can respect is found by binary search, which is
+   * exact rather than approximate: for a fixed budget, extending each run as far as it will go uses
+   * the fewest runs, so the smallest feasible budget is the optimal maximum. The floor of the search
+   * is the widest single fragment, below which no packing exists.
+   *
+   * Packing at that budget can use fewer runs than were asked for, which would cost parallelism, so
+   * the remainder are split at their own balance points. A split only ever lowers the heaviest run,
+   * so optimality survives it.
+   */
+  private def balancedRunLengths(rowsUpTo: Array[Long], segmentCount: Int): Seq[Int] = {
+    val fragmentCount = rowsUpTo.length - 1
+    def rowsOf(start: Int, length: Int): Long = rowsUpTo(start + length) - rowsUpTo(start)
+
+    var widestFragment = 0L
+    var index = 0
+    while (index < fragmentCount) {
+      widestFragment = math.max(widestFragment, rowsOf(index, 1))
+      index += 1
+    }
+
+    var low = widestFragment
+    var high = rowsUpTo(fragmentCount)
+    while (low < high) {
+      val budget = low + (high - low) / 2
+      if (runsWithin(rowsUpTo, budget) <= segmentCount) high = budget else low = budget + 1
+    }
+
+    // runLengthAt(start) is the length of the run beginning at `start`, and 0 elsewhere.
+    val runLengthAt = new Array[Int](fragmentCount)
+    var runCount = 0
+    var start = 0
+    while (start < fragmentCount) {
+      var length = 1
+      while (start + length < fragmentCount && rowsOf(start, length + 1) <= low) {
+        length += 1
+      }
+      runLengthAt(start) = length
+      runCount += 1
+      start += length
+    }
+
+    if (runCount < segmentCount) {
+      // Heaviest splittable run first, so each extra batch is spent where it helps most. Ties break
+      // on length then on the earlier run, to keep the result independent of heap internals.
+      val splittable = PriorityQueue.empty[(Long, Int, Int)](
+        Ordering.by[(Long, Int, Int), (Long, Int, Int)] {
+          case (rows, length, begin) => (rows, length, -begin)
+        })
+      var scan = 0
+      while (scan < fragmentCount) {
+        val length = runLengthAt(scan)
+        if (length > 1) {
+          splittable.enqueue((rowsOf(scan, length), length, scan))
+        }
+        scan += length
+      }
+      while (runCount < segmentCount && splittable.nonEmpty) {
+        val (_, length, begin) = splittable.dequeue()
+        val cut = balancePoint(rowsUpTo, begin, length)
+        runLengthAt(begin) = cut
+        runLengthAt(begin + cut) = length - cut
+        runCount += 1
+        if (cut > 1) {
+          splittable.enqueue((rowsOf(begin, cut), cut, begin))
+        }
+        if (length - cut > 1) {
+          splittable.enqueue((rowsOf(begin + cut, length - cut), length - cut, begin + cut))
+        }
       }
     }
 
-    val segmentOrdering: Ordering[SegmentBatch] =
-      Ordering
-        .by[SegmentBatch, (Long, Int, Int)](segment =>
-          (segment.numRows, segment.fragmentIds.size, segment.index))
-        .reverse
-
-    val segments = PriorityQueue.empty[SegmentBatch](segmentOrdering)
-    (0 until segmentCount).foreach(index => segments.enqueue(new SegmentBatch(index)))
-
-    val sortedFragments = fragments.sortBy(fragment => (-fragment.numRows, fragment.fragmentId))
-    sortedFragments.foreach { fragment =>
-      val segment = segments.dequeue()
-      segment.add(fragment)
-      segments.enqueue(segment)
+    val runs = ArrayBuffer.empty[Int]
+    var cursor = 0
+    while (cursor < fragmentCount) {
+      val length = runLengthAt(cursor)
+      runs += length
+      cursor += length
     }
+    runs.toList
+  }
 
-    segments.toSeq
-      .sortBy(_.index)
-      .map(segment => segment.fragmentIds.sortBy(_.intValue()).toList)
+  /**
+   * Fewest contiguous runs that keep every run's row count within `budget`.
+   *
+   * A fragment wider than `budget` still forms a run of its own, so callers must not search below
+   * the widest fragment or the count would understate what the budget can actually hold.
+   */
+  private def runsWithin(rowsUpTo: Array[Long], budget: Long): Int = {
+    val fragmentCount = rowsUpTo.length - 1
+    var runs = 0
+    var start = 0
+    while (start < fragmentCount) {
+      var length = 1
+      while (start + length < fragmentCount &&
+        rowsUpTo(start + length + 1) - rowsUpTo(start) <= budget) {
+        length += 1
+      }
+      runs += 1
+      start += length
+    }
+    runs
+  }
+
+  /** Where to cut a run of `length` fragments so the two halves are as even as possible. */
+  private def balancePoint(rowsUpTo: Array[Long], start: Int, length: Int): Int = {
+    val total = rowsUpTo(start + length) - rowsUpTo(start)
+    def leftOf(at: Int): Long = rowsUpTo(start + at) - rowsUpTo(start)
+    def heavierHalf(at: Int): Long = math.max(leftOf(at), total - leftOf(at))
+
+    var cut = 1
+    while (cut < length - 1 && leftOf(cut) < total - leftOf(cut)) {
+      cut += 1
+    }
+    if (cut > 1 && heavierHalf(cut - 1) < heavierHalf(cut)) cut - 1 else cut
   }
 
 }

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -40,7 +40,7 @@ import org.lance.spark.write.SingleBatchArrowReader
 import java.util.{Collections, Locale, UUID}
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable.{ArrayBuffer, PriorityQueue}
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 /**
@@ -735,13 +735,14 @@ object IndexUtils extends Logging {
 
   /**
    * Splits `fragments` into `numSegments` batches, each a contiguous run of fragment ids, chosen so
-   * that the heaviest batch is as light as possible.
+   * that the heaviest batch is as light as any contiguous split allows.
    *
    * Contiguity is not cosmetic. Lance's compaction planner only groups fragments that are covered by
    * the identical set of index segments, so batches whose fragment ids interleave leave every
    * adjacent pair of fragments in a different group and make OPTIMIZE a no-op for the whole table.
-   * Balance is not sacrificed to get it: the optimal contiguous partition is found exactly, so a
-   * workload that the previous least-loaded-first assignment balanced perfectly still is.
+   * It does cost some balance. `[10, 9, 8, 7]` into two batches is 19/15 here, where the previous
+   * least-loaded-first assignment reached 17/17 by interleaving. Optimal among contiguous splits is
+   * the guarantee, not optimal overall.
    *
    * Assignment is deterministic: the same fragments and segment count always produce the same
    * batches, whatever order `fragments` arrives in. Every batch holds at least one fragment, so the
@@ -793,8 +794,9 @@ object IndexUtils extends Logging {
    * is the widest single fragment, below which no packing exists.
    *
    * Packing at that budget can use fewer runs than were asked for, which would cost parallelism, so
-   * the remainder are split at their own balance points. A split only ever lowers the heaviest run,
-   * so optimality survives it.
+   * runs are divided until the count is reached. Which run gets divided does not matter: every run
+   * already fits the budget, so both halves of any split fit it too, and the budget is minimal, so
+   * the heaviest run cannot fall below it either.
    */
   private def balancedRunLengths(rowsUpTo: Array[Long], segmentCount: Int): Seq[Int] = {
     val fragmentCount = rowsUpTo.length - 1
@@ -828,33 +830,18 @@ object IndexUtils extends Logging {
       start += length
     }
 
-    if (runCount < segmentCount) {
-      // Heaviest splittable run first, so each extra batch is spent where it helps most. Ties break
-      // on length then on the earlier run, to keep the result independent of heap internals.
-      val splittable = PriorityQueue.empty[(Long, Int, Int)](
-        Ordering.by[(Long, Int, Int), (Long, Int, Int)] {
-          case (rows, length, begin) => (rows, length, -begin)
-        })
-      var scan = 0
-      while (scan < fragmentCount) {
-        val length = runLengthAt(scan)
-        if (length > 1) {
-          splittable.enqueue((rowsOf(scan, length), length, scan))
-        }
-        scan += length
-      }
-      while (runCount < segmentCount && splittable.nonEmpty) {
-        val (_, length, begin) = splittable.dequeue()
-        val cut = balancePoint(rowsUpTo, begin, length)
-        runLengthAt(begin) = cut
-        runLengthAt(begin + cut) = length - cut
+    // Divide from the left until the count is reached. Splitting the heaviest run first would be no
+    // better, since the budget already bounds every run.
+    var splitAt = 0
+    while (runCount < segmentCount && splitAt < fragmentCount) {
+      val length = runLengthAt(splitAt)
+      if (length > 1) {
+        val cut = balancePoint(rowsUpTo, splitAt, length)
+        runLengthAt(splitAt) = cut
+        runLengthAt(splitAt + cut) = length - cut
         runCount += 1
-        if (cut > 1) {
-          splittable.enqueue((rowsOf(begin, cut), cut, begin))
-        }
-        if (length - cut > 1) {
-          splittable.enqueue((rowsOf(begin + cut, length - cut), length - cut, begin + cut))
-        }
+      } else {
+        splitAt += length
       }
     }
 

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -148,6 +148,33 @@ public abstract class BaseAddIndexTest {
     }
   }
 
+  /** Four equal single-fragment appends: the shape a least-loaded batcher deals out round-robin. */
+  private void prepareEvenFragmentDataset() throws Exception {
+    spark.sql(String.format("create table %s (id int, text string) using lance;", fullTable));
+    StructType schema =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField("id", DataTypes.IntegerType, false),
+              DataTypes.createStructField("text", DataTypes.StringType, false)
+            });
+    for (int batch = 0; batch < 4; batch++) {
+      int startId = batch * 5;
+      List<Row> rows =
+          IntStream.range(startId, startId + 5)
+              .boxed()
+              .map(i -> RowFactory.create(i, String.format("text_%d", i)))
+              .collect(Collectors.toList());
+      spark.createDataFrame(rows, schema).coalesce(1).writeTo(fullTable).append();
+    }
+  }
+
+  private int liveFragmentCount() {
+    try (org.lance.Dataset lanceDataset =
+        Utils.openDatasetBuilder(LanceSparkReadOptions.from(tableDir)).build()) {
+      return lanceDataset.getFragments().size();
+    }
+  }
+
   private void prepareNestedDataset() {
     spark.sql(
         String.format(
@@ -448,6 +475,56 @@ public abstract class BaseAddIndexTest {
           "Expected row-count batching to avoid the 130/50 workload split produced by count batching");
       Assertions.assertEquals(fragmentRows.keySet(), coveredFragments);
     }
+  }
+
+  /**
+   * A multi-segment index must not freeze the table against OPTIMIZE. Lance's compaction planner
+   * groups fragments only when the identical set of index metadata entries covers them, and every
+   * segment is its own entry, so segment coverage that interleaves fragment ids leaves no adjacent
+   * pair of fragments in the same group and compaction finds nothing to coalesce.
+   *
+   * <p>btree rather than zonemap: on this Lance version a zonemap index that covers only part of
+   * the table prunes the fragments it does not cover, which would break the row assertions for a
+   * reason unrelated to compaction.
+   */
+  @Test
+  public void testOptimizeCompactsTableCoveredByMultiSegmentIndex() throws Exception {
+    prepareEvenFragmentDataset();
+
+    spark
+        .sql(
+            String.format(
+                "alter table %s create index idx_contiguous using btree (id) "
+                    + "with (num_segments = 2)",
+                fullTable))
+        .collectAsList();
+    Assertions.assertEquals(
+        4, liveFragmentCount(), "Expected each of the four appends to land in its own fragment");
+
+    spark
+        .sql(String.format("optimize %s with (target_rows_per_fragment = 1000)", fullTable))
+        .collectAsList();
+
+    Assertions.assertTrue(
+        liveFragmentCount() < 4,
+        "Expected OPTIMIZE to coalesce fragments covered by a two-segment index, "
+            + "but the live fragment count did not drop");
+
+    Assertions.assertEquals(
+        IntStream.range(0, 20)
+            .mapToObj(i -> String.format("[%d,text_%d]", i, i))
+            .collect(Collectors.toList()),
+        spark
+            .sql(String.format("select id, text from %s order by id", fullTable))
+            .collectAsList()
+            .stream()
+            .map(Row::toString)
+            .collect(Collectors.toList()),
+        "Compaction under a multi-segment index must not change what the table returns");
+    Assertions.assertEquals(
+        1L,
+        spark.sql(String.format("select * from %s where id = 13", fullTable)).count(),
+        "The index must still answer point lookups after compaction");
   }
 
   @ParameterizedTest(name = "{0}")

--- a/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
+++ b/lance-spark-base_2.12/src/test/scala/org/apache/spark/sql/execution/datasources/v2/IndexUtilsTest.scala
@@ -31,6 +31,21 @@ class IndexUtilsTest {
       FragmentWorkload(java.lang.Integer.valueOf(fragmentId), rowCount)
     }.toList
 
+  /**
+   * Asserts the batches partition the fragments into contiguous runs of the id order.
+   *
+   * Concatenating the batches in order and getting an ascending id sequence back is exactly that
+   * property: any partition whose concatenation is sorted consists of consecutive slices.
+   */
+  private def assertContiguousBatches(batches: Seq[List[Integer]]): Unit = {
+    val flattened = batches.flatten.map(_.intValue)
+    assertEquals(
+      flattened.sorted,
+      flattened,
+      s"batches must partition the fragments in id order, got $batches")
+    batches.foreach(batch => assertFalse(batch.isEmpty, s"no batch may be empty, got $batches"))
+  }
+
   // ── extractTrain ──────────────────────────────────────────────────────────
 
   @Test
@@ -228,15 +243,60 @@ class IndexUtilsTest {
     assertEquals(Seq.empty, IndexUtils.batchFragments(Nil, None, 4))
   }
 
+  /**
+   * Interleaved coverage makes Lance's compaction planner treat every adjacent fragment pair as
+   * ungroupable, so OPTIMIZE stops coalescing the table entirely. Batches must be contiguous runs.
+   */
+  @Test
+  def batchFragments_producesContiguousRuns(): Unit = {
+    Seq(
+      fragmentWorkloads(1, 1, 1, 1, 1, 1),
+      fragmentWorkloads(100, 1, 1, 1),
+      fragmentWorkloads(1, 1, 1, 100),
+      fragmentWorkloads(5, 9, 2, 7, 3, 8, 1, 6),
+      fragmentWorkloads(0, 0, 0, 0, 0)).foreach { fragments =>
+      (1 to fragments.size).foreach { segments =>
+        val batches = IndexUtils.batchFragments(fragments, Some(segments), 4)
+        assertEquals(
+          segments,
+          batches.size,
+          s"expected $segments batches for ${fragments.size} fragments, got $batches")
+        assertContiguousBatches(batches)
+        assertEquals(
+          fragments.map(_.fragmentId),
+          batches.flatten,
+          "every fragment must be assigned exactly once")
+      }
+    }
+  }
+
   @Test
   def batchFragments_balancesRowsDeterministically(): Unit = {
     val fragments = fragmentWorkloads(80, 50, 30, 20)
+    // Splitting after fragment 0 gives 80 / 100; the contiguous alternative gives 130 / 50.
     val expected = Seq(
-      List(java.lang.Integer.valueOf(0), java.lang.Integer.valueOf(3)),
-      List(java.lang.Integer.valueOf(1), java.lang.Integer.valueOf(2)))
+      List(java.lang.Integer.valueOf(0)),
+      List(
+        java.lang.Integer.valueOf(1),
+        java.lang.Integer.valueOf(2),
+        java.lang.Integer.valueOf(3)))
 
     assertEquals(expected, IndexUtils.batchFragments(fragments, Some(2), 4))
     assertEquals(expected, IndexUtils.batchFragments(fragments.reverse, Some(2), 4))
+  }
+
+  /** A single dominant fragment must not collapse the requested parallelism. */
+  @Test
+  def batchFragments_keepsRequestedParallelismUnderSkew(): Unit = {
+    val batches = IndexUtils.batchFragments(fragmentWorkloads(100, 1, 1, 1), Some(4), 4)
+
+    assertEquals(
+      Seq(
+        List(java.lang.Integer.valueOf(0)),
+        List(java.lang.Integer.valueOf(1)),
+        List(java.lang.Integer.valueOf(2)),
+        List(java.lang.Integer.valueOf(3))),
+      batches)
   }
 
   @Test
@@ -245,10 +305,96 @@ class IndexUtilsTest {
 
     assertEquals(
       Seq(
-        List(java.lang.Integer.valueOf(0), java.lang.Integer.valueOf(3)),
+        List(java.lang.Integer.valueOf(0)),
         List(java.lang.Integer.valueOf(1)),
-        List(java.lang.Integer.valueOf(2))),
+        List(java.lang.Integer.valueOf(2), java.lang.Integer.valueOf(3))),
       IndexUtils.batchFragments(fragments, Some(3), 4))
+  }
+
+  /** Fragment ids are not necessarily dense or zero-based once a table has been compacted. */
+  @Test
+  def batchFragments_keepsSparseFragmentIdsContiguousByPosition(): Unit = {
+    val fragments = List(
+      FragmentWorkload(java.lang.Integer.valueOf(17), 10L),
+      FragmentWorkload(java.lang.Integer.valueOf(4), 10L),
+      FragmentWorkload(java.lang.Integer.valueOf(9), 10L),
+      FragmentWorkload(java.lang.Integer.valueOf(31), 10L))
+
+    assertEquals(
+      Seq(
+        List(java.lang.Integer.valueOf(4), java.lang.Integer.valueOf(9)),
+        List(java.lang.Integer.valueOf(17), java.lang.Integer.valueOf(31))),
+      IndexUtils.batchFragments(fragments, Some(2), 4))
+  }
+
+  private def workloads(batches: Seq[List[Integer]], rows: Seq[Long]): Seq[Long] =
+    batches.map(_.map(id => rows(id.intValue)).sum)
+
+  /** Smallest achievable heaviest batch over all contiguous partitions into `segmentCount` runs. */
+  private def optimalHeaviestBatch(rows: Seq[Long], segmentCount: Int): Long = {
+    def best(from: Int, runs: Int): Long =
+      if (runs == 1) {
+        rows.drop(from).sum
+      } else {
+        (from until rows.size - runs + 1).map { cut =>
+          math.max(rows.slice(from, cut + 1).sum, best(cut + 1, runs - 1))
+        }.min
+      }
+    best(0, segmentCount)
+  }
+
+  /**
+   * The heaviest batch has to be as light as a contiguous partition allows. This workload is the
+   * counter-example that sank an earlier prefix-crossing heuristic: it cut after the three
+   * indivisible leading fragments had already overshot their even shares, leaving one batch of 162
+   * where 95 is forced by fragment 0 alone.
+   */
+  @Test
+  def batchFragments_minimisesTheHeaviestBatch(): Unit = {
+    val rows = Seq(95L, 93L, 89L, 8L, 1L, 4L, 74L, 88L, 38L)
+    val fragments = rows.zipWithIndex.map { case (count, fragmentId) =>
+      FragmentWorkload(java.lang.Integer.valueOf(fragmentId), count)
+    }.toList
+
+    val batches = IndexUtils.batchFragments(fragments, Some(6), 1)
+
+    assertEquals(6, batches.size)
+    assertContiguousBatches(batches)
+    assertEquals(
+      95L,
+      workloads(batches, rows).max,
+      s"expected the optimal heaviest batch, got ${workloads(batches, rows)}")
+  }
+
+  /**
+   * Optimality is checked against every contiguous partition rather than against a fixed expected
+   * split, so the property is pinned instead of one of its consequences.
+   */
+  @Test
+  def batchFragments_matchesTheOptimalContiguousPartition(): Unit = {
+    val workloadShapes = Seq(
+      Seq(95L, 93L, 89L, 8L, 1L, 4L, 74L, 88L, 38L),
+      Seq(100L, 1L, 1L, 1L, 1L, 1L),
+      Seq(1L, 1L, 1L, 1L, 1L, 100L),
+      Seq(5L, 9L, 2L, 7L, 3L, 8L, 1L, 6L),
+      Seq(7L, 7L, 7L, 7L, 7L, 7L, 7L),
+      Seq(50L, 1L, 50L, 1L, 50L, 1L, 50L),
+      Seq(0L, 0L, 5L, 0L, 0L))
+
+    workloadShapes.foreach { rows =>
+      val fragments = rows.zipWithIndex.map { case (count, fragmentId) =>
+        FragmentWorkload(java.lang.Integer.valueOf(fragmentId), count)
+      }.toList
+      (1 to rows.size).foreach { segmentCount =>
+        val batches = IndexUtils.batchFragments(fragments, Some(segmentCount), 1)
+        assertEquals(segmentCount, batches.size, s"$rows into $segmentCount")
+        assertContiguousBatches(batches)
+        assertEquals(
+          optimalHeaviestBatch(rows, segmentCount),
+          workloads(batches, rows).max,
+          s"$rows into $segmentCount batches: got ${workloads(batches, rows)}")
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Part of #789.

## What

`IndexUtils.batchFragments` assigns fragments to index segments with a least-loaded-first heap. For equal-sized fragments that deals them out round-robin, so segment coverage interleaves fragment ids: four equal fragments with `num_segments = 2` produce segments covering `[0, 2]` and `[1, 3]`.

Lance's compaction planner only groups fragments covered by an identical set of index metadata entries, and every segment is a separate entry. Interleaved coverage therefore puts every adjacent pair of fragments in a different group, so `OPTIMIZE` coalesces nothing at all on an indexed table.

Measured on Spark 3.5, with `OPTIMIZE ... WITH (target_rows_per_fragment = 1000)` over four single-fragment appends: two interleaved segments leave all four fragments untouched, one contiguous segment covering all four compacts them to one, two contiguous segments compact them to two (one per segment), and with no index at all they compact to one.

Batching used to be contiguous. #758 replaced it with row-balanced assignment, and its docs dropped the line "Each task covers a contiguous batch of fragments." This restores contiguity, at a bounded cost in balance.

## Change

The optimal contiguous partition is found exactly rather than approximated. Binary search the smallest row budget a contiguous packing can respect: for a fixed budget, extending each run as far as it will go uses the fewest runs, so the smallest feasible budget *is* the optimal maximum, with the widest single fragment as the search floor. Packing at that budget can use fewer runs than were asked for, which would cost parallelism, so runs are divided at their balance points until the count is reached. Which run gets divided does not matter: every run already fits the budget, so both halves of any split fit it too, and the budget is minimal, so the heaviest batch cannot fall below it either.

Contiguity does cost some balance, which the earlier revision of this PR wrongly claimed it did not. `[10, 9, 8, 7]` into two batches is 19/15 once runs must stay contiguous, where least-loaded-first reached 17/17 by interleaving. Optimal among contiguous splits is the guarantee, not optimal overall, and interleaving costs the whole table its compaction.

The result is contiguous, minimises the heaviest batch over all contiguous partitions, is deterministic regardless of input order, and always has exactly `num_segments` non-empty batches. `Math.addExact` on the prefix sums keeps the pre-existing overflow rejection.

A cheaper heuristic, placing each boundary where an even split would fall and moving it to the nearest fragment, was tried first and **rejected**: it cuts after indivisible leading fragments have already overshot their shares. On `[95, 93, 89, 8, 1, 4, 74, 88, 38]` across six segments it yields a batch of 162 where fragment 0 alone forces 95, so one task ends up 70% heavier than necessary. The least-loaded-first assignment it replaced reached 95, so that would have been a genuine regression of #758's contract rather than a preservation of it.

Docs no longer read as though contiguity restores compaction. A segment boundary is still a grouping boundary, so `num_segments` also bounds how far `OPTIMIZE` can get.
