### PR TITLE
feat: push zonemap ranges into fragment scans

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -15,6 +15,47 @@ Each benchmark is split into two independent Spark jobs:
 
 Both benchmarks share the same reporting infrastructure (`BenchmarkResult`, `BenchmarkReporter`, `QueryMetrics`, `QueryMetricsListener`) and produce output in the same CSV/summary format, so results are directly comparable across workloads.
 
+## FragmentSlice physical-read benchmark
+
+`FragmentSliceBenchmark` is a focused local benchmark for ZoneMap-driven physical row-range
+pruning. It creates one large, physically ordered Lance fragment, builds a ZoneMap, and compares
+four Java Scanner modes: with and without a physical slice, each with scalar-index execution enabled
+and disabled. The primary signal is native `ScanStats.bytesRead`; elapsed time is secondary and is
+expected to be noisier on a local filesystem.
+
+Run the default workload (4 million rows, approximately 1 GB of payload):
+
+```bash
+make bundle SPARK_VERSION=3.5 SCALA_VERSION=2.12
+./benchmark/scripts/run-fragment-slice-benchmark.sh
+```
+
+Run a small smoke workload, rebuilding the dataset if it already exists:
+
+```bash
+ROWS=65536 PAYLOAD_BYTES=64 ROWS_PER_ZONE=4096 \
+  WARMUPS=0 ITERATIONS=1 REGENERATE=true \
+  ./benchmark/scripts/run-fragment-slice-benchmark.sh
+```
+
+Configuration is provided through environment variables:
+
+| Variable | Default | Description |
+|---|---:|---|
+| `DATA_DIR` | `benchmark/data/fragment-slice` | Parent directory of the generated dataset |
+| `RESULTS_DIR` | `benchmark/results` | Local directory for result CSV files |
+| `ROWS` | `4000000` | Physical rows in the single fragment |
+| `PAYLOAD_BYTES` | `256` | Deterministic payload width per row |
+| `ROWS_PER_ZONE` | `8192` | ZoneMap rows per zone and selected slice size |
+| `WARMUPS` | `1` | Warmup passes over all four modes |
+| `ITERATIONS` | `5` | Recorded passes over all four modes |
+| `REGENERATE` | `false` | Overwrite an existing benchmark dataset |
+| `MAVEN_REPO_LOCAL` | unset | Maven repository containing a locally built Lance artifact |
+
+The runner verifies that all modes return the same row count and reports the planned row ratio,
+median elapsed time, bytes read, requests, I/O operations, and index loads. A byte reduction of at
+least 80% with scalar indexes disabled is printed as the initial physical-pruning target.
+
 ### TODO
 - **Delta / Iceberg support** — not yet included because they require additional catalog/metastore tooling outside lance-spark's scope.
 

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <spark.compat.version>3.5</spark.compat.version>
         <scala.compat.version>2.12</scala.compat.version>
+        <lance.version>12.0.0-beta.11</lance.version>
         <kyuubi.version>1.11.0</kyuubi.version>
         <java.release>11</java.release>
         <maven.compiler.release>${java.release}</maven.compiler.release>
@@ -20,6 +21,14 @@
     </properties>
 
     <dependencies>
+        <!-- Supplied at runtime by the lance-spark bundle. Keep this provided so the benchmark
+             jar does not package a second copy of lance-core, Arrow, or the JNI library. -->
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-core</artifactId>
+            <version>${lance.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.compat.version}</artifactId>

--- a/benchmark/scripts/run-fragment-slice-benchmark.sh
+++ b/benchmark/scripts/run-fragment-slice-benchmark.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BENCHMARK_DIR="${SCRIPT_DIR}/.."
+PROJECT_DIR="${BENCHMARK_DIR}/.."
+
+SPARK_VERSION="${SPARK_VERSION:-3.5}"
+SCALA_VERSION="${SCALA_VERSION:-2.12}"
+SPARK_MASTER="${SPARK_MASTER:-local[*]}"
+DATA_DIR="${DATA_DIR:-${BENCHMARK_DIR}/data/fragment-slice}"
+RESULTS_DIR="${RESULTS_DIR:-${BENCHMARK_DIR}/results}"
+ROWS="${ROWS:-4000000}"
+PAYLOAD_BYTES="${PAYLOAD_BYTES:-256}"
+ROWS_PER_ZONE="${ROWS_PER_ZONE:-8192}"
+WARMUPS="${WARMUPS:-1}"
+ITERATIONS="${ITERATIONS:-5}"
+
+MAVEN_ARGS=()
+if [ -n "${MAVEN_REPO_LOCAL:-}" ]; then
+  MAVEN_ARGS+=("-Dmaven.repo.local=${MAVEN_REPO_LOCAL}")
+fi
+
+echo "=== FragmentSlice Benchmark ==="
+echo "Spark master:    ${SPARK_MASTER}"
+echo "Data dir:        ${DATA_DIR}"
+echo "Results dir:     ${RESULTS_DIR}"
+echo "Rows:            ${ROWS}"
+echo "Payload bytes:   ${PAYLOAD_BYTES}"
+echo "Rows per zone:   ${ROWS_PER_ZONE}"
+echo "Warmups/runs:    ${WARMUPS}/${ITERATIONS}"
+echo ""
+
+BENCHMARK_JAR="${BENCHMARK_DIR}/target/lance-spark-benchmark.jar"
+if [ ! -f "${BENCHMARK_JAR}" ]; then
+  echo "--- Building benchmark jar ---"
+  (
+    cd "${BENCHMARK_DIR}"
+    ../mvnw package -DskipTests -q \
+      -Dspark.compat.version="${SPARK_VERSION}" \
+      -Dscala.compat.version="${SCALA_VERSION}" \
+      "${MAVEN_ARGS[@]}"
+  )
+fi
+
+BUNDLE_JAR=$(find "${PROJECT_DIR}" \
+  -path "*/lance-spark-bundle-${SPARK_VERSION}_${SCALA_VERSION}/target/lance-spark-bundle-*.jar" \
+  -not -name "*sources*" -not -name "*javadoc*" -print -quit)
+if [ -z "${BUNDLE_JAR}" ]; then
+  echo "ERROR: lance-spark bundle jar not found." >&2
+  echo "Build it first with:" >&2
+  echo "  make bundle SPARK_VERSION=${SPARK_VERSION} SCALA_VERSION=${SCALA_VERSION}" >&2
+  exit 1
+fi
+
+SPARK_SUBMIT="spark-submit"
+if [ -n "${SPARK_HOME:-}" ]; then
+  SPARK_SUBMIT="${SPARK_HOME}/bin/spark-submit"
+fi
+
+RUNNER_ARGS=(
+  --data-dir "${DATA_DIR}"
+  --results-dir "${RESULTS_DIR}"
+  --rows "${ROWS}"
+  --payload-bytes "${PAYLOAD_BYTES}"
+  --rows-per-zone "${ROWS_PER_ZONE}"
+  --warmups "${WARMUPS}"
+  --iterations "${ITERATIONS}"
+)
+if [ "${REGENERATE:-false}" = true ]; then
+  RUNNER_ARGS+=(--regenerate)
+fi
+
+mkdir -p "${RESULTS_DIR}"
+
+"${SPARK_SUBMIT}" \
+  --class org.lance.spark.benchmark.FragmentSliceBenchmark \
+  --master "${SPARK_MASTER}" \
+  --driver-memory "${DRIVER_MEMORY:-4g}" \
+  --executor-memory "${EXECUTOR_MEMORY:-4g}" \
+  --jars "${BUNDLE_JAR}" \
+  --conf spark.sql.extensions=org.lance.spark.extensions.LanceSparkSessionExtensions \
+  --conf spark.driver.extraJavaOptions="-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true" \
+  "${BENCHMARK_JAR}" \
+  "${RUNNER_ARGS[@]}"

