### PR TITLE
fix: release blob file handles on resolve error paths

### DIFF
--- a/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobReferenceResolver.java
+++ b/lance-spark-base_2.12/src/main/java/org/lance/spark/utils/BlobReferenceResolver.java
@@ -80,11 +80,15 @@ public class BlobReferenceResolver implements AutoCloseable {
     List<Long> rowAddresses = new ArrayList<>(1);
     rowAddresses.add(ref.getRowAddress());
     List<BlobFile> blobs = dataset.takeBlobs(rowAddresses, ref.getColumnName());
-    if (blobs.isEmpty()) {
-      return new byte[0];
-    }
-    try (BlobFile blob = blobs.get(0)) {
-      return blob.read();
+    try {
+      if (blobs.isEmpty()) {
+        return new byte[0];
+      }
+      return blobs.get(0).read();
+    } finally {
+      for (BlobFile blob : blobs) {
+        CloseableUtil.closeQuietly(blob);
+      }
     }
   }
 
@@ -137,31 +141,37 @@ public class BlobReferenceResolver implements AutoCloseable {
       List<Long> addresses = group.distinctAddresses; // requested order
       List<BlobFile> blobs = dataset.takeBlobs(addresses, group.columnName);
 
-      // takeBlobs must return exactly one BlobFile per requested address, in order. A mismatch
-      // means the selection hit deleted/null-descriptor rows, in which case positional mapping
-      // would skew and silently write the wrong bytes into the target table — fail loudly instead.
-      if (blobs.size() != addresses.size()) {
-        throw new IOException(
-            String.format(
-                "takeBlobs returned %d blobs for %d requested addresses (column=%s, dataset=%s); "
-                    + "cannot map results to rows",
-                blobs.size(), addresses.size(), group.columnName, group.datasetUri));
-      }
-
-      for (int i = 0; i < addresses.size(); i++) {
-        BlobFile blob = blobs.get(i);
-        if (blob == null) {
+      // Every handle takeBlobs returned is released in the finally below, including on the two
+      // throws: BlobFile wraps a native handle with no cleaner, so an abandoned one is only
+      // reclaimed when the JVM exits, and Spark retries the task in the same JVM.
+      try {
+        // takeBlobs must return exactly one BlobFile per requested address, in order. A mismatch
+        // means the selection hit deleted/null-descriptor rows, in which case positional mapping
+        // would skew and silently write the wrong bytes into the target table — fail loudly.
+        if (blobs.size() != addresses.size()) {
           throw new IOException(
               String.format(
-                  "takeBlobs returned a null blob for address %d (column=%s, dataset=%s)",
-                  addresses.get(i), group.columnName, group.datasetUri));
+                  "takeBlobs returned %d blobs for %d requested addresses (column=%s, dataset=%s); "
+                      + "cannot map results to rows",
+                  blobs.size(), addresses.size(), group.columnName, group.datasetUri));
         }
-        byte[] data;
-        try (BlobFile b = blob) {
-          data = b.read();
+
+        for (int i = 0; i < addresses.size(); i++) {
+          BlobFile blob = blobs.get(i);
+          if (blob == null) {
+            throw new IOException(
+                String.format(
+                    "takeBlobs returned a null blob for address %d (column=%s, dataset=%s)",
+                    addresses.get(i), group.columnName, group.datasetUri));
+          }
+          byte[] data = blob.read();
+          for (int vectorIndex : group.indicesByAddress.get(addresses.get(i))) {
+            resolved.put(vectorIndex, data);
+          }
         }
-        for (int vectorIndex : group.indicesByAddress.get(addresses.get(i))) {
-          resolved.put(vectorIndex, data);
+      } finally {
+        for (BlobFile blob : blobs) {
+          CloseableUtil.closeQuietly(blob);
         }
       }
     }


### PR DESCRIPTION
## Summary
- `resolveBatch` abandoned every `BlobFile` `takeBlobs` had returned when the count check or the
  null check threw, and the tail of the list when `read()` threw. `BlobFile` wraps a native handle
  with no cleaner, and Spark retries the task in the same JVM. Release all of them in a `finally`,
  and do the same in `resolve`

## Test plan
- [x] `*Blob*`/`*Join*` suites on Spark 4.1/Scala 2.13 and 3.5/Scala 2.12 (144 each); `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
