### PR TITLE
docs: add Spark 4.2 to supported versions

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -82,6 +82,7 @@ See [Configuration](config.md) for more details.
 
 | Spark Version       | Support Status  | Notes                                                        |
 |---------------------|-----------------|--------------------------------------------------------------|
+| Spark 4.2           | ✅ Supported     | Scala 2.13 only                                             |
 | Spark 4.1           | ✅ Supported     | Scala 2.13 only                                             |
 | Spark 4.0           | ✅ Supported     | Scala 2.13 only (Spark 4.0 dropped Scala 2.12 support)     |
 | Spark 3.5           | ✅ Supported     | Scala 2.12 and 2.13                                         |


### PR DESCRIPTION
## Summary
- Add Spark 4.2 (Scala 2.13 only) to the supported Apache Spark versions table in install docs

## Test plan
- [x] `mkdocs build --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