--- a/benchmark/src/main/java/org/lance/spark/benchmark/FragmentSliceBenchmark.java
+++ b/benchmark/src/main/java/org/lance/spark/benchmark/FragmentSliceBenchmark.java
@@ -1,0 +1,627 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.benchmark;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.lance.Fragment;
+import org.lance.index.scalar.ZoneStats;
+import org.lance.ipc.FragmentSlice;
+import org.lance.ipc.LanceScanner;
+import org.lance.ipc.ScanOptions;
+import org.lance.ipc.ScanStats;
+
+/**
+ * Measures physical read reduction from applying a {@link FragmentSlice} to a selective ZoneMap
+ * query.
+ *
+ * <p>The generated dataset deliberately contains one large, physically ordered fragment. A query
+ * selects exactly one ZoneMap zone while projecting a wide, deterministic payload. Four scanner
+ * modes isolate physical slicing from scalar-index execution:
+ *
+ * <ol>
+ *   <li>full fragment, scalar index disabled
+ *   <li>physical slice, scalar index disabled
+ *   <li>full fragment, scalar index enabled
+ *   <li>physical slice, scalar index enabled
+ * </ol>
+ */
+public final class FragmentSliceBenchmark {
+  private static final String DATASET_NAME = "fragment_slice.lance";
+  private static final String INDEX_NAME = "fragment_slice_zonemap";
+
+  private FragmentSliceBenchmark() {}
+
+  public static void main(String[] args) throws Exception {
+    Config config = Config.parse(args);
+    SparkSession spark = createSparkSession(config);
+    try {
+      String datasetUri = TpcdsDataGenerator.toLancePath(config.dataDir + "/" + DATASET_NAME);
+      prepareDataset(spark, datasetUri, config);
+      runBenchmark(datasetUri, config);
+    } finally {
+      spark.stop();
+    }
+  }
+
+  private static SparkSession createSparkSession(Config config) {
+    return SparkSession.builder()
+        .appName("Lance FragmentSlice Benchmark")
+        .config("spark.sql.extensions", "org.lance.spark.extensions.LanceSparkSessionExtensions")
+        .config("spark.sql.catalog.lance_default", "org.lance.spark.LanceNamespaceSparkCatalog")
+        .config("spark.sql.catalog.lance_default.impl", "dir")
+        .config("spark.sql.catalog.lance_default.root", config.dataDir)
+        .getOrCreate();
+  }
+
+  private static void prepareDataset(SparkSession spark, String datasetUri, Config config)
+      throws Exception {
+    Path datasetPath = new Path(datasetUri);
+    FileSystem fs = datasetPath.getFileSystem(spark.sparkContext().hadoopConfiguration());
+    boolean exists = fs.exists(datasetPath);
+
+    if (!exists || config.regenerate) {
+      System.out.printf(
+          Locale.ROOT,
+          "Generating %,d rows with a %d-byte payload at %s%n",
+          config.rows,
+          config.payloadBytes,
+          datasetUri);
+      Dataset<Row> data =
+          spark
+              .range(0, config.rows, 1, 1)
+              .selectExpr("id", payloadExpression(config.payloadBytes));
+      data.write()
+          .format("lance")
+          .mode(exists ? SaveMode.Overwrite : SaveMode.ErrorIfExists)
+          .option("max_row_per_file", String.valueOf(config.rows))
+          .option("file_format_version", "2.0")
+          .save(datasetUri);
+      createZonemap(spark, datasetUri, config.rowsPerZone);
+      return;
+    }
+
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(datasetUri).build()) {
+      validateDataset(dataset, config);
+      List<ZoneStats> zones = dataset.getZonemapStats("id");
+      if (zones.isEmpty()) {
+        createZonemap(spark, datasetUri, config.rowsPerZone);
+      } else {
+        validateZoneSize(zones, config.rowsPerZone);
+      }
+    }
+  }
+
+  private static String payloadExpression(int payloadBytes) {
+    int hashes = (payloadBytes + 63) / 64;
+    StringBuilder expression = new StringBuilder("substring(concat(");
+    for (int i = 0; i < hashes; i++) {
+      if (i > 0) {
+        expression.append(',');
+      }
+      expression
+          .append("sha2(concat(cast(id as string), ':fragment-slice:")
+          .append(i)
+          .append("'), 256)");
+    }
+    return expression.append("), 1, ").append(payloadBytes).append(") AS payload").toString();
+  }
+
+  private static void createZonemap(SparkSession spark, String datasetUri, long rowsPerZone) {
+    String escapedUri = datasetUri.replace("`", "``");
+    spark
+        .sql(
+            String.format(
+                Locale.ROOT,
+                "ALTER TABLE lance_default.`%s` CREATE INDEX %s USING zonemap (id) "
+                    + "WITH (rows_per_zone=%d)",
+                escapedUri,
+                INDEX_NAME,
+                rowsPerZone))
+        .collectAsList();
+  }
+
+  private static void validateDataset(org.lance.Dataset dataset, Config config) {
+    long actualRows = dataset.countRows();
+    if (actualRows != config.rows) {
+      throw new IllegalStateException(
+          String.format(
+              Locale.ROOT,
+              "Existing benchmark dataset has %,d rows, expected %,d; rerun with --regenerate",
+              actualRows,
+              config.rows));
+    }
+    List<Fragment> fragments = dataset.getFragments();
+    if (fragments.size() != 1) {
+      throw new IllegalStateException(
+          "FragmentSlice benchmark requires exactly one fragment, found " + fragments.size());
+    }
+  }
+
+  private static void validateZoneSize(List<ZoneStats> zones, long expectedRowsPerZone) {
+    long largestZoneLength = 0;
+    for (ZoneStats zone : zones) {
+      largestZoneLength = Math.max(largestZoneLength, zone.getZoneLength());
+    }
+    if (largestZoneLength != expectedRowsPerZone) {
+      throw new IllegalStateException(
+          String.format(
+              Locale.ROOT,
+              "Existing ZoneMap uses %,d rows per zone, expected %,d; rerun with --regenerate",
+              largestZoneLength,
+              expectedRowsPerZone));
+    }
+  }
+
+  private static void runBenchmark(String datasetUri, Config config) throws Exception {
+    try (org.lance.Dataset dataset = org.lance.Dataset.open().uri(datasetUri).build()) {
+      validateDataset(dataset, config);
+      List<ZoneStats> zones = dataset.getZonemapStats("id");
+      if (zones.isEmpty()) {
+        throw new IllegalStateException("ZoneMap index is missing after dataset preparation");
+      }
+      validateZoneSize(zones, config.rowsPerZone);
+
+      Fragment fragment = dataset.getFragments().get(0);
+      int fragmentId = fragment.getId();
+      long physicalRows = fragment.metadata().getPhysicalRows();
+      long sliceStart = alignedSliceStart(physicalRows, config.rowsPerZone);
+      long sliceRows = Math.min(config.rowsPerZone, physicalRows - sliceStart);
+      FragmentSlice slice = new FragmentSlice(fragmentId, sliceStart, sliceRows);
+      double pruningRatio = (double) sliceRows / physicalRows;
+
+      System.out.println("=== FragmentSlice Benchmark ===");
+      System.out.printf(Locale.ROOT, "Dataset:          %s%n", datasetUri);
+      System.out.printf(Locale.ROOT, "Physical rows:    %,d%n", physicalRows);
+      System.out.printf(
+          Locale.ROOT,
+          "Selected slice:   fragment=%d [%d, %d)%n",
+          fragmentId,
+          sliceStart,
+          sliceStart + sliceRows);
+      System.out.printf(Locale.ROOT, "Planned row ratio: %.4f%%%n", pruningRatio * 100.0);
+      System.out.printf(
+          Locale.ROOT, "Warmups/runs:      %d/%d%n%n", config.warmups, config.iterations);
+
+      List<Mode> forward = Arrays.asList(Mode.values());
+      List<Mode> reverse = new ArrayList<>(forward);
+      Collections.reverse(reverse);
+
+      for (int warmup = 0; warmup < config.warmups; warmup++) {
+        for (Mode mode : warmup % 2 == 0 ? forward : reverse) {
+          runScan(dataset, mode, fragmentId, slice, sliceStart, sliceRows, pruningRatio, 0);
+        }
+      }
+
+      List<Measurement> measurements = new ArrayList<>();
+      for (int iteration = 1; iteration <= config.iterations; iteration++) {
+        List<Mode> order = iteration % 2 == 1 ? forward : reverse;
+        for (Mode mode : order) {
+          Measurement measurement =
+              runScan(
+                  dataset, mode, fragmentId, slice, sliceStart, sliceRows, pruningRatio, iteration);
+          measurements.add(measurement);
+          System.out.println(measurement.toConsoleLine());
+        }
+      }
+
+      java.nio.file.Path csvPath = writeResults(measurements, config.resultsDir);
+      printSummary(measurements, pruningRatio, csvPath);
+    }
+  }
+
+  private static long alignedSliceStart(long physicalRows, long rowsPerZone) {
+    long midpoint = physicalRows / 2;
+    long start = (midpoint / rowsPerZone) * rowsPerZone;
+    if (start + rowsPerZone > physicalRows) {
+      start = Math.max(0, physicalRows - rowsPerZone);
+    }
+    return start;
+  }
+
+  private static Measurement runScan(
+      org.lance.Dataset dataset,
+      Mode mode,
+      int fragmentId,
+      FragmentSlice slice,
+      long filterStart,
+      long expectedRows,
+      double pruningRatio,
+      int iteration)
+      throws Exception {
+    ScanOptions.Builder options =
+        new ScanOptions.Builder()
+            .columns(Collections.singletonList("payload"))
+            .filter(
+                String.format(
+                    Locale.ROOT, "id >= %d AND id < %d", filterStart, filterStart + expectedRows))
+            .fragmentIds(Collections.singletonList(fragmentId))
+            .useScalarIndex(mode.useScalarIndex)
+            .collectStats(true);
+    if (mode.useSlice) {
+      options.fragmentSlices(Collections.singletonList(slice));
+    }
+
+    long rowsRead = 0;
+    ScanStats stats;
+    long start = System.nanoTime();
+    try (LanceScanner scanner = dataset.newScan(options.build())) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch()) {
+          rowsRead += reader.getVectorSchemaRoot().getRowCount();
+        }
+      }
+      stats =
+          scanner
+              .getStats()
+              .orElseThrow(() -> new IllegalStateException("ScanStats unavailable after scan"));
+    }
+    long elapsedNs = System.nanoTime() - start;
+
+    if (rowsRead != expectedRows) {
+      throw new IllegalStateException(
+          String.format(
+              Locale.ROOT,
+              "%s returned %,d rows, expected %,d",
+              mode.label,
+              rowsRead,
+              expectedRows));
+    }
+    return new Measurement(mode, iteration, rowsRead, pruningRatio, elapsedNs, stats);
+  }
+
+  private static java.nio.file.Path writeResults(List<Measurement> measurements, String resultsDir)
+      throws IOException {
+    java.nio.file.Path directory = Paths.get(resultsDir);
+    Files.createDirectories(directory);
+    String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+    java.nio.file.Path csvPath = directory.resolve("fragment_slice_" + timestamp + ".csv");
+    try (BufferedWriter writer = Files.newBufferedWriter(csvPath, StandardCharsets.UTF_8)) {
+      writer.write(Measurement.csvHeader());
+      writer.newLine();
+      for (Measurement measurement : measurements) {
+        writer.write(measurement.toCsv());
+        writer.newLine();
+      }
+    }
+    return csvPath;
+  }
+
+  private static void printSummary(
+      List<Measurement> measurements, double pruningRatio, java.nio.file.Path csvPath) {
+    System.out.println();
+    System.out.println("=== Median results ===");
+    for (Mode mode : Mode.values()) {
+      List<Measurement> modeMeasurements = selectMode(measurements, mode);
+      System.out.printf(
+          Locale.ROOT,
+          "%-26s elapsed=%8.2fms bytes=%12s requests=%8d iops=%8d indices=%4d parts=%4d "
+              + "comparisons=%6d%n",
+          mode.label,
+          medianElapsedMs(modeMeasurements),
+          formatBytes(medianLong(modeMeasurements, Value.BYTES)),
+          medianLong(modeMeasurements, Value.REQUESTS),
+          medianLong(modeMeasurements, Value.IOPS),
+          medianLong(modeMeasurements, Value.INDICES),
+          medianLong(modeMeasurements, Value.PARTS),
+          medianLong(modeMeasurements, Value.COMPARISONS));
+    }
+
+    double noIndexReduction =
+        byteReduction(
+            selectMode(measurements, Mode.FULL_NO_INDEX),
+            selectMode(measurements, Mode.SLICE_NO_INDEX));
+    double indexReduction =
+        byteReduction(
+            selectMode(measurements, Mode.FULL_WITH_INDEX),
+            selectMode(measurements, Mode.SLICE_WITH_INDEX));
+    System.out.printf(
+        Locale.ROOT, "%nPlanned row reduction:     %.2f%%%n", (1 - pruningRatio) * 100);
+    System.out.printf(
+        Locale.ROOT,
+        "Byte reduction, index off: %.2f%%%s%n",
+        noIndexReduction,
+        noIndexReduction >= 80.0 ? "  PASS (>= 80%)" : "  BELOW TARGET (< 80%)");
+    System.out.printf(Locale.ROOT, "Byte reduction, index on:  %.2f%%%n", indexReduction);
+    System.out.println("CSV: " + csvPath.toAbsolutePath());
+  }
+
+  private static List<Measurement> selectMode(List<Measurement> measurements, Mode mode) {
+    List<Measurement> selected = new ArrayList<>();
+    for (Measurement measurement : measurements) {
+      if (measurement.mode == mode) {
+        selected.add(measurement);
+      }
+    }
+    return selected;
+  }
+
+  private static double byteReduction(List<Measurement> baseline, List<Measurement> candidate) {
+    long baselineBytes = medianLong(baseline, Value.BYTES);
+    long candidateBytes = medianLong(candidate, Value.BYTES);
+    return baselineBytes == 0 ? 0 : (1.0 - (double) candidateBytes / baselineBytes) * 100.0;
+  }
+
+  private static double medianElapsedMs(List<Measurement> measurements) {
+    List<Long> values = new ArrayList<>(measurements.size());
+    for (Measurement measurement : measurements) {
+      values.add(measurement.elapsedNs);
+    }
+    return median(values) / 1_000_000.0;
+  }
+
+  private static long medianLong(List<Measurement> measurements, Value value) {
+    List<Long> values = new ArrayList<>(measurements.size());
+    for (Measurement measurement : measurements) {
+      values.add(value.get(measurement));
+    }
+    return median(values);
+  }
+
+  private static long median(List<Long> values) {
+    if (values.isEmpty()) {
+      throw new IllegalArgumentException("Cannot calculate median of an empty list");
+    }
+    values.sort(Comparator.naturalOrder());
+    int midpoint = values.size() / 2;
+    if (values.size() % 2 == 1) {
+      return values.get(midpoint);
+    }
+    return values.get(midpoint - 1) + (values.get(midpoint) - values.get(midpoint - 1)) / 2;
+  }
+
+  private static String formatBytes(long bytes) {
+    if (bytes < 1024) {
+      return bytes + " B";
+    }
+    if (bytes < 1024L * 1024) {
+      return String.format(Locale.ROOT, "%.1f KiB", bytes / 1024.0);
+    }
+    if (bytes < 1024L * 1024 * 1024) {
+      return String.format(Locale.ROOT, "%.1f MiB", bytes / (1024.0 * 1024));
+    }
+    return String.format(Locale.ROOT, "%.2f GiB", bytes / (1024.0 * 1024 * 1024));
+  }
+
+  private enum Mode {
+    FULL_NO_INDEX("full / scalar=false", false, false),
+    SLICE_NO_INDEX("slice / scalar=false", true, false),
+    FULL_WITH_INDEX("full / scalar=true", false, true),
+    SLICE_WITH_INDEX("slice / scalar=true", true, true);
+
+    private final String label;
+    private final boolean useSlice;
+    private final boolean useScalarIndex;
+
+    Mode(String label, boolean useSlice, boolean useScalarIndex) {
+      this.label = label;
+      this.useSlice = useSlice;
+      this.useScalarIndex = useScalarIndex;
+    }
+  }
+
+  private enum Value {
+    BYTES {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getBytesRead();
+      }
+    },
+    REQUESTS {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getRequests();
+      }
+    },
+    IOPS {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getIops();
+      }
+    },
+    INDICES {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getIndicesLoaded();
+      }
+    },
+    PARTS {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getPartsLoaded();
+      }
+    },
+    COMPARISONS {
+      @Override
+      long get(Measurement measurement) {
+        return measurement.stats.getIndexComparisons();
+      }
+    };
+
+    abstract long get(Measurement measurement);
+  }
+
+  private static final class Measurement {
+    private final Mode mode;
+    private final int iteration;
+    private final long rowsRead;
+    private final double pruningRatio;
+    private final long elapsedNs;
+    private final ScanStats stats;
+
+    private Measurement(
+        Mode mode,
+        int iteration,
+        long rowsRead,
+        double pruningRatio,
+        long elapsedNs,
+        ScanStats stats) {
+      this.mode = mode;
+      this.iteration = iteration;
+      this.rowsRead = rowsRead;
+      this.pruningRatio = pruningRatio;
+      this.elapsedNs = elapsedNs;
+      this.stats = stats;
+    }
+
+    private String toConsoleLine() {
+      return String.format(
+          Locale.ROOT,
+          "iter=%d %-26s rows=%,d elapsed=%8.2fms bytes=%s requests=%d iops=%d "
+              + "indices=%d parts=%d comparisons=%d",
+          iteration,
+          mode.label,
+          rowsRead,
+          elapsedNs / 1_000_000.0,
+          formatBytes(stats.getBytesRead()),
+          stats.getRequests(),
+          stats.getIops(),
+          stats.getIndicesLoaded(),
+          stats.getPartsLoaded(),
+          stats.getIndexComparisons());
+    }
+
+    private static String csvHeader() {
+      return "iteration,mode,use_slice,use_scalar_index,rows_read,planned_row_ratio,elapsed_ns,"
+          + "bytes_read,requests,iops,indices_loaded,parts_loaded,index_comparisons";
+    }
+
+    private String toCsv() {
+      return String.format(
+          Locale.ROOT,
+          "%d,%s,%s,%s,%d,%.8f,%d,%d,%d,%d,%d,%d,%d",
+          iteration,
+          mode.name(),
+          mode.useSlice,
+          mode.useScalarIndex,
+          rowsRead,
+          pruningRatio,
+          elapsedNs,
+          stats.getBytesRead(),
+          stats.getRequests(),
+          stats.getIops(),
+          stats.getIndicesLoaded(),
+          stats.getPartsLoaded(),
+          stats.getIndexComparisons());
+    }
+  }
+
+  private static final class Config {
+    private String dataDir = "benchmark/data/fragment-slice";
+    private String resultsDir = "benchmark/results";
+    private long rows = 4_000_000;
+    private int payloadBytes = 256;
+    private long rowsPerZone = 8_192;
+    private int warmups = 1;
+    private int iterations = 5;
+    private boolean regenerate;
+
+    private static Config parse(String[] args) {
+      Config config = new Config();
+      for (int i = 0; i < args.length; i++) {
+        switch (args[i]) {
+          case "--data-dir":
+            config.dataDir = requireValue(args, ++i, "--data-dir");
+            break;
+          case "--results-dir":
+            config.resultsDir = requireValue(args, ++i, "--results-dir");
+            break;
+          case "--rows":
+            config.rows = Long.parseLong(requireValue(args, ++i, "--rows"));
+            break;
+          case "--payload-bytes":
+            config.payloadBytes = Integer.parseInt(requireValue(args, ++i, "--payload-bytes"));
+            break;
+          case "--rows-per-zone":
+            config.rowsPerZone = Long.parseLong(requireValue(args, ++i, "--rows-per-zone"));
+            break;
+          case "--warmups":
+            config.warmups = Integer.parseInt(requireValue(args, ++i, "--warmups"));
+            break;
+          case "--iterations":
+            config.iterations = Integer.parseInt(requireValue(args, ++i, "--iterations"));
+            break;
+          case "--regenerate":
+            config.regenerate = true;
+            break;
+          case "--help":
+            printUsage();
+            System.exit(0);
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown argument: " + args[i]);
+        }
+      }
+      config.validate();
+      return config;
+    }
+
+    private void validate() {
+      if (rows <= 0 || rows > Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("--rows must be between 1 and " + Integer.MAX_VALUE);
+      }
+      if (payloadBytes <= 0) {
+        throw new IllegalArgumentException("--payload-bytes must be positive");
+      }
+      if (rowsPerZone <= 0 || rowsPerZone > rows) {
+        throw new IllegalArgumentException(
+            "--rows-per-zone must be positive and no greater than rows");
+      }
+      if (warmups < 0) {
+        throw new IllegalArgumentException("--warmups must be non-negative");
+      }
+      if (iterations <= 0) {
+        throw new IllegalArgumentException("--iterations must be positive");
+      }
+    }
+
+    private static String requireValue(String[] args, int index, String option) {
+      if (index >= args.length) {
+        throw new IllegalArgumentException("Missing value for " + option);
+      }
+      return args[index];
+    }
+  }
+
+  private static void printUsage() {
+    System.out.println(
+        "Usage: FragmentSliceBenchmark"
+            + " [--data-dir <path>]"
+            + " [--results-dir <path>]"
+            + " [--rows 4000000]"
+            + " [--payload-bytes 256]"
+            + " [--rows-per-zone 8192]"
+            + " [--warmups 1]"
+            + " [--iterations 5]"
+            + " [--regenerate]");
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/internal/LanceFragmentScanner.java
@@ -15,6 +15,7 @@ package org.lance.spark.internal;
 
 import org.lance.Dataset;
 import org.lance.Fragment;
+import org.lance.ipc.FragmentSlice;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.ipc.ScanStats;
@@ -134,6 +135,13 @@ public class LanceFragmentScanner implements AutoCloseable {
         scanOptions.fullTextQuery(readOptions.getFullTextQuery());
       }
       scanOptions.useScalarIndex(readOptions.isUseScalarIndex());
+      List<FragmentSlice> fragmentSlices =
+          inputPartition.getLanceSplit().getFragmentSlices().stream()
+              .filter(slice -> slice.getFragmentId() == fragmentId)
+              .collect(Collectors.toList());
+      if (!fragmentSlices.isEmpty()) {
+        scanOptions.fragmentSlices(fragmentSlices);
+      }
       if (inputPartition.getLimit().isPresent()) {
         scanOptions.limit(inputPartition.getLimit().get());
       }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceCountStarPartitionReader.java
@@ -14,6 +14,7 @@
 package org.lance.spark.read;
 
 import org.lance.Dataset;
+import org.lance.ipc.FragmentSlice;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.spark.LanceRuntime;
@@ -113,6 +114,10 @@ public class LanceCountStarPartitionReader implements PartitionReader<ColumnarBa
       scanOptionsBuilder.withRowId(true);
       scanOptionsBuilder.columns(Lists.newArrayList());
       scanOptionsBuilder.fragmentIds(fragmentIds);
+      List<FragmentSlice> fragmentSlices = inputPartition.getLanceSplit().getFragmentSlices();
+      if (!fragmentSlices.isEmpty()) {
+        scanOptionsBuilder.fragmentSlices(fragmentSlices);
+      }
 
       // Collect scan stats
       scanOptionsBuilder.collectStats(true);

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScan.java
@@ -78,11 +78,8 @@ public class LanceScan
   private final LanceStatistics statistics;
   private final String scanId = UUID.randomUUID().toString();
 
-  /**
-   * Pre-computed surviving fragment IDs from zonemap pruning in LanceScanBuilder. When non-null,
-   * {@link #pruneByZonemapStats} skips re-computing and uses these directly.
-   */
-  private final Set<Integer> cachedSurvivingFragmentIds;
+  /** Driver-computed zonemap plan. Null means no zonemap pruning can be applied. */
+  private final ZonemapScanPlan zonemapScanPlan;
 
   /**
    * Splits pre-computed on the driver during {@link LanceScanBuilder#build()}. Each entry is one
@@ -138,6 +135,46 @@ public class LanceScan
       java.util.Map<String, String> initialStorageOptions,
       String namespaceImpl,
       java.util.Map<String, String> namespaceProperties) {
+    this(
+        schema,
+        readOptions,
+        whereConditions,
+        limit,
+        offset,
+        topNSortOrders,
+        pushedAggregation,
+        pushedPredicates,
+        statistics,
+        survivingFragmentIds,
+        precomputedSplits,
+        precomputedFragmentRowCounts,
+        activeShardingExpression,
+        fragmentShardingKeys,
+        initialStorageOptions,
+        namespaceImpl,
+        namespaceProperties,
+        null);
+  }
+
+  LanceScan(
+      StructType schema,
+      LanceSparkReadOptions readOptions,
+      Optional<String> whereConditions,
+      Optional<Integer> limit,
+      Optional<Integer> offset,
+      Optional<List<ColumnOrdering>> topNSortOrders,
+      Optional<Aggregation> pushedAggregation,
+      Predicate[] pushedPredicates,
+      LanceStatistics statistics,
+      Set<Integer> survivingFragmentIds,
+      List<LanceSplit> precomputedSplits,
+      java.util.Map<Integer, Long> precomputedFragmentRowCounts,
+      Expression activeShardingExpression,
+      java.util.Map<Integer, Object> fragmentShardingKeys,
+      java.util.Map<String, String> initialStorageOptions,
+      String namespaceImpl,
+      java.util.Map<String, String> namespaceProperties,
+      ZonemapScanPlan physicalSlicePlan) {
     this.schema = schema;
     this.readOptions = readOptions;
     this.whereConditions = whereConditions;
@@ -150,7 +187,12 @@ public class LanceScan
             ? Arrays.copyOf(pushedPredicates, pushedPredicates.length)
             : new Predicate[0];
     this.statistics = statistics;
-    this.cachedSurvivingFragmentIds = survivingFragmentIds;
+    this.zonemapScanPlan =
+        physicalSlicePlan != null
+            ? physicalSlicePlan
+            : survivingFragmentIds == null
+                ? null
+                : ZonemapScanPlan.fullFragments(survivingFragmentIds);
     this.precomputedSplits = precomputedSplits;
     this.precomputedFragmentRowCounts =
         precomputedFragmentRowCounts != null
@@ -314,7 +356,8 @@ public class LanceScan
         || topNSortOrders.isPresent()
         || pushedAggregation.isPresent()
         || readOptions.getFullTextQuery() != null
-        || fragmentRowCounts.isEmpty()) {
+        || fragmentRowCounts.isEmpty()
+        || allSplits.stream().anyMatch(split -> !split.getFragmentSlices().isEmpty())) {
       return allSplits;
     }
 
@@ -357,15 +400,35 @@ public class LanceScan
    */
   private List<LanceSplit> pruneByZonemapStats(List<LanceSplit> allSplits) {
     // Null means the builder did not prune. Do not recompute here.
-    if (cachedSurvivingFragmentIds == null) {
+    if (zonemapScanPlan == null) {
       return allSplits;
     }
-    Set<Integer> allowedIds = cachedSurvivingFragmentIds;
+    Set<Integer> allowedIds = zonemapScanPlan.getSurvivingFragmentIds();
 
-    List<LanceSplit> pruned =
-        allSplits.stream()
-            .filter(split -> split.getFragments().stream().anyMatch(allowedIds::contains))
-            .collect(Collectors.toList());
+    List<LanceSplit> pruned = new java.util.ArrayList<>();
+    for (LanceSplit split : allSplits) {
+      if (split.getFragments().size() != 1) {
+        if (split.getFragments().stream().anyMatch(allowedIds::contains)) {
+          LOG.warn(
+              "Split contains {} fragments; physical zonemap slice attachment requires "
+                  + "single-fragment splits, so retaining the full split",
+              split.getFragments().size());
+          pruned.add(split);
+        }
+        continue;
+      }
+
+      int fragmentId = split.getFragments().get(0);
+      if (!allowedIds.contains(fragmentId)) {
+        continue;
+      }
+      if (zonemapScanPlan.scansFullFragment(fragmentId)) {
+        pruned.add(split);
+      } else {
+        pruned.add(
+            new LanceSplit(split.getFragments(), zonemapScanPlan.getFragmentSlices(fragmentId)));
+      }
+    }
 
     if (pruned.size() < allSplits.size()) {
       LOG.debug(

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -250,6 +250,12 @@ public class LanceScanBuilder
                 .orElse(null);
         if (zonemapScanPlan != null) {
           survivingFragmentIds = zonemapScanPlan.getSurvivingFragmentIds();
+          // Lance does not yet support combining physical fragment slices with full-text search.
+          // Keep the safe fragment-level pruning result, but do not attach intra-fragment ranges
+          // to local FTS scanners (including the scan-based COUNT(*) path).
+          if (readOptions.getFullTextQuery() != null) {
+            zonemapScanPlan = ZonemapScanPlan.fullFragments(survivingFragmentIds);
+          }
         }
       }
 

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceScanBuilder.java
@@ -226,15 +226,31 @@ public class LanceScanBuilder
         }
       }
 
-      // Pre-compute fragment pruning so we can (a) estimate post-pruning statistics for
-      // JoinSelection (BroadcastHashJoin vs SortMergeJoin) and (b) pass the cached result
-      // to LanceScan to avoid re-computing during planInputPartitions().
+      // Pre-compute splits from the same dataset handle used for manifest and zonemap loading.
+      // Besides pinning the resolved version, this gives zonemap planning the complete fragment
+      // domain so uncovered fragments can safely fall back to full scans.
+      LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset, readOptions);
+      Set<Integer> allFragmentIds =
+          scanPlan.getSplits().stream()
+              .flatMap(split -> split.getFragments().stream())
+              .collect(Collectors.toSet());
+
+      // Pre-compute physical slice pruning so we can (a) estimate post-pruning statistics and (b)
+      // ship the exact driver plan to executors without re-reading zonemap metadata there.
+      ZonemapScanPlan zonemapScanPlan = null;
       Set<Integer> survivingFragmentIds = null;
       if (pushedPredicates.length > 0 && !zonemapStats.isEmpty()) {
-        survivingFragmentIds =
-            ZonemapFragmentPruner.pruneFragments(
-                    pushedPredicates, zonemapStats, zonemapLoad.uncoveredByColumn)
+        zonemapScanPlan =
+            ZonemapFragmentPruner.planFragmentSlices(
+                    pushedPredicates,
+                    zonemapStats,
+                    zonemapLoad.uncoveredByColumn,
+                    allFragmentIds,
+                    scanPlan.getPhysicalFragmentRowCounts())
                 .orElse(null);
+        if (zonemapScanPlan != null) {
+          survivingFragmentIds = zonemapScanPlan.getSurvivingFragmentIds();
+        }
       }
 
       // Scale rows and full size by the zonemap fragment-pruning ratio first, then let
@@ -261,12 +277,8 @@ public class LanceScanBuilder
             summary.getTotalRows());
       }
 
