### PR TITLE
fix: name the index on uncommitted segment builds

### DIFF
--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -443,8 +443,8 @@ case class RangeBTreeIndexBuilder(
       // Build an uncommitted BTree segment for this fragment group from the
       // pre-sorted data. No UUID is set: Lance generates the segment UUID, and
       // the fragment ids declare the segment's coverage so the per-partition
-      // segments stay disjoint. See ScalarSegmentIndexTask for why the segment
-      // build names the index and sets replace.
+      // segments stay disjoint. Named and replace-flagged to suppress Lance's
+      // collision pre-check against the existing index.
       val btreeParamsBuilder = BTreeIndexParams.builder()
       if (zoneSize.isDefined) {
         btreeParamsBuilder.zoneSize(zoneSize.get)
@@ -525,15 +525,9 @@ class ScalarSegmentIndexJob(
 final private[v2] case class FragmentWorkload(fragmentId: Integer, numRows: Long)
 
 /**
- * A task to create a scalar index segment on a batch of fragments.
- *
- * The segment is named after the logical index it will join, and {@code replace} is set because that
- * index may already exist: on the uncommitted build path Lance consults {@code replace} only to
- * reject a name that is already taken, which is precisely the normal case for a CREATE INDEX that
- * replaces an index of the same name. Nothing is removed here — the driver's single
- * {@code commitExistingIndexSegments} transaction decides which existing segments to keep. Leaving
- * the name unset instead makes Lance derive its own default (`{column}_idx`) and reject the build
- * whenever an index of that name exists on the column.
+ * A task to create a scalar index segment on a batch of fragments. Named after the logical index
+ * and replace-flagged to suppress Lance's collision pre-check against the existing index; actual
+ * replacement is handled by the driver's {@code commitExistingIndexSegments} transaction.
  */
 case class ScalarSegmentIndexTask(
     encodedReadOptions: String,

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -440,11 +440,7 @@ case class RangeBTreeIndexBuilder(
 
       Data.exportArrayStream(allocator, reader, stream)
 
-      // Build an uncommitted BTree segment for this fragment group from the
-      // pre-sorted data. No UUID is set: Lance generates the segment UUID, and
-      // the fragment ids declare the segment's coverage so the per-partition
-      // segments stay disjoint. Named and replace-flagged to suppress Lance's
-      // collision pre-check against the existing index.
+      // replace is for Lance's name check, and the driver commit still publishes.
       val btreeParamsBuilder = BTreeIndexParams.builder()
       if (zoneSize.isDefined) {
         btreeParamsBuilder.zoneSize(zoneSize.get)
@@ -525,9 +521,7 @@ class ScalarSegmentIndexJob(
 final private[v2] case class FragmentWorkload(fragmentId: Integer, numRows: Long)
 
 /**
- * A task to create a scalar index segment on a batch of fragments. Named after the logical index
- * and replace-flagged to suppress Lance's collision pre-check against the existing index; actual
- * replacement is handled by the driver's {@code commitExistingIndexSegments} transaction.
+ * A task to create a scalar index segment on a batch of fragments.
  */
 case class ScalarSegmentIndexTask(
     encodedReadOptions: String,

--- a/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
+++ b/lance-spark-base_2.12/src/main/scala/org/apache/spark/sql/execution/datasources/v2/AddIndexExec.scala
@@ -335,6 +335,7 @@ class RangeBasedBTreeIndexJob(
 
     val indexBuilder = RangeBTreeIndexBuilder(
       encode(readOptions),
+      addIndexExec.indexName,
       columns,
       zoneSize,
       nsImpl,
@@ -364,6 +365,7 @@ class RangeBasedBTreeIndexJob(
  * This class is serialized and sent to executors to build the index for a specific range of data.
  *
  * @param encodedReadOptions      Serialized configuration for Lance dataset access.
+ * @param indexName               Name of the logical index the segment will belong to.
  * @param columns                 The names of the columns to be indexed.
  * @param zoneSize                Optional size of zones within the B-tree index.
  * @param namespaceImpl           Optional implementation class for namespace operations, used for credential vending.
@@ -374,6 +376,7 @@ class RangeBasedBTreeIndexJob(
  */
 case class RangeBTreeIndexBuilder(
     encodedReadOptions: String,
+    indexName: String,
     columns: List[String],
     zoneSize: Option[Long],
     namespaceImpl: Option[String],
@@ -438,9 +441,10 @@ case class RangeBTreeIndexBuilder(
       Data.exportArrayStream(allocator, reader, stream)
 
       // Build an uncommitted BTree segment for this fragment group from the
-      // pre-sorted data. No index name or UUID is set: Lance generates the
-      // segment UUID, and the fragment ids declare the segment's coverage so
-      // the per-partition segments stay disjoint.
+      // pre-sorted data. No UUID is set: Lance generates the segment UUID, and
+      // the fragment ids declare the segment's coverage so the per-partition
+      // segments stay disjoint. See ScalarSegmentIndexTask for why the segment
+      // build names the index and sets replace.
       val btreeParamsBuilder = BTreeIndexParams.builder()
       if (zoneSize.isDefined) {
         btreeParamsBuilder.zoneSize(zoneSize.get)
@@ -451,7 +455,8 @@ case class RangeBTreeIndexBuilder(
 
       val indexOptions = IndexOptions
         .builder(columns.asJava, IndexType.BTREE, indexParams)
-        .replace(false)
+        .withIndexName(indexName)
+        .replace(true)
         .withFragmentIds(fragmentIds.toList.asJava)
         .withPreprocessedData(stream)
         .build()
@@ -498,6 +503,7 @@ class ScalarSegmentIndexJob(
     val tasks = fragmentBatches.map { batch =>
       ScalarSegmentIndexTask(
         encodedReadOptions,
+        addIndexExec.indexName,
         columns,
         addIndexExec.method,
         argsJson,
@@ -520,9 +526,18 @@ final private[v2] case class FragmentWorkload(fragmentId: Integer, numRows: Long
 
 /**
  * A task to create a scalar index segment on a batch of fragments.
+ *
+ * The segment is named after the logical index it will join, and {@code replace} is set because that
+ * index may already exist: on the uncommitted build path Lance consults {@code replace} only to
+ * reject a name that is already taken, which is precisely the normal case for a CREATE INDEX that
+ * replaces an index of the same name. Nothing is removed here — the driver's single
+ * {@code commitExistingIndexSegments} transaction decides which existing segments to keep. Leaving
+ * the name unset instead makes Lance derive its own default (`{column}_idx`) and reject the build
+ * whenever an index of that name exists on the column.
  */
 case class ScalarSegmentIndexTask(
     encodedReadOptions: String,
+    indexName: String,
     columns: List[String],
     method: String,
     argsJson: String,
@@ -545,8 +560,9 @@ case class ScalarSegmentIndexTask(
 
     val indexOptions = IndexOptions
       .builder(java.util.Arrays.asList(columns: _*), indexType, params)
+      .withIndexName(indexName)
       .withFragmentIds(fragmentIds.asJava)
-      .replace(false)
+      .replace(true)
       .build()
 
     val dataset = Utils.openDatasetBuilder(readOptions)

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -670,11 +670,6 @@ public abstract class BaseAddIndexTest {
     }
   }
 
-  /**
-   * {@code id_idx} is the name Lance itself gives an index created on {@code id} without one, so it
-   * is the name a segment build that sets no name of its own lands on. Recreating an index under
-   * that name used to fail every executor task on a name collision with the index already there.
-   */
   @ParameterizedTest(name = "{0}")
   @MethodSource("segmentBuildIndexMethods")
   public void testRepeatedCreateIndexUnderLanceDefaultName(

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/update/BaseAddIndexTest.java
@@ -670,6 +670,55 @@ public abstract class BaseAddIndexTest {
     }
   }
 
+  /**
+   * {@code id_idx} is the name Lance itself gives an index created on {@code id} without one, so it
+   * is the name a segment build that sets no name of its own lands on. Recreating an index under
+   * that name used to fail every executor task on a name collision with the index already there.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("segmentBuildIndexMethods")
+  public void testRepeatedCreateIndexUnderLanceDefaultName(
+      String caseName, String method, String options) {
+    prepareDataset();
+
+    String sql =
+        String.format(
+            "alter table %s create index id_idx using %s (id) %s", fullTable, method, options);
+
+    spark.sql(sql);
+    checkIndex("id_idx");
+    spark.sql(sql);
+    checkIndex("id_idx");
+
+    org.lance.Dataset lanceDataset = org.lance.Dataset.open().uri(tableDir).build();
+    try {
+      int fragmentCount = lanceDataset.getFragments().size();
+      int coveredFragments =
+          lanceDataset.getIndexes().stream()
+              .filter(index -> "id_idx".equals(index.name()))
+              .map(index -> index.fragments().orElse(Collections.emptyList()).size())
+              .mapToInt(Integer::intValue)
+              .sum();
+      Assertions.assertEquals(
+          fragmentCount,
+          coveredFragments,
+          "Expected the recreated " + caseName + " segments to cover all fragments exactly once");
+    } finally {
+      lanceDataset.close();
+    }
+
+    // The index has to answer queries after the replacement, not merely exist in the manifest.
+    Dataset<Row> query = spark.sql(String.format("select * from %s where id=15", fullTable));
+    Assertions.assertEquals(1L, query.count());
+    Assertions.assertEquals("text_15", query.collectAsList().get(0).getString(1));
+  }
+
+  private static Stream<Arguments> segmentBuildIndexMethods() {
+    return Stream.of(
+        Arguments.of("zonemap", "zonemap", ""),
+        Arguments.of("btree-range", "btree", "with (build_mode = 'range')"));
+  }
+
   @ParameterizedTest(name = "{0}")
   @MethodSource("singleColumnIndexMethods")
   public void testIndexesRejectMultipleColumns(String method, IndexType indexType) {
@@ -994,8 +1043,8 @@ public abstract class BaseAddIndexTest {
         firstRunUuids.size(),
         "Expected one disjoint range segment per fragment on first create");
 
-    // Re-create with the same name: exercises replace(false) on the segment builds plus
-    // atomic replacement at commit time. The old segments must be replaced, not duplicated.
+    // Re-create with the same name: exercises the named segment builds plus atomic replacement at
+    // commit time. The old segments must be replaced, not duplicated.
     spark.sql(sql);
     checkIndex("test_range_repeat");
 


### PR DESCRIPTION
Part of #789.

## What

Both uncommitted segment builders set `.replace(false)` and never call `.withIndexName(...)`:

- `ScalarSegmentIndexTask.execute()`
- `RangeBTreeIndexBuilder.buildForFragmentGroup()`

With no name, Lance derives its own default `{column}_idx` and then runs a name-collision pre-check **before any build work**, even on the uncommitted path (`rust/lance/src/index/create.rs`, `if !existing_named_indices.is_empty() && !self.replace`). So whenever an index named `{column}_idx` already exists on that column, every executor task fails with:

```
LanceError(Index): Index name 'id_idx' already exists, please specify a different name or use replace=True
```

`{column}_idx` is the name Lance itself assigns an unnamed index, so it is a common one to hit. Re-running `CREATE INDEX id_idx USING zonemap (id)` fails today.

## Change

Name the segment after the index it will join, and set `replace`. On the uncommitted path `replace` is consulted **only** by that pre-check — the removal logic lives in `execute()`, which the uncommitted path bypasses — so this is inert apart from suppressing a collision that does not apply. The driver's single `commitExistingIndexSegments` transaction still decides which existing segments to keep.

Naming the segment explicitly has a second benefit: the genuine "already exists with different fields" check now runs against the real index name, so a `CREATE INDEX name_idx USING btree (id)` against an existing `name_idx` on a different column fails before the distributed build rather than after it.
