### PR TITLE
build: point scm metadata at lance-format/lance-spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,9 @@
         </license>
     </licenses>
 
-    <scm>
+    <scm child.scm.connection.inherit.append.path="false"
+         child.scm.developerConnection.inherit.append.path="false"
+         child.scm.url.inherit.append.path="false">
         <connection>scm:git:https://github.com/lance-format/lance-spark.git</connection>
         <developerConnection>scm:git:https://github.com/lance-format/lance-spark.git</developerConnection>
         <url>https://github.com/lance-format/lance-spark</url>

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:lancedb/lance-spark.git</connection>
-        <developerConnection>scm:git:git@github.com:lancedb/lance-spark.git</developerConnection>
-        <url>git@github.com:lancedb/lance-spark.git</url>
+        <connection>scm:git:https://github.com/lance-format/lance-spark.git</connection>
+        <developerConnection>scm:git:https://github.com/lance-format/lance-spark.git</developerConnection>
+        <url>https://github.com/lance-format/lance-spark</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
## Summary
- `<scm>` still points at `lancedb/lance-spark` over SSH; use `lance-format/lance-spark` over HTTPS
  so the published POMs carry a browsable repository URL

## Test plan
- [x] `./mvnw -N help:evaluate -Dexpression=project.scm.url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