-      // Pre-compute splits and per-fragment row counts from the same Dataset handle that we
-      // already opened above. This consolidates two driver-side opens into one and lets us pin
-      // the resolved version onto the read options shipped to workers, providing snapshot
-      // isolation across all tasks of this query. The version is kept as a long end-to-end so
-      // long-lived high-write-frequency datasets do not silently truncate to a wrong version.
-      LanceSplit.ScanPlanResult scanPlan = LanceSplit.planScan(dataset, readOptions);
+      // Pin the resolved version onto the read options shipped to workers, providing snapshot
+      // isolation across all tasks of this query. The version remains a long end-to-end.
       LanceSparkReadOptions resolvedReadOptions = readOptions.withRef(scanPlan.getRef());
 
       Optional<String> whereCondition =
@@ -281,14 +293,15 @@ public class LanceScanBuilder
           pushedAggregation,
           pushedPredicates,
           statistics,
-          survivingFragmentIds,
+          null,
           scanPlan.getSplits(),
           scanPlan.getFragmentRowCounts(),
           activeShardingExpression,
           fragmentShardingKeys,
           initialStorageOptions,
           namespaceImpl,
-          namespaceProperties);
+          namespaceProperties,
+          zonemapScanPlan);
     } finally {
       closeLazyDataset();
     }

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/LanceSplit.java
@@ -15,6 +15,7 @@ package org.lance.spark.read;
 
 import org.lance.Dataset;
 import org.lance.Fragment;
