### PR TITLE
fix: log dataset close failures in the blob reference resolver

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobReferenceResolver.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobReferenceResolver.java
@@ -190,11 +190,7 @@ public class BlobReferenceResolver implements AutoCloseable {
   @Override
   public void close() {
     for (Dataset dataset : datasetCache.values()) {
-      try {
-        dataset.close();
-      } catch (Exception e) {
-        // Best effort cleanup
-      }
+      CloseableUtil.closeQuietly(dataset);
     }
     datasetCache.clear();
   }


### PR DESCRIPTION
## Summary
- `BlobReferenceResolver.close` dropped close failures silently. Route them through the package's
  `CloseableUtil.closeQuietly`, which logs at WARN with the cause

## Test plan
- [x] blob/join suites on Spark 4.1/Scala 2.13 and 3.5/Scala 2.12; `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
