### PR TITLE
feat(knn): indexed Lance vector-join execution stage (Spark 4.2) [2/3]

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -85,6 +85,11 @@ filename = "lance-spark-4.2_2.13/pom.xml"
 search = "<version>{current_version}</version>"
 replace = "<version>{new_version}</version>"
 
+[[tool.bumpversion.files]]
+filename = "lance-spark-knn-4.2_2.13/pom.xml"
+search = "<version>{current_version}</version>"
+replace = "<version>{new_version}</version>"
+
 # Bundle module pom.xml files - parent version
 [[tool.bumpversion.files]]
 filename = "lance-spark-bundle-3.4_2.12/pom.xml"

--- a/lance-spark-knn-4.2_2.13/pom.xml
+++ b/lance-spark-knn-4.2_2.13/pom.xml
@@ -1,0 +1,112 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.lance</groupId>
+        <artifactId>lance-spark-root</artifactId>
+        <version>0.8.0-beta.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>lance-spark-knn-4.2_2.13</artifactId>
+    <name>${project.artifactId}</name>
+    <description>Indexed nearest-by join on Lance — Spark 4.2 SQL Catalyst integration (SPARK-56395)</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <scala.version>${scala213.version}</scala.version>
+        <scala.compat.version>${scala213.compat.version}</scala.compat.version>
+        <arrow.version>${arrow19.version}</arrow.version>
+        <java.release>${java17.release}</java.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.compat.version}</artifactId>
+            <version>${spark42.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-catalyst_${scala.compat.version}</artifactId>
+            <version>${spark42.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!--
+          The Lance connector base. Supplies LanceRuntime / LanceConstant (used by LanceProbe) and
+          pulls in lance-core for the Lance Java API. The knn core (LanceKnnJoinStage, LanceProbe,
+          Metric, ...) lives in this module's own src, so no separate knn artifact is needed.
+          Exclude the netty buffer patch: Spark 4.2 (provided) supplies arrow 19.0.0 already.
+        -->
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-spark-base_${scala.compat.version}</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.arrow</groupId>
+                    <artifactId>arrow-memory-netty-buffer-patch</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Test-runtime: the Spark 4.2 connector so the e2e test's format("lance") resolves. -->
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-spark-4.2_${scala.compat.version}</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- junit-jupiter (test) is inherited from the root pom's global dependencies. -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>scala-compile-first</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>scala-test-compile</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <args>
+                        <arg>-feature</arg>
+                        <arg>-release</arg>
+                        <arg>${java.release}</arg>
+                    </args>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <release>${java.release}</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>java21</id>
+            <properties>
+                <java.release>21</java.release>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceKnnJoinStage.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceKnnJoinStage.scala
@@ -1,0 +1,457 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.apache.spark.TaskContext
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StructField, StructType}
+import org.lance.Dataset
+import org.lance.spark.{LanceRef, LanceSparkReadOptions}
+import org.lance.spark.utils.Utils
+
+/**
+ * The whole indexed nearest-by join, done per Spark partition with NO shuffle.
+ *
+ * A single native `LanceProbe.probe(...)` call is already a complete distributed search: Lance
+ * probes the IVF index and scans the candidate fragments across its own threads, heap-merges in
+ * process, and returns the final top-K for one query. Handing that orchestration to Spark (a
+ * probe → shuffle → merge → materialize pipeline) only adds a shuffle round-trip, a redundant
+ * merge stage, a second materialize scan, and `M × N_frag × K` refs crossing the Rust→JVM
+ * boundary. So this stage keeps everything local:
+ *
+ * {{{
+ *   left.rdd.mapPartitions { rows =>
+ *     val probe = new LanceProbe(uri, fragmentIds = None, version)   // whole-index, once per task
+ *     rows.flatMap { leftRow =>
+ *       // No over-fetch (SQL path, internalK == k): search + project payload in ONE scan.
+ *       val hits = probe.probeRows(query(leftRow), k, projection, ...)
+ *       hits.map(hit => assembleRow(leftRow, hit.row, hit.score))
+ *       // Over-fetch path (internalK > k): search cheap refs → trim → materialize survivors.
+ *       //   val topK = trimToK(probe.probe(query, internalK, ...))
+ *       //   val payloads = probe.materialize(topK.map(_.rowAddr))
+ *       //   topK.map(ref => assembleRow(leftRow, payloads(ref), ref.score))
+ *     }
+ *   }
+ * }}}
+ *
+ * No `requiredChildDistribution`, no Exchange. Each task opens R's whole index (`fragmentIds =
+ * None`) — Lance does the cross-fragment merge internally — so per-executor resident memory grows
+ * with `|R|`.
+ *
+ * The SQL Catalyst node ([[org.lance.spark.knn.catalyst.LanceKnnJoinExec]]) drives this
+ * `runPartition`, so probe/trim/materialize semantics stay defined in exactly one place.
+ */
+object LanceKnnJoinStage {
+
+  /**
+   * Everything a probe task needs, shipped from the driver. `internalK` is the overfetch count
+   * handed to Lance (`k × overfetch`); `k` is the final per-left-row cut applied after the native
+   * search. `leftVecIdx` is the position of the query-vector column in the left row.
+   *
+   * The read context — `readOptions`, `relationOptions`, `initialStorageOptions`, `namespaceImpl`,
+   * `namespaceProperties` — is the full Lance scan context captured from the connector's
+   * `LanceDataset` plus the DataSourceV2 relation options (where a DataFrame read carries branch /
+   * version / storage credentials). [[resolveReadContext]] merges + pins these once on the driver
+   * before the probe RDD launches; the resolved `readOptions` carry the pinned ref so every task
+   * probes one consistent snapshot. All five fields are serializable so they ship to executors.
+   */
+  final case class Conf(
+      readOptions: LanceSparkReadOptions,
+      relationOptions: java.util.Map[String, String],
+      initialStorageOptions: java.util.Map[String, String],
+      namespaceImpl: String,
+      namespaceProperties: java.util.Map[String, String],
+      vectorColumn: String,
+      metric: Metric,
+      k: Int,
+      internalK: Int,
+      nprobes: Option[Int],
+      refineFactor: Option[Int],
+      ef: Option[Int],
+      prefilter: Option[String],
+      leftVecIdx: Int,
+      rightProjection: Seq[String],
+      rightFields: Seq[StructField],
+      leftFieldCount: Int,
+      outerJoin: Boolean,
+      smallerIsBetter: Boolean)
+    extends Serializable
+
+  /**
+   * Resolve and pin the Lance read context ONCE, on the driver, before the probe RDD is launched —
+   * the same thing the connector's `LanceScanBuilder` does at scan-build time. Merges the
+   * DataSourceV2 relation options over the base table read options (branch / version / storage
+   * credentials), opens the dataset to read its current version, and pins that version so every
+   * executor probe sees one consistent snapshot even under concurrent writes.
+   *
+   * Returns a [[Conf]] whose `readOptions` carry the pinned ref; `relationOptions` is cleared since
+   * it has been folded in. Call this from the physical operator's `doExecute` (driver side) — never
+   * from the Catalyst rule, which must stay I/O-free so it can pattern-match against fake-URI
+   * relations in unit tests.
+   */
+  def resolveReadContext(conf: Conf): Conf = {
+    val merged = mergeReadOptions(conf.readOptions, conf.relationOptions)
+    val builder = Utils.openDatasetBuilder(merged)
+    if (conf.initialStorageOptions != null) {
+      builder.initialStorageOptions(conf.initialStorageOptions)
+    }
+    builder.runtimeNamespace(conf.namespaceImpl, conf.namespaceProperties, merged.getTableId())
+    val dataset: Dataset = builder.build()
+    val pinned =
+      try merged.withRef(Utils.pinOpenedRef(dataset, merged.getRef()))
+      finally dataset.close()
+    conf.copy(readOptions = pinned, relationOptions = new java.util.HashMap[String, String]())
+  }
+
+  /**
+   * Port of the connector's `LanceDataset.mergeScanOptions`: overlay the DataSourceV2 relation
+   * options on the base table's read options. Storage options merge with the relation winning, and
+   * any stale `version` / `branch` keys are stripped from the base first so the relation's ref is
+   * not shadowed by a leftover storage entry. An empty relation returns the base options untouched.
+   *
+   * Preserves the connector's incompatible-ref guard: if the base options already carry a pinned
+   * `ref` (e.g. a catalog table time-travelled at load) and the relation ALSO sets `version` /
+   * `branch`, a same-named branch keeps the table ref while an incompatible combination is rejected
+   * with an `IllegalArgumentException` rather than silently letting the relation value win. On the
+   * plain DataFrame-relation path this rule usually matches, the base carries no ref and the guard
+   * is inert — but keeping it makes the merge behave identically to `LanceDataset.mergeScanOptions`
+   * for a pinned base, so a caller cannot smuggle a conflicting snapshot past the merge.
+   */
+  private[knn] def mergeReadOptions(
+      base: LanceSparkReadOptions,
+      relationOptions: java.util.Map[String, String]): LanceSparkReadOptions = {
+    if (relationOptions == null || relationOptions.isEmpty) {
+      return base
+    }
+    val tableRef = base.getRef
+    val scanSetsBranchOrVersion =
+      relationOptions.containsKey(LanceSparkReadOptions.CONFIG_VERSION) ||
+        relationOptions.containsKey(LanceSparkReadOptions.CONFIG_BRANCH)
+    val merged = new java.util.HashMap[String, String](base.getStorageOptions)
+    merged.remove(LanceSparkReadOptions.CONFIG_VERSION)
+    merged.remove(LanceSparkReadOptions.CONFIG_BRANCH)
+    merged.putAll(relationOptions)
+    val scanOptions = LanceSparkReadOptions
+      .builder()
+      .datasetUri(base.getDatasetUri)
+      .namespace(base.getNamespace)
+      .tableId(base.getTableId)
+      .catalogName(base.getCatalogName)
+      .indexCacheBackend(base.getIndexCacheBackend)
+      .metadataCacheBackend(base.getMetadataCacheBackend)
+      .ref(tableRef)
+      .fromOptions(merged)
+      .build()
+    if (tableRef != null && scanSetsBranchOrVersion) {
+      val scanRef = scanOptions.getRef
+      if (sameNamedBranch(tableRef, scanRef)) {
+        // Same named branch, different version → keep the table's pinned ref (snapshot isolation).
+        return scanOptions.withRef(tableRef)
+      }
+      require(
+        tableRef == scanRef,
+        s"Cannot combine $tableRef with $scanRef")
+    }
+    scanOptions
+  }
+
+  /** Same-named-branch check, mirroring the connector's `LanceDataset.sameNamedBranch`. */
+  private def sameNamedBranch(tableRef: LanceRef, scanRef: LanceRef): Boolean =
+    tableRef.isBranch &&
+      scanRef != null &&
+      scanRef.isBranch &&
+      tableRef.getBranchName.equals(scanRef.getBranchName)
+
+  /**
+   * Run the join for one partition of left rows. Opens the probe once, then streams the output: each
+   * left row expands to its (≤k) join rows on demand via [[lazyJoinIterator]], so the whole
+   * partition is never buffered.
+   *
+   * Because Spark pulls from `mapPartitions` lazily, the returned iterator can outlive this method —
+   * so the probe is closed on task completion (success OR failure) via the `TaskContext` listener,
+   * NOT a `try`/`finally` here (which would release the native handle before the consumer reads it).
+   * When there is no `TaskContext` (a direct call outside a Spark task, e.g. a JVM-only test), we
+   * fall back to draining eagerly and closing before returning so the handle cannot leak.
+   */
+  def runPartition(leftRows: Iterator[Row], conf: Conf): Iterator[Row] = {
+    if (leftRows.isEmpty) return Iterator.empty
+
+    val probe = new LanceProbe(
+      conf.readOptions,
+      conf.initialStorageOptions,
+      conf.namespaceImpl,
+      conf.namespaceProperties,
+      fragmentIds = None)
+
+    val output = lazyJoinIterator(leftRows, leftRow => processRow(leftRow, probe, conf))
+    TaskContext.get() match {
+      case null =>
+        try output.toList.iterator
+        finally probe.close()
+      case tc =>
+        tc.addTaskCompletionListener[Unit](_ => probe.close())
+        output
+    }
+  }
+
+  /**
+   * Lazily compose per-partition output: each left row expands to its (≤k) join rows on demand.
+   * Extracted so a unit test can assert laziness — the left iterator is pulled element-by-element,
+   * not drained up front — with a stub expander and no Lance dataset. [[runPartition]] wires the
+   * real per-row probe / trim / materialize expansion through here.
+   */
+  private[knn] def lazyJoinIterator(
+      leftRows: Iterator[Row],
+      expand: Row => Iterator[Row]): Iterator[Row] =
+    leftRows.flatMap(expand)
+
+  /**
+   * Whether [[processRow]] may take the folded one-scan fast path. True only when there is no
+   * JVM-side over-fetch (`internalK <= k`, so every probed row is kept and no trim is needed) AND
+   * the payload projection does not name a column the nearest scan injects itself — `_rowid`,
+   * `_distance`, `_score` (see [[LanceProbe.fusesCleanly]]). A colliding projection must fall
+   * through to the split probe → materialize path, whose scan injects only `_rowid` and therefore
+   * reads any `_distance` / `_score` payload column straight from the dataset without collision.
+   * Extracted so the routing decision is unit-testable without a Lance dataset.
+   */
+  private[knn] def foldsInOneScan(internalK: Int, k: Int, projection: Seq[String]): Boolean =
+    internalK <= k && LanceProbe.fusesCleanly(projection)
+
+  /**
+   * Expand one left row into its join output rows: probe R's index, trim to `k`, late-materialize
+   * the surviving right rows by `_rowid`, and assemble `left ++ right ++ score`. Returns an empty
+   * iterator (inner join) or a single null-right row (outer join) when there is no query vector or
+   * no hit.
+   */
+  private def processRow(leftRow: Row, probe: LanceProbe, conf: Conf): Iterator[Row] = {
+    val q = extractVector(leftRow, conf.leftVecIdx)
+    if (q == null) {
+      // Null query vector: nothing to search. Emit a null-right row only for an outer join.
+      if (conf.outerJoin) {
+        Iterator.single(assembleRow(leftRow, conf.leftFieldCount, conf.rightFields, null, null))
+      } else {
+        Iterator.empty
+      }
+    } else if (foldsInOneScan(conf.internalK, conf.k, conf.rightProjection)) {
+      // No JVM-side over-fetch (the SQL path: internalK == k) AND the payload projection does not
+      // collide with an injected column (see [[foldsInOneScan]]). Every probed row is kept, so probe
+      // and materialize in ONE native scan: Lance searches the index AND projects the payload
+      // columns in a single pass. A split probe → trim → materialize would re-scan the exact rows
+      // the search already found, for nothing. Lance returns them best-first, so no trim is needed.
+      val hits = probe.probeRows(
+        conf.vectorColumn,
+        q,
+        conf.internalK,
+        conf.metric,
+        conf.rightProjection,
+        conf.rightFields,
+        conf.nprobes,
+        conf.refineFactor,
+        conf.ef,
+        conf.prefilter)
+      if (hits.isEmpty) {
+        if (conf.outerJoin) {
+          Iterator.single(assembleRow(leftRow, conf.leftFieldCount, conf.rightFields, null, null))
+        } else {
+          Iterator.empty
+        }
+      } else {
+        hits.iterator.map { hit =>
+          assembleRow(leftRow, conf.leftFieldCount, conf.rightFields, hit.row, hit.score)
+        }
+      }
+    } else {
+      // Split probe → trim → materialize path. Taken when the caller over-fetches (internalK > k)
+      // OR when the payload projection collides with an injected column name and the fold above
+      // had to decline. Fetch `internalK` cheap refs natively, trim to the final `k`, then
+      // late-materialize ONLY the survivors by `_rowid`. With internalK == k (the SQL rule) nothing
+      // is trimmed; the split still buys collision-safety, since materialize injects only `_rowid`.
+      // Lance already returns refs best-first.
+      val refs = probe
+        .probe(
+          conf.vectorColumn,
+          q,
+          conf.internalK,
+          conf.metric,
+          conf.nprobes,
+          conf.refineFactor,
+          conf.ef,
+          conf.prefilter)
+        .toArray
+      val trimmed =
+        if (refs.length <= conf.k) refs
+        else {
+          val heap = new TopKHeap(conf.k, conf.smallerIsBetter)
+          heap.offerAll(refs)
+          heap.drain()
+        }
+
+      if (trimmed.isEmpty) {
+        if (conf.outerJoin) {
+          Iterator.single(assembleRow(leftRow, conf.leftFieldCount, conf.rightFields, null, null))
+        } else {
+          Iterator.empty
+        }
+      } else {
+        // Late materialization: point-fetch the surviving right rows by `_rowid`. Building the
+        // `rowAddr -> row` map collapses any duplicate rowAddr to one payload; we still emit one
+        // output row per surviving ref. Bounded by `k`, so this stays per-row, not per-partition.
+        val materialized: Map[Long, Map[String, Any]] = probe
+          .materialize(
+            trimmed.iterator.map(_.rowAddr).toSeq,
+            conf.rightProjection,
+            conf.rightFields)
+          .map(m => extractRowAddr(m) -> m)
+          .toMap
+        trimmed.iterator.map { ref =>
+          val rightMap = materialized.getOrElse(ref.rowAddr, null)
+          assembleRow(leftRow, conf.leftFieldCount, conf.rightFields, rightMap, ref.score)
+        }
+      }
+    }
+  }
+
+  /**
+   * Pull a query vector out of a Spark `Row`'s ArrayType column. The Scala 2.13 `Seq` gotcha is
+   * real: `Row.get` on `ArrayType` returns `mutable.ArraySeq`, which `case s: Seq[_]` only matches
+   * against the root `scala.collection.Seq` trait (the default `Seq` alias is `immutable.Seq` on
+   * 2.13).
+   */
+  private[knn] def extractVector(row: Row, idx: Int): Array[Float] = {
+    if (row.isNullAt(idx)) return null
+    row.get(idx) match {
+      case s: scala.collection.Seq[_] =>
+        s.iterator.map {
+          case f: java.lang.Float => f.floatValue()
+          case f: Float => f
+          case d: java.lang.Double => d.doubleValue().toFloat
+          case d: Double => d.toFloat
+          case other =>
+            throw new IllegalStateException(
+              s"Unsupported vector element type: ${other.getClass.getName}")
+        }.toArray
+      case arr: Array[Float] => arr
+      case arr: Array[java.lang.Float] => arr.map(_.floatValue())
+      case other =>
+        throw new IllegalStateException(
+          s"Unsupported vector column representation: ${other.getClass.getName}")
+    }
+  }
+
+  /** Read the `_rowid` key out of a materialized row map (tolerating boxed / stringy longs). */
+  private def extractRowAddr(m: Map[String, Any]): Long =
+    m.get(LanceProbe.RowIdColumn) match {
+      case Some(l: java.lang.Long) => l.longValue()
+      case Some(l: Long) => l
+      case Some(other) => other.toString.toLong
+      case None =>
+        throw new IllegalStateException(
+          s"Materialized row missing ${LanceProbe.RowIdColumn}; " +
+            s"got keys: ${m.keys.mkString(", ")}")
+    }
+
+  /**
+   * Assemble one output row: `left fields ++ right fields ++ score`. A null `rightValues` (outer
+   * join with no hit) fills the right side with nulls. Each right value is shaped to its target
+   * Spark type via [[coerceToSpark]] so the join's `ExpressionEncoder` accepts it.
+   */
+  private def assembleRow(
+      leftRow: Row,
+      leftFieldCount: Int,
+      rightFields: Seq[StructField],
+      rightValues: Map[String, Any],
+      score: Any): Row = {
+    val arr = new Array[Any](leftFieldCount + rightFields.size + 1)
+    var i = 0
+    while (i < leftFieldCount) { arr(i) = leftRow.get(i); i += 1 }
+    var j = 0
+    while (j < rightFields.size) {
+      val field = rightFields(j)
+      arr(leftFieldCount + j) =
+        if (rightValues == null) null
+        else coerceToSpark(rightValues.getOrElse(field.name, null), field.dataType)
+      j += 1
+    }
+    arr(leftFieldCount + rightFields.size) = score
+    Row.fromSeq(arr.toSeq)
+  }
+
+  /**
+   * Shape a materialized right-side value to match its target Spark [[DataType]] so the assembled
+   * row satisfies the join's `ExpressionEncoder`. [[LanceProbe]] returns payloads Spark-agnostically
+   * — an Arrow struct cell arrives as a `Map[String, Any]` keyed by child-field name and a list cell
+   * as a `Seq` — but a Spark `StructType` slot expects a positional `Row`, not a `Map`. Without this
+   * coercion a nested-struct payload column is handed to the encoder as a `Map` and either fails
+   * encoding or materializes as garbage.
+   *
+   * Recurses so nested shapes all land correctly:
+   *  - `StructType` → `Row` built in declared field order, each field coerced to its type
+   *  - `ArrayType`  → `Seq` with every element coerced to the element type
+   *  - `MapType`    → map with keys and values coerced
+   *  - anything else (numeric / string / boolean primitives) → passed through unchanged
+   */
+  private[knn] def coerceToSpark(value: Any, dataType: DataType): Any = {
+    if (value == null) return null
+    dataType match {
+      case s: StructType =>
+        value match {
+          case m: scala.collection.Map[_, _] =>
+            val byName = m.asInstanceOf[scala.collection.Map[String, Any]]
+            Row.fromSeq(
+              s.fields.map(f => coerceToSpark(byName.getOrElse(f.name, null), f.dataType)).toSeq)
+          case r: Row => r
+          case _ => value
+        }
+      case ArrayType(elementType, _) =>
+        value match {
+          case seq: scala.collection.Seq[_] => seq.map(v => coerceToSpark(v, elementType))
+          case arr: Array[_] => arr.toSeq.map(v => coerceToSpark(v, elementType))
+          case _ => value
+        }
+      case MapType(keyType, valueType, _) =>
+        value match {
+          case m: scala.collection.Map[_, _] =>
+            m.map { case (k, v) => coerceToSpark(k, keyType) -> coerceToSpark(v, valueType) }
+          case entries: scala.collection.Seq[_] =>
+            // The shape a real Arrow map cell actually arrives in. Arrow represents a `MapType`
+            // cell as a LIST of `{key, value}` entry structs, so `LanceProbe.toSparkValue` turns it
+            // into a `Seq(Map("key" -> …, "value" -> …), …)` — NOT a Scala map. Left uncoerced the
+            // encoder would see a sequence where a `MapType` slot is expected and either fail or
+            // materialize garbage. Rebuild a real map from the entries. (The `Map` case above stays
+            // for direct-map payloads and JVM-only tests.)
+            entries.iterator.map { entry =>
+              val (k, v) = mapEntryKeyValue(entry)
+              coerceToSpark(k, keyType) -> coerceToSpark(v, valueType)
+            }.toMap
+          case _ => value
+        }
+      case _ => value
+    }
+  }
+
+  /**
+   * Pull `(key, value)` out of a single Arrow map entry. `LanceProbe.toSparkValue` renders each
+   * entry as a `Map("key" -> …, "value" -> …)` (Arrow's `MapVector` names the entry-struct children
+   * `key` / `value`); a positional `Row(key, value)` is tolerated defensively.
+   */
+  private def mapEntryKeyValue(entry: Any): (Any, Any) = entry match {
+    case m: scala.collection.Map[_, _] =>
+      val byName = m.asInstanceOf[scala.collection.Map[String, Any]]
+      (byName.getOrElse("key", null), byName.getOrElse("value", null))
+    case r: Row if r.length >= 2 => (r.get(0), r.get(1))
+    case other =>
+      throw new IllegalStateException(
+        s"Unexpected Arrow map-entry representation: ${other.getClass.getName}")
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceProbe.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceProbe.scala
@@ -1,0 +1,618 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.{BigIntVector, FieldVector, Float4Vector, Float8Vector, UInt8Vector, VectorSchemaRoot}
+import org.apache.arrow.vector.ipc.ArrowReader
+import org.apache.spark.sql.catalyst.CatalystTypeConverters
+import org.apache.spark.sql.types.{DataType, StructField}
+import org.apache.spark.sql.vectorized.{ColumnarBatch, ColumnVector}
+import org.lance.Dataset
+import org.lance.ipc.{LanceScanner, Query, ScanOptions}
+import org.lance.spark.{LanceConstant, LanceRef, LanceRuntime, LanceSparkReadOptions}
+import org.lance.spark.utils.Utils
+import org.lance.spark.vectorized.LanceArrowColumnVector
+
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+/**
+ * Per-task vector-index probe primitive. Opens a Lance dataset once and serves many queries against
+ * a fixed set of fragments. Two query shapes:
+ *  - [[probe]] returns row references + scores only (no payload); the payload is fetched later via
+ *    [[materialize]]. This split late-materialization is the right shape when the caller OVER-FETCHES
+ *    candidates and trims before materializing — only the survivors are paid for.
+ *  - [[probeRows]] folds the nearest search AND the payload projection into a SINGLE scan. This is
+ *    the right shape when there is NO JVM-side over-fetch (every probed row is kept), so a separate
+ *    materialize scan would just re-fetch the exact rows the search already found.
+ *
+ * This is the core primitive Phase 0 of the indexed nearest-by design depends on. Validating its
+ * cost profile is the first thing to do on a new Lance build:
+ *  - dataset open should be one-time cost
+ *  - per-probe cost should be index traversal + small overhead, not full fragment scan
+ *  - returning top-K row addrs should match Lance's native nearest search recall
+ *
+ * Lifecycle: instantiate per task, call `probe(...)` repeatedly, close at end.
+ *
+ * @param readOptions           Fully resolved Lance read context — dataset URI, storage
+ *                              credentials, catalog / cache backends, and the pinned branch /
+ *                              version ref. Inside a join this is resolved and pinned once on the
+ *                              driver (see [[LanceKnnJoinStage.resolveReadContext]]) so every task
+ *                              probes the same snapshot.
+ * @param initialStorageOptions Driver-side storage options from `namespace.describeTable()`, merged
+ *                              into the base storage options at open. May be `null`.
+ * @param namespaceImpl         Namespace implementation type, for reconnecting the namespace on an
+ *                              executor where the live handle did not survive serialization. May be
+ *                              `null` for a plain URI dataset.
+ * @param namespaceProperties   Namespace connection properties for that reconnection. May be `null`.
+ * @param fragmentIds           Fragments this probe is restricted to. Pass `None` for whole-dataset
+ *                              search.
+ * @param allocator             Arrow allocator. Defaults to lance-spark's shared
+ *                              `LanceRuntime.allocator()`.
+ */
+final class LanceProbe(
+    readOptions: LanceSparkReadOptions,
+    initialStorageOptions: java.util.Map[String, String],
+    namespaceImpl: String,
+    namespaceProperties: java.util.Map[String, String],
+    fragmentIds: Option[Seq[Int]],
+    allocator: BufferAllocator = LanceRuntime.allocator())
+  extends AutoCloseable {
+
+  /**
+   * URI + optional pinned-version convenience constructor. Builds read options straight from a bare
+   * dataset URI and pins `version` on the main branch when present. For callers / tests that have
+   * only a plain URI and no namespace or storage context.
+   */
+  def this(datasetUri: String, fragmentIds: Option[Seq[Int]], version: Option[Long]) =
+    this(LanceProbe.readOptionsFor(datasetUri, version), null, null, null, fragmentIds)
+
+  def this(datasetUri: String, fragmentIds: Option[Seq[Int]]) =
+    this(datasetUri, fragmentIds, None)
+
+  // Open the dataset once. Lance's Java binding caches index metadata against the Dataset handle,
+  // so reusing it across probes keeps subsequent calls index-warm. Opening through
+  // `Utils.openDatasetBuilder` (rather than a bare `Dataset.open().uri(...)`) makes the probe honor
+  // the full resolved read context — storage credentials, catalog / cache backends, the pinned
+  // branch / version ref, and (on executors, where the live namespace handle is transient) the
+  // runtime-namespace reconnection — exactly as the connector's own scan path does.
+  private val dataset: Dataset = openDataset()
+
+  private val javaFragmentIds: Option[util.List[Integer]] = fragmentIds.map { ids =>
+    val javaList = new util.ArrayList[Integer](ids.size)
+    ids.foreach(i => javaList.add(Integer.valueOf(i)))
+    javaList: util.List[Integer]
+  }
+
+  private def openDataset(): Dataset = {
+    // Apply the connector's exact worker-open namespace policy (`LanceFragmentScanner.create`):
+    // touch the namespace ONLY when a namespace impl is configured AND executor credential refresh
+    // is enabled. When refresh is on, either rebuild the namespace client (impls that must run on
+    // workers) or clear it (impls that must not, so the open falls back to the URI + initial storage
+    // options). When refresh is OFF we leave the read options' namespace exactly as shipped — this
+    // is the whole point of `executor_credential_refresh=false`, and forcing a rebuild here would
+    // turn that policy into a namespace class-load / RPC that can fail before the dataset even opens.
+    //
+    // Notably this does NOT call `builder.runtimeNamespace(namespaceImpl, ...)` unconditionally
+    // (which always loads the namespace impl class) — matching the fragment scanner, which reaches
+    // the namespace only through the guarded `setNamespace` path above.
+    if (namespaceImpl != null && readOptions.isExecutorCredentialRefresh()) {
+      if (LanceRuntime.useNamespaceOnWorkers(namespaceImpl)) {
+        readOptions.setNamespace(
+          LanceRuntime.getOrCreateNamespace(namespaceImpl, namespaceProperties))
+      } else {
+        readOptions.setNamespace(null)
+      }
+    }
+    val builder = Utils.openDatasetBuilder(readOptions)
+    if (initialStorageOptions != null) {
+      builder.initialStorageOptions(initialStorageOptions)
+    }
+    builder.build()
+  }
+
+  /**
+   * Run a single nearest-neighbor query. Returns up to `k` row references for the configured
+   * fragments, ordered best-first by `metric`.
+   *
+   * Implementation note: lance-spark mandates `prefilter = true` for fragmented vector queries
+   * (see `LanceFragmentScanner.create`). We mirror that here — Lance's index probe semantics
+   * require it when fragment scope is restricted.
+   *
+   * `vectorColumn` is a per-call argument (not a constructor field) because the same
+   * `LanceProbe` instance also serves the materialize stage via [[materialize]], which
+   * doesn't reference any vector column. Keeping it on the call sidesteps the smell of
+   * passing a placeholder string when constructing for materialize-only use.
+   *
+   * `prefilter` is a Lance SQL filter string (DataFusion-flavored). Lance applies it BEFORE the
+   * vector index lookup when `prefilter = true` (which we always set), so the top-K is computed
+   * over only the rows matching the filter — exactly what a `Filter(cond, lance) RIGHT JOIN ...
+   * APPROX NEAREST K` should do. Without prefilter pushdown, a per-fragment vector probe could
+   * return K rows that are all later filtered out post-join, masking truly-nearest-but-also-
+   * matching rows further down the index — a recall bug. The translator in
+   * `IndexedNearestByJoinRule` is responsible for producing only safely-translated SQL; here we
+   * just hand it through.
+   */
+  def probe(
+      vectorColumn: String,
+      query: Array[Float],
+      k: Int,
+      metric: Metric,
+      nprobes: Option[Int] = None,
+      refineFactor: Option[Int] = None,
+      ef: Option[Int] = None,
+      prefilter: Option[String] = None): Seq[ScoredRowRef] = {
+    require(vectorColumn != null && vectorColumn.nonEmpty, "vectorColumn must be non-empty")
+    require(query != null && query.length > 0, "Query vector must be non-empty")
+    require(k > 0, "k must be positive")
+
+    val q = buildNearestQuery(vectorColumn, query, k, metric, nprobes, refineFactor, ef)
+
+    val opts = new ScanOptions.Builder()
+      .nearest(q)
+      // EXPERIMENT: drop prefilter(true). The single-machine reference path
+      // doesn't set it; this LanceProbe call does. Comparing wallclock with
+      // and without isolates whether the prefilter branch in
+      // vector_search_source forces a slower index plan than the postfilter
+      // (default) branch. Re-enable when fragmented probe + prefilter
+      // pushdown is needed (we know fragmentIds requires prefilter from the
+      // Lance-side error, but at probeParallelism=1 there are no fragments).
+      .withRowId(true)
+      // Project only what we need into the result. The vector column is implied by `nearest`;
+      // requesting an empty user column list keeps the Arrow batch narrow (just the rowid +
+      // distance metadata). Materialization fetches payload columns later.
+      .columns(java.util.Collections.emptyList[String]())
+
+    if (prefilter.nonEmpty || javaFragmentIds.nonEmpty) {
+      // Real prefilter or fragment scope is requested — keep prefilter(true)
+      // so Lance applies the filter / restricts to fragments correctly.
+      opts.prefilter(true)
+    }
+
+    prefilter.filter(_.nonEmpty).foreach(opts.filter)
+    javaFragmentIds.foreach(opts.fragmentIds)
+
+    val scanner: LanceScanner = LanceScanner.create(dataset, opts.build(), allocator)
+    try {
+      readScored(scanner.scanBatches())
+    } finally {
+      scanner.close()
+    }
+  }
+
+  /**
+   * Nearest search AND payload projection in a SINGLE scan. Runs the top-`k` search projecting the
+   * requested payload `projection` columns directly into the result batch, so each hit comes back
+   * with its row-id, ranking score, AND materialized payload — no second point-fetch scan.
+   *
+   * This is the no-overfetch fast path. When the caller does not over-fetch at the JVM level (the
+   * SQL path: `internalK == k`), every probed row is kept, so the split [[probe]] → trim →
+   * [[materialize]] would just re-scan the exact rows the search already found — a second Lance scan
+   * plus a `k`-element `_rowid IN (arrow_cast …)` filter parse, per query, for nothing. Folding the
+   * two removes both. Rows come back best-first (Lance's native ordering), same as [[probe]].
+   *
+   * Use [[probe]] + [[materialize]] instead when the caller OVER-fetches candidates and trims before
+   * materializing — there, deferring the payload fetch to only the survivors is the win. `projection`
+   * / `projectionFields` follow [[materialize]]'s contract: an empty `projection` means "all columns",
+   * and each projected cell is converted to the Spark EXTERNAL value its declared type expects (see
+   * [[readRows]]).
+   */
+  def probeRows(
+      vectorColumn: String,
+      query: Array[Float],
+      k: Int,
+      metric: Metric,
+      projection: Seq[String],
+      projectionFields: Seq[StructField],
+      nprobes: Option[Int] = None,
+      refineFactor: Option[Int] = None,
+      ef: Option[Int] = None,
+      prefilter: Option[String] = None): Seq[MaterializedHit] = {
+    require(vectorColumn != null && vectorColumn.nonEmpty, "vectorColumn must be non-empty")
+    require(query != null && query.length > 0, "Query vector must be non-empty")
+    require(k > 0, "k must be positive")
+
+    val q = buildNearestQuery(vectorColumn, query, k, metric, nprobes, refineFactor, ef)
+
+    val opts = new ScanOptions.Builder()
+      .nearest(q)
+      .withRowId(true)
+    // Project the payload columns into the nearest scan itself. `_distance` is added by `nearest`
+    // regardless (Lance includes it even when explicit columns omit it), so the drain still finds a
+    // score column. An empty projection leaves columns unset → all columns, matching `materialize`.
+    if (projection.nonEmpty) {
+      opts.columns(projection.toList.asJava)
+    }
+
+    if (prefilter.nonEmpty || javaFragmentIds.nonEmpty) {
+      opts.prefilter(true)
+    }
+    prefilter.filter(_.nonEmpty).foreach(opts.filter)
+    javaFragmentIds.foreach(opts.fragmentIds)
+
+    val scanner: LanceScanner = LanceScanner.create(dataset, opts.build(), allocator)
+    try {
+      readScoredRows(scanner.scanBatches(), projectionFields)
+    } finally {
+      scanner.close()
+    }
+  }
+
+  /**
+   * Build the Lance nearest-neighbor query. Shared by [[probe]] (refs only) and [[probeRows]]
+   * (refs + folded payload) so both search the index identically.
+   */
+  private def buildNearestQuery(
+      vectorColumn: String,
+      query: Array[Float],
+      k: Int,
+      metric: Metric,
+      nprobes: Option[Int],
+      refineFactor: Option[Int],
+      ef: Option[Int]): Query = {
+    val b = new Query.Builder()
+      .setColumn(vectorColumn)
+      .setKey(query)
+      .setK(k)
+      .setDistanceType(metric.lanceType)
+    nprobes.foreach(b.setNprobes(_))
+    // refineFactor: IVF-PQ recall knob. Lance fetches `k * refineFactor` approximate
+    // candidates, then re-ranks them with exact distance and trims to k. Bigger factor =
+    // better recall, more compute. None leaves Lance's default (= 1, no re-rank).
+    refineFactor.foreach(b.setRefineFactor(_))
+    // ef: HNSW search depth. Higher = better recall, more compute. None leaves Lance's
+    // index-default. Only meaningful for HNSW indexes; ignored for IVF-PQ.
+    ef.foreach(b.setEf(_))
+    b.build()
+  }
+
+  /**
+   * Drain the Arrow stream from a nearest-search scan into `(rowId, score)` pairs.
+   *
+   * Expected schema:
+   *   - `_rowid`   : UInt8 / BigInt — Lance logical row identifier
+   *   - `_distance` (or score column added by `nearest`) : Float4 / Float8 — ranking value
+   *
+   * We resolve columns by name to be encoding-version-agnostic; the underlying primitive type
+   * (UInt8 vs BigInt for the id, Float4 vs Float8 for score) varies across Arrow / Lance combos
+   * and we tolerate both.
+   */
+  private def readScored(reader: ArrowReader): Seq[ScoredRowRef] = {
+    val out = mutable.ArrayBuffer.empty[ScoredRowRef]
+    try {
+      while (reader.loadNextBatch()) {
+        val root = reader.getVectorSchemaRoot
+        val addrVec: FieldVector = root.getVector(LanceProbe.RowIdColumn)
+        val scoreVec: FieldVector = resolveScoreVector(root)
+
+        val n = root.getRowCount
+        var i = 0
+        while (i < n) {
+          out += ScoredRowRef(rowAddrAt(addrVec, i), scoreAt(scoreVec, i))
+          i += 1
+        }
+      }
+    } finally {
+      reader.close()
+    }
+    out.toSeq
+  }
+
+  /**
+   * Drain a nearest-search scan that ALSO projected payload columns into `(rowId, score, payload)`
+   * hits — the folded counterpart of [[readScored]] + [[readRows]]. Row-id and score are read out of
+   * the `_rowid` / `_distance` vectors directly; the payload columns (those with a Spark target type
+   * in `projectionFields`) go through the canonical [[org.lance.spark.vectorized.LanceArrowColumnVector]]
+   * adapter and back through [[CatalystTypeConverters]] to the external value the encoder expects —
+   * exactly as [[readRows]] does. `_rowid` / `_distance` are handled here, so they are deliberately
+   * excluded from the payload map (unlike [[readRows]], which surfaces `_rowid` for re-keying).
+   */
+  private def readScoredRows(
+      reader: ArrowReader,
+      projectionFields: Seq[StructField]): Seq[MaterializedHit] = {
+    val schemaByName: Map[String, StructField] =
+      projectionFields.iterator.map(f => f.name -> f).toMap
+    val out = mutable.ArrayBuffer.empty[MaterializedHit]
+    try {
+      while (reader.loadNextBatch()) {
+        val root: VectorSchemaRoot = reader.getVectorSchemaRoot
+        val n = root.getRowCount
+        val fields = root.getSchema.getFields.asScala.toIndexedSeq
+
+        val addrVec: FieldVector = root.getVector(LanceProbe.RowIdColumn)
+        val scoreVec: FieldVector = resolveScoreVector(root)
+
+        // Payload columns only (those with a Spark target type). `_rowid` / `_distance` are read out
+        // separately, so they are deliberately excluded from the payload map here.
+        val mapped = fields.filter(af => schemaByName.contains(af.getName))
+        val mappedNames: Array[String] = mapped.iterator.map(_.getName).toArray
+        val mappedTypes: Array[DataType] =
+          mapped.iterator.map(af => schemaByName(af.getName).dataType).toArray
+        val mappedConverters: Array[Any => Any] = mapped.iterator
+          .map(af =>
+            CatalystTypeConverters.createToScalaConverter(schemaByName(af.getName).dataType))
+          .toArray
+        val mappedVectors: Array[ColumnVector] = mapped.iterator
+          .map(af =>
+            new LanceArrowColumnVector(root.getVector(af.getName), false, schemaByName(af.getName))
+              .asInstanceOf[ColumnVector])
+          .toArray
+        // Thin view over the reader-owned Arrow vectors (closeVectorOnClose=false): `reader.close()`
+        // in the finally frees the buffers once the values below are copied out.
+        val batch = new ColumnarBatch(mappedVectors, n)
+
+        var i = 0
+        while (i < n) {
+          val rowMap = mutable.LinkedHashMap.empty[String, Any]
+          val internalRow = batch.getRow(i)
+          var j = 0
+          while (j < mappedNames.length) {
+            val internal = internalRow.get(j, mappedTypes(j))
+            rowMap(mappedNames(j)) = if (internal == null) null else mappedConverters(j)(internal)
+            j += 1
+          }
+          out += MaterializedHit(rowAddrAt(addrVec, i), scoreAt(scoreVec, i), rowMap.toMap)
+          i += 1
+        }
+      }
+    } finally {
+      reader.close()
+    }
+    out.toSeq
+  }
+
+  /** Locate the nearest-search score column by name, tolerant of `_distance` vs `_score`. */
+  private def resolveScoreVector(root: VectorSchemaRoot): FieldVector =
+    LanceProbe.ScoreColumns.iterator
+      .map(name => Option(root.getVector(name)).orNull)
+      .find(_ != null)
+      .getOrElse(throw new IllegalStateException(
+        "Lance nearest scan did not return a score column. Got: " +
+          root.getSchema.getFields.asScala.map(_.getName).mkString(", ")))
+
+  /** Read a Lance row id out of an Arrow `_rowid` vector (UInt8 or BigInt, encoding-dependent). */
+  private def rowAddrAt(addrVec: FieldVector, i: Int): Long = addrVec match {
+    case v: UInt8Vector => v.get(i)
+    case v: BigIntVector => v.get(i)
+    case other =>
+      throw new IllegalStateException(
+        s"Unexpected row-address vector type: ${other.getClass.getName}")
+  }
+
+  /** Read a ranking score out of an Arrow score vector (Float4 or Float8, encoding-dependent). */
+  private def scoreAt(scoreVec: FieldVector, i: Int): Float = scoreVec match {
+    case v: Float4Vector => v.get(i)
+    case v: Float8Vector => v.get(i).toFloat
+    case other =>
+      throw new IllegalStateException(
+        s"Unexpected score vector type: ${other.getClass.getName}")
+  }
+
+  /**
+   * Materialize a set of right-side rows by their `_rowaddr`s. Used by the join's materialize
+   * stage to fetch full payloads after the probe + merge has decided which rows survive.
+   *
+   * The row addresses are pushed down as a `_rowaddr IN (...)` filter, which Lance executes via
+   * its row-address index — the natural point-fetch path. The result is unordered with respect
+   * to the input list; the caller re-aligns by `_rowaddr`.
+   *
+   * @param rowAddrs   list of Lance `_rowid` values (parameter name retained for source
+   *                   compatibility with callers — semantically these are now row IDs).
+   * @param projection projected column list. `Seq.empty` means "all columns".
+   * @param projectionFields Spark target fields (name + dataType) for the projected columns. When
+   *                   non-empty, each projected payload cell is converted to the Spark EXTERNAL
+   *                   value its declared type expects (see [[readRows]]); when empty, cells fall
+   *                   back to a generic Arrow-object conversion.
+   * @return a sequence of materialized rows, each a `Map[String, Any]` keyed by column name. With
+   *         `projectionFields` supplied, each projected value is already the Spark external
+   *         representation of its target type — the shape the join's `ExpressionEncoder` accepts —
+   *         plus an entry under `LanceProbe.RowIdColumn` (a plain long) so the caller can re-key.
+   *         Building those values into a `Row` / `InternalRow` happens in the join stage.
+   */
+  def materialize(
+      rowAddrs: Seq[Long],
+      projection: Seq[String] = Seq.empty,
+      projectionFields: Seq[StructField] = Seq.empty): Seq[Map[String, Any]] = {
+    if (rowAddrs.isEmpty) return Seq.empty
+
+    val opts = new ScanOptions.Builder().withRowId(true)
+    if (projection.nonEmpty) {
+      opts.columns(projection.toList.asJava)
+    }
+    // `_rowid IN (a, b, c)` — Lance lowers this to its row-id lookup path. Same point-fetch
+    // semantics as `_rowaddr IN (...)` previously used here, but `_rowid` is the universal
+    // identifier (works on indexed + non-indexed scan paths alike).
+    //
+    // Each row ID is rendered as `arrow_cast('<unsigned-string>', 'UInt64')` for two
+    // compounding reasons:
+    //
+    //   1. Lance row IDs are 64-bit UNSIGNED; storing them as Java signed `long` means
+    //      values >= 2^63 come back negative. `mkString(", ")` would render them as
+    //      negative integer literals and Lance/DataFusion would reject (`Int64(-...)
+    //      cannot convert to UInt64`).
+    //   2. Even after `Long.toUnsignedString` produces a positive 20-digit decimal,
+    //      DataFusion's SQL parser tries `Int64` first, overflows, then falls back to
+    //      `Float64`. `Float64` loses precision past 2^53 — the literal becomes a
+    //      different number — and DataFusion then can't downcast `Float64` to `UInt64`.
+    //
+    // `arrow_cast(string, 'UInt64')` bypasses both: the string literal goes through
+    // `arrow_cast`'s own coercion, which is precision-preserving for UInt64.
+    //
+    // At 100K rows row IDs stay below 2^53 and both layers of the bug are invisible; at
+    // 1M+ rows they bite. Caught when the DataFrame benchmark hit 1M-row scale.
+    val rowIdLiterals = rowAddrs.iterator
+      .map(addr => s"arrow_cast('${java.lang.Long.toUnsignedString(addr)}', 'UInt64')")
+      .mkString(", ")
+    opts.filter(s"${LanceProbe.RowIdColumn} IN ($rowIdLiterals)")
+    javaFragmentIds.foreach(opts.fragmentIds)
+
+    val scanner: LanceScanner = LanceScanner.create(dataset, opts.build(), allocator)
+    try {
+      readRows(scanner.scanBatches(), projectionFields)
+    } finally {
+      scanner.close()
+    }
+  }
+
+  /**
+   * Drain the materialize scan into row maps, converting each projected payload cell to the Spark
+   * EXTERNAL value its target type expects — the shape the join's `ExpressionEncoder` (external
+   * `Row` → `InternalRow`) accepts.
+   *
+   * Projected data columns are materialized through the connector's canonical Arrow→Spark adapter
+   * [[org.lance.spark.vectorized.LanceArrowColumnVector]] — the same vector-and-schema-aware path
+   * the connector's own reader uses — so every payload type Lance can store round-trips to the
+   * value Spark produces for that column on an ordinary read: DateType, the various timestamp / time
+   * units, unsigned integers, decimals, fixed/large binary and varchar, and nested structs / lists /
+   * maps. A raw Arrow `getObject` would instead hand back e.g. a `LocalDate` for a DateType column,
+   * which the encoder then rejects. The adapter yields Spark INTERNAL values (days for a date,
+   * micros for a timestamp, …), so each is run back through [[CatalystTypeConverters]] to the
+   * external representation the `Row` encoder wants.
+   *
+   * Columns absent from `projectionFields` — notably the `_rowid` virtual column, which carries no
+   * Spark type here — keep the generic Arrow `getObject` fallback; the caller reads `_rowid` only as
+   * a plain long.
+   */
+  private def readRows(
+      reader: ArrowReader,
+      projectionFields: Seq[StructField]): Seq[Map[String, Any]] = {
+    val schemaByName: Map[String, StructField] =
+      projectionFields.iterator.map(f => f.name -> f).toMap
+    val out = mutable.ArrayBuffer.empty[Map[String, Any]]
+    try {
+      while (reader.loadNextBatch()) {
+        val root: VectorSchemaRoot = reader.getVectorSchemaRoot
+        val n = root.getRowCount
+        val fields = root.getSchema.getFields.asScala.toIndexedSeq
+
+        // Columns with a Spark target type are converted through the canonical connector adapter;
+        // the rest (e.g. `_rowid`) keep the raw Arrow-object fallback.
+        val mapped = fields.filter(af => schemaByName.contains(af.getName))
+        val unmapped = fields.filterNot(af => schemaByName.contains(af.getName))
+        val mappedNames: Array[String] = mapped.iterator.map(_.getName).toArray
+        val mappedTypes: Array[DataType] =
+          mapped.iterator.map(af => schemaByName(af.getName).dataType).toArray
+        val mappedConverters: Array[Any => Any] = mapped.iterator
+          .map(af =>
+            CatalystTypeConverters.createToScalaConverter(schemaByName(af.getName).dataType))
+          .toArray
+        val mappedVectors: Array[ColumnVector] = mapped.iterator
+          .map(af =>
+            new LanceArrowColumnVector(root.getVector(af.getName), false, schemaByName(af.getName))
+              .asInstanceOf[ColumnVector])
+          .toArray
+        // The batch is a thin view over the (reader-owned) Arrow vectors; closeVectorOnClose=false
+        // above means neither the batch nor its column vectors free the underlying buffers — the
+        // `reader.close()` in the finally does, once the values below have been copied out.
+        val batch = new ColumnarBatch(mappedVectors, n)
+
+        var i = 0
+        while (i < n) {
+          val rowMap = mutable.LinkedHashMap.empty[String, Any]
+          val internalRow = batch.getRow(i)
+          var j = 0
+          while (j < mappedNames.length) {
+            val internal = internalRow.get(j, mappedTypes(j))
+            rowMap(mappedNames(j)) = if (internal == null) null else mappedConverters(j)(internal)
+            j += 1
+          }
+          unmapped.foreach { af =>
+            val v = root.getVector(af.getName)
+            rowMap(af.getName) = if (v.isNull(i)) null else LanceProbe.toSparkValue(v.getObject(i))
+          }
+          out += rowMap.toMap
+          i += 1
+        }
+      }
+    } finally {
+      reader.close()
+    }
+    out.toSeq
+  }
+
+  override def close(): Unit = dataset.close()
+}
+
+object LanceProbe {
+
+  /**
+   * Lance row-identity virtual column name. We use `_rowid` rather than `_rowaddr` because
+   * Lance's INDEXED nearest-search path materializes `_rowid` but not `_rowaddr`, while
+   * non-indexed scans materialize both. `_rowid` therefore works on every code path that
+   * calls `probe()` (with or without a vector index built on the column). Sourced from
+   * `LanceConstant` to keep the literal defined in exactly one place.
+   */
+  val RowIdColumn: String = LanceConstant.ROW_ID
+
+  /**
+   * Candidate names for the score column in a Lance nearest-search result. Lance's vector indexes
+   * have used `_distance` historically; tolerate `_score` too in case future versions rename it.
+   * The lookup is name-based so the consumer is agnostic to where Lance puts the column in its
+   * output schema.
+   */
+  val ScoreColumns: Seq[String] = Seq("_distance", "_score")
+
+  /**
+   * Build read options from a bare dataset URI, pinning `version` on the main branch when present.
+   * Backs the URI convenience constructor.
+   */
+  private[knn] def readOptionsFor(
+      datasetUri: String,
+      version: Option[Long]): LanceSparkReadOptions = {
+    val base = LanceSparkReadOptions.from(datasetUri)
+    version match {
+      case Some(v) => base.withRef(LanceRef.ofMain(v))
+      case None => base
+    }
+  }
+
+  /**
+   * Convert an Arrow-returned cell value into something Spark's encoders accept when stuffed
+   * into a `Row`. Arrow's `FieldVector.getObject` returns Java types (boxed primitives,
+   * `JsonStringArrayList` for list cells, `Text` for utf8) which Spark's `RowEncoder` does not
+   * always understand directly — most painfully, a `java.util.ArrayList` can't satisfy a Spark
+   * `ArrayType` slot, which expects a `scala.collection.Seq`.
+   *
+   * Conversion rules, in order:
+   *  - `java.util.List` → recursively-converted `Seq`
+   *  - `java.util.Map`  → recursively-converted Scala `Map`
+   *  - `org.apache.arrow.vector.util.Text` → `String`
+   *  - `Number` boxed primitives → returned as-is (Spark handles them)
+   *  - everything else → returned as-is (caller's responsibility)
+   *
+   * Recursive on lists/maps to handle nested types (arrays of structs, etc.) without surprises
+   * for callers.
+   */
+  def toSparkValue(value: Any): Any = value match {
+    case null => null
+    case list: java.util.List[_] =>
+      val out = scala.collection.mutable.ArrayBuffer.empty[Any]
+      val it = list.iterator
+      while (it.hasNext) out += toSparkValue(it.next())
+      out.toSeq
+    case map: java.util.Map[_, _] =>
+      val out = scala.collection.mutable.LinkedHashMap.empty[Any, Any]
+      val it = map.entrySet().iterator
+      while (it.hasNext) {
+        val e = it.next()
+        out(toSparkValue(e.getKey)) = toSparkValue(e.getValue)
+      }
+      out.toMap
+    case t: org.apache.arrow.vector.util.Text => t.toString
+    case other => other
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceProbe.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/LanceProbe.scala
@@ -225,6 +225,17 @@ final class LanceProbe(
     require(vectorColumn != null && vectorColumn.nonEmpty, "vectorColumn must be non-empty")
     require(query != null && query.length > 0, "Query vector must be non-empty")
     require(k > 0, "k must be positive")
+    // The fused scan injects `_rowid` (via withRowId) and the score column (via nearest). A payload
+    // column that shares one of those names would collide with the injected column inside the SAME
+    // scan — Lance fails the scan with "merge incompatible fields". Such a schema must go through the
+    // split probe + materialize path (whose materialize scan injects no score column), so reject it
+    // here rather than let the collision surface as an opaque Arrow error. The join stage checks
+    // [[LanceProbe.fusesCleanly]] and routes accordingly.
+    require(
+      LanceProbe.fusesCleanly(projection),
+      "probeRows cannot project a column whose name collides with Lance search metadata " +
+        s"(${LanceProbe.ReservedProjectionColumns.toSeq.sorted.mkString(", ")}); the nearest scan " +
+        "injects those columns itself. Route such schemas through the split probe + materialize path.")
 
     val q = buildNearestQuery(vectorColumn, query, k, metric, nprobes, refineFactor, ef)
 
@@ -315,11 +326,13 @@ final class LanceProbe(
   /**
    * Drain a nearest-search scan that ALSO projected payload columns into `(rowId, score, payload)`
    * hits — the folded counterpart of [[readScored]] + [[readRows]]. Row-id and score are read out of
-   * the `_rowid` / `_distance` vectors directly; the payload columns (those with a Spark target type
-   * in `projectionFields`) go through the canonical [[org.lance.spark.vectorized.LanceArrowColumnVector]]
-   * adapter and back through [[CatalystTypeConverters]] to the external value the encoder expects —
-   * exactly as [[readRows]] does. `_rowid` / `_distance` are handled here, so they are deliberately
-   * excluded from the payload map (unlike [[readRows]], which surfaces `_rowid` for re-keying).
+   * the `_rowid` / score vectors directly and excluded from the payload map. Every OTHER column the
+   * scan returned is payload and follows [[readRows]]' contract exactly: a column with a Spark target
+   * type in `projectionFields` goes through the canonical
+   * [[org.lance.spark.vectorized.LanceArrowColumnVector]] adapter and back through
+   * [[CatalystTypeConverters]] to the external value the encoder expects; a projected column WITHOUT
+   * a supplied type falls back to the generic Arrow conversion ([[LanceProbe.toSparkValue]]) rather
+   * than being silently dropped.
    */
   private def readScoredRows(
       reader: ArrowReader,
@@ -336,9 +349,15 @@ final class LanceProbe(
         val addrVec: FieldVector = root.getVector(LanceProbe.RowIdColumn)
         val scoreVec: FieldVector = resolveScoreVector(root)
 
-        // Payload columns only (those with a Spark target type). `_rowid` / `_distance` are read out
-        // separately, so they are deliberately excluded from the payload map here.
-        val mapped = fields.filter(af => schemaByName.contains(af.getName))
+        // `_rowid` and the injected score column are read out-of-band (above) and excluded from the
+        // payload. Everything else the scan returned IS payload: columns with a Spark target type go
+        // through the canonical adapter, the rest fall back to the generic Arrow conversion — the
+        // same split `readRows` / `materialize` apply, so a projected column with no supplied type is
+        // surfaced (via `toSparkValue`) instead of being silently dropped.
+        val reserved = Set(LanceProbe.RowIdColumn, scoreVec.getField.getName)
+        val payloadFields = fields.filterNot(af => reserved.contains(af.getName))
+        val mapped = payloadFields.filter(af => schemaByName.contains(af.getName))
+        val unmapped = payloadFields.filterNot(af => schemaByName.contains(af.getName))
         val mappedNames: Array[String] = mapped.iterator.map(_.getName).toArray
         val mappedTypes: Array[DataType] =
           mapped.iterator.map(af => schemaByName(af.getName).dataType).toArray
@@ -364,6 +383,10 @@ final class LanceProbe(
             val internal = internalRow.get(j, mappedTypes(j))
             rowMap(mappedNames(j)) = if (internal == null) null else mappedConverters(j)(internal)
             j += 1
+          }
+          unmapped.foreach { af =>
+            val v = root.getVector(af.getName)
+            rowMap(af.getName) = if (v.isNull(i)) null else LanceProbe.toSparkValue(v.getObject(i))
           }
           out += MaterializedHit(rowAddrAt(addrVec, i), scoreAt(scoreVec, i), rowMap.toMap)
           i += 1
@@ -565,6 +588,24 @@ object LanceProbe {
    * output schema.
    */
   val ScoreColumns: Seq[String] = Seq("_distance", "_score")
+
+  /**
+   * Column names Lance's nearest scan injects itself: `_rowid` (from `withRowId`) and the score
+   * column (from `nearest`). A right-side payload column with one of these names collides with the
+   * injected column inside the fused [[LanceProbe.probeRows]] scan, which Lance rejects with a
+   * "merge incompatible fields" error. A schema that projects one of them must be served through the
+   * split [[LanceProbe.probe]] + [[LanceProbe.materialize]] path instead — the materialize scan does
+   * not inject a score column, so there is no collision. See [[fusesCleanly]].
+   */
+  val ReservedProjectionColumns: Set[String] = ScoreColumns.toSet + RowIdColumn
+
+  /**
+   * True if `projection` can be served by the fused [[LanceProbe.probeRows]] scan — i.e. it names no
+   * column the nearest scan injects (see [[ReservedProjectionColumns]]). The join stage calls this to
+   * decide between the fold and the split probe + materialize path.
+   */
+  def fusesCleanly(projection: Seq[String]): Boolean =
+    !projection.exists(ReservedProjectionColumns.contains)
 
   /**
    * Build read options from a bare dataset URI, pinning `version` on the main branch when present.

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/Metric.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/Metric.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.lance.index.DistanceType
+
+/**
+ * Vector distance / similarity metric. Mirrors `org.lance.index.DistanceType` but exposed as a
+ * Scala enumeration so callers don't have to import Lance internals. Each metric fixes the
+ * "best-first" direction used during merge:
+ *
+ *  - L2:           smaller score is better (distance)
+ *  - Cosine / Dot: larger score is better (similarity)
+ */
+sealed trait Metric {
+
+  /** The Lance distance type used when configuring a `Query`. */
+  def lanceType: DistanceType
+
+  /** True if smaller scores rank better (distance), false if larger (similarity). */
+  def smallerIsBetter: Boolean
+}
+
+object Metric {
+
+  case object L2 extends Metric {
+    val lanceType: DistanceType = DistanceType.L2
+    val smallerIsBetter: Boolean = true
+  }
+
+  case object Cosine extends Metric {
+    val lanceType: DistanceType = DistanceType.Cosine
+    val smallerIsBetter: Boolean = false
+  }
+
+  case object Dot extends Metric {
+    val lanceType: DistanceType = DistanceType.Dot
+    val smallerIsBetter: Boolean = false
+  }
+
+  /**
+   * Parse a metric name. Accepts the same set of names Lance accepts plus a few synonyms commonly
+   * used in Spark vector functions:
+   *
+   *  - "l2" | "euclidean"        → L2
+   *  - "cosine"                  → Cosine
+   *  - "dot" | "inner" | "ip"    → Dot
+   */
+  def fromName(name: String): Metric = name.trim.toLowerCase match {
+    case "l2" | "euclidean" => L2
+    case "cosine" => Cosine
+    case "dot" | "inner" | "ip" => Dot
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unknown metric '$other'. Expected one of: l2, cosine, dot.")
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/Metric.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/Metric.scala
@@ -18,10 +18,15 @@ import org.lance.index.DistanceType
 /**
  * Vector distance / similarity metric. Mirrors `org.lance.index.DistanceType` but exposed as a
  * Scala enumeration so callers don't have to import Lance internals. Each metric fixes the
- * "best-first" direction used during merge:
+ * "best-first" direction used during merge.
  *
- *  - L2:           smaller score is better (distance)
- *  - Cosine / Dot: larger score is better (similarity)
+ * Lance's vector search returns a DISTANCE for every metric — including the similarity-flavored
+ * ones, which it reports as `1 - cosine_similarity` and `1 - dot_product`. So smaller is better for
+ * ALL three metrics; there is no larger-is-better case:
+ *
+ *  - L2:     smaller score is better (squared L2 distance)
+ *  - Cosine: smaller score is better (`1 - cosine_similarity`)
+ *  - Dot:    smaller score is better (`1 - dot_product`)
  */
 sealed trait Metric {
 
@@ -41,12 +46,14 @@ object Metric {
 
   case object Cosine extends Metric {
     val lanceType: DistanceType = DistanceType.Cosine
-    val smallerIsBetter: Boolean = false
+    // Lance returns `1 - cosine_similarity`, a distance: smaller is better.
+    val smallerIsBetter: Boolean = true
   }
 
   case object Dot extends Metric {
     val lanceType: DistanceType = DistanceType.Dot
-    val smallerIsBetter: Boolean = false
+    // Lance returns `1 - dot_product`, a distance: smaller is better.
+    val smallerIsBetter: Boolean = true
   }
 
   /**

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/ScoredRowRef.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/ScoredRowRef.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+/**
+ * A reference to a single right-side row produced by a vector index probe, along with the ranking
+ * score. Carries no payload — payloads are fetched in the materialize stage by row address. Pairing
+ * a tiny ref with a score is the unit of work passing through the shuffle and is what keeps the
+ * shuffle volume to `O(|L| × tasks × K × ~24B)` instead of `O(|L| × tasks × K × payload_bytes)`.
+ *
+ * @param rowAddr Lance row address (`_rowaddr`): packed `(frag_id << 32) | row_in_frag`. Stable
+ *               within a Lance dataset version.
+ * @param score   Distance or similarity returned by Lance's vector search. Smaller-is-better for
+ *               distance metrics (L2), larger-is-better for similarity metrics (cosine/dot).
+ *               Direction is carried out-of-band in the operator config; this struct stays metric-
+ *               agnostic.
+ */
+final case class ScoredRowRef(rowAddr: Long, score: Float)
+
+object ScoredRowRef {
+
+  /** Order best-first for distance metrics (smallest score wins). */
+  val distanceOrdering: Ordering[ScoredRowRef] =
+    Ordering.by[ScoredRowRef, Float](_.score)
+
+  /** Order best-first for similarity metrics (largest score wins). */
+  val similarityOrdering: Ordering[ScoredRowRef] =
+    Ordering.by[ScoredRowRef, Float](-_.score)
+}
+
+/**
+ * A single probe hit WITH its materialized payload — the unit produced by the no-overfetch fast path
+ * ([[LanceProbe.probeRows]]), which folds the nearest search and the payload projection into one
+ * scan. Unlike [[ScoredRowRef]] (a payload-free ref bound for a later materialize point-fetch), this
+ * already carries the right row.
+ *
+ * @param rowAddr Lance row id of the hit (kept for de-duplication / re-keying by the join stage).
+ * @param score   Distance or similarity from Lance's vector search; direction is carried out-of-band
+ *                in the operator config, so this stays metric-agnostic (see [[ScoredRowRef.score]]).
+ * @param row     Materialized right-side payload keyed by column name, each value already the Spark
+ *                EXTERNAL representation its target type expects (the join's `ExpressionEncoder`
+ *                accepts it directly).
+ */
+final case class MaterializedHit(rowAddr: Long, score: Float, row: Map[String, Any])

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/TopKHeap.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/TopKHeap.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import scala.collection.mutable
+
+/**
+ * Bounded top-K heap with metric-aware ordering. Used by the probe stage for map-side combine
+ * across fragments owned by a single task — keeps the per-left-row state at exactly K entries no
+ * matter how many fragments contribute, and again on the reduce side to merge contributions from
+ * different tasks for the same `leftId`.
+ *
+ * Semantics:
+ *  - `smallerIsBetter = true`  (distance, e.g. L2): retain the K smallest-score entries.
+ *  - `smallerIsBetter = false` (similarity, e.g. cosine): retain the K largest-score entries.
+ *
+ * Internally, the heap's *head* holds the worst surviving element so eviction is O(log K). Scala's
+ * `mutable.PriorityQueue` is a max-heap by the supplied `Ordering`, so the ordering is chosen to
+ * place "worst surviving" at the top:
+ *  - distance     → max-heap on `score`            (largest score is worst)
+ *  - similarity   → max-heap on `-score`           (smallest score is worst)
+ *
+ * Not thread-safe. Each left row in a probe stage gets its own heap.
+ */
+final class TopKHeap(k: Int, smallerIsBetter: Boolean) {
+  require(k > 0, "k must be positive")
+
+  private val ord: Ordering[ScoredRowRef] =
+    if (smallerIsBetter) Ordering.by[ScoredRowRef, Float](_.score)
+    else Ordering.by[ScoredRowRef, Float](-_.score)
+
+  private val heap = new mutable.PriorityQueue[ScoredRowRef]()(ord)
+
+  /**
+   * Insert `ref` if it would survive the top-K cut. Either grows the heap up to K or evicts the
+   * current worst-surviving element if `ref` is strictly better than it.
+   */
+  def offer(ref: ScoredRowRef): Unit = {
+    if (heap.size < k) {
+      heap.enqueue(ref)
+    } else {
+      val worst = heap.head
+      val isBetter =
+        if (smallerIsBetter) ref.score < worst.score
+        else ref.score > worst.score
+      if (isBetter) {
+        heap.dequeue()
+        heap.enqueue(ref)
+      }
+    }
+  }
+
+  def offerAll(refs: TraversableOnce[ScoredRowRef]): Unit = refs.foreach(offer)
+
+  /**
+   * Drain the heap into a best-first sorted Array. After this call the heap is empty. Best-first
+   * means index 0 is the top-ranked entry (smallest score for distance, largest for similarity).
+   */
+  def drain(): Array[ScoredRowRef] = {
+    val out = new Array[ScoredRowRef](heap.size)
+    var i = heap.size - 1
+    // PriorityQueue.dequeue returns the worst surviving element first; walking the array in
+    // reverse places best at index 0.
+    while (i >= 0) {
+      out(i) = heap.dequeue()
+      i -= 1
+    }
+    out
+  }
+
+  def size: Int = heap.size
+  def isEmpty: Boolean = heap.isEmpty
+}
+
+object TopKHeap {
+
+  /**
+   * Convenience: merge several already-sorted (best-first) ref arrays into one top-K array. Used
+   * by the merge stage as the `reduceByKey` combine function.
+   */
+  def merge(
+      a: Array[ScoredRowRef],
+      b: Array[ScoredRowRef],
+      k: Int,
+      smallerIsBetter: Boolean): Array[ScoredRowRef] = {
+    if (a.isEmpty) return takeBest(b, k, smallerIsBetter)
+    if (b.isEmpty) return takeBest(a, k, smallerIsBetter)
+    val heap = new TopKHeap(k, smallerIsBetter)
+    heap.offerAll(a)
+    heap.offerAll(b)
+    heap.drain()
+  }
+
+  private def takeBest(
+      arr: Array[ScoredRowRef],
+      k: Int,
+      smallerIsBetter: Boolean): Array[ScoredRowRef] = {
+    if (arr.length <= k) return arr
+    val heap = new TopKHeap(k, smallerIsBetter)
+    heap.offerAll(arr)
+    heap.drain()
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/TopKHeap.scala
+++ b/lance-spark-knn-4.2_2.13/src/main/scala/org/lance/spark/knn/internal/TopKHeap.scala
@@ -51,9 +51,13 @@ final class TopKHeap(k: Int, smallerIsBetter: Boolean) {
       heap.enqueue(ref)
     } else {
       val worst = heap.head
-      val isBetter =
-        if (smallerIsBetter) ref.score < worst.score
-        else ref.score > worst.score
+      // Admission must use the SAME total ordering as the heap, not a raw float `<` / `>`. Float
+      // comparisons involving NaN are always false, so a NaN worst-survivor would never test as
+      // "beatable" and could never be evicted — a single NaN score would then pin a slot forever.
+      // `ord` is `java.lang.Float.compare`-based (NaN sorts as the largest Float, i.e. the worst
+      // for a distance), and `ord.lt(ref, worst)` means exactly "ref ranks strictly better than the
+      // current worst" in both directions — so a finite score correctly displaces a NaN worst.
+      val isBetter = ord.lt(ref, worst)
       if (isBetter) {
         heap.dequeue()
         heap.enqueue(ref)

--- a/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceKnnJoinStageTest.scala
+++ b/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceKnnJoinStageTest.scala
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{ArrayType, IntegerType, MapType, StringType, StructType}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+import org.lance.spark.{LanceRef, LanceSparkReadOptions}
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Backend-free unit tests for the two pieces of [[LanceKnnJoinStage]] that don't need a Lance
+ * dataset: the lazy per-partition output composition ([[LanceKnnJoinStage.lazyJoinIterator]]) and
+ * the Spark-type coercion of materialized right-side payloads
+ * ([[LanceKnnJoinStage.coerceToSpark]]). Both are `private[knn]`, so this test lives in the
+ * `org.lance.spark.knn.internal` package to reach them. The full probe → trim → materialize
+ * pipeline is covered by the e2e test in this module against a real Lance dataset.
+ */
+class LanceKnnJoinStageTest {
+
+  // -- fix #5: streaming output must be lazy ------------------------------------------------
+
+  /**
+   * `lazyJoinIterator` must pull left rows ON DEMAND, never drain them up front — otherwise the
+   * whole partition would materialize in memory before a single output row is produced (the exact
+   * regression the streaming rewrite fixed). We feed a large source with a side-effect pull counter,
+   * take only the first 3 outputs (one per left row here), and assert only 3 left rows were pulled.
+   */
+  @Test def testLazyJoinIteratorPullsLeftRowsOnDemand(): Unit = {
+    val pulled = new AtomicInteger(0)
+    val left: Iterator[Row] = Iterator.range(0, 1000000).map { i =>
+      pulled.incrementAndGet()
+      Row(i)
+    }
+    val out = LanceKnnJoinStage.lazyJoinIterator(left, r => Iterator.single(r))
+    val first3 = out.take(3).toList
+    assertEquals(3, first3.size, "should surface exactly the requested rows")
+    assertTrue(
+      pulled.get() <= 3,
+      s"lazyJoinIterator must pull left rows on demand, not drain them; pulled ${pulled.get()}")
+  }
+
+  /**
+   * Fan-out (each left row expands to several join rows) stays lazy too: taking 3 outputs at 2 rows
+   * per left row must pull only the first 2 left rows, not the whole source.
+   */
+  @Test def testLazyJoinIteratorFansOutLazily(): Unit = {
+    val pulled = new AtomicInteger(0)
+    val left: Iterator[Row] = Iterator.range(0, 1000000).map { i =>
+      pulled.incrementAndGet()
+      Row(i)
+    }
+    val out = LanceKnnJoinStage.lazyJoinIterator(
+      left,
+      r => {
+        val i = r.getInt(0)
+        Iterator(Row(i, 0), Row(i, 1))
+      })
+    val first3 = out.take(3).toList
+    assertEquals(3, first3.size)
+    assertTrue(pulled.get() <= 2, s"expected <= 2 left pulls for 3 outputs, got ${pulled.get()}")
+  }
+
+  // -- fix #3: schema-aware materialization -------------------------------------------------
+
+  /** A `Map` payload for a `StructType` slot becomes a positional `Row` in declared field order. */
+  @Test def testCoerceStructFromMapToRowInFieldOrder(): Unit = {
+    val dt = new StructType().add("a", IntegerType).add("b", StringType)
+    // Keyed by name and deliberately out of declared order — coercion must reorder by field.
+    val value = Map("b" -> "x", "a" -> Integer.valueOf(1))
+    val row = LanceKnnJoinStage.coerceToSpark(value, dt).asInstanceOf[Row]
+    assertEquals(1, row.getInt(0))
+    assertEquals("x", row.getString(1))
+  }
+
+  /** A field absent from the payload map materializes as null, not a missing slot. */
+  @Test def testCoerceStructFillsMissingFieldWithNull(): Unit = {
+    val dt = new StructType().add("a", IntegerType).add("b", StringType)
+    val value = Map[String, Any]("a" -> Integer.valueOf(1))
+    val row = LanceKnnJoinStage.coerceToSpark(value, dt).asInstanceOf[Row]
+    assertEquals(1, row.getInt(0))
+    assertTrue(row.isNullAt(1), "missing struct field should be null")
+  }
+
+  /** `ArrayType` recurses: an array of struct payloads becomes a `Seq[Row]`. */
+  @Test def testCoerceArrayOfStructsRecurses(): Unit = {
+    val dt = ArrayType(new StructType().add("a", IntegerType))
+    val value = Seq(Map("a" -> Integer.valueOf(7)))
+    val out = LanceKnnJoinStage.coerceToSpark(value, dt).asInstanceOf[Seq[_]]
+    assertEquals(1, out.size)
+    assertEquals(7, out.head.asInstanceOf[Row].getInt(0))
+  }
+
+  /** `MapType` recurses on its values: a struct-valued map entry becomes a `Row`. */
+  @Test def testCoerceMapOfStructsRecurses(): Unit = {
+    val dt = MapType(StringType, new StructType().add("a", IntegerType))
+    val value = Map("k" -> Map("a" -> Integer.valueOf(9)))
+    val out =
+      LanceKnnJoinStage.coerceToSpark(value, dt).asInstanceOf[scala.collection.Map[String, Any]]
+    assertEquals(9, out("k").asInstanceOf[Row].getInt(0))
+  }
+
+  /**
+   * The shape a REAL Arrow map cell actually arrives in. Arrow encodes a `MapType` cell as a LIST
+   * of `{key, value}` entry structs, so [[LanceProbe.toSparkValue]] hands `coerceToSpark` a
+   * `Seq(Map("key" -> …, "value" -> …), …)` — a sequence, not a Scala map. Coercion must rebuild a
+   * real Spark map keyed/valued by type; leaving it a sequence is the exact bug the reviewer flagged
+   * (a `MapType` slot filled with a `Seq` fails the encoder or materializes garbage).
+   */
+  @Test def testCoerceMapFromArrowEntryList(): Unit = {
+    val dt = MapType(StringType, IntegerType)
+    val arrowShape = Seq(
+      Map[String, Any]("key" -> "a", "value" -> Integer.valueOf(1)),
+      Map[String, Any]("key" -> "b", "value" -> Integer.valueOf(2)))
+    val out =
+      LanceKnnJoinStage.coerceToSpark(arrowShape, dt).asInstanceOf[scala.collection.Map[
+        String,
+        Any]]
+    assertEquals(2, out.size, "both entries should survive")
+    assertEquals(1, out("a"))
+    assertEquals(2, out("b"))
+  }
+
+  // -- fix #2: merge must reject a conflicting pinned ref -----------------------------------
+
+  /**
+   * When the base read options already carry a pinned `ref` and the relation options ALSO pin a
+   * different `version` / `branch`, the merge must REJECT the combination (as
+   * `LanceDataset.mergeScanOptions` does) rather than silently letting the relation value win — that
+   * would read a different snapshot than the caller pinned. Here base = `main@1`, relation =
+   * `version=2` (`main@2`), which is neither the same ref nor the same named branch, so the merge
+   * throws `IllegalArgumentException`.
+   */
+  @Test def testMergeRejectsConflictingPinnedRef(): Unit = {
+    val base = LanceSparkReadOptions.from("/tmp/knn_merge_guard").withRef(LanceRef.ofMain(1L))
+    val relation = new java.util.HashMap[String, String]()
+    relation.put(LanceSparkReadOptions.CONFIG_VERSION, "2")
+    assertThrows(
+      classOf[IllegalArgumentException],
+      () => LanceKnnJoinStage.mergeReadOptions(base, relation))
+  }
+
+  /**
+   * The same-named-branch case is allowed and keeps the table's pinned ref: base pinned to branch
+   * `dev` (version 1), relation re-specifies `branch=dev` — the merge must NOT throw and must retain
+   * the base ref for snapshot isolation.
+   */
+  @Test def testMergeKeepsPinnedRefForSameNamedBranch(): Unit = {
+    val base =
+      LanceSparkReadOptions.from("/tmp/knn_merge_branch").withRef(LanceRef.ofBranch("dev", 1L))
+    val relation = new java.util.HashMap[String, String]()
+    relation.put(LanceSparkReadOptions.CONFIG_BRANCH, "dev")
+    val merged = LanceKnnJoinStage.mergeReadOptions(base, relation)
+    assertEquals(base.getRef, merged.getRef, "same-named branch must keep the base's pinned ref")
+  }
+
+  // -- fold vs split routing: reserved-name projections must decline the fold ----------------
+
+  /**
+   * The folded one-scan path is sound only when there is no over-fetch (internalK == k) AND the
+   * payload projection does not collide with a column the nearest scan injects. A plain projection
+   * at internalK == k folds.
+   */
+  @Test def testFoldsInOneScanForCleanProjectionAtNoOverfetch(): Unit = {
+    assertTrue(
+      LanceKnnJoinStage.foldsInOneScan(internalK = 5, k = 5, projection = Seq("id", "vec")),
+      "clean projection with internalK == k should fold in one scan")
+  }
+
+  /**
+   * A projection naming ANY reserved column (`_rowid`, `_distance`, `_score`) must decline the fold
+   * even at internalK == k, so the stage routes it to the split probe → materialize path whose scan
+   * injects only `_rowid`. This is the gatekeeper's headline finding: the fold must preserve Spark's
+   * fallback for a payload column whose name collides with the injected search metadata.
+   */
+  @Test def testDoesNotFoldForReservedProjection(): Unit = {
+    LanceProbe.ReservedProjectionColumns.foreach { reserved =>
+      assertFalse(
+        LanceKnnJoinStage.foldsInOneScan(internalK = 5, k = 5, projection = Seq("id", reserved)),
+        s"projection naming reserved column '$reserved' must NOT fold; route to the split path")
+    }
+  }
+
+  /** Over-fetch (internalK > k) always takes the split path, regardless of projection. */
+  @Test def testDoesNotFoldWhenOverfetching(): Unit = {
+    assertFalse(
+      LanceKnnJoinStage.foldsInOneScan(internalK = 20, k = 5, projection = Seq("id")),
+      "over-fetch (internalK > k) must take the split probe → trim → materialize path")
+  }
+
+  /** Primitives pass straight through; null stays null. */
+  @Test def testCoercePrimitivesAndNullPassThrough(): Unit = {
+    assertEquals("hello", LanceKnnJoinStage.coerceToSpark("hello", StringType))
+    assertEquals(42, LanceKnnJoinStage.coerceToSpark(Integer.valueOf(42), IntegerType))
+    assertNull(LanceKnnJoinStage.coerceToSpark(null, IntegerType).asInstanceOf[AnyRef])
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceProbeValidationTest.scala
+++ b/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceProbeValidationTest.scala
@@ -1,0 +1,290 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.apache.spark.sql.{Row, RowFactory, SparkSession}
+import org.apache.spark.sql.types._
+import org.junit.jupiter.api.{AfterEach, BeforeEach, Test}
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.io.TempDir
+import org.lance.spark.LanceSparkReadOptions
+
+import java.nio.file.Path
+import java.util.{Collections, Random}
+
+import scala.collection.JavaConverters._
+
+/**
+ * End-to-end validation of [[LanceProbe]] against a real Lance dataset written by Spark. These are
+ * the day-1 validation tasks the implementation plan calls out:
+ *
+ *  - Per-probe call should succeed and return Lance's nearest neighbors.
+ *  - Repeated probes against the same `LanceProbe` instance should reuse the open dataset
+ *    handle; the second call should not re-pay the dataset open cost.
+ *  - `fragmentIds` restriction should narrow the search to specified fragments only.
+ *  - Without an explicit vector index the probe falls back to a brute-force per-fragment scan,
+ *    which gives recall = 1.0 — making the no-index path the natural correctness oracle.
+ *
+ * These tests do NOT require an actual vector index; that is exercised in the indexed test
+ * suites which build IVF-PQ via Lance's index DDL. Validating the brute-force path first lets us
+ * isolate any LanceProbe bugs from index-quality issues.
+ */
+class LanceProbeValidationTest {
+
+  @TempDir var tempDir: Path = _
+  private var spark: SparkSession = _
+
+  // Small synthetic dataset: 64 vectors, dim 8. Enough to exercise the probe loop without making
+  // the test slow.
+  private val NumRows = 64
+  private val VectorDim = 8
+  private val Seed = 42L
+
+  @BeforeEach def setup(): Unit = {
+    spark = SparkSession.builder()
+      .appName("lance-probe-validation")
+      .master("local[2]")
+      // Pin the driver to loopback so test JVMs in restricted networks (CI sandboxes, dev
+      // containers) can bind without scanning the host's interfaces.
+      .config("spark.driver.bindAddress", "127.0.0.1")
+      .config("spark.driver.host", "127.0.0.1")
+      .getOrCreate()
+  }
+
+  @AfterEach def teardown(): Unit = {
+    if (spark != null) spark.stop()
+  }
+
+  /**
+   * Smoke test: write a dataset, probe it, get K rows back. No correctness assertion beyond
+   * "result has the right shape" — the brute-force-equivalence test below covers semantics.
+   */
+  @Test def testProbeReturnsKResults(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val query = randomVector(new Random(7L), VectorDim)
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    try {
+      val results = probe.probe(vectorColumn = "vec", query, k = 5, metric = Metric.L2)
+      assertEquals(5, results.size, "probe should return exactly k results")
+      // Distances must be monotonically non-decreasing for L2 (best-first).
+      val scores = results.map(_.score)
+      assertEquals(scores, scores.sorted, "L2 results should be sorted ascending by distance")
+      // Row addresses are stable u64s; we just sanity-check they aren't all zero.
+      assertTrue(results.exists(_.rowAddr != 0L), "row addresses should be populated")
+    } finally probe.close()
+  }
+
+  /**
+   * Without a vector index, Lance does an exact per-fragment scan. That makes it a recall = 1.0
+   * oracle: the probe result should equal the ground-truth top-K computed in plain Scala.
+   */
+  @Test def testProbeMatchesBruteForceOracle(): Unit = {
+    val rng = new Random(Seed)
+    val (rows, vectors) = generateRows(rng, NumRows, VectorDim)
+    val datasetUri = writeRows(rows)
+
+    val query = randomVector(new Random(123L), VectorDim)
+    val k = 10
+
+    val oracle: Seq[(Int, Float)] = vectors.zipWithIndex
+      .map { case (v, idx) => (idx, l2Distance(query, v)) }
+      .sortBy(_._2)
+      .take(k)
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    val actual =
+      try probe.probe("vec", query, k, Metric.L2)
+      finally probe.close()
+
+    assertEquals(k, actual.size)
+    // Compare scores within float tolerance.
+    val expectedScores = oracle.map(_._2)
+    val actualScores = actual.map(_.score)
+    expectedScores.zip(actualScores).foreach { case (expected, actualScore) =>
+      assertEquals(
+        expected,
+        actualScore,
+        1e-4f,
+        s"top-K distance mismatch: oracle=$expectedScores actual=$actualScores")
+    }
+  }
+
+  /**
+   * The folded fast path ([[LanceProbe.probeRows]]) must be observationally identical to the split
+   * probe + materialize path: the SAME (rowAddr, score) hits in the SAME order, and the SAME
+   * materialized payload per row. This is the invariant the SQL join relies on when it single-scans
+   * (internalK == k) instead of probing then late-materializing. Runs on the brute-force path so the
+   * search itself is deterministic.
+   */
+  @Test def testProbeRowsMatchesProbeThenMaterialize(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val query = randomVector(new Random(321L), VectorDim)
+    val k = 8
+    val projection = Seq("id", "vec")
+    val projectionFields = Seq(
+      StructField("id", IntegerType, nullable = false),
+      StructField("vec", ArrayType(FloatType, containsNull = false), nullable = false))
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    try {
+      // Split path: search for refs, then late-materialize the payload by _rowid.
+      val refs = probe.probe("vec", query, k, Metric.L2)
+      val expectedPayload: Map[Long, Map[String, Any]] = probe
+        .materialize(refs.map(_.rowAddr), projection, projectionFields)
+        .map(m => rowAddrOf(m) -> m)
+        .toMap
+
+      // Folded path: search AND project the payload in one scan.
+      val hits = probe.probeRows("vec", query, k, Metric.L2, projection, projectionFields)
+
+      assertEquals(k, hits.size, "probeRows should return exactly k hits")
+      // Same search: identical (rowAddr, score) sequence, in order.
+      assertEquals(
+        refs.map(r => (r.rowAddr, r.score)),
+        hits.map(h => (h.rowAddr, h.score)),
+        "probeRows hits must match probe refs (rowAddr + score), in order")
+      // Same payload: each folded hit equals the split materialize's row for that rowAddr, on the
+      // projected columns.
+      hits.foreach { h =>
+        val expected = expectedPayload(h.rowAddr)
+        assertEquals(expected("id"), h.row("id"), s"id mismatch for rowAddr=${h.rowAddr}")
+        assertEquals(
+          expected("vec").asInstanceOf[Seq[_]].toList,
+          h.row("vec").asInstanceOf[Seq[_]].toList,
+          s"vec mismatch for rowAddr=${h.rowAddr}")
+      }
+    } finally probe.close()
+  }
+
+  /**
+   * Validate the dataset handle is reused across calls. The exact perf invariant ("second call
+   * faster than first by some factor") is too brittle for CI, so we only assert that repeated
+   * probes succeed and don't OOM — i.e., no JNI handle / Arrow buffer leak per call.
+   */
+  @Test def testRepeatedProbesShareDatasetHandle(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val probe = new LanceProbe(datasetUri, None)
+    try {
+      val rng = new Random(99L)
+      val k = 4
+      var i = 0
+      while (i < 50) {
+        val results = probe.probe("vec", randomVector(rng, VectorDim), k, Metric.L2)
+        assertEquals(k, results.size, s"iteration $i returned wrong size")
+        i += 1
+      }
+    } finally probe.close()
+  }
+
+  /** Empty fragment-id list ⇒ no rows match. Confirms the pushdown actually narrows search. */
+  @Test def testEmptyFragmentRestrictionReturnsNothing(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val probe = new LanceProbe(datasetUri, Some(Seq.empty))
+    try {
+      val results = probe.probe("vec", randomVector(new Random(1L), VectorDim), 5, Metric.L2)
+      assertTrue(results.isEmpty, s"empty fragmentIds should yield no results, got ${results.size}")
+    } finally probe.close()
+  }
+
+  /**
+   * When `executor_credential_refresh = false`, the probe must NOT rebuild (or even load) the
+   * runtime namespace on the worker — exactly the policy `LanceFragmentScanner.create` applies.
+   * Regression against the earlier `openDataset` that called `builder.runtimeNamespace(impl, ...)`
+   * unconditionally, which forced the namespace impl class to load regardless of the refresh flag.
+   *
+   * We pass a namespace impl that does not exist on the classpath and point the probe at a
+   * non-existent dataset URI. The open must fail because the DATASET is missing — not because it
+   * tried to load the bogus namespace class. Asserting the failure message does not mention the
+   * namespace class proves the namespace path was skipped.
+   */
+  @Test def testExecutorCredentialRefreshFalseSkipsNamespaceRebuild(): Unit = {
+    val missingUri = tempDir.resolve("does_not_exist").toString
+    val readOptions = LanceSparkReadOptions
+      .builder()
+      .datasetUri(missingUri)
+      .executorCredentialRefresh(false)
+      .build()
+    val ex = assertThrows(
+      classOf[RuntimeException],
+      () =>
+        new LanceProbe(
+          readOptions,
+          null,
+          "example.namespace.MustNotBeLoaded",
+          Collections.emptyMap[String, String](),
+          None))
+    assertFalse(
+      String.valueOf(ex.getMessage).contains("MustNotBeLoaded"),
+      s"namespace impl must not be loaded when executor credential refresh is off; got: " +
+        ex.getMessage)
+  }
+
+  // -- helpers ------------------------------------------------------------------------------
+
+  /** Write a fresh dataset and return its file:// URI. */
+  private def writeSyntheticDataset(): String = {
+    val rng = new Random(Seed)
+    val (rows, _) = generateRows(rng, NumRows, VectorDim)
+    writeRows(rows)
+  }
+
+  private def writeRows(rows: Seq[Row]): String = {
+    val schema = new StructType(Array(
+      StructField("id", IntegerType, nullable = false),
+      StructField(
+        "vec",
+        ArrayType(FloatType, containsNull = false),
+        nullable = false,
+        new MetadataBuilder().putLong("arrow.fixed-size-list.size", VectorDim.toLong).build())))
+    val df = spark.createDataFrame(rows.asJava, schema)
+
+    val outDir = tempDir.resolve(s"probe_test_${System.nanoTime()}").toString
+    df.write.format("lance").save(outDir)
+    outDir
+  }
+
+  private def generateRows(rng: Random, n: Int, dim: Int): (Seq[Row], Seq[Array[Float]]) = {
+    val vectors = (0 until n).map(_ => randomVector(rng, dim))
+    val rows = vectors.zipWithIndex.map { case (v, idx) =>
+      RowFactory.create(Integer.valueOf(idx), v)
+    }
+    (rows, vectors)
+  }
+
+  /** Read the `_rowid` key out of a materialized row map (a boxed / stringy long). */
+  private def rowAddrOf(m: Map[String, Any]): Long = m(LanceProbe.RowIdColumn) match {
+    case l: java.lang.Long => l.longValue()
+    case l: Long => l
+    case other => other.toString.toLong
+  }
+
+  private def randomVector(rng: Random, dim: Int): Array[Float] = {
+    val v = new Array[Float](dim)
+    var i = 0
+    while (i < dim) { v(i) = rng.nextFloat(); i += 1 }
+    v
+  }
+
+  private def l2Distance(a: Array[Float], b: Array[Float]): Float = {
+    var s = 0.0f
+    var i = 0
+    while (i < a.length) {
+      val d = a(i) - b(i)
+      s += d * d
+      i += 1
+    }
+    s
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceProbeValidationTest.scala
+++ b/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/LanceProbeValidationTest.scala
@@ -122,6 +122,105 @@ class LanceProbeValidationTest {
   }
 
   /**
+   * Cosine and Dot must rank best-first the same direction L2 does. Lance returns a DISTANCE for
+   * every metric (`1 - cosine_similarity`, `1 - dot_product` for the similarity-flavored ones), so
+   * smaller is better for all three — [[Metric.smallerIsBetter]] must be `true` for each. This
+   * reproduces the gatekeeper's failure directly: run a real Lance query, then merge the results
+   * through the size-1 [[TopKHeap]] the join stage uses, keyed by the metric's own direction flag.
+   * The nearest ref (Lance returns best-first, so `refs.head`) must survive; a wrong flag (treating a
+   * Lance distance as larger-is-better) would retain the FARTHEST ref instead.
+   */
+  @Test def testMetricFlagsKeepNearestThroughHeap(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val query = randomVector(new Random(555L), VectorDim)
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    try {
+      Seq[Metric](Metric.L2, Metric.Cosine, Metric.Dot).foreach { metric =>
+        val refs = probe.probe("vec", query, k = 5, metric)
+        assertEquals(5, refs.size, s"$metric probe should return k results")
+        // Lance returns best-first, so refs.head is the true nearest for this metric.
+        val nearest = refs.head
+        val heap = new TopKHeap(k = 1, metric.smallerIsBetter)
+        heap.offerAll(refs)
+        val survivor = heap.drain()
+        assertEquals(1, survivor.length, s"$metric: size-1 heap should retain one ref")
+        assertEquals(
+          nearest.rowAddr,
+          survivor.head.rowAddr,
+          s"$metric: size-1 heap must keep the nearest ref (rowAddr=${nearest.rowAddr}), " +
+            s"got ${survivor.head.rowAddr} — wrong smallerIsBetter direction?")
+        assertEquals(nearest.score, survivor.head.score, 1e-6f, s"$metric: kept score mismatch")
+      }
+    } finally probe.close()
+  }
+
+  /**
+   * A projected payload column WITHOUT a supplied Spark type must be preserved through the generic
+   * Arrow conversion — the same fallback [[LanceProbe.materialize]] / `readRows` apply — not silently
+   * dropped. Regression: `projection = Seq("id")` with empty `projectionFields` must return payload
+   * keys `Set("id")` (the injected `_rowid` / score columns stay out of the payload).
+   */
+  @Test def testProbeRowsPreservesUnmappedProjectedFields(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val query = randomVector(new Random(321L), VectorDim)
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    try {
+      val hits = probe.probeRows(
+        "vec",
+        query,
+        k = 5,
+        Metric.L2,
+        projection = Seq("id"),
+        projectionFields = Seq.empty)
+      assertEquals(5, hits.size, "probeRows should return k hits")
+      hits.foreach { h =>
+        assertEquals(
+          Set("id"),
+          h.row.keySet,
+          s"unmapped projected field must be preserved (id only, no _rowid/_distance); " +
+            s"got ${h.row.keySet}")
+        assertNotNull(h.row("id"), "unmapped id payload must be populated")
+      }
+    } finally probe.close()
+  }
+
+  /**
+   * The fused [[LanceProbe.probeRows]] scan injects `_rowid` and the score column itself, so a
+   * payload projection naming one of those reserved columns would collide inside the single scan.
+   * `probeRows` must reject such a projection (so the join stage can route it through the split
+   * probe + materialize path) rather than surfacing an opaque Arrow "merge incompatible fields"
+   * error, and [[LanceProbe.fusesCleanly]] must report it as not fusible.
+   */
+  @Test def testProbeRowsRejectsReservedProjection(): Unit = {
+    val datasetUri = writeSyntheticDataset()
+    val query = randomVector(new Random(1L), VectorDim)
+
+    val probe = new LanceProbe(datasetUri, fragmentIds = None)
+    try {
+      LanceProbe.ReservedProjectionColumns.foreach { reserved =>
+        assertFalse(
+          LanceProbe.fusesCleanly(Seq("id", reserved)),
+          s"projection naming reserved column '$reserved' must not be fusible")
+        val ex = assertThrows(
+          classOf[IllegalArgumentException],
+          () =>
+            probe.probeRows(
+              "vec",
+              query,
+              k = 5,
+              Metric.L2,
+              projection = Seq("id", reserved),
+              projectionFields = Seq.empty))
+        assertTrue(
+          String.valueOf(ex.getMessage).contains(reserved),
+          s"guard message should name reserved column '$reserved'; got: ${ex.getMessage}")
+      }
+    } finally probe.close()
+  }
+
+  /**
    * The folded fast path ([[LanceProbe.probeRows]]) must be observationally identical to the split
    * probe + materialize path: the SAME (rowAddr, score) hits in the SAME order, and the SAME
    * materialized payload per row. This is the invariant the SQL join relies on when it single-scans

--- a/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/TopKHeapTest.scala
+++ b/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/TopKHeapTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.knn.internal
+
+import org.junit.jupiter.api.Assertions._
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [[TopKHeap]]. The heap's correctness is the foundation of the merge stage —
+ * any off-by-one or wrong-direction ordering would silently corrupt top-K results. We test both
+ * metric directions explicitly.
+ */
+class TopKHeapTest {
+
+  private def ref(addr: Long, score: Float): ScoredRowRef = ScoredRowRef(addr, score)
+
+  /** Distance metric: smaller score is better. Top-K must hold the K smallest. */
+  @Test def testDistanceKeepsKSmallest(): Unit = {
+    val heap = new TopKHeap(k = 3, smallerIsBetter = true)
+    Seq(5.0f, 1.0f, 4.0f, 2.0f, 8.0f, 0.5f).zipWithIndex.foreach { case (s, i) =>
+      heap.offer(ref(i.toLong, s))
+    }
+    val out = heap.drain()
+    val scores = out.map(_.score).toSeq
+    assertEquals(Seq(0.5f, 1.0f, 2.0f), scores, "distance heap should retain three smallest")
+  }
+
+  /** Similarity metric: larger score is better. Top-K must hold the K largest. */
+  @Test def testSimilarityKeepsKLargest(): Unit = {
+    val heap = new TopKHeap(k = 3, smallerIsBetter = false)
+    Seq(5.0f, 1.0f, 4.0f, 2.0f, 8.0f, 0.5f).zipWithIndex.foreach { case (s, i) =>
+      heap.offer(ref(i.toLong, s))
+    }
+    val out = heap.drain()
+    val scores = out.map(_.score).toSeq
+    assertEquals(Seq(8.0f, 5.0f, 4.0f), scores, "similarity heap should retain three largest")
+  }
+
+  /** Drain order is best-first regardless of insertion order. */
+  @Test def testDrainOrderIsBestFirst(): Unit = {
+    val heap = new TopKHeap(k = 4, smallerIsBetter = true)
+    heap.offerAll(Seq(ref(1, 9f), ref(2, 1f), ref(3, 5f), ref(4, 3f), ref(5, 2f)))
+    val drained = heap.drain()
+    val scores = drained.map(_.score).toSeq
+    assertEquals(Seq(1f, 2f, 3f, 5f), scores)
+    assertTrue(heap.isEmpty, "drain should leave the heap empty")
+  }
+
+  /** Heap with fewer than K elements drains them all in best-first order. */
+  @Test def testFewerThanKReturnsAll(): Unit = {
+    val heap = new TopKHeap(k = 10, smallerIsBetter = true)
+    heap.offerAll(Seq(ref(1, 3f), ref(2, 1f), ref(3, 2f)))
+    assertEquals(Seq(1f, 2f, 3f), heap.drain().map(_.score).toSeq)
+  }
+
+  /** A worse-than-current-worst candidate is rejected. */
+  @Test def testRejectsWorseCandidate(): Unit = {
+    val heap = new TopKHeap(k = 2, smallerIsBetter = true)
+    heap.offer(ref(1, 1f))
+    heap.offer(ref(2, 2f))
+    heap.offer(ref(3, 5f)) // worse than existing 2 → rejected
+    val drained = heap.drain()
+    assertEquals(Seq(1f, 2f), drained.map(_.score).toSeq)
+    assertEquals(Seq(1L, 2L), drained.map(_.rowAddr).toSeq)
+  }
+
+  /** `merge` combines two pre-sorted arrays preserving top-K. */
+  @Test def testMergeCombinesTwoArrays(): Unit = {
+    val a = Array(ref(1, 1f), ref(2, 3f), ref(3, 5f))
+    val b = Array(ref(4, 2f), ref(5, 4f), ref(6, 6f))
+    val merged = TopKHeap.merge(a, b, k = 4, smallerIsBetter = true)
+    assertEquals(Seq(1f, 2f, 3f, 4f), merged.map(_.score).toSeq)
+  }
+
+  /** Merging with one empty input is a noop modulo trim to K. */
+  @Test def testMergeWithEmpty(): Unit = {
+    val a = Array(ref(1, 1f), ref(2, 2f), ref(3, 3f))
+    val merged = TopKHeap.merge(a, Array.empty[ScoredRowRef], k = 2, smallerIsBetter = true)
+    assertEquals(Seq(1f, 2f), merged.map(_.score).toSeq)
+  }
+}

--- a/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/TopKHeapTest.scala
+++ b/lance-spark-knn-4.2_2.13/src/test/scala/org/lance/spark/knn/internal/TopKHeapTest.scala
@@ -75,6 +75,22 @@ class TopKHeapTest {
     assertEquals(Seq(1L, 2L), drained.map(_.rowAddr).toSeq)
   }
 
+  /**
+   * A NaN score must not pin a heap slot forever. Admission derives from the heap's total ordering
+   * (`java.lang.Float.compare`, which sorts NaN as the largest Float), not a raw float `<` — with
+   * raw `<`, `1.0f < NaN` is false, so a NaN worst-survivor would test as un-beatable and never be
+   * evicted. Regression for exactly that: offer NaN then a finite score into a size-1 distance heap;
+   * the finite score must win.
+   */
+  @Test def testNaNScoreIsEvictable(): Unit = {
+    val heap = new TopKHeap(k = 1, smallerIsBetter = true)
+    heap.offer(ref(1, Float.NaN))
+    heap.offer(ref(2, 1.0f))
+    val drained = heap.drain()
+    assertEquals(Seq(2L), drained.map(_.rowAddr).toSeq, "finite score must evict the NaN worst")
+    assertEquals(1.0f, drained.head.score, "size-1 distance heap must retain the finite minimum")
+  }
+
   /** `merge` combines two pre-sorted arrays preserving top-K. */
   @Test def testMergeCombinesTwoArrays(): Unit = {
     val a = Array(ref(1, 1f), ref(2, 3f), ref(3, 5f))

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,7 @@
         <module>lance-spark-bundle-4.1_2.13</module>
         <module>lance-spark-4.2_2.13</module>
         <module>lance-spark-bundle-4.2_2.13</module>
+        <module>lance-spark-knn-4.2_2.13</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Part [2/3] of the indexed nearest-by vector join over Lance, split by architectural layer from the umbrella #796.

This slice adds the per-partition **execution stage** (`internal/LanceKnnJoinStage`) that drives the join, layered on the probe-core primitives from **#797** ([1/3]).

## Stacked on #797
This PR is stacked on #797. Until #797 merges to `main`, this diff also shows the [1/3] probe-core files (`Metric`, `TopKHeap`, `ScoredRowRef`, `LanceProbe`) because `main` does not yet contain them; once #797 merges, this diff reduces to the join-stage layer alone. **Review target here:** `internal/LanceKnnJoinStage.scala` and `internal/LanceKnnJoinStageTest.scala`.

## What this stage does
- `runPartition`: open one `LanceProbe` per partition, stream the join output lazily (no per-partition buffering), close the native handle on task completion (success or failure).
- Fused vs split routing (`foldsInOneScan`): with no over-fetch and a payload projection that does not collide with an injected column (`_rowid` / `_distance` / `_score`), search and project in ONE native scan; otherwise probe → trim → late-materialize survivors by `_rowid`.
- `resolveReadContext` / `mergeReadOptions`: pin the Lance snapshot once on the driver so every task probes one consistent version; mirror the connector's incompatible-pinned-ref guard.
- `coerceToSpark`: schema-aware payload coercion (structs, arrays, and the Arrow entry-list shape a `MapType` cell arrives in) to the shape the join's encoder accepts.

## Tests
`LanceKnnJoinStageTest` (backend-free) covers lazy output, fold-vs-split routing for reserved-name projections, read-option merge conflicts, and payload coercion. Full module `test` phase: 30 pass.

The SQL Catalyst rule, physical/logical plan, strategy, and session extension — plus their tests and docs — follow in [3/3].

🤖 Generated with [Claude Code](https://claude.com/claude-code)