+import org.lance.ipc.FragmentSlice;
 import org.lance.spark.LanceRef;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.utils.Utils;
@@ -30,13 +31,26 @@ public class LanceSplit implements Serializable {
   private static final long serialVersionUID = 2983749283749283749L;
 
   private final List<Integer> fragments;
+  private final List<FragmentSlice> fragmentSlices;
 
   public LanceSplit(List<Integer> fragments) {
-    this.fragments = fragments;
+    this(fragments, Collections.emptyList());
+  }
+
+  public LanceSplit(List<Integer> fragments, List<FragmentSlice> fragmentSlices) {
+    this.fragments = Collections.unmodifiableList(new ArrayList<>(fragments));
+    this.fragmentSlices = Collections.unmodifiableList(new ArrayList<>(fragmentSlices));
   }
 
   public List<Integer> getFragments() {
     return fragments;
+  }
+
+  /**
+   * Physical row slices selected for this split. An empty list means scan the full fragment list.
+   */
+  public List<FragmentSlice> getFragmentSlices() {
+    return fragmentSlices == null ? Collections.emptyList() : fragmentSlices;
   }
 
   /** Result of scan planning containing splits, resolved version, and per-fragment row counts. */
@@ -47,11 +61,23 @@ public class LanceSplit implements Serializable {
     /** Per-fragment logical row counts (after deletions). Key is fragment ID. */
     private final Map<Integer, Long> fragmentRowCounts;
 
+    /** Per-fragment physical row counts (before deletions). Key is fragment ID. */
+    private final Map<Integer, Long> physicalFragmentRowCounts;
+
     public ScanPlanResult(
         List<LanceSplit> splits, LanceRef ref, Map<Integer, Long> fragmentRowCounts) {
+      this(splits, ref, fragmentRowCounts, fragmentRowCounts);
+    }
+
+    public ScanPlanResult(
+        List<LanceSplit> splits,
+        LanceRef ref,
+        Map<Integer, Long> fragmentRowCounts,
+        Map<Integer, Long> physicalFragmentRowCounts) {
       this.splits = splits;
       this.ref = ref;
       this.fragmentRowCounts = fragmentRowCounts;
+      this.physicalFragmentRowCounts = physicalFragmentRowCounts;
     }
 
     public List<LanceSplit> getSplits() {
@@ -64,6 +90,10 @@ public class LanceSplit implements Serializable {
 
     public Map<Integer, Long> getFragmentRowCounts() {
       return fragmentRowCounts;
+    }
+
+    public Map<Integer, Long> getPhysicalFragmentRowCounts() {
+      return physicalFragmentRowCounts;
     }
   }
 
@@ -93,14 +123,16 @@ public class LanceSplit implements Serializable {
     List<Fragment> fragments = dataset.getFragments();
     List<LanceSplit> splits = new ArrayList<>(fragments.size());
     Map<Integer, Long> fragmentRowCounts = new HashMap<>(fragments.size());
+    Map<Integer, Long> physicalFragmentRowCounts = new HashMap<>(fragments.size());
     for (Fragment fragment : fragments) {
       int id = fragment.getId();
       splits.add(new LanceSplit(Collections.singletonList(id)));
       fragmentRowCounts.put(id, fragment.metadata().getNumRows());
+      physicalFragmentRowCounts.put(id, fragment.metadata().getPhysicalRows());
     }
 
     LanceRef ref = Utils.pinOpenedRef(dataset, readOptions.getRef());
-    return new ScanPlanResult(splits, ref, fragmentRowCounts);
+    return new ScanPlanResult(splits, ref, fragmentRowCounts, physicalFragmentRowCounts);
   }
 
   /**

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -14,6 +14,7 @@
 package org.lance.spark.read;
 
 import org.lance.index.scalar.ZoneStats;
+import org.lance.ipc.FragmentSlice;
 
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Literal;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,8 +38,8 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Analyzes pushed Spark predicates against zonemap index statistics to determine which fragments
- * can be pruned.
+ * Analyzes pushed Spark predicates against zonemap index statistics to determine which physical
+ * fragment ranges can be scanned.
  *
  * <p>This is analogous to partition pruning in traditional data sources: if all zones within a
  * fragment provably cannot match a predicate, that fragment is eliminated from the scan — avoiding
@@ -45,10 +48,9 @@ import java.util.Set;
  * <p>Zonemap pruning is inexact (conservative): it may include fragments that ultimately contain no
  * matching rows, but it will never exclude fragments that do contain matching rows.
  *
- * <p>Multiple predicates are treated as conjuncts (implicit AND); their fragment sets are
- * intersected. For each column that has both a pushed predicate and zonemap stats, we evaluate
- * which fragments could possibly match. Multiple columns produce independent fragment sets that are
- * intersected.
+ * <p>Multiple predicates are treated as conjuncts (implicit AND); their physical ranges are
+ * intersected. The original filter remains on the native scan, so zonemap results are always a
+ * conservative prefilter.
  */
 public final class ZonemapFragmentPruner {
 
@@ -79,130 +81,510 @@ public final class ZonemapFragmentPruner {
       Predicate[] pushedPredicates,
       Map<String, List<ZoneStats>> zonemapStatsByColumn,
       Map<String, Set<Integer>> uncoveredFragmentsByColumn) {
+    Set<Integer> allFragmentIds = new HashSet<>();
+    if (zonemapStatsByColumn != null) {
+      for (List<ZoneStats> zones : zonemapStatsByColumn.values()) {
+        for (ZoneStats zone : zones) {
+          allFragmentIds.add(zone.getFragmentId());
+        }
+      }
+    }
+    if (uncoveredFragmentsByColumn != null) {
+      for (Set<Integer> uncovered : uncoveredFragmentsByColumn.values()) {
+        allFragmentIds.addAll(uncovered);
+      }
+    }
+    return planFragmentSlices(
+            pushedPredicates, zonemapStatsByColumn, uncoveredFragmentsByColumn, allFragmentIds)
+        .map(ZonemapScanPlan::getSurvivingFragmentIds);
+  }
 
+  /**
+   * Plans physical fragment slices for pushed predicates.
+   *
+   * <p>The result distinguishes a full-fragment scan from a set of physical row ranges. A fragment
+   * absent from both result sets is proven not to match and can be omitted. Unsupported predicates
+   * are handled conservatively: they contribute no pruning under AND and force a full scan under
+   * OR.
+   */
+  static Optional<ZonemapScanPlan> planFragmentSlices(
+      Predicate[] pushedPredicates,
+      Map<String, List<ZoneStats>> zonemapStatsByColumn,
+      Map<String, Set<Integer>> uncoveredFragmentsByColumn,
+      Set<Integer> allFragmentIds) {
+    return planFragmentSlices(
+        pushedPredicates,
+        zonemapStatsByColumn,
+        uncoveredFragmentsByColumn,
+        allFragmentIds,
+        Collections.emptyMap());
+  }
+
+  static Optional<ZonemapScanPlan> planFragmentSlices(
+      Predicate[] pushedPredicates,
+      Map<String, List<ZoneStats>> zonemapStatsByColumn,
+      Map<String, Set<Integer>> uncoveredFragmentsByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts) {
     if (pushedPredicates == null
         || pushedPredicates.length == 0
         || zonemapStatsByColumn == null
-        || zonemapStatsByColumn.isEmpty()) {
+        || zonemapStatsByColumn.isEmpty()
+        || allFragmentIds == null) {
       return Optional.empty();
     }
 
-    Set<Integer> result = null;
+    Map<Integer, RangeSet> result = null;
     for (Predicate predicate : pushedPredicates) {
-      Optional<Set<Integer>> fragmentIds = analyzePredicate(predicate, zonemapStatsByColumn);
-      if (!fragmentIds.isPresent()) {
+      Optional<Map<Integer, RangeSet>> predicateRanges =
+          analyzePredicateRanges(
+              predicate,
+              zonemapStatsByColumn,
+              uncoveredFragmentsByColumn,
+              allFragmentIds,
+              physicalRowCounts);
+      if (!predicateRanges.isPresent()) {
         continue;
       }
-      // Widen before intersecting: a fragment column B describes but A does not says
-      // nothing about A, so A's predicate must not exclude it.
-      Set<Integer> widened = new HashSet<>(fragmentIds.get());
-      for (String column : referencedColumns(predicate)) {
-        Set<Integer> uncovered = uncoveredFragmentsByColumn.get(column);
-        if (uncovered != null) {
-          widened.addAll(uncovered);
-        }
-      }
-
-      if (result == null) {
-        result = widened;
-      } else {
-        result.retainAll(widened);
-      }
+      result =
+          result == null
+              ? predicateRanges.get()
+              : combineRanges(result, predicateRanges.get(), allFragmentIds, true);
     }
 
     if (result == null) {
       return Optional.empty();
     }
 
-    return Optional.of(Collections.unmodifiableSet(result));
-  }
-
-  /** Every column referenced anywhere in a predicate tree, including nested AND/OR/NOT. */
-  private static Set<String> referencedColumns(Predicate predicate) {
-    Set<String> columns = new HashSet<>();
-    for (NamedReference ref : predicate.references()) {
-      String[] names = ref.fieldNames();
-      columns.add(names.length == 1 ? names[0] : String.join(".", names));
+    Set<Integer> fullScanFragments = new HashSet<>();
+    Map<Integer, List<FragmentSlice>> slicesByFragment = new HashMap<>();
+    for (int fragmentId : allFragmentIds) {
+      RangeSet ranges = result.getOrDefault(fragmentId, RangeSet.full());
+      if (ranges.isFull()) {
+        fullScanFragments.add(fragmentId);
+      } else if (!ranges.isEmpty()) {
+        List<FragmentSlice> slices = new ArrayList<>(ranges.ranges.size());
+        for (RowRange range : ranges.ranges) {
+          slices.add(new FragmentSlice(fragmentId, range.start, range.end - range.start));
+        }
+        slicesByFragment.put(fragmentId, slices);
+      }
     }
-    return columns;
+    return Optional.of(new ZonemapScanPlan(fullScanFragments, slicesByFragment));
   }
 
-  /**
-   * Recursively analyzes a single predicate to extract fragment IDs from zonemap constraints.
-   *
-   * <p>CONTRACT: when present, the returned Set is always a fresh mutable {@link HashSet} that is
-   * not aliased by any other reference. Callers may freely mutate it.
-   */
-  private static Optional<Set<Integer>> analyzePredicate(
-      Predicate predicate, Map<String, List<ZoneStats>> statsByColumn) {
-
+  private static Optional<Map<Integer, RangeSet>> analyzePredicateRanges(
+      Predicate predicate,
+      Map<String, List<ZoneStats>> statsByColumn,
+      Map<String, Set<Integer>> uncoveredByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts) {
     if (predicate instanceof And) {
-      return analyzeAnd((And) predicate, statsByColumn);
+      Optional<Map<Integer, RangeSet>> left =
+          analyzePredicateRanges(
+              ((And) predicate).left(),
+              statsByColumn,
+              uncoveredByColumn,
+              allFragmentIds,
+              physicalRowCounts);
+      Optional<Map<Integer, RangeSet>> right =
+          analyzePredicateRanges(
+              ((And) predicate).right(),
+              statsByColumn,
+              uncoveredByColumn,
+              allFragmentIds,
+              physicalRowCounts);
+      if (left.isPresent() && right.isPresent()) {
+        return Optional.of(combineRanges(left.get(), right.get(), allFragmentIds, true));
+      }
+      return left.isPresent() ? left : right;
     }
     if (predicate instanceof Or) {
-      return analyzeOr((Or) predicate, statsByColumn);
+      Optional<Map<Integer, RangeSet>> left =
+          analyzePredicateRanges(
+              ((Or) predicate).left(),
+              statsByColumn,
+              uncoveredByColumn,
+              allFragmentIds,
+              physicalRowCounts);
+      Optional<Map<Integer, RangeSet>> right =
+          analyzePredicateRanges(
+              ((Or) predicate).right(),
+              statsByColumn,
+              uncoveredByColumn,
+              allFragmentIds,
+              physicalRowCounts);
+      if (!left.isPresent() || !right.isPresent()) {
+        return Optional.empty();
+      }
+      return Optional.of(combineRanges(left.get(), right.get(), allFragmentIds, false));
     }
     if (predicate instanceof Not) {
       return Optional.empty();
     }
 
     Expression[] children = predicate.children();
-    String name = predicate.name();
-    switch (name) {
+    switch (predicate.name()) {
       case "=":
-        return analyzeComparison(children, statsByColumn, ComparisonType.EQUALS);
+        return comparisonRanges(
+            children,
+            statsByColumn,
+            uncoveredByColumn,
+            allFragmentIds,
+            physicalRowCounts,
+            ComparisonType.EQUALS);
       case "<":
-        return analyzeComparison(children, statsByColumn, ComparisonType.LESS_THAN);
+        return comparisonRanges(
+            children,
+            statsByColumn,
+            uncoveredByColumn,
+            allFragmentIds,
+            physicalRowCounts,
+            ComparisonType.LESS_THAN);
       case "<=":
-        return analyzeComparison(children, statsByColumn, ComparisonType.LESS_THAN_OR_EQUAL);
+        return comparisonRanges(
+            children,
+            statsByColumn,
+            uncoveredByColumn,
+            allFragmentIds,
+            physicalRowCounts,
+            ComparisonType.LESS_THAN_OR_EQUAL);
       case ">":
-        return analyzeComparison(children, statsByColumn, ComparisonType.GREATER_THAN);
+        return comparisonRanges(
+            children,
+            statsByColumn,
+            uncoveredByColumn,
+            allFragmentIds,
+            physicalRowCounts,
+            ComparisonType.GREATER_THAN);
       case ">=":
-        return analyzeComparison(children, statsByColumn, ComparisonType.GREATER_THAN_OR_EQUAL);
+        return comparisonRanges(
+            children,
+            statsByColumn,
+            uncoveredByColumn,
+            allFragmentIds,
+            physicalRowCounts,
+            ComparisonType.GREATER_THAN_OR_EQUAL);
       case "IN":
-        return analyzeIn(children, statsByColumn);
+        return inRanges(
+            children, statsByColumn, uncoveredByColumn, allFragmentIds, physicalRowCounts);
       case "IS_NULL":
-        return analyzeIsNull(children, statsByColumn);
+        return nullRanges(
+            children, statsByColumn, uncoveredByColumn, allFragmentIds, physicalRowCounts, true);
       case "IS_NOT_NULL":
-        return analyzeIsNotNull(children, statsByColumn);
+        return nullRanges(
+            children, statsByColumn, uncoveredByColumn, allFragmentIds, physicalRowCounts, false);
       default:
         return Optional.empty();
     }
   }
 
   @SuppressWarnings("unchecked")
-  private static Optional<Set<Integer>> analyzeComparison(
-      Expression[] children, Map<String, List<ZoneStats>> statsByColumn, ComparisonType type) {
-
+  private static Optional<Map<Integer, RangeSet>> comparisonRanges(
+      Expression[] children,
+      Map<String, List<ZoneStats>> statsByColumn,
+      Map<String, Set<Integer>> uncoveredByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts,
+      ComparisonType type) {
     if (children.length != 2
         || !(children[0] instanceof NamedReference)
         || !(children[1] instanceof Literal)) {
       return Optional.empty();
     }
-    String column = columnName((NamedReference) children[0]);
     Object value = normalizeLiteral(((Literal<?>) children[1]).value());
-
-    List<ZoneStats> stats = statsByColumn.get(column);
-    if (stats == null || value == null) {
+    if (value == null) {
       return Optional.empty();
     }
-
     Comparable<Object> target;
     try {
       target = (Comparable<Object>) value;
     } catch (ClassCastException e) {
-      LOG.warn("Cannot cast predicate value {} to Comparable for zonemap pruning", value);
+      return Optional.empty();
+    }
+    return matchingRanges(
+        columnName((NamedReference) children[0]),
+        statsByColumn,
+        uncoveredByColumn,
+        allFragmentIds,
+        physicalRowCounts,
+        zone -> zoneMatchesComparison(zone, target, type));
+  }
+
+  private static Optional<Map<Integer, RangeSet>> inRanges(
+      Expression[] children,
+      Map<String, List<ZoneStats>> statsByColumn,
+      Map<String, Set<Integer>> uncoveredByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts) {
+    if (children.length < 1 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    List<Object> values = new ArrayList<>(children.length - 1);
+    for (int i = 1; i < children.length; i++) {
+      if (!(children[i] instanceof Literal)) {
+        return Optional.empty();
+      }
+      values.add(normalizeLiteral(((Literal<?>) children[i]).value()));
+    }
+    return matchingRanges(
+        columnName((NamedReference) children[0]),
+        statsByColumn,
+        uncoveredByColumn,
+        allFragmentIds,
+        physicalRowCounts,
+        zone -> {
+          for (Object value : values) {
+            if (value == null) {
+              if (zone.getNullCount() > 0) {
+                return true;
+              }
+            } else {
+              @SuppressWarnings("unchecked")
+              Comparable<Object> target = (Comparable<Object>) value;
+              if (zoneMatchesComparison(zone, target, ComparisonType.EQUALS)) {
+                return true;
+              }
+            }
+          }
+          return false;
+        });
+  }
+
+  private static Optional<Map<Integer, RangeSet>> nullRanges(
+      Expression[] children,
+      Map<String, List<ZoneStats>> statsByColumn,
+      Map<String, Set<Integer>> uncoveredByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts,
+      boolean isNull) {
+    if (children.length != 1 || !(children[0] instanceof NamedReference)) {
+      return Optional.empty();
+    }
+    return matchingRanges(
+        columnName((NamedReference) children[0]),
+        statsByColumn,
+        uncoveredByColumn,
+        allFragmentIds,
+        physicalRowCounts,
+        zone -> isNull ? zone.getNullCount() > 0 : zone.getNullCount() < zone.getZoneLength());
+  }
+
+  private static Optional<Map<Integer, RangeSet>> matchingRanges(
+      String column,
+      Map<String, List<ZoneStats>> statsByColumn,
+      Map<String, Set<Integer>> uncoveredByColumn,
+      Set<Integer> allFragmentIds,
+      Map<Integer, Long> physicalRowCounts,
+      ZoneMatcher matcher) {
+    List<ZoneStats> stats = statsByColumn.get(column);
+    if (stats == null) {
       return Optional.empty();
     }
 
-    Set<Integer> matchingFragments = new HashSet<>();
+    Map<Integer, List<ZoneStats>> statsByFragment = new HashMap<>();
     for (ZoneStats zone : stats) {
-      if (zoneMatchesComparison(zone, target, type)) {
-        matchingFragments.add(zone.getFragmentId());
+      statsByFragment.computeIfAbsent(zone.getFragmentId(), ignored -> new ArrayList<>()).add(zone);
+    }
+    Set<Integer> uncovered =
+        uncoveredByColumn == null
+            ? Collections.emptySet()
+            : uncoveredByColumn.getOrDefault(column, Collections.emptySet());
+
+    Map<Integer, RangeSet> result = new HashMap<>();
+    for (int fragmentId : allFragmentIds) {
+      List<ZoneStats> fragmentStats = statsByFragment.get(fragmentId);
+      if (uncovered.contains(fragmentId) || fragmentStats == null || fragmentStats.isEmpty()) {
+        result.put(fragmentId, RangeSet.full());
+        continue;
       }
+
+      List<RowRange> matching = new ArrayList<>();
+      List<RowRange> coverage = new ArrayList<>(fragmentStats.size());
+      boolean invalidRange = false;
+      Long physicalRowCount = physicalRowCounts == null ? null : physicalRowCounts.get(fragmentId);
+      for (ZoneStats zone : fragmentStats) {
+        long start = zone.getZoneStart();
+        long length = zone.getZoneLength();
+        long nullCount = zone.getNullCount();
+        if (start < 0
+            || length < 0
+            || start > Long.MAX_VALUE - length
+            || nullCount < 0
+            || nullCount > length
+            || (physicalRowCount != null
+                && (physicalRowCount < 0 || start + length > physicalRowCount))) {
+          LOG.warn(
+              "Invalid zonemap physical range for column '{}': fragment={}, start={}, length={}; "
+                  + "falling back to a full fragment scan",
+              column,
+              fragmentId,
+              start,
+              length);
+          invalidRange = true;
+          break;
+        }
+        RowRange range = new RowRange(start, start + length);
+        coverage.add(range);
+        if (length > 0) {
+          try {
+            if (matcher.matches(zone)) {
+              matching.add(range);
+            }
+          } catch (RuntimeException e) {
+            LOG.warn(
+                "Incompatible zonemap metadata for column '{}', fragment={}; "
+                    + "falling back to a full fragment scan: {}",
+                column,
+                fragmentId,
+                e.toString());
+            invalidRange = true;
+            break;
+          }
+        }
+      }
+      if (!invalidRange
+          && physicalRowCount != null
+          && !coversPhysicalFragment(coverage, physicalRowCount)) {
+        LOG.warn(
+            "Incomplete zonemap coverage for column '{}', fragment={}: physical_row_count={}; "
+                + "falling back to a full fragment scan",
+            column,
+            fragmentId,
+            physicalRowCount);
+        invalidRange = true;
+      }
+      result.put(fragmentId, invalidRange ? RangeSet.full() : RangeSet.of(matching));
+    }
+    return Optional.of(result);
+  }
+
+  private static boolean coversPhysicalFragment(List<RowRange> coverage, long physicalRowCount) {
+    if (physicalRowCount == 0) {
+      return coverage.isEmpty()
+          || coverage.stream().allMatch(range -> range.start == 0 && range.end == 0);
+    }
+    List<RowRange> sorted = new ArrayList<>(coverage);
+    sorted.sort(Comparator.comparingLong(range -> range.start));
+    long coveredUntil = 0;
+    for (RowRange range : sorted) {
+      if (range.start > coveredUntil) {
+        return false;
+      }
+      coveredUntil = Math.max(coveredUntil, range.end);
+    }
+    return coveredUntil == physicalRowCount;
+  }
+
+  private static Map<Integer, RangeSet> combineRanges(
+      Map<Integer, RangeSet> left,
+      Map<Integer, RangeSet> right,
+      Set<Integer> allFragmentIds,
+      boolean intersect) {
+    Map<Integer, RangeSet> result = new HashMap<>();
+    for (int fragmentId : allFragmentIds) {
+      RangeSet leftRanges = left.getOrDefault(fragmentId, RangeSet.full());
+      RangeSet rightRanges = right.getOrDefault(fragmentId, RangeSet.full());
+      result.put(
+          fragmentId,
+          intersect ? leftRanges.intersect(rightRanges) : leftRanges.union(rightRanges));
+    }
+    return result;
+  }
+
+  @FunctionalInterface
+  private interface ZoneMatcher {
+    boolean matches(ZoneStats zone);
+  }
+
+  private static final class RowRange {
+    private final long start;
+    private final long end;
+
+    private RowRange(long start, long end) {
+      this.start = start;
+      this.end = end;
+    }
+  }
+
+  private static final class RangeSet {
+    private final boolean full;
+    private final List<RowRange> ranges;
+
+    private RangeSet(boolean full, List<RowRange> ranges) {
+      this.full = full;
+      this.ranges = ranges;
     }
 
-    return Optional.of(matchingFragments);
+    private static RangeSet full() {
+      return new RangeSet(true, Collections.emptyList());
+    }
+
+    private static RangeSet of(List<RowRange> ranges) {
+      if (ranges.isEmpty()) {
+        return new RangeSet(false, Collections.emptyList());
+      }
+      List<RowRange> sorted = new ArrayList<>(ranges);
+      sorted.sort(Comparator.comparingLong(range -> range.start));
+      List<RowRange> merged = new ArrayList<>();
+      RowRange current = sorted.get(0);
+      for (int i = 1; i < sorted.size(); i++) {
+        RowRange next = sorted.get(i);
+        if (next.start <= current.end) {
+          current = new RowRange(current.start, Math.max(current.end, next.end));
+        } else {
+          merged.add(current);
+          current = next;
+        }
+      }
+      merged.add(current);
+      return new RangeSet(false, Collections.unmodifiableList(merged));
+    }
+
+    private boolean isFull() {
+      return full;
+    }
+
+    private boolean isEmpty() {
+      return !full && ranges.isEmpty();
+    }
+
+    private RangeSet intersect(RangeSet other) {
+      if (full) {
+        return other;
+      }
+      if (other.full) {
+        return this;
+      }
+      List<RowRange> intersection = new ArrayList<>();
+      int leftIndex = 0;
+      int rightIndex = 0;
+      while (leftIndex < ranges.size() && rightIndex < other.ranges.size()) {
+        RowRange left = ranges.get(leftIndex);
+        RowRange right = other.ranges.get(rightIndex);
+        long start = Math.max(left.start, right.start);
+        long end = Math.min(left.end, right.end);
+        if (start < end) {
+          intersection.add(new RowRange(start, end));
+        }
+        if (left.end < right.end) {
+          leftIndex++;
+        } else {
+          rightIndex++;
+        }
+      }
+      return of(intersection);
+    }
+
+    private RangeSet union(RangeSet other) {
+      if (full || other.full) {
+        return full();
+      }
+      List<RowRange> union = new ArrayList<>(ranges.size() + other.ranges.size());
+      union.addAll(ranges);
+      union.addAll(other.ranges);
+      return of(union);
+    }
   }
 
   @SuppressWarnings("unchecked")
@@ -218,149 +600,20 @@ public final class ZonemapFragmentPruner {
       return false;
     }
 
-    try {
-      switch (type) {
-        case EQUALS:
-          return target.compareTo(min) >= 0 && target.compareTo(max) <= 0;
-        case LESS_THAN:
-          return min.compareTo(target) < 0;
-        case LESS_THAN_OR_EQUAL:
-          return min.compareTo(target) <= 0;
-        case GREATER_THAN:
-          return max.compareTo(target) > 0;
-        case GREATER_THAN_OR_EQUAL:
-          return max.compareTo(target) >= 0;
-        default:
-          return true;
-      }
-    } catch (ClassCastException e) {
-      LOG.warn("Type mismatch in zonemap comparison, skipping pruning for zone", e);
-      return true;
+    switch (type) {
+      case EQUALS:
+        return target.compareTo(min) >= 0 && target.compareTo(max) <= 0;
+      case LESS_THAN:
+        return min.compareTo(target) < 0;
+      case LESS_THAN_OR_EQUAL:
+        return min.compareTo(target) <= 0;
+      case GREATER_THAN:
+        return max.compareTo(target) > 0;
+      case GREATER_THAN_OR_EQUAL:
+        return max.compareTo(target) >= 0;
+      default:
+        return true;
     }
-  }
-
-  private static Optional<Set<Integer>> analyzeIn(
-      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
-
-    if (children.length < 1 || !(children[0] instanceof NamedReference)) {
-      return Optional.empty();
-    }
-    String column = columnName((NamedReference) children[0]);
-    List<ZoneStats> stats = statsByColumn.get(column);
-    if (stats == null) {
-      return Optional.empty();
-    }
-
-    // Hoist literal extraction out of the per-zone loop: invariant across zones.
-    // Bail (no pruning) on any non-Literal child rather than silently dropping it,
-    // which would shrink the IN list and risk excluding fragments that actually match.
-    List<Object> normalizedValues = new ArrayList<>(children.length - 1);
-    for (int i = 1; i < children.length; i++) {
-      if (!(children[i] instanceof Literal)) {
-        return Optional.empty();
-      }
-      normalizedValues.add(normalizeLiteral(((Literal<?>) children[i]).value()));
-    }
-
-    Set<Integer> matchingFragments = new HashSet<>();
-    for (ZoneStats zone : stats) {
-      for (Object value : normalizedValues) {
-        if (value == null) {
-          if (zone.getNullCount() > 0) {
-            matchingFragments.add(zone.getFragmentId());
-            break;
-          }
-        } else {
-          try {
-            @SuppressWarnings("unchecked")
-            Comparable<Object> target = (Comparable<Object>) value;
-            if (zoneMatchesComparison(zone, target, ComparisonType.EQUALS)) {
-              matchingFragments.add(zone.getFragmentId());
-              break;
-            }
-          } catch (ClassCastException e) {
-            matchingFragments.add(zone.getFragmentId());
-            break;
-          }
-        }
-      }
-    }
-
-    return Optional.of(matchingFragments);
-  }
-
-  private static Optional<Set<Integer>> analyzeIsNull(
-      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
-
-    if (children.length != 1 || !(children[0] instanceof NamedReference)) {
-      return Optional.empty();
-    }
-    String column = columnName((NamedReference) children[0]);
-    List<ZoneStats> stats = statsByColumn.get(column);
-    if (stats == null) {
-      return Optional.empty();
-    }
-
-    Set<Integer> matchingFragments = new HashSet<>();
-    for (ZoneStats zone : stats) {
-      if (zone.getNullCount() > 0) {
-        matchingFragments.add(zone.getFragmentId());
-      }
-    }
-
-    return Optional.of(matchingFragments);
-  }
-
-  private static Optional<Set<Integer>> analyzeIsNotNull(
-      Expression[] children, Map<String, List<ZoneStats>> statsByColumn) {
-
-    if (children.length != 1 || !(children[0] instanceof NamedReference)) {
-      return Optional.empty();
-    }
-    String column = columnName((NamedReference) children[0]);
-    List<ZoneStats> stats = statsByColumn.get(column);
-    if (stats == null) {
-      return Optional.empty();
-    }
-
-    Set<Integer> matchingFragments = new HashSet<>();
-    for (ZoneStats zone : stats) {
-      // Zone has non-null rows if zoneLength exceeds nullCount.
-      // Conservative: zoneLength may include gaps from deletions.
-      if (zone.getNullCount() < zone.getZoneLength()) {
-        matchingFragments.add(zone.getFragmentId());
-      }
-    }
-
-    return Optional.of(matchingFragments);
-  }
-
-  private static Optional<Set<Integer>> analyzeAnd(
-      And predicate, Map<String, List<ZoneStats>> statsByColumn) {
-    Optional<Set<Integer>> left = analyzePredicate(predicate.left(), statsByColumn);
-    Optional<Set<Integer>> right = analyzePredicate(predicate.right(), statsByColumn);
-
-    if (left.isPresent() && right.isPresent()) {
-      Set<Integer> intersection = new HashSet<>(left.get());
-      intersection.retainAll(right.get());
-      return Optional.of(intersection);
-    }
-    if (left.isPresent()) return left;
-    if (right.isPresent()) return right;
-    return Optional.empty();
-  }
-
-  private static Optional<Set<Integer>> analyzeOr(
-      Or predicate, Map<String, List<ZoneStats>> statsByColumn) {
-    Optional<Set<Integer>> left = analyzePredicate(predicate.left(), statsByColumn);
-    Optional<Set<Integer>> right = analyzePredicate(predicate.right(), statsByColumn);
-
-    if (left.isPresent() && right.isPresent()) {
-      Set<Integer> union = new HashSet<>(left.get());
-      union.addAll(right.get());
-      return Optional.of(union);
-    }
-    return Optional.empty();
   }
 
   private static String columnName(NamedReference ref) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapFragmentPruner.java
@@ -160,7 +160,8 @@ public final class ZonemapFragmentPruner {
     Map<Integer, List<FragmentSlice>> slicesByFragment = new HashMap<>();
     for (int fragmentId : allFragmentIds) {
       RangeSet ranges = result.getOrDefault(fragmentId, RangeSet.full());
-      if (ranges.isFull()) {
+      Long physicalRowCount = physicalRowCounts == null ? null : physicalRowCounts.get(fragmentId);
+      if (ranges.isFull() || ranges.coversWholeFragment(physicalRowCount)) {
         fullScanFragments.add(fragmentId);
       } else if (!ranges.isEmpty()) {
         List<FragmentSlice> slices = new ArrayList<>(ranges.ranges.size());
@@ -547,6 +548,14 @@ public final class ZonemapFragmentPruner {
 
     private boolean isEmpty() {
       return !full && ranges.isEmpty();
+    }
+
+    private boolean coversWholeFragment(Long physicalRowCount) {
+      return physicalRowCount != null
+          && physicalRowCount > 0
+          && ranges.size() == 1
+          && ranges.get(0).start == 0
+          && ranges.get(0).end == physicalRowCount;
     }
 
     private RangeSet intersect(RangeSet other) {

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapScanPlan.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/read/ZonemapScanPlan.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.ipc.FragmentSlice;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Driver-side zonemap result describing full-fragment scans and physical fragment slices. */
+final class ZonemapScanPlan implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final Set<Integer> fullScanFragments;
+  private final Map<Integer, List<FragmentSlice>> slicesByFragment;
+
+  ZonemapScanPlan(
+      Set<Integer> fullScanFragments, Map<Integer, List<FragmentSlice>> slicesByFragment) {
+    this.fullScanFragments = Collections.unmodifiableSet(new HashSet<>(fullScanFragments));
+
+    Map<Integer, List<FragmentSlice>> slicesCopy = new HashMap<>();
+    for (Map.Entry<Integer, List<FragmentSlice>> entry : slicesByFragment.entrySet()) {
+      slicesCopy.put(
+          entry.getKey(), Collections.unmodifiableList(new ArrayList<>(entry.getValue())));
+    }
+    this.slicesByFragment = Collections.unmodifiableMap(slicesCopy);
+  }
+
+  static ZonemapScanPlan fullFragments(Set<Integer> fragmentIds) {
+    return new ZonemapScanPlan(fragmentIds, Collections.emptyMap());
+  }
+
+  Set<Integer> getSurvivingFragmentIds() {
+    Set<Integer> result = new HashSet<>(fullScanFragments);
+    result.addAll(slicesByFragment.keySet());
+    return Collections.unmodifiableSet(result);
+  }
+
+  boolean scansFullFragment(int fragmentId) {
+    return fullScanFragments.contains(fragmentId);
+  }
+
+  List<FragmentSlice> getFragmentSlices(int fragmentId) {
+    return slicesByFragment.getOrDefault(fragmentId, Collections.emptyList());
+  }
+}

--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceSearchColumnarPartitionReader.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/search/LanceSearchColumnarPartitionReader.java
@@ -84,7 +84,7 @@ public class LanceSearchColumnarPartitionReader implements PartitionReader<Colum
       throw new IOException("Lance namespace is required for search");
     }
     try {
-      byte[] bytes = namespace.queryTable(query.toQueryTableRequest());
+      byte[] bytes = namespace.queryTable(query.toQueryTableRequest()).getData();
       arrowReader =
           new ArrowFileReader(
               new ByteArrayReadableSeekableByteChannel(bytes), LanceRuntime.allocator());

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/LanceRuntimeQueryTableSupportTest.java
@@ -15,6 +15,7 @@ package org.lance.spark;
 
 import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.junit.jupiter.api.Test;
@@ -97,8 +98,8 @@ class LanceRuntimeQueryTableSupportTest {
     public QueryingNamespace() {}
 
     @Override
-    public byte[] queryTable(QueryTableRequest request) {
-      return new byte[0];
+    public QueryTableResponse queryTable(QueryTableRequest request) {
+      return new QueryTableResponse().data(new byte[0]);
     }
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
@@ -34,11 +34,13 @@ import org.lance.namespace.model.ListNamespacesResponse;
 import org.lance.namespace.model.ListTablesRequest;
 import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
 import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.spark.sql.Dataset;
@@ -276,8 +278,8 @@ public abstract class BaseFtsCatalogOnlyNamespaceTest {
     }
 
     @Override
-    public void namespaceExists(NamespaceExistsRequest request) {
-      delegate.namespaceExists(request);
+    public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
+      return delegate.namespaceExists(request);
     }
 
     @Override
@@ -306,8 +308,8 @@ public abstract class BaseFtsCatalogOnlyNamespaceTest {
     }
 
     @Override
-    public void tableExists(TableExistsRequest request) {
-      delegate.tableExists(request);
+    public TableExistsResponse tableExists(TableExistsRequest request) {
+      return delegate.tableExists(request);
     }
 
     @Override

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseFtsCatalogOnlyNamespaceTest.java
@@ -238,6 +238,25 @@ public abstract class BaseFtsCatalogOnlyNamespaceTest {
         "count(*) must count only ids 15-19, which match both 'hello' and id >= 10");
   }
 
+  @Test
+  public void zonemapFilterWithFtsFallsBackToFragmentPruning() {
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX id_zm USING zonemap (id) WITH (rows_per_zone=2)",
+            fullTable));
+
+    List<Row> rows =
+        spark
+            .sql(
+                String.format(
+                    "SELECT id FROM %s WHERE lance_match(body, 'hello') AND id >= 10", fullTable))
+            .collectAsList();
+
+    assertEquals(
+        List.of(15, 16, 17, 18, 19),
+        rows.stream().map(row -> row.getInt(0)).sorted().collect(Collectors.toList()));
+  }
+
   /**
    * Delegates every operation the connector uses to a {@link DirectoryNamespace}, but deliberately
    * leaves {@code queryTable} unimplemented so it keeps the interface default that throws.

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZonemapIndexTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/BaseZonemapIndexTest.java
@@ -13,7 +13,12 @@
  */
 package org.lance.spark.read;
 
+import org.lance.ipc.FragmentSlice;
+import org.lance.spark.LanceSparkReadOptions;
+
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.apache.spark.sql.connector.read.InputPartition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +26,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,12 +38,13 @@ import static org.junit.jupiter.api.Assertions.*;
 public abstract class BaseZonemapIndexTest {
   protected String catalogName = "lance_zonemap_test";
   protected SparkSession spark;
+  protected Path rootPath;
 
   @TempDir Path tempDir;
 
   @BeforeEach
   public void setup() {
-    Path rootPath = tempDir.resolve(UUID.randomUUID().toString());
+    rootPath = tempDir.resolve(UUID.randomUUID().toString());
     rootPath.toFile().mkdirs();
     spark =
         SparkSession.builder()
@@ -100,5 +110,91 @@ public abstract class BaseZonemapIndexTest {
 
     assertEquals(2, spark.sql("SELECT * FROM " + t1).count());
     assertEquals(2, spark.sql("SELECT * FROM " + t2).count());
+  }
+
+  @Test
+  public void testZonemapPhysicalSlicesForRowsAndCount() throws Exception {
+    String tableName = "zm_slice_" + UUID.randomUUID().toString().replace("-", "");
+    String table = catalogName + ".default." + tableName;
+
+    spark.sql(String.format("CREATE TABLE %s (id INT, payload STRING) USING lance", table));
+    spark
+        .range(12)
+        .selectExpr("cast(id as int) AS id", "concat('v', id) AS payload")
+        .coalesce(1)
+        .writeTo(table)
+        .append();
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX id_zm USING zonemap (id) WITH (rows_per_zone=4)", table));
+
+    LanceScanBuilder builder =
+        new LanceScanBuilder(
+            spark.table(table).schema(),
+            LanceSparkReadOptions.builder()
+                .datasetUri(rootPath.resolve(tableName + ".lance").toString())
+                .build(),
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap());
+    builder.pushPredicates(
+        new Predicate[] {TestPredicates.gte("id", 4L), TestPredicates.lt("id", 8L)});
+    InputPartition[] partitions = ((LanceScan) builder.build()).planInputPartitions();
+    assertEquals(1, partitions.length);
+    LanceSplit split = ((LanceInputPartition) partitions[0]).getLanceSplit();
+    assertEquals(1, split.getFragments().size());
+    assertEquals(
+        Arrays.asList(new FragmentSlice(split.getFragments().get(0), 4, 4)),
+        split.getFragmentSlices());
+
+    List<Integer> ids =
+        spark
+            .sql(String.format("SELECT id FROM %s WHERE id >= 4 AND id < 8", table))
+            .collectAsList()
+            .stream()
+            .map(row -> row.getInt(0))
+            .sorted()
+            .collect(Collectors.toList());
+    assertEquals(Arrays.asList(4, 5, 6, 7), ids);
+
+    long count =
+        spark
+            .sql(String.format("SELECT count(*) FROM %s WHERE id >= 4 AND id < 8", table))
+            .first()
+            .getLong(0);
+    assertEquals(4, count);
+  }
+
+  @Test
+  public void testZonemapSliceOffsetsAreNotCompactedByDeletion() throws Exception {
+    String table =
+        catalogName + ".default.zm_delete_" + UUID.randomUUID().toString().replace("-", "");
+
+    spark.sql(String.format("CREATE TABLE %s (id INT) USING lance", table));
+    spark.range(12).selectExpr("cast(id as int) AS id").coalesce(1).writeTo(table).append();
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX id_zm USING zonemap (id) WITH (rows_per_zone=4)", table));
+    spark.sql(String.format("DELETE FROM %s WHERE id = 1", table));
+
+    assertEquals(1, spark.sql(String.format("SELECT * FROM %s WHERE id = 4", table)).count());
+  }
+
+  @Test
+  public void testZonemapPhysicalSlicesWithStableRowIds() throws Exception {
+    String table =
+        catalogName + ".default.zm_stable_" + UUID.randomUUID().toString().replace("-", "");
+
+    spark.sql(
+        String.format(
+            "CREATE TABLE %s (id INT) USING lance "
+                + "TBLPROPERTIES ('enable_stable_row_ids'='true')",
+            table));
+    spark.range(12).selectExpr("cast(id as int) AS id").coalesce(1).writeTo(table).append();
+    spark.sql(
+        String.format(
+            "ALTER TABLE %s CREATE INDEX id_zm USING zonemap (id) WITH (rows_per_zone=4)", table));
+
+    assertEquals(1, spark.sql(String.format("SELECT * FROM %s WHERE id = 8", table)).count());
   }
 }

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/LanceScanTest.java
@@ -13,6 +13,7 @@
  */
 package org.lance.spark.read;
 
+import org.lance.ipc.FragmentSlice;
 import org.lance.ipc.FullTextQuery;
 import org.lance.spark.LanceSparkReadOptions;
 import org.lance.spark.TestUtils;
@@ -37,7 +38,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -144,6 +147,50 @@ public class LanceScanTest {
     assertTrue(
         partitions.length <= allPartitions.length,
         "Limit-pruned partitions should not exceed total partitions");
+  }
+
+  @Test
+  public void testZonemapPlanAttachesSlicesAndDisablesFullFragmentLimitPruning() {
+    List<LanceSplit> splits =
+        java.util.Arrays.asList(
+            new LanceSplit(Collections.singletonList(0)),
+            new LanceSplit(Collections.singletonList(1)));
+    Map<Integer, Long> rowCounts = new HashMap<>();
+    rowCounts.put(0, 100L);
+    rowCounts.put(1, 100L);
+    Map<Integer, List<FragmentSlice>> slices = new HashMap<>();
+    slices.put(0, Collections.singletonList(new FragmentSlice(0, 10, 1)));
+    slices.put(1, Collections.singletonList(new FragmentSlice(1, 20, 1)));
+
+    LanceScan scan =
+        new LanceScan(
+            TEST_SCHEMA,
+            TestUtils.TestTable1Config.readOptions,
+            org.lance.spark.utils.Optional.empty(),
+            org.lance.spark.utils.Optional.of(2),
+            org.lance.spark.utils.Optional.empty(),
+            org.lance.spark.utils.Optional.empty(),
+            org.lance.spark.utils.Optional.empty(),
+            new Predicate[0],
+            null,
+            null,
+            splits,
+            rowCounts,
+            null,
+            null,
+            Collections.emptyMap(),
+            null,
+            Collections.emptyMap(),
+            new ZonemapScanPlan(Set.of(), slices));
+
+    InputPartition[] partitions = scan.planInputPartitions();
+    assertEquals(2, partitions.length, "slice scans must not use full-fragment rows for LIMIT");
+    assertEquals(
+        Collections.singletonList(new FragmentSlice(0, 10, 1)),
+        ((LanceInputPartition) partitions[0]).getLanceSplit().getFragmentSlices());
+    assertEquals(
+        Collections.singletonList(new FragmentSlice(1, 20, 1)),
+        ((LanceInputPartition) partitions[1]).getLanceSplit().getFragmentSlices());
   }
 
   // --- outputPartitioning ---

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentSlicePlannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentSlicePlannerTest.java
@@ -204,6 +204,25 @@ public class ZonemapFragmentSlicePlannerTest {
   }
 
   @Test
+  public void testWholePhysicalFragmentRangeIsNormalizedToFullScan() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "x", Arrays.asList(new ZoneStats(0, 0, 5, 0L, 4L, 0), new ZoneStats(0, 5, 5, 5L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        ZonemapFragmentPruner.planFragmentSlices(
+                new Predicate[] {TestPredicates.gte("x", 0L)},
+                stats,
+                Collections.emptyMap(),
+                Set.of(0),
+                Collections.singletonMap(0, 10L))
+            .orElseThrow(AssertionError::new);
+
+    assertTrue(plan.scansFullFragment(0));
+    assertTrue(plan.getFragmentSlices(0).isEmpty());
+  }
+
+  @Test
   public void testTypeMismatchFallsBackToFullScan() {
     Map<String, List<ZoneStats>> stats = new HashMap<>();
     stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 10, 0L, 9L, 0)));

--- a/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentSlicePlannerTest.java
+++ b/lance-spark-base_2.12/src/test/java/org/lance/spark/read/ZonemapFragmentSlicePlannerTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.spark.read;
+
+import org.lance.index.scalar.ZoneStats;
+import org.lance.ipc.FragmentSlice;
+
+import org.apache.spark.sql.connector.expressions.filter.Predicate;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ZonemapFragmentSlicePlannerTest {
+
+  @Test
+  public void testPlansAndMergesMatchingPhysicalZones() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "x",
+        Arrays.asList(
+            new ZoneStats(0, 0, 10, 0L, 9L, 0),
+            new ZoneStats(0, 10, 10, 10L, 19L, 0),
+            new ZoneStats(0, 20, 10, 100L, 109L, 0),
+            new ZoneStats(0, 40, 10, 15L, 18L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.lt("x", 20L)},
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertEquals(
+        Arrays.asList(new FragmentSlice(0, 0, 20), new FragmentSlice(0, 40, 10)),
+        plan.getFragmentSlices(0));
+    assertFalse(plan.scansFullFragment(0));
+  }
+
+  @Test
+  public void testPlansMultipleFragmentsAndSlices() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "x",
+        Arrays.asList(
+            new ZoneStats(0, 0, 10, 0L, 9L, 0),
+            new ZoneStats(0, 10, 10, 100L, 109L, 0),
+            new ZoneStats(0, 20, 10, 5L, 14L, 0),
+            new ZoneStats(1, 0, 10, 50L, 59L, 0),
+            new ZoneStats(1, 10, 10, 0L, 9L, 0),
+            new ZoneStats(2, 0, 10, 100L, 109L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.lt("x", 20L)},
+            stats,
+            Collections.emptyMap(),
+            Set.of(0, 1, 2));
+
+    assertEquals(Set.of(0, 1), plan.getSurvivingFragmentIds());
+    assertEquals(
+        Arrays.asList(new FragmentSlice(0, 0, 10), new FragmentSlice(0, 20, 10)),
+        plan.getFragmentSlices(0));
+    assertEquals(
+        Collections.singletonList(new FragmentSlice(1, 10, 10)), plan.getFragmentSlices(1));
+    assertTrue(plan.getFragmentSlices(2).isEmpty());
+  }
+
+  @Test
+  public void testAndIntersectsRangesAcrossColumns() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "x",
+        Arrays.asList(
+            new ZoneStats(0, 0, 20, 0L, 19L, 0), new ZoneStats(0, 20, 20, 100L, 119L, 0)));
+    stats.put(
+        "y",
+        Arrays.asList(
+            new ZoneStats(0, 0, 10, 100L, 109L, 0),
+            new ZoneStats(0, 10, 20, 0L, 19L, 0),
+            new ZoneStats(0, 30, 10, 100L, 109L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.lt("x", 50L), TestPredicates.lt("y", 50L)},
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertEquals(
+        Collections.singletonList(new FragmentSlice(0, 10, 10)), plan.getFragmentSlices(0));
+  }
+
+  @Test
+  public void testOrUnionsRanges() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put(
+        "x",
+        Arrays.asList(
+            new ZoneStats(0, 0, 10, 0L, 9L, 0),
+            new ZoneStats(0, 10, 10, 50L, 59L, 0),
+            new ZoneStats(0, 20, 10, 100L, 109L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {
+              TestPredicates.or(TestPredicates.eq("x", 5L), TestPredicates.eq("x", 105L))
+            },
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertEquals(
+        Arrays.asList(new FragmentSlice(0, 0, 10), new FragmentSlice(0, 20, 10)),
+        plan.getFragmentSlices(0));
+  }
+
+  @Test
+  public void testOrWithUnsupportedSideDoesNotPlanSlices() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 10, 0L, 9L, 0)));
+
+    Optional<ZonemapScanPlan> plan =
+        ZonemapFragmentPruner.planFragmentSlices(
+            new Predicate[] {
+              TestPredicates.or(TestPredicates.eq("x", 5L), TestPredicates.eq("y", 5L))
+            },
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertFalse(plan.isPresent());
+  }
+
+  @Test
+  public void testUncoveredFragmentFallsBackToFullScan() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 10, 0L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.eq("x", 100L)},
+            stats,
+            Collections.singletonMap("x", Set.of(1)),
+            Set.of(0, 1));
+
+    assertEquals(Set.of(1), plan.getSurvivingFragmentIds());
+    assertTrue(plan.scansFullFragment(1));
+    assertTrue(plan.getFragmentSlices(0).isEmpty());
+  }
+
+  @Test
+  public void testInvalidRangeFallsBackToFullScan() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, Long.MAX_VALUE - 5, 10, 0L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.eq("x", 5L)}, stats, Collections.emptyMap(), Set.of(0));
+
+    assertTrue(plan.scansFullFragment(0));
+    assertEquals(Set.of(0), plan.getSurvivingFragmentIds());
+  }
+
+  @Test
+  public void testRangeBeyondPhysicalFragmentFallsBackToFullScan() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 11, 0L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        ZonemapFragmentPruner.planFragmentSlices(
+                new Predicate[] {TestPredicates.eq("x", 5L)},
+                stats,
+                Collections.emptyMap(),
+                Set.of(0),
+                Collections.singletonMap(0, 10L))
+            .orElseThrow(AssertionError::new);
+
+    assertTrue(plan.scansFullFragment(0));
+  }
+
+  @Test
+  public void testTypeMismatchFallsBackToFullScan() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 10, 0L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.eq("x", "not-a-number")},
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertTrue(plan.scansFullFragment(0));
+  }
+
+  @Test
+  public void testNoMatchingZoneRemovesFragment() {
+    Map<String, List<ZoneStats>> stats = new HashMap<>();
+    stats.put("x", Collections.singletonList(new ZoneStats(0, 0, 10, 0L, 9L, 0)));
+
+    ZonemapScanPlan plan =
+        plan(
+            new Predicate[] {TestPredicates.eq("x", 50L)},
+            stats,
+            Collections.emptyMap(),
+            Set.of(0));
+
+    assertTrue(plan.getSurvivingFragmentIds().isEmpty());
+  }
+
+  @Test
+  public void testLanceSplitSerializesFragmentSlices() throws Exception {
+    LanceSplit split =
+        new LanceSplit(
+            Collections.singletonList(7),
+            Arrays.asList(new FragmentSlice(7, 10, 5), new FragmentSlice(7, 30, 8)));
+
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(split);
+    }
+
+    LanceSplit restored;
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = (LanceSplit) input.readObject();
+    }
+    assertEquals(split.getFragments(), restored.getFragments());
+    assertEquals(split.getFragmentSlices(), restored.getFragmentSlices());
+  }
+
+  private static ZonemapScanPlan plan(
+      Predicate[] predicates,
+      Map<String, List<ZoneStats>> stats,
+      Map<String, Set<Integer>> uncovered,
+      Set<Integer> allFragmentIds) {
+    Optional<ZonemapScanPlan> result =
+        ZonemapFragmentPruner.planFragmentSlices(predicates, stats, uncovered, allFragmentIds);
+    assertTrue(result.isPresent());
+    return result.get();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
 
     <properties>
         <lance-spark.version>0.8.0-beta.1</lance-spark.version>
-        <lance.version>11.0.0-beta.21</lance.version>
-        <lance-namespace.version>0.8.6</lance-namespace.version>
+        <lance.version>12.0.0-beta.11</lance.version>
+        <lance-namespace.version>0.11.1</lance-namespace.version>
         <lance-namespace-impl.version>0.4.0</lance-namespace-impl.version>
 
         <arrow14.version>14.0.2</arrow14.version>


### PR DESCRIPTION
## Summary

- plan physical row ranges from zonemap statistics on the driver
- attach merged FragmentSlice ranges to single-fragment Lance splits
- pass slices through both ordinary columnar scans and pushed COUNT(*) scans
- conservatively fall back to full-fragment scans for unsupported predicates, incomplete coverage, or invalid metadata
- preserve snapshot isolation by planning zonemap ranges and fragments from the same opened dataset version
- disable fragment row-count limit pruning when a split carries physical slices

## Validation

- `./mvnw -Dmaven.repo.local=/tmp/lance-fragment-slice-m2 spotless:check`
- `./mvnw -Dmaven.repo.local=/tmp/lance-fragment-slice-m2 compile -pl lance-spark-3.5_2.13 -am`
- `./mvnw -Dmaven.repo.local=/tmp/lance-fragment-slice-m2 test -pl lance-spark-3.5_2.13 -am`
  - 1401 tests, 0 failures, 0 errors
- focused FragmentSlice planner tests, including multi-fragment and multi-slice planning
  - 11 tests, 0 failures

## Dependency / draft status

Depends on lance-format/lance#8951 for the Java/JNI FragmentSlice scanner API.

The branch currently targets `lance-core:12.0.0-beta.11`, built locally from that PR into an isolated Maven repository. Keep this PR as draft until the Lance change is merged and a public artifact is available; then replace the dependency version in a follow-up commit.

## Scope

This PR only implements ZoneMap to FragmentSlice scan pruning. It does not introduce distributed BTree/FTS index planning, index scan tasks, or `plan_splits`.